### PR TITLE
Mangle '$' identifier to "$dollar"

### DIFF
--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -40,6 +40,7 @@ identToJs (Op op) = concatMap identCharToString op
 identCharToString :: Char -> String
 identCharToString c | isAlphaNum c = [c]
 identCharToString '_' = "_"
+identCharToString '$' = "$dollar"
 identCharToString '~' = "$tilde"
 identCharToString '=' = "$eq"
 identCharToString '<' = "$less"


### PR DESCRIPTION
The only identifier left in Prelude which was still mangled via `ord`.
