### PR TITLE
Refine optparse-applicative dependency version

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -107,7 +107,7 @@ library
 
 executable psc
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any, 
-                   mtl -any, optparse-applicative -any, parsec -any, purescript -any,
+                   mtl -any, optparse-applicative >= 0.10.0, parsec -any, purescript -any,
                    transformers -any, utf8-string -any
     main-is: Main.hs
     buildable: True
@@ -117,7 +117,7 @@ executable psc
 
 executable psc-make
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any, 
-                   mtl -any, optparse-applicative -any, parsec -any, purescript -any, 
+                   mtl -any, optparse-applicative >= 0.10.0, parsec -any, purescript -any, 
                    transformers -any, utf8-string -any
     main-is: Main.hs
     buildable: True
@@ -127,7 +127,7 @@ executable psc-make
 
 executable psci
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any,
-                   mtl -any, optparse-applicative -any, parsec -any, 
+                   mtl -any, optparse-applicative >= 0.10.0, parsec -any, 
                    haskeline >= 0.7.0.0, purescript -any, transformers -any, 
                    utf8-string -any, process -any
                    
@@ -140,7 +140,7 @@ executable psci
 
 executable psc-docs
     build-depends: base >=4 && <5, purescript -any, utf8-string -any,
-                   optparse-applicative -any, process -any, mtl -any
+                   optparse-applicative >= 0.10.0, process -any, mtl -any
     main-is: Main.hs
     buildable: True
     hs-source-dirs: psc-docs
@@ -148,7 +148,7 @@ executable psc-docs
     ghc-options: -Wall -O2
 
 executable hierarchy
-    build-depends: base >=4 && <5, purescript -any, utf8-string -any, optparse-applicative -any,
+    build-depends: base >=4 && <5, purescript -any, utf8-string -any, optparse-applicative >= 0.10.0,
                    process -any, mtl -any, parsec -any, filepath -any, directory -any
     main-is: Main.hs
     buildable: True


### PR DESCRIPTION
The function `strArgument` (used everywhere) was introduced in 0.10.0, while some distributions are still at 0.9.  Make this dependency version explicit.
