### PR TITLE
Fix for broken isNaN implementation in browsers

### DIFF
--- a/prelude/prelude.purs
+++ b/prelude/prelude.purs
@@ -862,7 +862,9 @@ module Global where
 
   foreign import decodeURI :: String -> String
 
-  foreign import isNaN :: Number -> Boolean
+  foreign import isNaN "function isNaNImpl(n) {\
+                       \  return n !== n;\
+                       \}" :: Number -> Boolean
 
 module Math where
 


### PR DESCRIPTION
This is a subtle bug which comes from `undefined` being considered `NaN`, and the fix comes from the strange property of `NaN` in that it is not equal to itself. This should be caught by the type checker, but not if called from the outside world, like jQuery AJAX callbacks.

``` javascript
isNaN(undefined) // True;
NaN !== NaN // True
```
