### PR TITLE
Prevent unused arguments from being renamed

### DIFF
--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -201,6 +201,9 @@ main = "main"
 __superclass_ :: String
 __superclass_ = "__superclass_"
 
+__unused :: String
+__unused = "__unused"
+
 -- Modules
 
 prim :: String

--- a/src/Language/PureScript/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/Optimizer/Inliner.hs
@@ -49,8 +49,8 @@ etaConvert = everywhereOnJS convert
       not (any (`isRebound` block) (map JSVar idents)) &&
       not (any (`isRebound` block) args)
       = JSBlock (map (replaceIdents (zip idents args)) body)
-  convert (JSFunction Nothing ["_"] (JSBlock [JSReturn (JSApp fn@JSVar{} [JSObjectLiteral []])]))
-      = fn
+  convert (JSFunction Nothing [arg] (JSBlock [JSReturn (JSApp fn@JSVar{} [JSObjectLiteral []])]))
+    | arg == C.__unused = fn
   convert js = js
 
 unThunk :: JS -> JS

--- a/src/Language/PureScript/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/Optimizer/MagicDo.hs
@@ -60,7 +60,7 @@ magicDo' = everywhereOnJS undo . everywhereOnJSTopDown convert
   -- Desugar pure
   convert (JSApp (JSApp pure' [val]) []) | isPure pure' = val
   -- Desugar >>
-  convert (JSApp (JSApp bind [m]) [JSFunction Nothing ["_"] (JSBlock js)]) | isBind bind && isJSReturn (last js) =
+  convert (JSApp (JSApp bind [m]) [JSFunction Nothing [arg] (JSBlock js)]) | isBind bind && isJSReturn (last js) && arg == C.__unused =
     let JSReturn ret = last js in
     JSFunction (Just fnName) [] $ JSBlock (JSApp m [] : init js ++ [JSReturn (JSApp ret [])] )
   -- Desugar >>=

--- a/src/Language/PureScript/Renamer.hs
+++ b/src/Language/PureScript/Renamer.hs
@@ -28,6 +28,8 @@ import Language.PureScript.Environment
 import Language.PureScript.Names
 import Language.PureScript.Traversals
 
+import qualified Language.PureScript.Constants as C
+
 -- |
 -- The state object used in this module
 --
@@ -69,6 +71,7 @@ newScope x = do
 -- unique name is generated and stored.
 --
 updateScope :: Ident -> Rename Ident
+updateScope i@(Ident name) | name == C.__unused = return i
 updateScope name = do
   scope <- get
   let name' = case name `S.member` rsUsedNames scope of
@@ -87,6 +90,7 @@ updateScope name = do
 -- Finds the new name to use for an ident.
 --
 lookupIdent :: Ident -> Rename Ident
+lookupIdent i@(Ident name) | name == C.__unused = return i
 lookupIdent name = do
   name' <- gets $ M.lookup name . rsBoundNames
   case name' of

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -57,7 +57,7 @@ desugarDo d =
   go [DoNotationValue val] = return val
   go (DoNotationValue val : rest) = do
     rest' <- go rest
-    return $ App (App bind val) (Abs (Left (Ident "_")) rest')
+    return $ App (App bind val) (Abs (Left (Ident C.__unused)) rest')
   go [DoNotationBind _ _] = lift $ Left $ mkErrorStack "Bind statement cannot be the last statement in a do block" Nothing
   go (DoNotationBind NullBinder val : rest) = go (DoNotationValue val : rest)
   go (DoNotationBind (VarBinder ident) val : rest) = do

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -239,7 +239,7 @@ typeInstanceDictionaryDeclaration name mn deps className tys decls =
       -- must be guarded by at least one function abstraction. For that reason, if the dictionary has no
       -- dependencies, we introduce an unnamed function parameter.
       let superclasses =
-            [ (fieldName, Abs (Left (Ident "_")) (SuperClassDictionary superclass tyArgs))
+            [ (fieldName, Abs (Left (Ident C.__unused)) (SuperClassDictionary superclass tyArgs))
             | (index, (superclass, suTyArgs)) <- zip [0..] implies
             , let tyArgs = map (replaceAllTypeVars (zip args tys)) suTyArgs
             , let fieldName = mkSuperclassDictionaryName superclass index
@@ -249,7 +249,7 @@ typeInstanceDictionaryDeclaration name mn deps className tys decls =
           dictTy = foldl TypeApp (TypeConstructor className) tys
           constrainedTy = quantify (if null deps then function unit dictTy else ConstrainedType deps dictTy)
           dict = TypeClassDictionaryConstructorApp className memberNames'
-          dict' = if null deps then Abs (Left (Ident "_")) dict else dict
+          dict' = if null deps then Abs (Left (Ident C.__unused)) dict else dict
           result = ValueDeclaration name TypeInstanceDictionaryValue [] Nothing (TypedValue True dict' constrainedTy)
       return result
 


### PR DESCRIPTION
These arguments used to be called `_`, but the renamer was renaming them to `__1`, etc in some circumstances.
