### PR TITLE
Bumped utf8-string version and updated code accordingly.

### DIFF
--- a/hierarchy/Main.hs
+++ b/hierarchy/Main.hs
@@ -25,13 +25,12 @@ import Options.Applicative
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((</>))
 import System.Exit (exitFailure, exitSuccess)
-import System.IO (stderr)
+import System.IO (hPutStr, stderr)
 
 import Text.Parsec as Par (ParseError)
 
 import qualified Language.PureScript as P
 import qualified Paths_purescript as Paths
-import qualified System.IO.UTF8 as U
 
 
 data HierarchyOptions = HierarchyOptions
@@ -56,14 +55,14 @@ runModuleName (P.ModuleName pns) = intercalate "_" (P.runProperName `map` pns)
 
 readInput :: FilePath -> IO (Either Par.ParseError [P.Module])
 readInput filename = do
-  content <- U.readFile filename
+  content <- readFile filename
   return $ fmap (map snd) $ P.parseModulesFromFiles id [(filename, content)]
 
 compile :: HierarchyOptions -> IO ()
 compile (HierarchyOptions input mOutput) = do
   modules <- readInput input
   case modules of
-    Left err -> U.hPutStr stderr (show err) >> exitFailure
+    Left err -> hPutStr stderr (show err) >> exitFailure
     Right ms -> do
       for_ ms $ \(P.Module moduleName decls _) ->
         let name = runModuleName moduleName
@@ -76,8 +75,8 @@ compile (HierarchyOptions input mOutput) = do
         in unless (null supers) $ case mOutput of
           Just output -> do
             createDirectoryIfMissing True output
-            U.writeFile (output </> name) hier
-          Nothing -> U.putStrLn hier
+            writeFile (output </> name) hier
+          Nothing -> putStrLn hier
       exitSuccess
 
 superClasses :: P.Declaration -> [SuperMap]

--- a/psc-docs/Main.hs
+++ b/psc-docs/Main.hs
@@ -27,9 +27,8 @@ import Options.Applicative
 
 import qualified Language.PureScript as P
 import qualified Paths_purescript as Paths
-import qualified System.IO.UTF8 as U
 import System.Exit (exitSuccess, exitFailure)
-import System.IO (stderr)
+import System.IO (hPutStr, stderr)
 
 
 data PSCDocsOptions = PSCDocsOptions
@@ -43,14 +42,14 @@ docgen (PSCDocsOptions showHierarchy input) = do
   e <- P.parseModulesFromFiles (fromMaybe "") <$> mapM (fmap (first Just) . parseFile) (nub input)
   case e of
     Left err -> do
-      U.hPutStr stderr $ show err
+      hPutStr stderr $ show err
       exitFailure
     Right ms -> do
-      U.putStrLn . runDocs $ (renderModules showHierarchy) (map snd ms)
+      putStrLn . runDocs $ (renderModules showHierarchy) (map snd ms)
       exitSuccess
 
 parseFile :: FilePath -> IO (FilePath, String)
-parseFile input = (,) input <$> U.readFile input
+parseFile input = (,) input <$> readFile input
 
 type Docs = Writer [String] ()
 

--- a/psci/Main.hs
+++ b/psci/Main.hs
@@ -42,7 +42,6 @@ import System.Exit
 import System.FilePath (pathSeparator, takeDirectory, (</>), isPathSeparator)
 import System.IO.Error (tryIOError)
 import System.Process (readProcessWithExitCode)
-import qualified System.IO.UTF8 as U (writeFile, putStrLn, print, readFile)
 
 import qualified Text.Parsec as Par (ParseError)
 
@@ -129,7 +128,7 @@ getHistoryFilename = do
 --
 loadModule :: FilePath -> IO (Either String [P.Module])
 loadModule filename = do
-  content <- U.readFile filename
+  content <- readFile filename
   return $ either (Left . show) (Right . map snd) $ P.parseModulesFromFiles id [(filename, content)]
 
 -- |
@@ -138,7 +137,7 @@ loadModule filename = do
 loadAllModules :: [FilePath] -> IO (Either Par.ParseError [(Either P.RebuildPolicy FilePath, P.Module)])
 loadAllModules files = do
   filesAndContent <- forM files $ \filename -> do
-    content <- U.readFile filename
+    content <- readFile filename
     return (Right filename, content)
   return $ P.parseModulesFromFiles (either (const "") id) $ (Left P.RebuildNever, P.prelude) : filesAndContent
 
@@ -329,12 +328,12 @@ instance P.MonadMake Make where
     if exists
       then Just <$> getModificationTime path
       else return Nothing
-  readTextFile path = makeIO $ U.readFile path
+  readTextFile path = makeIO $ readFile path
   writeTextFile path text = makeIO $ do
     mkdirp path
-    U.writeFile path text
+    writeFile path text
   liftError = either throwError return
-  progress s = unless (s == "Compiling $PSCI") $ makeIO . U.putStrLn $ s
+  progress s = unless (s == "Compiling $PSCI") $ makeIO . putStrLn $ s
 
 mkdirp :: FilePath -> IO ()
 mkdirp = createDirectoryIfMissing True . takeDirectory
@@ -579,9 +578,9 @@ loadUserConfig = do
   exists <- doesFileExist configFile
   if exists
   then do
-    ls <- lines <$> U.readFile configFile
+    ls <- lines <$> readFile configFile
     case mapM parseCommand ls of
-      Left err -> U.print err >> exitFailure
+      Left err -> print err >> exitFailure
       Right cs -> return $ Just cs
   else
     return Nothing

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -1,5 +1,5 @@
 name: purescript
-version: 0.6.3
+version: 0.6.4
 cabal-version: >=1.8
 build-type: Simple
 license: MIT
@@ -32,7 +32,7 @@ library
                    mtl >= 2.1.0 && < 2.3.0,
                    parsec -any,
                    transformers >= 0.3 && < 0.5,
-                   utf8-string -any,
+                   utf8-string >= 1,
                    pattern-arrows >= 0.0.2 && < 0.1,
                    monad-unify >= 0.2.2 && < 0.3,
                    file-embed >= 0.0.7 && < 0.0.8,
@@ -119,7 +119,7 @@ library
 executable psc
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any,
                    mtl -any, optparse-applicative >= 0.10.0, parsec -any, purescript -any,
-                   transformers -any, utf8-string -any
+                   transformers -any, utf8-string >= 1
     main-is: Main.hs
     buildable: True
     hs-source-dirs: psc
@@ -129,7 +129,7 @@ executable psc
 executable psc-make
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any,
                    mtl -any, optparse-applicative >= 0.10.0, parsec -any, purescript -any,
-                   transformers -any, utf8-string -any
+                   transformers -any, utf8-string >= 1
     main-is: Main.hs
     buildable: True
     hs-source-dirs: psc-make
@@ -140,7 +140,7 @@ executable psci
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any,
                    mtl -any, optparse-applicative >= 0.10.0, parsec -any,
                    haskeline >= 0.7.0.0, purescript -any, transformers -any,
-                   utf8-string -any, process -any
+                   utf8-string >= 1, process -any
 
     main-is: Main.hs
     buildable: True
@@ -150,7 +150,7 @@ executable psci
     ghc-options: -Wall -fno-warn-warnings-deprecations -O2
 
 executable psc-docs
-    build-depends: base >=4 && <5, purescript -any, utf8-string -any,
+    build-depends: base >=4 && <5, purescript -any, utf8-string >= 1,
                    optparse-applicative >= 0.10.0, process -any, mtl -any
     main-is: Main.hs
     buildable: True
@@ -159,7 +159,7 @@ executable psc-docs
     ghc-options: -Wall -fno-warn-warnings-deprecations -O2
 
 executable hierarchy
-    build-depends: base >=4 && <5, purescript -any, utf8-string -any, optparse-applicative >= 0.10.0,
+    build-depends: base >=4 && <5, purescript -any, utf8-string >= 1, optparse-applicative >= 0.10.0,
                    process -any, mtl -any, parsec -any, filepath -any, directory -any
     main-is: Main.hs
     buildable: True
@@ -170,7 +170,7 @@ executable hierarchy
 test-suite tests
     build-depends: base >=4 && <5, containers -any, directory -any,
                    filepath -any, mtl -any, parsec -any, purescript -any,
-                   transformers -any, utf8-string -any, process -any
+                   transformers -any, utf8-string >= 1, process -any
     type: exitcode-stdio-1.0
     main-is: Main.hs
     buildable: True

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -28,11 +28,10 @@ import System.Process
 import System.FilePath (pathSeparator)
 import System.Directory (getCurrentDirectory, getTemporaryDirectory, getDirectoryContents, findExecutable)
 import Text.Parsec (ParseError)
-import qualified System.IO.UTF8 as U
 
 readInput :: [FilePath] -> IO [(FilePath, String)]
 readInput inputFiles = forM inputFiles $ \inputFile -> do
-  text <- U.readFile inputFile
+  text <- readFile inputFile
   return (inputFile, text)
 
 loadPrelude :: Either String (String, String, P.Environment)


### PR DESCRIPTION
Fixes #825 
* added lower bound of >= 1 to utf8-string
* bumped minor release number
* updated code to not use the IO wrappers

Couldn't find any reference to `purescript-test-everything` or `starter-kit` in the repo (though it's rather late so I could have missed it), but I did reconfigure with tests enabled and ran the one test suite with success.