### PR TITLE
Operator sections

### DIFF
--- a/examples/passing/OperatorSections.purs
+++ b/examples/passing/OperatorSections.purs
@@ -1,0 +1,21 @@
+module Main where
+
+foreign import eqeqeq
+  """
+  function eqeqeq(x) {
+    return function (y) {
+      if (x == y) return x;
+      throw new Error("Unexpected result: " + x + " /== " + y);
+    };
+  };
+  """ :: forall a. a -> a -> a
+
+(===) = eqeqeq
+infixl 4 ===
+
+main = do
+  Debug.Trace.print $ (/ 2) 4 === 2
+  Debug.Trace.print $ (2 /) 4 === 0.5
+  Debug.Trace.print $ (`const` 1) 2 === 2
+  Debug.Trace.print $ (1 `const`) 2 === 1
+  Debug.Trace.trace "Done!"

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -312,6 +312,11 @@ data Expr
   --
   | Parens Expr
   -- |
+  -- Operator section. This will be removed during desugaring and replaced with a partially applied
+  -- operator or lambda to flip the arguments.
+  --
+  | OperatorSection (Qualified Ident) (Either Expr Expr)
+  -- |
   -- An array literal
   --
   | ArrayLiteral [Expr]

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -353,8 +353,8 @@ parseValueAtom = P.choice
             , parseIfThenElse
             , parseDo
             , parseLet
-            , P.try parseOperatorSection
-            , Parens <$> parens parseValue ]
+            , P.try $ Parens <$> parens parseValue
+            , parseOperatorSection ]
 
 parseOperatorSection :: TokenParser Expr
 parseOperatorSection = parens $ left <|> right

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -353,7 +353,14 @@ parseValueAtom = P.choice
             , parseIfThenElse
             , parseDo
             , parseLet
+            , P.try parseOperatorSection
             , Parens <$> parens parseValue ]
+
+parseOperatorSection :: TokenParser Expr
+parseOperatorSection = parens $ left <|> right
+  where
+  right = OperatorSection <$> parseIdentInfix <* indented <*> (Right <$> parseValueAtom)
+  left = flip OperatorSection <$> (Left <$> parseValueAtom) <* indented <*> parseIdentInfix
 
 parsePropertyUpdate :: TokenParser (String, Maybe Expr)
 parsePropertyUpdate = do

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -73,6 +73,8 @@ literals = mkPattern' match
     , withIndent $ prettyPrintMany prettyPrintDoNotationElement els
     , currentIndent
     ]
+  match (OperatorSection op (Right val)) = return $ "(" ++ show op ++ " " ++ prettyPrintValue val ++ ")"
+  match (OperatorSection op (Left val)) = return $ "(" ++ prettyPrintValue val ++ " " ++ show op ++ ")"
   match (TypeClassDictionary name _ _) = return $ "<<dict " ++ show name ++ ">>"
   match (SuperClassDictionary name _) = return $ "<<superclass dict " ++ show name ++ ">>"
   match (TypedValue _ val _) = prettyPrintValue' val

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -37,7 +37,9 @@ import Language.PureScript.Sugar.TypeDeclarations as S
 --
 --  * Remove signed literals in favour of `negate` applications
 --
---  * Desguar object literals with wildcards into lambdas
+--  * Desugar object literals with wildcards into lambdas
+--
+--  * Desugar operator sections
 --
 --  * Desugar do-notation using the @Prelude.Monad@ type class
 --
@@ -56,6 +58,7 @@ import Language.PureScript.Sugar.TypeDeclarations as S
 desugar :: [Module] -> SupplyT (Either ErrorStack) [Module]
 desugar = map removeSignedLiterals
           >>> map desugarObjectConstructors
+          >>> map desugarOperatorSections
           >>> mapM desugarDoModule
           >=> desugarCasesModule
           >=> lift . (desugarTypeDeclarationsModule

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -58,8 +58,8 @@ import Language.PureScript.Sugar.TypeDeclarations as S
 desugar :: [Module] -> SupplyT (Either ErrorStack) [Module]
 desugar = map removeSignedLiterals
           >>> map desugarObjectConstructors
-          >>> map desugarOperatorSections
-          >>> mapM desugarDoModule
+          >>> mapM desugarOperatorSections
+          >=> mapM desugarDoModule
           >=> desugarCasesModule
           >=> lift . (desugarTypeDeclarationsModule
                       >=> desugarImports


### PR DESCRIPTION
Resolves #410, successfully ran `test-everything`.

There is one problem, but Haskell gets this wrong too: `(- 1) 1` results in a type error rather than `0`, as the `negate` case is used to parse the `(- 1)` part of the expression, so it's desugared as `(negate 1) 1`.