### PR TITLE
replace JS code generated by desugarer for typeclasses with PS code

### DIFF
--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -73,11 +73,7 @@ data ForeignImportType
   -- |
   -- A foreign import which contains inline Javascript as a string literal
   --
-  | InlineJavascript
-  -- |
-  -- A type class dictionary member accessor import, generated during desugaring of type class declarations
-  --
-  | TypeClassAccessorImport deriving (Show, Eq, Data, Typeable)
+  | InlineJavascript deriving (Show, Eq, Data, Typeable)
 
 -- |
 -- The kind of a name
@@ -87,6 +83,10 @@ data NameKind
   -- A value introduced as a binding in a module
   --
   = Value
+  -- |
+  -- A type class dictionary member accessor import, generated during desugaring of type class declarations
+  --
+  | TypeClassAccessorImport
   -- |
   -- A foreign import
   --

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -143,9 +143,9 @@ typeClassDictionaryDeclaration name args implies members =
 
 typeClassMemberToDictionaryAccessor :: ModuleName -> ProperName -> [String] -> Declaration -> Declaration
 typeClassMemberToDictionaryAccessor mn name args (TypeDeclaration ident ty) =
-  ExternDeclaration TypeClassAccessorImport ident
-    (Just (JSFunction (Just $ identToJs ident) ["dict"] (JSBlock [JSReturn (JSIndexer (JSStringLiteral (identToProperty ident)) (JSVar "dict"))])))
-    (moveQuantifiersToFront (quantify (ConstrainedType [(Qualified (Just mn) name, map TypeVar args)] ty)))
+  ValueDeclaration ident TypeClassAccessorImport [] Nothing $
+    TypedValue False (Abs (Left $ Ident "dict") (Accessor (runIdent ident) (Var $ Qualified Nothing (Ident "dict")))) $
+    moveQuantifiersToFront (quantify (ConstrainedType [(Qualified (Just mn) name, map TypeVar args)] ty))
 typeClassMemberToDictionaryAccessor mn name args (PositionedDeclaration pos d) =
   PositionedDeclaration pos $ typeClassMemberToDictionaryAccessor mn name args d
 typeClassMemberToDictionaryAccessor _ _ _ _ = error "Invalid declaration in type class definition"


### PR DESCRIPTION
While desugaring typeclasses, compiler was generating code in JS syntax. For all other backends this is a problem because we can't generate backend code from JS.

With this patch compiler generates PS syntax when desugaring typeclasses. I had to replace `Maybe JS` part of `ExternDeclaration` with `Maybe Value`, and add `RawValue` constructor to `Value` type for extern declarations given in backend code.
