### PR TITLE
Fix instance detection for inliner optimization

### DIFF
--- a/src/Language/PureScript/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/Optimizer/Inliner.hs
@@ -153,7 +153,7 @@ inlineCommonOperators = applyAll $
     convert other = other
     isOp (JSAccessor fnName' (JSVar prelude)) = prelude == C.prelude && fnName' == fnName
     isOp _ = False
-  isOpDict dictName (JSApp (JSAccessor prop (JSVar prelude)) []) = prelude == C.prelude && prop == dictName
+  isOpDict dictName (JSAccessor prop (JSVar prelude)) = prelude == C.prelude && prop == dictName
   isOpDict _ _ = False
   mkFn :: Int -> JS -> JS
   mkFn 0 = everywhereOnJS convert


### PR DESCRIPTION
Caused by #648.  I'll try to review for similar breakages.  I already caught the MagicDo one in the original PR, so should've thought of this one.

I do note that this `isOpDict` check is different than the `isEffDict` check in that it doesn't optimize within `Prelude`.  I guess that doesn't matter.
