### PR TITLE
refine syb dependency

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -19,7 +19,7 @@ data-dir: ""
 
 library
     build-depends: base >=4 && <5, cmdtheline -any, containers -any,
-                   directory >= 1.2, filepath -any, mtl -any, parsec -any, syb -any,
+                   directory >= 1.2, filepath -any, mtl -any, parsec -any, syb >= 0.4.1 && < 0.5,
                    transformers -any, utf8-string -any, 
                    pattern-arrows >= 0.0.2 && < 0.1, 
                    monad-unify >= 0.2.1 && < 0.3,
@@ -87,7 +87,7 @@ library
 executable psc
     build-depends: base >=4 && <5, cmdtheline -any, containers -any,
                    directory -any, filepath -any, mtl -any, parsec -any,
-                   purescript -any, syb -any, transformers -any, utf8-string -any
+                   purescript -any, syb >= 0.4.1 && < 0.5, transformers -any, utf8-string -any
     main-is: Main.hs
     buildable: True
     hs-source-dirs: psc
@@ -97,7 +97,7 @@ executable psc
 executable psc-make
     build-depends: base >=4 && <5, cmdtheline -any, containers -any,
                    directory -any, filepath -any, mtl -any, parsec -any,
-                   purescript -any, syb -any, transformers -any, utf8-string -any
+                   purescript -any, syb >= 0.4.1 && < 0.5, transformers -any, utf8-string -any
     main-is: Main.hs
     buildable: True
     hs-source-dirs: psc-make
@@ -107,7 +107,7 @@ executable psc-make
 executable psci
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any,
                    mtl -any, parsec -any, haskeline -any, purescript -any,
-                   syb -any, transformers -any, utf8-string -any, process -any,
+                   syb >= 0.4.1 && < 0.5, transformers -any, utf8-string -any, process -any,
                    xdg-basedir -any, cmdtheline -any
     main-is: Main.hs
     buildable: True
@@ -127,7 +127,7 @@ executable docgen
 
 test-suite tests
     build-depends: base >=4 && <5, containers -any, directory -any,
-                   filepath -any, mtl -any, parsec -any, purescript -any, syb -any,
+                   filepath -any, mtl -any, parsec -any, purescript -any, syb >= 0.4.1 && < 0.5,
                    transformers -any, utf8-string -any, process -any
     type: exitcode-stdio-1.0
     main-is: Main.hs


### PR DESCRIPTION
to combat `cabal install purescript` failure:

src/Language/PureScript/TypeChecker/Types.hs:48:9:
 Module `Data.Generics' does not export`everythingWithContext'
