### PR TITLE
Include file path in syntax errors

### DIFF
--- a/psc/Main.hs
+++ b/psc/Main.hs
@@ -28,10 +28,10 @@ preludeFilename :: IO FilePath
 preludeFilename = Paths.getDataFileName "libraries/prelude/prelude.purs"
 
 readInput :: Maybe [FilePath] -> IO (Either ParseError [P.Module])
-readInput Nothing = getContents >>= return . P.runIndentParser P.parseModules
+readInput Nothing = getContents >>= return . P.runIndentParser "" P.parseModules
 readInput (Just input) = fmap (fmap concat . sequence) $ forM input $ \inputFile -> do
   text <- U.readFile inputFile
-  return $ P.runIndentParser P.parseModules text
+  return $ P.runIndentParser inputFile P.parseModules text
 
 compile :: P.Options -> Maybe [FilePath] -> Maybe FilePath -> Maybe FilePath -> IO ()
 compile opts input output externs = do

--- a/psci/Main.hs
+++ b/psci/Main.hs
@@ -106,7 +106,7 @@ loadModule :: FilePath -> IO (Either String [P.Module])
 loadModule moduleFile = do
   print moduleFile
   moduleText <- U.readFile moduleFile
-  return . either (Left . show) Right $ P.runIndentParser P.parseModules moduleText
+  return . either (Left . show) Right $ P.runIndentParser "" P.parseModules moduleText
 
 main :: IO ()
 main = do
@@ -128,7 +128,7 @@ main = do
     case cmd of
       Empty -> go imports loadedModules
       Expression ls -> do
-        case P.runIndentParser (P.whiteSpace *> P.parseValue <* Parsec.eof) (unlines ls) of
+        case P.runIndentParser "" (P.whiteSpace *> P.parseValue <* Parsec.eof) (unlines ls) of
           Left err -> outputStrLn (show err)
           Right decl -> handleDeclaration loadedModules imports decl
         go imports loadedModules

--- a/src/Language/PureScript/Parser/Common.hs
+++ b/src/Language/PureScript/Parser/Common.hs
@@ -399,5 +399,5 @@ same = checkIndentation (==) P.<?> "no indentation"
 -- |
 -- Run a parser which supports indentation
 --
-runIndentParser :: P.Parsec String ParseState a -> String -> Either P.ParseError a
-runIndentParser p = P.runParser p (ParseState 0) ""
+runIndentParser :: FilePath -> P.Parsec String ParseState a -> String -> Either P.ParseError a
+runIndentParser filePath p = P.runParser p (ParseState 0) filePath

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -39,7 +39,7 @@ preludeFilename = Paths.getDataFileName "libraries/prelude/prelude.purs"
 readInput :: [FilePath] -> IO (Either ParseError [P.Module])
 readInput inputFiles = fmap (fmap concat . sequence) $ forM inputFiles $ \inputFile -> do
   text <- U.readFile inputFile
-  return $ P.runIndentParser P.parseModules text
+  return $ P.runIndentParser inputFile P.parseModules text
 
 compile :: P.Options -> [FilePath] -> IO (Either String String)
 compile opts inputFiles = do


### PR DESCRIPTION
Easy fix for part of #166, doing the same for type errors etc. will be a little more involved.
