### PR TITLE
Cleanup JS in prelude.

### DIFF
--- a/prelude/prelude.purs
+++ b/prelude/prelude.purs
@@ -803,7 +803,7 @@ module Control.Monad.Eff where
 
   foreign import untilE "function untilE(f) {\
                         \  return function() {\
-                        \    while (!f()) { }\
+                        \    while (!f());\
                         \    return {};\
                         \  };\
                         \}" :: forall e. Eff e Boolean -> Eff e Unit


### PR DESCRIPTION
I tidied up the the JS `function` definitions in `prelude.purs` file as I was reading through. They're were inconsistent with other the definitions in the file. I hope it's not being too picky but I've been writing a lot of JS lately :wink: 
