### PR TITLE
Initial implementation of type wildcards

### DIFF
--- a/examples/passing/TypeWildcards.purs
+++ b/examples/passing/TypeWildcards.purs
@@ -1,0 +1,10 @@
+module Main where
+
+test :: forall a. (Eq a) => (a -> a) -> a -> a
+test f a = go (f a) a
+  where
+  go :: _ -> _ -> _
+  go a1 a2 | a1 == a2 = a1
+  go a1 _ = go (f a1) a1
+
+main = Debug.Trace.trace "Done"

--- a/src/Language/PureScript/Parser/Types.hs
+++ b/src/Language/PureScript/Parser/Types.hs
@@ -51,6 +51,9 @@ parseFunction = parens $ P.try (lexeme (P.string "->")) >> return tyFunction
 parseObject :: P.Parsec String ParseState Type
 parseObject = braces $ TypeApp tyObject <$> parseRow False
 
+parseTypeWildcard :: P.Parsec String ParseState Type
+parseTypeWildcard = lexeme (P.char '_') >> return TypeWildcard
+
 parseTypeVariable :: P.Parsec String ParseState Type
 parseTypeVariable = do
   ident <- identifier
@@ -76,6 +79,7 @@ parseTypeAtom = indented *> P.choice (map P.try
             , parseArrayOf
             , parseFunction
             , parseObject
+            , parseTypeWildcard
             , parseTypeVariable
             , parseTypeConstructor
             , parseForAll

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -32,6 +32,7 @@ import Language.PureScript.Environment
 typeLiterals :: Pattern () Type String
 typeLiterals = mkPattern match
   where
+  match TypeWildcard = Just "_"
   match (TypeVar var) = Just var
   match (PrettyPrintObject row) = Just $ "{ " ++ prettyPrintRow row ++ " }"
   match (PrettyPrintArray ty) = Just $ "[" ++ prettyPrintType ty ++ "]"
@@ -116,4 +117,5 @@ prettyPrintTypeAtom = fromMaybe (error "Incomplete pattern") . pattern matchType
 --
 prettyPrintType :: Type -> String
 prettyPrintType = fromMaybe (error "Incomplete pattern") . pattern matchType () . insertPlaceholders
+
 

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -179,6 +179,7 @@ infer' (ConstrainedType deps ty) = do
   k <- infer ty
   k =?= Star
   return Star
+infer' TypeWildcard = fresh
 infer' _ = error "Invalid argument to infer"
 
 

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -200,3 +200,14 @@ liftUnify unify = do
   modify $ \st' -> st' { checkNextVar = unifyNextVar ust }
   return (a, unifyCurrentSubstitution ust)
 
+-- |
+-- Replace type wildcards with unknowns
+--
+replaceTypeWildcards :: Type -> UnifyT t Check Type
+replaceTypeWildcards = everywhereOnTypesM replace
+  where
+  replace TypeWildcard = do
+    u <- fresh'
+    return $ TUnknown u
+  replace other = return other
+

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -78,6 +78,10 @@ data Type
   --
   | RCons String Type Type
   -- |
+  -- A type wildcard, as would appear in a partial type synonym
+  --
+  | TypeWildcard
+  -- |
   -- A placeholder used in pretty printing
   --
   | PrettyPrintFunction Type Type


### PR DESCRIPTION
For #287 Partial Type Signatures

@garyb @joneshf @puffnfresh for your consideration ...

I'd also like to add the ability to label a wildcard so that two wildcards can be declared equal:

```
foo :: _a -> _a -> Boolean
```

but I can't decide on a good syntax.
