### PR TITLE
Specify version bounds for utf8-string

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -32,7 +32,7 @@ library
                    mtl >= 2.1.0 && < 2.3.0,
                    parsec -any,
                    transformers >= 0.3 && < 0.5,
-                   utf8-string -any,
+                   utf8-string >= 0.3 && <1,
                    pattern-arrows >= 0.0.2 && < 0.1,
                    monad-unify >= 0.2.2 && < 0.3,
                    file-embed >= 0.0.7 && < 0.0.8,


### PR DESCRIPTION
Workaround https://github.com/purescript/purescript/issues/825
http://stackoverflow.com/questions/28110769/system-io-utf8-not-found-installing-purescript/28111390#28111390