### PR TITLE
Combine nested `if` blocks in JS

### DIFF
--- a/src/Language/PureScript/Optimizer.hs
+++ b/src/Language/PureScript/Optimizer.hs
@@ -53,6 +53,7 @@ optimize :: Options -> JS -> JS
 optimize opts | optionsNoOptimizations opts = id
               | otherwise = untilFixedPoint (applyAll
   [ collapseNestedBlocks
+  , collapseNestedIfs
   , tco opts
   , magicDo opts
   , removeCodeAfterReturnStatements

--- a/src/Language/PureScript/Optimizer/Blocks.hs
+++ b/src/Language/PureScript/Optimizer/Blocks.hs
@@ -13,9 +13,10 @@
 --
 -----------------------------------------------------------------------------
 
-module Language.PureScript.Optimizer.Blocks (
-  collapseNestedBlocks
-) where
+module Language.PureScript.Optimizer.Blocks
+  ( collapseNestedBlocks
+  , collapseNestedIfs
+  ) where
 
 import Language.PureScript.CodeGen.JS.AST
 
@@ -31,3 +32,11 @@ collapseNestedBlocks = everywhereOnJS collapse
   go :: JS -> [JS]
   go (JSBlock sts) = sts
   go s = [s]
+
+collapseNestedIfs :: JS -> JS
+collapseNestedIfs = everywhereOnJS collapse
+  where
+  collapse :: JS -> JS
+  collapse (JSIfElse cond1 (JSBlock [JSIfElse cond2 body Nothing]) Nothing) =
+      JSIfElse (JSBinary And cond1 cond2) body Nothing
+  collapse js = js


### PR DESCRIPTION
So for example

``` js
var ordBoolean = function (_) {
        return new Ord(eqBoolean, function (_18) {
            return function (_19) {
                if (!_18) {
                    if (!_19) {
                        return EQ.value;
                    };
                };
                if (!_18) {
                    if (_19) {
                        return LT.value;
                    };
                };
                if (_18) {
                    if (_19) {
                        return EQ.value;
                    };
                };
                if (_18) {
                    if (!_19) {
                        return GT.value;
                    };
                };
                throw "Failed pattern match";
            };
        });
    };
```

Becomes:

``` js
    var ordBoolean = function (_) {
        return new Ord(eqBoolean, function (_18) {
            return function (_19) {
                if (!_18 && !_19) {
                    return EQ.value;
                };
                if (!_18 && _19) {
                    return LT.value;
                };
                if (_18 && _19) {
                    return EQ.value;
                };
                if (_18 && !_19) {
                    return GT.value;
                };
                throw "Failed pattern match";
            };
        });
    };
```
