### PR TITLE
Fix #569

### DIFF
--- a/examples/passing/OperatorAssociativity.purs
+++ b/examples/passing/OperatorAssociativity.purs
@@ -1,0 +1,15 @@
+module Main where
+
+import Control.Monad.Eff
+
+bug :: Number -> Number -> Number
+bug a b = 0 - (a - b)
+
+foreign import explode 
+  "function explode() {\
+  \  throw new Error('Assertion failed!');\
+  \}":: forall eff a. Eff eff a
+
+main = case bug 0 2 of
+  2 -> Debug.Trace.trace "Done!"
+  _ -> explode

--- a/src/Language/PureScript/Pretty/JS.hs
+++ b/src/Language/PureScript/Pretty/JS.hs
@@ -190,7 +190,7 @@ unary op str = Wrap match (++)
     match' _ = Nothing
 
 binary :: BinaryOperator -> String -> Operator PrinterState JS String
-binary op str = AssocR match (\v1 v2 -> v1 ++ " " ++ str ++ " " ++ v2)
+binary op str = AssocL match (\v1 v2 -> v1 ++ " " ++ str ++ " " ++ v2)
   where
   match :: Pattern PrinterState JS (JS, JS)
   match = mkPattern match'


### PR DESCRIPTION
@garyb Could you please review this? Sort of surprising that this lasted so long, but binary operators in JS are associated left-to-right, not right-to-left.
