### PR TITLE
Cannot install with cabal from hackage.

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -91,7 +91,8 @@ executable psci
     main-is: Main.hs
     buildable: True
     hs-source-dirs: psci
-    other-modules:
+    other-modules: Commands
+                   Parser
     ghc-options: -Wall -O2
 
 executable docgen


### PR DESCRIPTION
Sorry, I forgot to include the `Commands` and `Parser` modules for psci.
So currently the install is broken from cabal for version `0.4.2`.

This should fix it.
