### PR TITLE
Specify mtl and transformers dependencies

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -107,7 +107,7 @@ library
 
 executable psc
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any, 
-                   mtl >= 2.1.0 && < 2.3, optparse-applicative -any, parsec -any, purescript -any,
+                   mtl >= 2.1.0 && < 2.3, optparse-applicative >= 0.10.0, parsec -any, purescript -any,
                    transformers >= 0.3 && < 0.5, utf8-string -any
     main-is: Main.hs
     buildable: True
@@ -117,7 +117,7 @@ executable psc
 
 executable psc-make
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any, 
-                   mtl >= 2.1.0 && < 2.3, optparse-applicative -any, parsec -any, purescript -any, 
+                   mtl >= 2.1.0 && < 2.3, optparse-applicative >= 0.10.0, parsec -any, purescript -any, 
                    transformers >= 0.3 && < 0.5, utf8-string -any
     main-is: Main.hs
     buildable: True
@@ -127,7 +127,7 @@ executable psc-make
 
 executable psci
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any,
-                   mtl >= 2.1.0 && < 2.3, optparse-applicative -any, parsec -any, 
+                   mtl >= 2.1.0 && < 2.3, optparse-applicative >= 0.10.0, parsec -any, 
                    haskeline >= 0.7.0.0, purescript -any, transformers >= 0.3 && < 0.5, 
                    utf8-string -any, process -any
                    
@@ -140,7 +140,7 @@ executable psci
 
 executable psc-docs
     build-depends: base >=4 && <5, purescript -any, utf8-string -any,
-                   optparse-applicative -any, process -any, mtl >= 2.1.0 && < 2.3.0 
+                   optparse-applicative >= 0.10.0, process -any, mtl >= 2.1.0 && < 2.3.0 
     main-is: Main.hs
     buildable: True
     hs-source-dirs: psc-docs
@@ -148,7 +148,7 @@ executable psc-docs
     ghc-options: -Wall -O2
 
 executable hierarchy
-    build-depends: base >=4 && <5, purescript -any, utf8-string -any, optparse-applicative -any,
+    build-depends: base >=4 && <5, purescript -any, utf8-string -any, optparse-applicative >= 0.10.0,
                    process -any, mtl >= 2.1.0 && < 2.3.0, parsec -any, filepath -any, directory -any
     main-is: Main.hs
     buildable: True


### PR DESCRIPTION
I tried moving code over to `ExceptT` instead of `ErrorT`, but it seems to have different semantics for `MonadPlus`, which don't work out easily for us (among other things). I'm going to move that issue out of 0.7 for now.

This change simply specifies the dependency bounds for `mtl` and `transformers` for the various front-end executables.
