### PR TITLE
Change PSCI module name to $PSCI (https://github.com/purescript/purescript/issues/530)

### DIFF
--- a/psci/Main.hs
+++ b/psci/Main.hs
@@ -245,7 +245,7 @@ mkdirp = createDirectoryIfMissing True . takeDirectory
 createTemporaryModule :: Bool -> PSCiState -> P.Value -> P.Module
 createTemporaryModule exec PSCiState{psciImportedModuleNames = imports, psciLetBindings = lets} value =
   let
-    moduleName = P.ModuleName [P.ProperName "Main"]
+    moduleName = P.ModuleName [P.ProperName "$PSCI"]
     importDecl m = P.ImportDeclaration m Nothing Nothing
     traceModule = P.ModuleName [P.ProperName "Debug", P.ProperName "Trace"]
     trace = P.Var (P.Qualified (Just traceModule) (P.Ident "print"))
@@ -263,7 +263,7 @@ createTemporaryModule exec PSCiState{psciImportedModuleNames = imports, psciLetB
 createTemporaryModuleForKind :: PSCiState -> P.Type -> P.Module
 createTemporaryModuleForKind PSCiState{psciImportedModuleNames = imports} typ =
   let
-    moduleName = P.ModuleName [P.ProperName "Main"]
+    moduleName = P.ModuleName [P.ProperName "$PSCI"]
     importDecl m = P.ImportDeclaration m Nothing Nothing
     itDecl = P.TypeSynonymDeclaration (P.ProperName "IT") [] typ
   in
@@ -282,11 +282,11 @@ handleDeclaration :: P.Value -> PSCI ()
 handleDeclaration value = do
   st <- PSCI $ lift get
   let m = createTemporaryModule True st value
-  e <- psciIO . runMake $ P.make modulesDir options (psciLoadedModules st ++ [("Main.purs", m)])
+  e <- psciIO . runMake $ P.make modulesDir options (psciLoadedModules st ++ [("$PSCI.purs", m)])
   case e of
     Left err -> PSCI $ outputStrLn err
     Right _ -> do
-      psciIO $ writeFile indexFile $ "require('Main').main();"
+      psciIO $ writeFile indexFile $ "require('$PSCI').main();"
       process <- psciIO findNodeProcess
       result  <- psciIO $ traverse (\node -> readProcessWithExitCode node [indexFile] "") process
       case result of
@@ -301,11 +301,11 @@ handleTypeOf :: P.Value -> PSCI ()
 handleTypeOf value = do
   st <- PSCI $ lift get
   let m = createTemporaryModule False st value
-  e <- psciIO . runMake $ P.make modulesDir options (psciLoadedModules st ++ [("Main.purs", m)])
+  e <- psciIO . runMake $ P.make modulesDir options (psciLoadedModules st ++ [("$PSCI.purs", m)])
   case e of
     Left err -> PSCI $ outputStrLn err
     Right env' ->
-      case M.lookup (P.ModuleName [P.ProperName "Main"], P.Ident "it") (P.names env') of
+      case M.lookup (P.ModuleName [P.ProperName "$PSCI"], P.Ident "it") (P.names env') of
         Just (ty, _, _) -> PSCI . outputStrLn . P.prettyPrintType $ ty
         Nothing -> PSCI $ outputStrLn "Could not find type"
 
@@ -316,8 +316,8 @@ handleKindOf :: P.Type -> PSCI ()
 handleKindOf typ = do
   st <- PSCI $ lift get
   let m = createTemporaryModuleForKind st typ
-      mName = P.ModuleName [P.ProperName "Main"]
-  e <- psciIO . runMake $ P.make modulesDir options (psciLoadedModules st ++ [("Main.purs", m)])
+      mName = P.ModuleName [P.ProperName "$PSCI"]
+  e <- psciIO . runMake $ P.make modulesDir options (psciLoadedModules st ++ [("$PSCI.purs", m)])
   case e of
     Left err -> PSCI $ outputStrLn err
     Right env' ->
@@ -340,6 +340,7 @@ getCommand = do
   firstLine <- getInputLine "> "
   case firstLine of
     Nothing -> return (Right Nothing)
+    Just "" -> return (Right Nothing)
     Just s@ (':' : _) -> return . either Left (Right . Just) $ parseCommand s -- The start of a command
     Just s -> either Left (Right . Just) . parseCommand <$> go [s]
   where


### PR DESCRIPTION
This fixes https://github.com/purescript/purescript/issues/530, and also resets the prompt to display `>` when the input string is empty. Multi-line commands still work, but one won't start unless there's a partial command being parsed (i.e. you won't have to press ctrl+d in order to get the prompt to come back).

I can remove the prompt thing if necessary, but I don't think it causes any issues and seems like it might be the desired behavior.
