### PR TITLE
Inlining

### DIFF
--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -23,12 +23,6 @@ module Language.PureScript.Constants where
 (#) :: String
 (#) = "#"
 
-(<<<) :: String
-(<<<) = "<<<"
-
-(>>>) :: String
-(>>>) = ">>>"
-
 (<>) :: String
 (<>) = "<>"
 

--- a/src/Language/PureScript/Optimizer.hs
+++ b/src/Language/PureScript/Optimizer.hs
@@ -61,8 +61,6 @@ optimize opts | optionsNoOptimizations opts = id
   , etaConvert
   , evaluateIifes
   , inlineVariables
-  , inlinePure
-  , inlineCompose
   , inlineOperator (C.prelude, (C.$)) $ \f x -> JSApp f [x]
   , inlineOperator (C.prelude, (C.#)) $ \x f -> JSApp f [x]
   , inlineOperator (C.preludeUnsafe, C.unsafeIndex) $ flip JSIndexer


### PR DESCRIPTION
The combination of inlining `pure` for `Eff` and `(<<<)`/`(>>>)` for `(->)` means that instead of this code:

``` purescript
module Foo where
  import Debug.Trace (print)

  main = do
    pure unit
    print <<< ((<>) "1") $ "4"
```

generating this:

``` javascript
var PS = PS || {};
PS.Foo = (function () {
    "use strict";
    var Prelude = PS.Prelude;
    var Control_Monad_Eff = PS.Control_Monad_Eff;
    var Debug_Trace = PS.Debug_Trace;
    var main = function __do() {
        Prelude.pure(Control_Monad_Eff.applicativeEff({}))(Prelude.unit)();
        return Prelude["<<<"](Prelude.semigroupoidArr({}))(Debug_Trace.print(Prelude.showString({})))(Prelude["<>"](Prelude.semigroupString({}))("1"))("4")();
    };
    return {
        main: main
    };
})();
```

it now generates this:

``` javascript
var PS = PS || {};
PS.Foo = (function () {
    "use strict";
    var Prelude = PS.Prelude;
    var Control_Monad_Eff = PS.Control_Monad_Eff;
    var Debug_Trace = PS.Debug_Trace;
    var main = function __do() {
        Prelude.unit;
        return Debug_Trace.print(Prelude.showString({}))("1" + "4")();
    };
    return {
        main: main
    };
})();
```

Much more readable.
