### PR TITLE
Added infix example that should pass.

### DIFF
--- a/examples/passing/Infix.purs
+++ b/examples/passing/Infix.purs
@@ -1,0 +1,28 @@
+module Main where
+
+  import Debug.Trace
+
+  data Bool = True | False
+
+  instance boolLikeBool :: BoolLike Bool where
+    (&&) True True = True
+    (&&) _    _    = False
+
+    (||) False False = False
+    (||) _     _     = True
+
+    not True  = False
+    not False = True
+
+  instance eqBool :: Eq Bool where
+    (==) True  True  = true
+    (==) False False = true
+    (==) _     _     = false
+
+    (/=) b b' = not (b == b')
+
+  instance showBool :: Show Bool where
+    show True  = "True"
+    show False = "False"
+
+  main = trace $ "True && False == False: " ++ (show (True && False == False))


### PR DESCRIPTION
Re: #311 and what we were talking about in irc. Figured I should just make an example that should pass.

It  should be parsed as `(True && False) == False`, but instead it's parsed as `True && (False == False)`
