### PR TITLE
Escape any operators characters in objects.

### DIFF
--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -65,5 +65,5 @@ prettyPrintMany f xs = do
 --
 prettyPrintObjectKey :: String -> String
 prettyPrintObjectKey s | s `elem` reservedPsNames = show s
-                       | head s `elem` opChars = show s
+                       | any (`elem` opChars) s = show s
                        | otherwise = s


### PR DESCRIPTION
Ran into this when using a record with a quoted name, like:

```
type Foo = {"foo-bar" :: Bar}
```

Externs would not escape the field, then parsing of externs later on will fail on the `-` symbol.
Couldn't think of how to test with the way cabal is working at the moment.

Let me know if I messed up/missed something.
