### PR TITLE
Upload binaries to releases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,4 @@ deploy:
   skip_cleanup: true
   on:
     all_branches: true
-    repo: joneshf/purescript
     tags: true


### PR DESCRIPTION
I threw this together to speed up other ps library builds.

As an example, for `purescript-parsing` it goes from an around 10 mins per build: https://travis-ci.org/purescript-contrib/purescript-parsing/builds to about 30 seconds!!: https://travis-ci.org/purescript-contrib/purescript-parsing/builds/33435799

What i'm doing there is exporting the paths to where the psc binary is and the prelude is held, then `wget`ing (because of redirects) the precompiled binaries. I've only built `0.5.4.1`, but you can tag the rest of the versions and have it build them if you want older ones available. I figured more people would find this useful until we figured out builds, hence the PR. If not I'll keep it available on my local fork and just push new tags when versions arrive.

This might only work for travis builds BTW, so you probably shouldn't use this on your local machine.
