### PR TITLE
Fix inlineVariables

### DIFF
--- a/examples/passing/Assign.purs
+++ b/examples/passing/Assign.purs
@@ -3,11 +3,34 @@ module Assign where
   sum = \n -> {
       var x = 0;
       for (i <- 0 until n) {
-	x = x + i;
+        x = x + i;
       }
       return x;
     }
-    
+
+  arr = [1, 2]
+
+  foo = {
+    var x = 0; -- mutable
+    var y = 1; -- immutable
+
+    -- x should not be inlined since x is mutable
+    while (x < 10) {
+      x = x + 1;
+    }
+
+    var z1 = arr !! x; -- immutable
+    var b = (\x -> z1) 2; -- z1 should not be inlined since x is bound
+
+    var z2 = arr !! x; -- immutable
+    var z3 = arr !! x; -- immutable
+    var a = (\z2 -> z2) 2; -- z3 should not be inlined since z2 is bound
+
+    -- y should be inlined
+    -- z3 should be inlined
+    return x + y + z1 + z2 + z3 + a + b;
+  }
+
 module Main where
 
 main = Trace.trace "Done"


### PR DESCRIPTION
Probrem 1: mutable variable should not be inlined.

Input:

``` Haskell
module Foo where 

foo = {
  var x = 0;

  while (x < 10) {
    x = x + 1;
  }

  return x;
}
```

Actual output:

``` JavaScript
var Foo;
(function (Foo) {
    var foo = (function () {
        while (0 < 10) {
            x = 0 + 1;
        };
        return 0;
    })();
    Foo.foo = foo;
})(Foo = Foo || {

});
```

Expected output:

``` JavaScript
var Foo;
(function (Foo) {
    var foo = (function () {
        var x = 0;
        while (x < 10) {
            x = x + 1;
        };
        return x;
    })();
    Foo.foo = foo;
})(Foo = Foo || {

});
```

Probrem 2: Variable should not be inlined if variables in RHS are captured.

Input:

``` Haskell
module Foo where 

arr = [1, 2]

foo = {
  var x = 0;
  var y = arr !! x;
  var z = (\x -> y) 1;

  return x + y + z;
}
```

Actual output (note that y is inlined and x is captured):

``` JavaScript
var Foo;
(function (Foo) {
    var arr = [ 1, 2 ];
    Foo.arr = arr;
    var foo = (function () {
        var x = 0;
        var z = (function (x) {
            return arr[x];
        })(1);
        return (x + arr[x]) + z;
    })();
    Foo.foo = foo;
})(Foo = Foo || {

});
```

Expected output:

``` JavaScript
var Foo;
(function (Foo) {
    var arr = [ 1, 2 ];
    Foo.arr = arr;
    var foo = (function () {
        var x = 0;
        var y = arr[x]
        var z = (function (x) {
            return y;
        })(1);
        return (x + y) + z;
    })();
    Foo.foo = foo;
})(Foo = Foo || {

});
```

Question:
I modified `isRebound` that is also called by `etaConvert`. Is the modification have any negative effects on `etaConvert`?
