### PR TITLE
Add span information to errors

### DIFF
--- a/src/Language/PureScript/AST/Binders.hs
+++ b/src/Language/PureScript/AST/Binders.hs
@@ -68,7 +68,7 @@ data Binder
   -- |
   -- A binder with source position information
   --
-  | PositionedBinder SourcePos Binder deriving (Show, D.Data, D.Typeable)
+  | PositionedBinder SourceSpan Binder deriving (Show, D.Data, D.Typeable)
 
 -- |
 -- Collect all names introduced in binders in an expression

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -57,7 +57,7 @@ data DeclarationRef
   -- |
   -- A declaration reference with source position information
   --
-  | PositionedDeclarationRef SourcePos DeclarationRef
+  | PositionedDeclarationRef SourceSpan DeclarationRef
   deriving (Show, D.Data, D.Typeable)
 
 instance Eq DeclarationRef where
@@ -147,7 +147,7 @@ data Declaration
   -- |
   -- A declaration with source position information
   --
-  | PositionedDeclaration SourcePos Declaration
+  | PositionedDeclaration SourceSpan Declaration
   deriving (Show, D.Data, D.Typeable)
 
 -- |
@@ -324,7 +324,7 @@ data Expr
   -- |
   -- A value with source position information
   --
-  | PositionedValue SourcePos Expr deriving (Show, D.Data, D.Typeable)
+  | PositionedValue SourceSpan Expr deriving (Show, D.Data, D.Typeable)
 
 -- |
 -- An alternative in a case statement
@@ -359,4 +359,4 @@ data DoNotationElement
   -- |
   -- A do notation element with source position information
   --
-  | PositionedDoNotationElement SourcePos DoNotationElement deriving (Show, D.Data, D.Typeable)
+  | PositionedDoNotationElement SourceSpan DoNotationElement deriving (Show, D.Data, D.Typeable)

--- a/src/Language/PureScript/AST/SourcePos.hs
+++ b/src/Language/PureScript/AST/SourcePos.hs
@@ -23,13 +23,9 @@ import qualified Data.Data as D
 --
 data SourcePos = SourcePos
   { -- |
-    -- Source name
-    --
-    sourceName :: String
-    -- |
     -- Line number
     --
-  , sourcePosLine :: Int
+    sourcePosLine :: Int
     -- |
     -- Column number
     --
@@ -37,4 +33,21 @@ data SourcePos = SourcePos
   } deriving (D.Data, D.Typeable)
 
 instance Show SourcePos where
-  show sp = sourceName sp ++ " line " ++ show (sourcePosLine sp) ++ ", column " ++ show (sourcePosColumn sp)
+  show sp = "line " ++ show (sourcePosLine sp) ++ ", column " ++ show (sourcePosColumn sp)
+
+data SourceSpan = SourceSpan
+  { -- |
+    -- Source name
+    --
+    spanName :: String
+    -- |
+    -- Start of the span
+    --
+  , spanStart :: SourcePos
+    -- End of the span
+    --
+  , spanEnd :: SourcePos
+  } deriving (D.Data, D.Typeable)
+  
+instance Show SourceSpan where
+  show sp = spanName sp ++ " " ++ show (spanStart sp) ++ " - " ++ show (spanEnd sp)

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -56,7 +56,7 @@ data CompileError
         -- |
         -- Optional source position information
         --
-      , compileErrorPosition :: Maybe SourcePos
+      , compileErrorPosition :: Maybe SourceSpan
       }
   deriving (Show)
 
@@ -109,7 +109,7 @@ showError (CompileError msg (Just (TypeError ty)) _) = "Error in type " ++ prett
 mkErrorStack :: String -> Maybe ErrorSource -> ErrorStack
 mkErrorStack msg t = ErrorStack [CompileError msg t Nothing]
 
-positionError :: SourcePos -> ErrorStack
+positionError :: SourceSpan -> ErrorStack
 positionError pos = ErrorStack [CompileError "" Nothing (Just pos)]
 
 -- |
@@ -121,7 +121,7 @@ rethrow f = flip catchError $ \e -> throwError (f e)
 -- |
 -- Rethrow an error with source position information
 --
-rethrowWithPosition :: (MonadError ErrorStack m) => SourcePos -> m a -> m a
+rethrowWithPosition :: (MonadError ErrorStack m) => SourceSpan -> m a -> m a
 rethrowWithPosition pos = rethrow (positionError pos <>)
 
 -- |

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -48,10 +48,15 @@ import qualified Text.Parsec.Expr as P
 -- |
 -- Read source position information
 --
-sourcePos :: P.Parsec s u SourcePos
-sourcePos = toSourcePos <$> P.getPosition
+withSourceSpan :: (SourceSpan -> a -> a) -> P.Parsec s u a -> P.Parsec s u a
+withSourceSpan f p = do
+  start <- P.getPosition
+  x <- p
+  end <- P.getPosition
+  let sp = SourceSpan (P.sourceName start) (toSourcePos start) (toSourcePos end)
+  return $ f sp x
   where
-  toSourcePos p = SourcePos (P.sourceName p) (P.sourceLine p) (P.sourceColumn p)
+  toSourcePos pos = SourcePos (P.sourceLine pos) (P.sourceColumn pos)
 
 kindedIdent :: P.Parsec String ParseState (String, Maybe Kind)
 kindedIdent = (, Nothing) <$> identifier
@@ -165,11 +170,11 @@ parseImportDeclaration = do
 
 
 parseDeclarationRef :: P.Parsec String ParseState DeclarationRef
-parseDeclarationRef = PositionedDeclarationRef <$> sourcePos <*>
-  (ValueRef <$> parseIdent
-   <|> do name <- properName
-          dctors <- P.optionMaybe $ parens (lexeme (P.string "..") *> pure Nothing <|> Just <$> commaSep properName)
-          return $ maybe (TypeClassRef name) (TypeRef name) dctors)
+parseDeclarationRef = withSourceSpan PositionedDeclarationRef $
+  ValueRef <$> parseIdent
+    <|> do name <- properName
+           dctors <- P.optionMaybe $ parens (lexeme (P.string "..") *> pure Nothing <|> Just <$> commaSep properName)
+           return $ maybe (TypeClassRef name) (TypeRef name) dctors
 
 parseTypeClassDeclaration :: P.Parsec String ParseState Declaration
 parseTypeClassDeclaration = do
@@ -203,7 +208,7 @@ parseTypeInstanceDeclaration = do
   return $ TypeInstanceDeclaration name (fromMaybe [] deps) className ty members
 
 positioned :: P.Parsec String ParseState Declaration -> P.Parsec String ParseState Declaration
-positioned d = PositionedDeclaration <$> sourcePos <*> d
+positioned d = withSourceSpan PositionedDeclaration d
 
 -- |
 -- Parse a single declaration
@@ -222,10 +227,10 @@ parseDeclaration = positioned (P.choice
                    ]) P.<?> "declaration"
 
 parseLocalDeclaration :: P.Parsec String ParseState Declaration
-parseLocalDeclaration = PositionedDeclaration <$> sourcePos <*> P.choice
+parseLocalDeclaration = positioned (P.choice
                    [ parseTypeDeclaration
                    , parseValueDeclaration
-                   ] P.<?> "local declaration"
+                   ] P.<?> "local declaration")
 
 -- |
 -- Parse a module header and a collection of declarations
@@ -374,10 +379,10 @@ parseDoNotationElement = P.choice
 -- Parse a value
 --
 parseValue :: P.Parsec String ParseState Expr
-parseValue = PositionedValue <$> sourcePos <*>
+parseValue = withSourceSpan PositionedValue
   (P.buildExpressionParser operators
-   . C.buildPostfixParser postfixTable2
-   $ indexersAndAccessors) P.<?> "expression"
+    . C.buildPostfixParser postfixTable2
+    $ indexersAndAccessors) P.<?> "expression"
   where
   indexersAndAccessors = C.buildPostfixParser postfixTable1 parseValueAtom
   postfixTable1 = [ parseAccessor
@@ -439,8 +444,7 @@ parseIdentifierAndBinder = do
 -- Parse a binder
 --
 parseBinder :: P.Parsec String ParseState Binder
-parseBinder = PositionedBinder <$> sourcePos <*>
-    P.buildExpressionParser operators parseBinderAtom P.<?> "expression"
+parseBinder = withSourceSpan PositionedBinder (P.buildExpressionParser operators parseBinderAtom P.<?> "expression")
   where
   operators = [ [ P.Infix ( C.lexeme (P.try $ C.indented *> C.reservedOp ":") >> return ConsBinder) P.AssocRight ] ]
   parseBinderAtom :: P.Parsec String ParseState Binder

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -76,15 +76,15 @@ removeParens =
   go (Parens val) = val
   go val = val
 
-collectFixities :: Module -> [(Qualified Ident, SourcePos, Fixity)]
+collectFixities :: Module -> [(Qualified Ident, SourceSpan, Fixity)]
 collectFixities (Module moduleName ds _) = concatMap collect ds
   where
-  collect :: Declaration -> [(Qualified Ident, SourcePos, Fixity)]
+  collect :: Declaration -> [(Qualified Ident, SourceSpan, Fixity)]
   collect (PositionedDeclaration pos (FixityDeclaration fixity name)) = [(Qualified (Just moduleName) (Op name), pos, fixity)]
   collect FixityDeclaration{} = error "Fixity without srcpos info"
   collect _ = []
 
-ensureNoDuplicates :: [(Qualified Ident, SourcePos)] -> Either ErrorStack ()
+ensureNoDuplicates :: [(Qualified Ident, SourceSpan)] -> Either ErrorStack ()
 ensureNoDuplicates m = go $ sortBy (compare `on` fst) m
   where
   go [] = return ()


### PR DESCRIPTION
Resolves #432.

@garyb @joneshf @ExternalReality Could you please review?

I tried to keep the format of the old error messages as much as possible, so that things like purscheck should continue to work.
