### PR TITLE
Add preludeFilename to Language.PureScript

### DIFF
--- a/psc-make/Main.hs
+++ b/psc-make/Main.hs
@@ -34,9 +34,6 @@ import qualified Language.PureScript as P
 import qualified Paths_purescript as Paths
 import qualified System.IO.UTF8 as U
 
-preludeFilename :: IO FilePath
-preludeFilename = Paths.getDataFileName "prelude/prelude.purs"
-
 readInput :: [FilePath] -> IO (Either ParseError [(FilePath, P.Module)])
 readInput input = fmap collect $ forM input $ \inputFile -> do
   text <- U.readFile inputFile
@@ -141,5 +138,5 @@ termInfo = defTI
 
 main :: IO ()
 main = do
-  prelude <- preludeFilename
+  prelude <- P.preludeFilename
   run (term prelude, termInfo)

--- a/psc/Main.hs
+++ b/psc/Main.hs
@@ -33,9 +33,6 @@ import qualified Language.PureScript as P
 import qualified Paths_purescript as Paths
 import qualified System.IO.UTF8 as U
 
-preludeFilename :: IO FilePath
-preludeFilename = Paths.getDataFileName "prelude/prelude.purs"
-
 readInput :: Maybe [FilePath] -> IO (Either ParseError [(FilePath, P.Module)])
 readInput Nothing = do
   text <- getContents
@@ -149,6 +146,6 @@ termInfo = defTI
 
 main :: IO ()
 main = do
-  prelude <- preludeFilename
+  prelude <- P.preludeFilename
   run (term prelude, termInfo)
 

--- a/psci/Main.hs
+++ b/psci/Main.hs
@@ -117,12 +117,6 @@ getHistoryFilename :: IO FilePath
 getHistoryFilename = getUserConfigFile "purescript" "psci_history"
 
 -- |
--- Grabs the filename where prelude is.
---
-getPreludeFilename :: IO FilePath
-getPreludeFilename = Paths.getDataFileName "prelude/prelude.purs"
-
--- |
 -- Loads a file for use with imports.
 --
 loadModule :: FilePath -> IO (Either String [P.Module])
@@ -400,7 +394,7 @@ loadUserConfig = do
 loop :: [FilePath] -> IO ()
 loop files = do
   config <- loadUserConfig
-  preludeFilename <- getPreludeFilename
+  preludeFilename <- P.preludeFilename
   filesAndModules <- mapM (\file -> fmap (fmap (map ((,) file))) . loadModule $ file) (preludeFilename : files)
   let modulesOrFirstError = fmap concat $ sequence filesAndModules
   case modulesOrFirstError of

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -88,7 +88,7 @@ library
     exposed: True
     buildable: True
     hs-source-dirs: src
-    other-modules:
+    other-modules: Paths_purescript
     ghc-options: -Wall -O2
 
 executable psc

--- a/src/Language/PureScript.hs
+++ b/src/Language/PureScript.hs
@@ -13,7 +13,7 @@
 --
 -----------------------------------------------------------------------------
 
-module Language.PureScript (module P, compile, compile', MonadMake(..), make) where
+module Language.PureScript (module P, compile, compile', MonadMake(..), make, preludeFilename) where
 
 import Language.PureScript.Types as P
 import Language.PureScript.Kinds as P
@@ -34,6 +34,7 @@ import Language.PureScript.Supply as P
 import Language.PureScript.Renamer as P
 
 import qualified Language.PureScript.Constants as C
+import qualified Paths_purescript as Paths
 
 import Data.List (find, sortBy, groupBy, intercalate)
 import Data.Time.Clock
@@ -261,3 +262,6 @@ importPrim = addDefaultImport (ModuleName [ProperName C.prim])
 
 importPrelude :: Module -> Module
 importPrelude = addDefaultImport (ModuleName [ProperName C.prelude])
+
+preludeFilename :: IO FilePath
+preludeFilename = Paths.getDataFileName "prelude/prelude.purs"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -27,11 +27,7 @@ import System.Process
 import System.FilePath (pathSeparator)
 import System.Directory (getCurrentDirectory, getTemporaryDirectory, getDirectoryContents, findExecutable)
 import Text.Parsec (ParseError)
-import qualified Paths_purescript as Paths
 import qualified System.IO.UTF8 as U
-
-preludeFilename :: IO FilePath
-preludeFilename = Paths.getDataFileName "prelude/prelude.purs"
 
 readInput :: [FilePath] -> IO (Either ParseError [P.Module])
 readInput inputFiles = fmap (fmap concat . sequence) $ forM inputFiles $ \inputFile -> do
@@ -80,7 +76,7 @@ findNodeProcess = runMaybeT . msum $ map (MaybeT . findExecutable) names
 
 main :: IO ()
 main = do
-  prelude <- preludeFilename
+  prelude <- P.preludeFilename
   putStrLn "Compiling Prelude"
   preludeResult <- compile (P.defaultOptions { P.optionsBrowserNamespace = Just "Tests" }) [prelude]
   case preludeResult of


### PR DESCRIPTION
This makes it easier to embed purescript as a library in other programs.
Returns path wrapped in Maybe instead of simply returning path because in theory in different packaging scenarios or environments (runtime sandboxing? embedded systems?) there might be no way to package data files and I think public API should take this into account - API should not promise/require existence of file system.
