### PR TITLE
Parentheses lost when different operators of same precedence in expression

### DIFF
--- a/examples/passing/OperatorAssociativity.purs
+++ b/examples/passing/OperatorAssociativity.purs
@@ -1,15 +1,36 @@
 module Main where
 
 import Control.Monad.Eff
+import Debug.Trace
+
+foreign import data Assert :: !
+
+foreign import assert
+  "function assert(x) { return function (desc) {\
+  \  return function () {\
+  \    if (!x) throw new Error('assertion (' + desc + ') failed');\
+  \    return {};\
+  \  };\
+  \};};" :: forall e. Boolean -> String -> Eff (assert :: Assert | e) Unit
 
 bug :: Number -> Number -> Number
 bug a b = 0 - (a - b)
 
-foreign import explode 
+foreign import explode
   "function explode() {\
   \  throw new Error('Assertion failed!');\
   \}":: forall eff a. Eff eff a
 
-main = case bug 0 2 of
-  2 -> Debug.Trace.trace "Done!"
-  _ -> explode
+main = do
+    assert (bug 0 2 == 2)       "bug 0 2 == 2"
+    assert (0 - (0 - 2) == 2)   "0 - (0 - 2) == 2"
+    assert (0 - (0 + 2) == -2)  "0 - (0 + 2) == -2"
+
+    assert (6 / (3 * 2) == 1)   "6 / (3 * 2) == 1"
+    assert ((6 / 3) * 2 == 4)   "(6 / 3) * 2 == 4"
+
+    assert (6 % (2 * 2) == 2)   "6 % (2 * 2) == 2"
+    assert ((6 % 2) * 2 == 0)   "(6 % 2) * 2 == 0"
+
+    assert (4 % (9 / 3) == 1)   "4 % (9 / 3) == 1"
+    assert ((4 % 9) / 2 == 2)   "(4 % 9) / 2 == 2"

--- a/src/Language/PureScript/Pretty/JS.hs
+++ b/src/Language/PureScript/Pretty/JS.hs
@@ -273,11 +273,11 @@ prettyPrintJS' = A.runKleisli $ runPattern matchValue
                   , [ unary     BitwiseNot           "~" ]
                   , [ unary     Negate               "-" ]
                   , [ unary     Positive             "+" ]
-                  , [ binary    Multiply             "*" ]
-                  , [ binary    Divide               "/" ]
-                  , [ binary    Modulus              "%" ]
-                  , [ binary    Add                  "+" ]
-                  , [ binary    Subtract             "-" ]
+                  , [ binary    Multiply             "*"
+                    , binary    Divide               "/"
+                    , binary    Modulus              "%" ]
+                  , [ binary    Add                  "+"
+                    , binary    Subtract             "-" ]
                   , [ binary    ShiftLeft            "<<" ]
                   , [ binary    ShiftRight           ">>" ]
                   , [ binary    ZeroFillShiftRight   ">>>" ]


### PR DESCRIPTION
Expressions with different operators of equal JavaScript precedence did not keep the original structure, but were flattened:
"a - (b + c)" compiled as "a - b + c"; 
"a / (b * c)" compliled as "a / b * c"