### PR TITLE
fixes #497: do not throw plain strings for failed pattern matches

### DIFF
--- a/examples/passing/PartialFunction.purs
+++ b/examples/passing/PartialFunction.purs
@@ -1,0 +1,17 @@
+module Main where
+
+foreign import testError
+  "function testError(f) {\
+  \  try {\
+  \    return f();\
+  \  } catch (e) {\
+  \    if (e instanceof Error) return 'success';\
+  \    throw new Error('Pattern match failure is not TypeError');\
+  \  }\
+  \}" :: (Unit -> Number) -> Number
+
+fn :: Number -> Number
+fn 0 = 0
+fn 1 = 2
+
+main = Debug.Trace.trace (show $ testError $ \_ -> fn 2)

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -302,7 +302,7 @@ bindersToJs opts m e binders vals = do
   jss <- forM binders $ \(CaseAlternative bs grd result) -> do
     ret <- valueToJs opts m e result
     go valNames [JSReturn ret] bs grd
-  return $ JSApp (JSFunction Nothing valNames (JSBlock (concat jss ++ [JSThrow (JSStringLiteral "Failed pattern match")])))
+  return $ JSApp (JSFunction Nothing valNames (JSBlock (concat jss ++ [JSThrow $ JSApp (JSVar "Error") $ [(JSStringLiteral "Failed pattern match")]])))
                  vals
   where
     go :: (Functor m, Applicative m, Monad m) => [String] -> [JS] -> [Binder] -> Maybe Guard -> SupplyT m [JS]


### PR DESCRIPTION
Fixes #497. I wasn't sure about how to confirm the fix using the test, but the test at least exercises the modified part of the program. Tested manually and it works.

Side note: `JSNew` only takes one `JS` for the callee, but no argument list. Thankfully, `new` is unnecessary for constructing instances of native constructors. But we should look into fixing that.
