### PR TITLE
More completion improvements for PSCI

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -34,6 +34,10 @@ import Language.PureScript.Environment
 --
 data Module = Module ModuleName [Declaration] (Maybe [DeclarationRef]) deriving (Show, D.Data, D.Typeable)
 
+-- | Return a module's name.
+getModuleName :: Module -> ModuleName
+getModuleName (Module name _ _) = name
+
 -- |
 -- Test if a declaration is exported, given a module's export list.
 --
@@ -44,6 +48,7 @@ isExported exps (PositionedDeclaration _ d) = isExported exps d
 isExported (Just exps) decl = any (matches decl) exps
   where
   matches (TypeDeclaration ident _) (ValueRef ident') = ident == ident'
+  matches (ValueDeclaration ident _ _ _) (ValueRef ident') = ident == ident'
   matches (ExternDeclaration _ ident _ _) (ValueRef ident') = ident == ident'
   matches (DataDeclaration _ ident _ _) (TypeRef ident' _) = ident == ident'
   matches (ExternDataDeclaration ident _) (TypeRef ident' _) = ident == ident'
@@ -77,6 +82,7 @@ exportedDctors (Module _ decls exps) ident =
   where
   dctors = concatMap getDctors decls
   getDctors (DataDeclaration _ _ _ ctors) = map fst ctors
+  getDctors (PositionedDeclaration _ d) = getDctors d
   getDctors _ = []
 
 -- |

--- a/src/Language/PureScript/ModuleDependencies.hs
+++ b/src/Language/PureScript/ModuleDependencies.hs
@@ -64,9 +64,6 @@ usedModules = let (f, _, _, _, _) = everythingOnValues (++) forDecls forValues (
   forTypes (ConstrainedType cs _) = mapMaybe (\(Qualified mn _, _) -> mn) cs
   forTypes _ = []
 
-getModuleName :: Module -> ModuleName
-getModuleName (Module mn _ _) = mn
-
 -- |
 -- Convert a strongly connected component of the module graph to a module
 --


### PR DESCRIPTION
Complete type names for `:k`, complete data constructors where identifiers are expected. Also only complete unqualified names when the module that contains them is imported. (Otherwise they're unavailable!)

I had to drill a little deeper into the data structures that represent modules; not all of the resulting stuff is what I'd consider 'pretty', so feedback is very welcome!