### PR TITLE
Added Data.Foldable and Data.Traversable to Prelude.

### DIFF
--- a/examples/passing/Foldable.purs
+++ b/examples/passing/Foldable.purs
@@ -2,8 +2,18 @@ module Main where
 
   import Prelude
   import Data.Foldable
+  import Data.Monoid
 
-  sum :: [Number] -> Number
-  sum = foldr (+) 0
+  data Tree a = Node a | Branch (Tree a) (Tree a)
 
-  main = Debug.Trace.print <<< sum $ [1,2,3,4,5]
+  instance foldableTree :: Foldable Tree where
+    foldr f z (Node x)     = x `f` z
+    foldr f z (Branch l r) = foldr f (foldr f z r) l
+
+    foldl f z (Node x)     = z `f` x
+    foldl f z (Branch l r) = foldl f (foldl f z l) r
+
+    foldMap f (Node x)     = f x
+    foldMap f (Branch l r) = foldMap f l <> foldMap f r
+
+  main = Debug.Trace.print <<< sum $ Branch (Node 1) (Branch (Node 2) (Node 3))

--- a/examples/passing/Traversable.purs
+++ b/examples/passing/Traversable.purs
@@ -1,8 +1,8 @@
 module Main where
 
   import Prelude
+  import Data.Array
   import Data.Maybe
   import Data.Traversable
-  import Data.Tuple
 
-  main = Debug.Trace.print (sequence (Tuple 3 (Just 4)))
+  main = Debug.Trace.print (sequence (Just [1,2,3]))

--- a/prelude/prelude.purs
+++ b/prelude/prelude.purs
@@ -599,11 +599,6 @@ module Data.Array where
   filter p (x:xs) | p x = x : filter p xs
   filter p (_:xs) = filter p xs
 
-  find :: forall a. (a -> Boolean) -> [a] -> Maybe a
-  find _ [] = Nothing
-  find p (x:xs) | p x = Just x
-  find p (_:xs) = find p xs
-
   isEmpty :: forall a. [a] -> Boolean
   isEmpty [] = true
   isEmpty _ = false
@@ -615,14 +610,6 @@ module Data.Array where
   zipWith :: forall a b c. (a -> b -> c) -> [a] -> [b] -> [c]
   zipWith f (a:as) (b:bs) = f a b : zipWith f as bs
   zipWith _ _ _ = []
-
-  any :: forall a. (a -> Boolean) -> [a] -> Boolean
-  any _ [] = false
-  any p (a:as) = p a || any p as
-
-  all :: forall a. (a -> Boolean) -> [a] -> Boolean
-  all _ [] = true
-  all p (a:as) = p a && all p as
 
   drop :: forall a. Number -> [a] -> [a]
   drop 0 xs = xs
@@ -1294,6 +1281,35 @@ module Data.Foldable where
 
   mconcat :: forall f m. (Foldable f, Monoid m) => f m -> m
   mconcat = foldl (<>) mempty
+
+  and :: forall f. (Foldable f) => f Boolean -> Boolean
+  and = foldl (&&) true
+
+  or :: forall f. (Foldable f) => f Boolean -> Boolean
+  or = foldl (||) false
+
+  any :: forall a f. (Foldable f) => (a -> Boolean) -> f a -> Boolean
+  any p = or <<< foldMap (\x -> [p x])
+
+  all :: forall a f. (Foldable f) => (a -> Boolean) -> f a -> Boolean
+  all p = and <<< foldMap (\x -> [p x])
+
+  sum :: forall f. (Foldable f) => f Number -> Number
+  sum = foldl (+) 0
+
+  product :: forall f. (Foldable f) => f Number -> Number
+  product = foldl (*) 1
+
+  elem :: forall a f. (Eq a, Foldable f) => a -> f a -> Boolean
+  elem = any  <<< (==)
+
+  notElem :: forall a f. (Eq a, Foldable f) => a -> f a -> Boolean
+  notElem x = not <<< elem x
+
+  find :: forall a f. (Foldable f) => (a -> Boolean) -> f a -> Maybe a
+  find p f = case foldMap (\x -> if p x then [x] else []) f of
+    (x:_) -> Just x
+    []    -> Nothing
 
 module Data.Traversable where
 


### PR DESCRIPTION
Couple of things.
- I tried to move all the specific functions like `Data.Array.foldr` into `Data.Foldable` and just make `Array` and instance of `Foldable` This will break a few libraries that depend on `Data.Array` having foldr and whatnot, so I'll update those as well.
- I'm unsure about `foldr1` and `foldl1`. If we're sticking to the "no partials" thing (which I'm behind) then should these have the type: `foldr :: forall a b f. (Foldable f) => (a -> b -> b) -> f a -> Maybe b` and `foldl :: forall a b f. (Foldable f) => (b -> a -> b) -> f a -> Maybe b`?
- I combined the `for`/`forM`, `traverse`/`mapM`, etc functions because we shouldn't support `Applicatives` and `Monads` having different semantics.
