### PR TITLE
Lift restriction on underscores in unames

### DIFF
--- a/examples/failing/UnderscoreModuleName.purs
+++ b/examples/failing/UnderscoreModuleName.purs
@@ -1,0 +1,3 @@
+module Bad_Module where
+
+main = Debug.Trace.trace "Done"

--- a/examples/passing/UnderscoreIdent.purs
+++ b/examples/passing/UnderscoreIdent.purs
@@ -1,0 +1,9 @@
+module Main where
+
+data Data_type = Con_Structor | Con_2 String
+
+type Type_name = Data_type
+
+done (Con_2 s) = s
+
+main = Debug.Trace.trace (done (Con_2 "Done"))

--- a/src/Language/PureScript/Parser/Common.hs
+++ b/src/Language/PureScript/Parser/Common.hs
@@ -37,7 +37,7 @@ moduleName = part []
   where
   part path = (do name <- ProperName <$> P.try qualifier
                   part (path `snoc` name))
-              <|> (ModuleName . snoc path <$> properName)
+              <|> (ModuleName . snoc path . ProperName <$> mname)
   snoc path name = path ++ [name]
 
 -- |


### PR DESCRIPTION
Also allows apostrophes.

The only trick here is we need to keep the restriction on module names, due to CommonJS module naming. I did a quick review of the rest of the parser and didn't find anywhere else that module names were parsed as normal unames.  Requested by @jutaro.
