### PR TITLE
Fixed Arrays.sort mutating the passed in list.

### DIFF
--- a/examples/passing/Arrays.purs
+++ b/examples/passing/Arrays.purs
@@ -4,7 +4,7 @@ import Prelude
 
 test1 arr = arr !! 0 + arr !! 1 + 1
 
-test2 = \arr -> case arr of 
+test2 = \arr -> case arr of
   [x, y] -> x + y
   [x] -> x
   [] -> 0
@@ -16,12 +16,19 @@ test3 = \tree sum -> case tree of
   One n -> n
   Some (n1 : n2 : rest) -> test3 n1 sum * 10 + test3 n2 sum * 5 + sum rest
 
-test4 = \arr -> case arr of 
+test4 = \arr -> case arr of
   [] -> 0
   [_] -> 0
   x : y : xs -> x * y + test4 xs
-    
+
 module Main where
 
-main = Trace.trace "Done"
+import Arrays
+import Prelude
 
+main = do
+  let x = [3,2,1]
+  let y = sort x
+  if x == [3,2,1]
+    then Trace.trace "Done"
+    else Errors.throwError "Not done"

--- a/prelude/prelude.purs
+++ b/prelude/prelude.purs
@@ -578,7 +578,7 @@ module Arrays where
 
   foreign import sort "function sort(l) {\
                       \  var l1 = l.slice();\
-                      \  l.sort();\
+                      \  l1.sort();\
                       \  return l1;\
                       \}" :: forall a. [a] -> [a]
 


### PR DESCRIPTION
I tried to add a test case for this,
but it didn't seem to make a difference with `cabal test`.
It passed before and after the fix.

You can test it by

```
module Main where

import Arrays
import Eff
import Prelude
import Trace

x :: [Number]
x = [3,2,1]

main = do
    trace $ show x
    trace $ show (sort x)
    trace $ show x
```

Before the fix you'll get:

```
3 : 2 : 1 : []
3 : 2 : 1 : []
1 : 2 : 3 : []
```

After the fix you get the expected output:

```
3 : 2 : 1 : []
1 : 2 : 3 : []
3 : 2 : 1 : []
```
