### PR TITLE
Never rebuild the Prelude. Always rebuild temporary modules in PSCI.

### DIFF
--- a/psc-docs/Main.hs
+++ b/psc-docs/Main.hs
@@ -20,6 +20,7 @@ import Control.Monad.Writer
 import Control.Arrow (first)
 import Data.Function (on)
 import Data.List
+import Data.Maybe (fromMaybe)
 import Data.Version (showVersion)
 import qualified Language.PureScript as P
 import qualified Paths_purescript as Paths
@@ -30,7 +31,7 @@ import System.IO (stderr)
 
 docgen :: Bool -> [FilePath] -> IO ()
 docgen showHierarchy input = do
-  e <- P.parseModulesFromFiles <$> mapM (fmap (first Just) . parseFile) (nub input)
+  e <- P.parseModulesFromFiles (fromMaybe "") <$> mapM (fmap (first Just) . parseFile) (nub input)
   case e of
     Left err -> do
       U.hPutStr stderr $ show err

--- a/psc/Main.hs
+++ b/psc/Main.hs
@@ -20,6 +20,7 @@ import Control.Applicative
 import Control.Monad.Error
 
 import Data.Bool (bool)
+import Data.Maybe (fromMaybe)
 import Data.Version (showVersion)
 
 import System.Console.CmdTheLine
@@ -46,7 +47,7 @@ readInput InputOptions{..}
 
 compile :: P.Options P.Compile -> Bool -> [FilePath] -> Maybe FilePath -> Maybe FilePath -> Bool -> IO ()
 compile opts stdin input output externs usePrefix = do
-  modules <- P.parseModulesFromFiles <$> readInput (InputOptions (P.optionsNoPrelude opts) stdin input)
+  modules <- P.parseModulesFromFiles (fromMaybe "") <$> readInput (InputOptions (P.optionsNoPrelude opts) stdin input)
   case modules of
     Left err -> do
       U.hPutStr stderr $ show err

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -1,5 +1,5 @@
 name: purescript
-version: 0.6.0
+version: 0.6.0.1
 cabal-version: >=1.8
 build-type: Simple 
 license: MIT

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -235,10 +235,10 @@ parseModule = do
 -- |
 -- Parse a collection of modules 
 --
-parseModulesFromFiles :: [(Maybe FilePath, String)] -> Either P.ParseError [(Maybe FilePath, Module)]
-parseModulesFromFiles input = 
+parseModulesFromFiles :: (k -> String) -> [(k, String)] -> Either P.ParseError [(k, Module)]
+parseModulesFromFiles toFilePath input = 
   fmap collect . forM input $ \(filename, content) -> do
-    ms <- runIndentParser (fromMaybe "" filename) parseModules content
+    ms <- runIndentParser (toFilePath filename) parseModules content
     return (filename, ms)
   where
   collect :: [(k, [v])] -> [(k, v)]

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -30,20 +30,20 @@ import System.Directory (getCurrentDirectory, getTemporaryDirectory, getDirector
 import Text.Parsec (ParseError)
 import qualified System.IO.UTF8 as U
 
-readInput :: [FilePath] -> IO [(Maybe FilePath, String)]
+readInput :: [FilePath] -> IO [(FilePath, String)]
 readInput inputFiles = forM inputFiles $ \inputFile -> do
   text <- U.readFile inputFile
-  return (Just inputFile, text)
+  return (inputFile, text)
 
 loadPrelude :: Either String (String, String, P.Environment)
 loadPrelude = 
-  case P.parseModulesFromFiles [(Nothing, P.prelude)] of
+  case P.parseModulesFromFiles id [("", P.prelude)] of
     Left parseError -> Left (show parseError)
     Right ms -> P.compile (P.defaultCompileOptions { P.optionsAdditional = P.CompileOptions "Tests" [] [] }) (map snd ms) []
 
 compile :: P.Options P.Compile -> [FilePath] -> IO (Either String (String, String, P.Environment))
 compile opts inputFiles = do
-  modules <- P.parseModulesFromFiles <$> readInput inputFiles
+  modules <- P.parseModulesFromFiles id <$> readInput inputFiles
   case modules of
     Left parseError ->
       return (Left $ show parseError)


### PR DESCRIPTION
Resolves #692.

@joneshf @garyb Can you please review this? This fixes a bug introduced by the embedded prelude changes in 0.6.

Thanks.
