### PR TITLE
Fixed tests with missing instance names.

### DIFF
--- a/examples/failing/MPTCs.purs
+++ b/examples/failing/MPTCs.purs
@@ -3,5 +3,5 @@ module Main where
 class Foo a where
   f :: a -> a
 
-instance Foo String String where
+instance fooStringString :: Foo String String where
   f a = a

--- a/examples/failing/OverlappingVars.purs
+++ b/examples/failing/OverlappingVars.purs
@@ -5,7 +5,7 @@ class OverlappingVars a where
 
 data Foo a b = Foo a b
 
-instance OverlappingVars (Foo a a) where
+instance overlappingVarsFoo :: OverlappingVars (Foo a a) where
   f a = a
 
 test = f (Foo "" 0)

--- a/examples/failing/TypeClassInstances.purs
+++ b/examples/failing/TypeClassInstances.purs
@@ -4,5 +4,5 @@ class A a where
   a :: a -> String
   b :: a -> Number
 
-instance A String where
+instance aString :: A String where
   a s = s

--- a/examples/failing/TypeSynonyms2.purs
+++ b/examples/failing/TypeSynonyms2.purs
@@ -5,5 +5,5 @@ class Foo a where
 
 type Bar = String
 
-instance Foo Bar where
+instance fooBar :: Foo Bar where
   foo s = s

--- a/examples/failing/TypeSynonyms3.purs
+++ b/examples/failing/TypeSynonyms3.purs
@@ -5,5 +5,5 @@ class Foo a where
 
 type Bar = String
 
-instance Foo Bar where
+instance fooBar :: Foo Bar where
   foo s = s


### PR DESCRIPTION
Also, realized after the fact, but does there need to be a test that actually ensures instances have names?
