### PR TITLE
Improve whitespace parser

### DIFF
--- a/src/Language/PureScript/Parser/Lexer.hs
+++ b/src/Language/PureScript/Parser/Lexer.hs
@@ -70,6 +70,8 @@ module Language.PureScript.Parser.Lexer
 
 import Prelude hiding (lex)
 
+import Data.Char (isSpace)
+
 import Control.Monad (void, guard)
 import Data.Functor.Identity
 
@@ -158,7 +160,7 @@ parseTokens :: P.Parsec String u [PositionedToken]
 parseTokens = whitespace *> P.many parsePositionedToken <* P.skipMany parseComment <* P.eof
 
 whitespace :: P.Parsec String u ()
-whitespace = P.skipMany (P.oneOf " \t\r\n")
+whitespace = P.skipMany (P.satisfy isSpace)
     
 parseComment :: P.Parsec String u Comment
 parseComment = (BlockComment <$> blockComment <|> LineComment <$> lineComment) <* whitespace


### PR DESCRIPTION
This fixes an issue which I noticed with the latest compiler using `purescript-channels`. Specifically, we aren't handling the `\160` (non-breaking space) character.

@joneshf @jdegoes @gary Please review?