### PR TITLE
Implement tuples as syntax sugar for newtype for record types

### DIFF
--- a/prelude/prelude.purs
+++ b/prelude/prelude.purs
@@ -22,6 +22,15 @@ module Prelude
   , not
   , Semigroup, (<>), (++)
   , Unit(..), unit
+  , Tuple2(..)
+  , Tuple3(..)
+  , Tuple4(..)
+  , Tuple5(..)
+  , Tuple6(..)
+  , Tuple7(..)
+  , Tuple8(..)
+  , Tuple9(..)
+  , Tuple10(..)
   ) where
 
   flip :: forall a b c. (a -> b -> c) -> b -> a -> c
@@ -156,6 +165,7 @@ module Prelude
     f' <- f
     a' <- a
     return (f' a')
+
 
   instance functorArr :: Functor ((->) r) where
     (<$>) = (<<<)
@@ -487,6 +497,16 @@ module Prelude
 
   (++) :: forall s. (Semigroup s) => s -> s -> s
   (++) = (<>)
+
+  newtype Tuple2 a b = Tuple2 {_1 :: a, _2 :: b}
+  newtype Tuple3 a b c = Tuple3 {_1 :: a, _2 :: b, _3 :: c}
+  newtype Tuple4 a b c d = Tuple4 {_1 :: a, _2 :: b, _3 :: c, _4 :: d}
+  newtype Tuple5 a b c d e = Tuple5 {_1 :: a, _2 :: b, _3 :: c, _4 :: d, _5 :: e}
+  newtype Tuple6 a b c d e f = Tuple6 {_1 :: a, _2 :: b, _3 :: c, _4 :: d, _5 :: e, _6 :: f}
+  newtype Tuple7 a b c d e f g = Tuple7 {_1 :: a, _2 :: b, _3 :: c, _4 :: d, _5 :: e, _6 :: f, _7 :: g}
+  newtype Tuple8 a b c d e f g h = Tuple8 {_1 :: a, _2 :: b, _3 :: c, _4 :: d, _5 :: e, _6 :: f, _7 :: g, _8 :: h}
+  newtype Tuple9 a b c d e f g h i = Tuple9 {_1 :: a, _2 :: b, _3 :: c, _4 :: d, _5 :: e, _6 :: f, _7 :: g, _8 :: h, _9 :: i}
+  newtype Tuple10 a b c d e f g h i j = Tuple10 {_1 :: a, _2 :: b, _3 :: c, _4 :: d, _5 :: e, _6 :: f, _7 :: g, _8 :: h, _9 :: i, _10 :: j}
 
 module Data.Function where
 

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -50,6 +50,7 @@ library
                      Language.PureScript.ModuleDependencies
                      Language.PureScript.Sugar.CaseDeclarations
                      Language.PureScript.Sugar.DoNotation
+                     Language.PureScript.Sugar.Tuple
                      Language.PureScript.Sugar.TypeDeclarations
                      Language.PureScript.Sugar.BindingGroups
                      Language.PureScript.Sugar.Operators

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -223,3 +223,30 @@ st = "Control_Monad_ST"
 
 dataFunction :: String
 dataFunction = "Data_Function"
+
+tuple2 :: String
+tuple2 = "Tuple2"
+
+tuple3 :: String
+tuple3 = "Tuple3"
+
+tuple4 :: String
+tuple4 = "Tuple4"
+
+tuple5 :: String
+tuple5 = "Tuple5"
+
+tuple6 :: String
+tuple6 = "Tuple5"
+
+tuple7 :: String
+tuple7 = "Tuple7"
+
+tuple8 :: String
+tuple8 = "Tuple8"
+
+tuple9 :: String
+tuple9 = "Tuple9"
+
+tuple10 :: String
+tuple10 = "Tuple10"

--- a/src/Language/PureScript/Declarations.hs
+++ b/src/Language/PureScript/Declarations.hs
@@ -301,6 +301,10 @@ data Expr
   --
   | ArrayLiteral [Expr]
   -- |
+  -- A tuple literal
+  --
+  | TupleLiteral [Expr]
+  -- |
   -- An object literal
   --
   | ObjectLiteral [(String, Expr)]
@@ -449,6 +453,10 @@ data Binder
   -- A binder which matches a record and binds its properties
   --
   | ObjectBinder [(String, Binder)]
+  -- |
+  -- A binder which matches a tuple and binds its elements
+  --
+  | TupleBinder [Binder]
   -- |
   -- A binder which matches an array and binds its elements
   --

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -25,6 +25,7 @@ import Language.PureScript.Supply
 
 import Language.PureScript.Sugar.Operators as S
 import Language.PureScript.Sugar.DoNotation as S
+import Language.PureScript.Sugar.Tuple as S
 import Language.PureScript.Sugar.CaseDeclarations as S
 import Language.PureScript.Sugar.TypeDeclarations as S
 import Language.PureScript.Sugar.BindingGroups as S
@@ -51,6 +52,7 @@ import Language.PureScript.Sugar.Names as S
 desugar :: [Module] -> SupplyT (Either ErrorStack) [Module]
 desugar = map removeSignedLiterals
           >>> mapM desugarDoModule
+          >=> mapM desugarTupleModule
           >=> desugarCasesModule
           >=> lift . (desugarTypeDeclarationsModule
                       >=> desugarImports

--- a/src/Language/PureScript/Sugar/Tuple.hs
+++ b/src/Language/PureScript/Sugar/Tuple.hs
@@ -1,0 +1,93 @@
+-----------------------------------------------------------------------------
+--
+-- Module      :  Language.PureScript.Sugar.Tuple
+-- Copyright   :  (c) Phil Freeman 2013
+-- License     :  MIT
+--
+-- Maintainer  :  Andrey Popp <8mayday@gmail.com>
+-- Stability   :  experimental
+-- Portability :
+--
+-- |
+-- This module implements the desugaring pass which:
+--
+-- * replaces TupleLiteral with ObjectLiteral wrapped in a Tuple newtype of the
+--   corresponding arity.
+-- * replaces TupleBinder with ObjectBinder wrapped in a Tuple newtype of the
+--   corresponding arity.
+--
+-----------------------------------------------------------------------------
+
+module Language.PureScript.Sugar.Tuple (
+    desugarTupleModule
+) where
+
+import Language.PureScript.Names
+import Language.PureScript.Declarations
+import Language.PureScript.Errors
+import Language.PureScript.Supply
+
+import qualified Language.PureScript.Constants as C
+
+import Control.Applicative
+import Control.Monad.Trans.Class
+
+desugarTupleModule :: Module -> SupplyT (Either ErrorStack) Module
+desugarTupleModule (Module mn ds exts) = Module mn <$> mapM desugarTuple ds <*> pure exts
+
+desugarTuple :: Declaration -> SupplyT (Either ErrorStack) Declaration
+desugarTuple (PositionedDeclaration pos d) = (PositionedDeclaration pos) <$> (rethrowWithPosition pos $ desugarTuple d)
+desugarTuple d =
+  let (f, _, _) = everywhereOnValuesM return replaceValue replaceBinder
+  in f d
+  where
+
+  replaceValue :: Expr -> SupplyT (Either ErrorStack) Expr
+  replaceValue (TupleLiteral vals) | length vals > 10 = maxArityError
+  replaceValue (TupleLiteral vals) | length vals < 2 = minArityError
+  replaceValue (TupleLiteral vals) = do
+    let arity = length vals
+    let ctor = Constructor $ tupleProperName arity
+    let value = ObjectLiteral $ zipWithRowNames vals
+    return $ App ctor value
+  replaceValue (PositionedValue pos v) = PositionedValue pos <$> rethrowWithPosition pos (replaceValue v)
+  replaceValue other = return other
+
+  replaceBinder :: Binder -> SupplyT (Either ErrorStack) Binder
+  replaceBinder (TupleBinder binders) | length binders > 10 = maxArityError
+  replaceBinder (TupleBinder binders) | length binders < 2 = minArityError
+  replaceBinder (TupleBinder binders) = do
+    let arity = length binders
+    let binder = ObjectBinder $ zipWithRowNames binders
+    return $ ConstructorBinder (tupleProperName arity) [binder]
+  replaceBinder (PositionedBinder pos b) = PositionedBinder pos <$> rethrowWithPosition pos (replaceBinder b)
+  replaceBinder other = return other
+
+  tupleProperName :: Int -> Qualified ProperName
+  tupleProperName 2 = preludeIdent C.tuple2
+  tupleProperName 3 = preludeIdent C.tuple3
+  tupleProperName 4 = preludeIdent C.tuple4
+  tupleProperName 5 = preludeIdent C.tuple5
+  tupleProperName 6 = preludeIdent C.tuple6
+  tupleProperName 7 = preludeIdent C.tuple7
+  tupleProperName 8 = preludeIdent C.tuple8
+  tupleProperName 9 = preludeIdent C.tuple9
+  tupleProperName 10 = preludeIdent C.tuple10
+  tupleProperName _ = error "impossible tupleProperName argument"
+
+  preludeIdent :: String -> Qualified ProperName
+  preludeIdent ident = Qualified (Just prelude) (ProperName ident)
+
+  prelude :: ModuleName
+  prelude = ModuleName [ProperName C.prelude]
+
+  zipWithRowNames :: [a] -> [(String, a)]
+  zipWithRowNames items =
+    let rowNames = (\idx -> '_':(show idx)) <$> ([1..] :: [Int]) in
+    zip rowNames items
+
+  minArityError :: SupplyT (Either ErrorStack) a
+  minArityError = lift $ Left $ mkErrorStack "Tuples of arity less than 2 are not supported" Nothing
+
+  maxArityError :: SupplyT (Either ErrorStack) a
+  maxArityError = lift $ Left $ mkErrorStack "Tuples of arity greater than 10 are not supported" Nothing


### PR DESCRIPTION
Discuss!

Tuples are represented as

    newtype TupleX a b ... = { _1 :: a, _2 :: b, ... }

This commit implements a desugaring pass which translates TupleLiteral values
and TupleBinder binders into AST corresponding to chosen representation.

It's OK If you are not going to merge this. Anyway, I gained more understanding of PureScript internals.