### PR TITLE
Catch erroneous (singleton) recursive definitions

### DIFF
--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -151,7 +151,6 @@ getProperName _ = error "Expected DataDeclaration"
 --
 toBindingGroup :: ModuleName -> SCC Declaration -> Either ErrorStack Declaration
 toBindingGroup _ (AcyclicSCC d) = return d
-toBindingGroup _ (CyclicSCC [d]) = return d
 toBindingGroup moduleName (CyclicSCC ds') =
   -- Once we have a mutually-recursive group of declarations, we need to sort
   -- them further by their immediate dependencies (those outside function


### PR DESCRIPTION
We can't safely bypass the extra immediate reference check even when only one definition is involved in the recursion.

From a discussion on IRC, @NightRa pointed out that calling a class function in an instance declaration can lead to an undefined value (because of the recursive reference to the instance being constructed): http://lpaste.net/115029
Currently extra checks are done to catch and reject these kinds of recursive references, but only when multiple definitions are involved (mutual recursion). This simply performs the same check even when a single definition (in this case the instance) is recursive.

Basic tests pass.  Haven't done more extensive testing yet.
