### PR TITLE
Allow guards access to current scope

### DIFF
--- a/examples/failing/PatternScope.ps
+++ b/examples/failing/PatternScope.ps
@@ -1,0 +1,7 @@
+-- Pattern scope doesn't leak
+foobar = \x -> do
+  var y = case x of
+    z | z % 2 == 0 -> 1
+    _ -> 2
+  return z
+

--- a/examples/passing/Guards.ps
+++ b/examples/passing/Guards.ps
@@ -1,3 +1,8 @@
 collatz = \x -> case x of
   y | y % 2 == 0 -> y / 2
   y -> y * 3 + 1
+
+-- Guards have access to current scope
+collatz2 = \x, y -> case x of
+  z | y > 0 -> z / 2
+  z -> z * 3 + 1


### PR DESCRIPTION
Guards don't have access to the local scope, just the pattern and the top-level environment. This change fixes that and includes access to the local scope. Tests are included to verify the fix and to make sure the change doesn't break scoping rules and allow pattern variables to leak to the outside scope.
