### PR TITLE
Update intro.rst

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -89,7 +89,7 @@ which compiles to the following Javascript, ignoring the Prelude::
 
 The following command will compile and execute the PureScript code above::
 
-  psc input.purs --main | nodejs
+  psc input.purs --main | node
 
 Another Example
 ---------------


### PR DESCRIPTION
The node binary, at least in nodejs 0.10.25, is `node`, not `nodejs`
