### PR TITLE
Fix #760: Allow ':' in place of '=' in record match

### DIFF
--- a/examples/passing/Objects.purs
+++ b/examples/passing/Objects.purs
@@ -26,5 +26,10 @@ module Main where
 
   test5 = case { "***": 1 } of
     { "***" = n } -> n
+
+  test6 = case { "***": 1 } of
+               { "***": n } -> n
+
+  test7 {a:    snoog , b     : blah } = blah
     
   main = Debug.Trace.trace "Done"

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -436,7 +436,7 @@ parseNullBinder = C.lexeme (P.char '_' *> P.notFollowedBy C.identLetter) *> retu
 parseIdentifierAndBinder :: P.Parsec String ParseState (String, Binder)
 parseIdentifierAndBinder = do
   name <- C.lexeme (C.identifierName <|> C.stringLiteral)
-  _ <- C.lexeme $ C.indented *> P.char '='
+  _ <- C.lexeme $ C.indented *> (P.char '=' <|> P.char ':')
   binder <- C.indented *> parseBinder
   return (name, binder)
 


### PR DESCRIPTION
My humble attempt ;)
