### PR TITLE
Import void from Control.Monad for backwards compatibility

### DIFF
--- a/src/Language/PureScript/Parser/Lexer.hs
+++ b/src/Language/PureScript/Parser/Lexer.hs
@@ -69,7 +69,7 @@ module Language.PureScript.Parser.Lexer
 
 import Prelude hiding (lex)
 
-import Data.Functor (void)
+import Control.Monad (void)
 import Data.Functor.Identity
 
 import Control.Applicative


### PR DESCRIPTION
ghc 7.6 needs this, and it shouldn't hurt anything (`Data.Functor.void` is really just a re-export of `Control.Monad.void` anyway).
