### PR TITLE
Better auto-completion in psci.

### DIFF
--- a/psci/Commands.hs
+++ b/psci/Commands.hs
@@ -69,16 +69,19 @@ data Command
 -- |
 -- The help menu.
 --
-help :: [[String]]
+help :: [(String, String, String)]
 help =
-  [ [":?          ", "Show this help menu"]
-  , [":i <module> ", "Import <module> for use in PSCI"]
-  , [":b <module> ", "Browse <module>"]
-  , [":m <file>   ", "Load <file> for importing"]
-  , [":q          ", "Quit PSCi"]
-  , [":r          ", "Reset"]
-  , [":s import   ", "Show imported modules"]
-  , [":s loaded   ", "Show loaded modules"]
-  , [":t <expr>   ", "Show the type of <expr>"]
-  , [":k <type>   ", "Show the kind of <type>"]
+  [ (":?", "",         "Show this help menu")
+  , (":i", "<module>", "Import <module> for use in PSCI")
+  , (":b", "<module>", "Browse <module>")
+  , (":m", "<file>",   "Load <file> for importing")
+  , (":q", "",         "Quit PSCi")
+  , (":r", "",         "Reset")
+  , (":s", "import",   "Show imported modules")
+  , (":s", "loaded",   "Show loaded modules")
+  , (":t", "<expr>",   "Show the type of <expr>")
+  , (":k", "<type>",   "Show the kind of <type>")
   ]
+
+commands :: [String]
+commands = map (\ (a, _, _) -> a) help


### PR DESCRIPTION
`:m` completes file names, `:b` and `:i` complete modules etc. Also completion for the names of the actual commands; mostly for completeness' sake, but this gets us about 90% of the way to multi-character commands.
