### PR TITLE
Apply and Bind

### DIFF
--- a/examples/passing/Do.purs
+++ b/examples/passing/Do.purs
@@ -15,10 +15,12 @@ instance applyMaybe :: Apply Maybe where
 instance applicativeMaybe :: Applicative Maybe where
   pure = Just
 
-instance monadMaybe :: Prelude.Monad Maybe where
-  return = Just
+instance bindMaybe :: Bind Maybe where
   (>>=) Nothing _ = Nothing
   (>>=) (Just a) f = f a
+
+instance monadMaybe :: Prelude.Monad Maybe where
+  return = Just
 
 test1 = \_ -> do
   Just "abc"

--- a/examples/passing/MonadState.purs
+++ b/examples/passing/MonadState.purs
@@ -21,10 +21,12 @@ instance applyState :: Apply (State s) where
 instance applicativeState :: Applicative (State s) where
   pure = return
 
-instance monadState :: Prelude.Monad (State s) where
-  return a = State $ \s -> Tuple s a
+instance bindState :: Bind (State s) where
   (>>=) f g = State $ \s -> case runState s f of
                               Tuple s1 a -> runState s1 (g a)
+
+instance monadState :: Monad (State s) where
+  return a = State $ \s -> Tuple s a
 
 instance monadStateState :: MonadState s (State s) where
   get = State (\s -> Tuple s s)

--- a/examples/passing/Superclasses3.purs
+++ b/examples/passing/Superclasses3.purs
@@ -30,9 +30,11 @@ instance applyMTrace :: Apply MTrace where
 instance applicativeMTrace :: Applicative MTrace where
   pure = return
 
+instance bindMTrace :: Bind MTrace where
+  (>>=) m f = MTrace (runMTrace m >>= (runMTrace <<< f))
+
 instance monadMTrace :: Monad MTrace where
   return = MTrace <<< return
-  (>>=) m f = MTrace (runMTrace m >>= (runMTrace <<< f))
 
 instance writerMTrace :: MonadWriter String MTrace where
   tell s = MTrace (trace s)

--- a/examples/passing/TypeClasses.purs
+++ b/examples/passing/TypeClasses.purs
@@ -30,9 +30,11 @@ instance applyData :: Apply Data where
 instance applicativeData :: Applicative Data where
   pure = return
 
-instance monadData :: Prelude.Monad Data where
-  return = Data
+instance bindData :: Bind Data where
   (>>=) (Data a) f = f a
+
+instance monadData :: Monad Data where
+  return = Data
 
 data Maybe a = Nothing | Just a
 
@@ -45,10 +47,12 @@ instance applyMaybe :: Apply Maybe where
 instance applicativeMaybe :: Applicative Maybe where
   pure = return
 
-instance monadMaybe :: Prelude.Monad Maybe where
-  return = Just
+instance bindMaybe :: Bind Maybe where
   (>>=) Nothing _ = Nothing
   (>>=) (Just a) f = f a
+
+instance monadMaybe :: Monad Maybe where
+  return = Just
 
 test4 :: forall a m. (Monad m) => a -> m Number
 test4 = \_ -> return 1
@@ -70,9 +74,11 @@ instance applyFunction :: Apply ((->) r) where
 instance applicativeFunction :: Applicative ((->) r) where
   pure = return
 
-instance monadFunction :: Prelude.Monad ((->) r) where
-  return a r = a
+instance bindFunction :: Bind ((->) r) where
   (>>=) f g r = g (f r) r
+
+instance monadFunction :: Monad ((->) r) where
+  return a r = a
 
 ask r = r
 

--- a/prelude/prelude.purs
+++ b/prelude/prelude.purs
@@ -76,9 +76,11 @@ module Prelude where
 
   infixl 1 >>=
 
-  class (Applicative m) <= Monad m where
-    return :: forall a. a -> m a
+  class (Apply m) <= Bind m where
     (>>=) :: forall a b. m a -> (a -> m b) -> m b
+
+  class (Applicative m, Bind m) <= Monad m where
+    return :: forall a. a -> m a
 
   liftM1 :: forall m a b. (Monad m) => (a -> b) -> m a -> m b
   liftM1 f a = do
@@ -398,9 +400,11 @@ module Control.Monad.Eff where
   instance applicativeEff :: Applicative (Eff e) where
     pure = return
 
+  instance bindEffInstance :: Bind (Eff e) where
+    (>>=) = bindEff
+
   instance monadEff :: Monad (Eff e) where
     return = retEff
-    (>>=) = bindEff
 
   foreign import untilE "function untilE(f) {\
                         \  return function() {\


### PR DESCRIPTION
Following @garyb's checklist, I attempted to add `Apply` and `Bind` into the hierarchy. `Apply` went painlessly, but `Bind` borked a couple of things.
- The examples using `Control.Monad.ST` seem to fail during the test with

```
[stdin]:26
        function showNumberImpl(n) {  return n.toString();};
                                               ^
TypeError: Cannot call method 'toString' of undefined
    at showNumberImpl ([stdin]:26:48)
    at [stdin]:623:62
    at [stdin]:736:147
    at [stdin]:521:88
    at [stdin]:521:94
    at [stdin]:521:94
    at [stdin]:521:94
    at Object.main ([stdin]:521:94)
    at window.PS ([stdin]:758:14)
    at [stdin]:759:3
```

or similar.

They seem to pass with `--no-magic-do` enabled.  It also seems to compile properly, and run fine on node if you're running node as a separate process. I'm using version `v0.10.26` if that makes any difference.
- The Collatz example appears to be in an infinite loop.
- This example: https://github.com/purescript/purescript/blob/superclasses/examples/passing/Superclasses3.purs#L10-L11 has an overlapping `Functor` instance from `Monad` being a subclass of both `Applicative` and `Bind`.
