### PR TITLE
Add case for function application to a type class dictionary

### DIFF
--- a/examples/passing/CheckTypeClass.purs
+++ b/examples/passing/CheckTypeClass.purs
@@ -1,0 +1,16 @@
+module Main where
+
+  data Bar a = Bar
+  data Baz
+
+  class Foo a where
+    foo :: Bar a -> Baz
+
+  foo_ :: forall a. (Foo a) => a -> Baz
+  foo_ x = foo ((mkBar :: forall a. (Foo a) => a -> Bar a) x)
+
+  mkBar :: forall a. a -> Bar a
+  mkBar _ = Bar
+
+  main = Debug.Trace.trace "Done"
+


### PR DESCRIPTION
Resolves #536.

Basically, this case should hardly ever get hit, but it is reasonable that we have to check an application of a value to a typeclass dictionary, so here it is.
