### PR TITLE
Create .tar.gz bundle during Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ after_script:
   - hpc-coveralls --exclude-dir=tests tests
 notifications:
   email: true
-before_deploy: "./bundle/build.sh"
+before_deploy: "./bundle/build.sh linux64"
 deploy:
   provider: releases
   api_key: $RELEASE_KEY
   file:
-    - bundle/*.tar.gz
-    - bundle/*.sha
+    - bundle/linux64.tar.gz
+    - bundle/linux64.sha
   skip_cleanup: true
   on:
     all_branches: true

--- a/bundle/build.sh
+++ b/bundle/build.sh
@@ -2,7 +2,13 @@ set -e
 
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 
-OS=$( uname )
+OS=$1
+
+if [ -z $OS ] 
+then
+  echo "Usage: build.sh osname"
+  exit 1
+fi
 
 pushd ${SCRIPTPATH} > /dev/null
 


### PR DESCRIPTION
@garyb @joneshf I made this to bundle up the Mac distribution, but it also works nicely during the Travis build. @garyb, if you have Cygwin, maybe we could even tweak the script to generate Windows executables?
