### PR TITLE
Expand one of the inliner rules to enable better TCO

### DIFF
--- a/src/Language/PureScript/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/Optimizer/Inliner.hs
@@ -53,7 +53,11 @@ unThunk :: JS -> JS
 unThunk = everywhereOnJS convert
   where
   convert :: JS -> JS
-  convert (JSBlock [JSReturn (JSApp (JSFunction Nothing [] (JSBlock body)) [])]) = JSBlock body
+  convert (JSBlock []) = JSBlock []
+  convert (JSBlock jss) =
+    case (last jss) of
+      JSReturn (JSApp (JSFunction Nothing [] (JSBlock body)) []) -> JSBlock $ init jss ++ body
+      _ -> JSBlock jss
   convert js = js
 
 evaluateIifes :: JS -> JS


### PR DESCRIPTION
The inliner previously would turn

```
{
  return (function() {
    ... blah ...
  })();
}
```

into

```
{
  ... blah ...
}
```

Now it turns

```
{
  ... bleh ...
  return (function() {
    ... blah ...
  })();
}
```

into

```
{
  ... bleh ...
  ... blah ...
}
```
