### PR TITLE
Name errors

### DIFF
--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -331,7 +331,7 @@ findExports = foldM addModule $ M.singleton (ModuleName [ProperName C.prim]) pri
   addDecl mn env (ExternDataDeclaration tn _) = addType env mn tn []
   addDecl mn env (ValueDeclaration name _ _ _) = addValue env mn name
   addDecl mn env (ExternDeclaration _ name _ _) = addValue env mn name
-  addDecl mn env (PositionedDeclaration _ _ d) = addDecl mn env d
+  addDecl mn env (PositionedDeclaration pos _ d) = rethrowWithPosition pos $ addDecl mn env d
   addDecl _  env _ = return env
 
 -- |


### PR DESCRIPTION
- Fixes #740.
- Fixes a bug where the error message for duplicate data constructor or type definitions wasn't being handled in the right place, and instead was being shown as an import conflict.
- Adds position info to error about duplicate definitions.