### PR TITLE
Do not descend into Let bindings multiple times during desugaring

### DIFF
--- a/examples/passing/NestedWhere.purs
+++ b/examples/passing/NestedWhere.purs
@@ -1,0 +1,10 @@
+module Main where
+
+f x = g x
+  where
+  g x = go x
+    where
+    go x = go1 (x - 1)
+    go1 x = go x
+
+main = Debug.Trace.trace "Done"


### PR DESCRIPTION
Resolves #730 

The issue here is subtle. Basically it was a problem with the recursion pattern we were using, which would cause some of the `Let` bindings to be handled twice, resulting in them being filtered out.

The `StringLiteral` part is a bit of a hack, I'll admit, but a simple `undefined` will not work, since `go` is strict in its argument.
