### PR TITLE
Added parsing check for wildcard type when parsing row endings.

### DIFF
--- a/examples/passing/TypeWildcardsRecordExtension.purs
+++ b/examples/passing/TypeWildcardsRecordExtension.purs
@@ -1,0 +1,6 @@
+module Main where
+    
+foo :: forall a. {b :: Number | a} -> {b :: Number | _}
+foo f = f
+
+main = Debug.Trace.trace "Done"

--- a/src/Language/PureScript/Parser/Types.hs
+++ b/src/Language/PureScript/Parser/Types.hs
@@ -126,7 +126,9 @@ parseNameAndType :: TokenParser t -> TokenParser (String, t)
 parseNameAndType p = (,) <$> (indented *> (lname <|> stringLiteral) <* indented <* doubleColon) <*> p
 
 parseRowEnding :: TokenParser Type
-parseRowEnding = P.option REmpty (TypeVar <$> (indented *> pipe *> indented *> identifier))
+parseRowEnding = P.option REmpty $ indented *> pipe *> indented *> P.choice  (map P.try
+            [ parseTypeWildcard
+            , TypeVar <$> identifier ])
 
 parseRow :: TokenParser Type
 parseRow = (curry rowFromList <$> commaSep (parseNameAndType parsePolyType) <*> parseRowEnding) P.<?> "row"


### PR DESCRIPTION
Partial fix for #788. However the example given in #788:  

```purescript
module Wild where

  type Foo = { | _}
```
Now gives:

➜  purs  psc wild.purs
Warning: "wild.purs" (line 3, column 19):
unexpected type wildcard
expecting :: or operator
ambiguous use of a left associative operator Use --force to continue

due to the noWildcards check in Declarations.hs:

```haskell
parseTypeSynonymDeclaration =
  TypeSynonymDeclaration <$> (P.try (reserved "type") *> indented *> properName)
                         <*> many (indented *> kindedIdent)
                         <*> (indented *> equals *> noWildcards parsePolyType)
```
