### PR TITLE
Make everywhereOnValuesM only apply functions once at top level

### DIFF
--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -135,7 +135,7 @@ everywhereOnValuesM :: (Functor m, Applicative m, Monad m) =>
   (Expr -> m Expr) ->
   (Binder -> m Binder) ->
   (Declaration -> m Declaration, Expr -> m Expr, Binder -> m Binder)
-everywhereOnValuesM f g h = (f' <=< f, g' <=< g, h' <=< h)
+everywhereOnValuesM f g h = (f', g', h')
   where
   f' (DataBindingGroupDeclaration ds) = (DataBindingGroupDeclaration <$> mapM f' ds) >>= f
   f' (ValueDeclaration name nameKind bs val) = (ValueDeclaration name nameKind <$> mapM h' bs <*> eitherM (mapM (pairM g' g')) g' val) >>= f


### PR DESCRIPTION
I am not sure about this, but it seems like `everywhereOnValuesM` was passing whatever top-level thing through the given function twice: once before processing (on the way down), and again on the way back up.  This presumably wasn't doing any harm, but it doesn't seem quite right either.  (`everywhereOnValuesTopDownM` does this too but it's correct there.)  (Noticed while trying to understand #733.)
