### PR TITLE
Fix #642 - Allow rows in instance contexts

### DIFF
--- a/examples/passing/RowPolyInstanceContext.purs
+++ b/examples/passing/RowPolyInstanceContext.purs
@@ -1,0 +1,20 @@
+module Main where
+
+class T s m where
+  state :: (s -> s) -> m Unit
+
+data S s a = S (s -> { new :: s, ret :: a })
+
+instance st :: T s (S s) where
+  state f = S $ \s -> { new: f s, ret: unit }
+
+test1 :: forall r . S { foo :: String | r } Unit
+test1 = state $ \o -> o { foo = o.foo ++ "!" }
+
+test2 :: forall m r . (T { foo :: String | r } m) => m Unit
+test2 = state $ \o -> o { foo = o.foo ++ "!" }
+
+main = do
+  let t1 = test1
+  let t2 = test2
+  Debug.Trace.trace "Done"

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -199,14 +199,14 @@ entails env moduleName context = solve (sortedNubBy canonicalizeDictionary (filt
 -- and return a substitution from type variables to types which makes the type heads unify.
 --
 typeHeadsAreEqual :: ModuleName -> Environment -> Type -> Type -> Maybe [(String, Type)]
-typeHeadsAreEqual _ _ (Skolem _ s1 _) (Skolem _ s2 _) | s1 == s2 = Just []
 typeHeadsAreEqual _ _ t (TypeVar v) = Just [(v, t)]
-typeHeadsAreEqual _ _ (TypeConstructor c1) (TypeConstructor c2) | c1 == c2 = Just []
 typeHeadsAreEqual m e (TypeApp h1 t1) (TypeApp h2 t2) = (++) <$> typeHeadsAreEqual m e h1 h2 <*> typeHeadsAreEqual m e t1 t2
 typeHeadsAreEqual m e (SaturatedTypeSynonym name args) t2 = case expandTypeSynonym' e name args of
   Left  _  -> Nothing
   Right t1 -> typeHeadsAreEqual m e t1 t2
-typeHeadsAreEqual _ _ _ _ = Nothing
+typeHeadsAreEqual _ e t1 t2
+  | unifiesWith e t1 t2 = Just []
+  | otherwise           = Nothing
 
 -- |
 -- Check all values in a list pairwise match a predicate


### PR DESCRIPTION
Original discussion here: https://github.com/purescript/purescript/issues/642
As for unifying TUnknowns with everything, it breaks these tests:
```
Assert C:\purescript\purescript\examples\failing\UnknownValue.purs does not compile
Assert C:\purescript\purescript\examples\failing\UnknownType.purs does not compile
Assert C:\purescript\purescript\examples\failing\UnifyInTypeInstanceLookup.purs does not compile
Should not have compiled
```
But it seems it's ok to unify them with just skolems (and it fixes the problem).