### PR TITLE
Supply object wildcards

### DIFF
--- a/examples/passing/ObjectUpdater.purs
+++ b/examples/passing/ObjectUpdater.purs
@@ -3,21 +3,30 @@ module Main where
 import Control.Monad.Eff
 import Debug.Trace
 
-foreign import data Error :: !
-
-foreign import error
+foreign import eqeqeq
   """
-  function error() {
-    throw new Error("Object update failed");
-  }
-  """ :: forall e. Eff (error :: Error | e) Unit
+  function eqeqeq(x) {
+    return function (y) {
+      if (x == y) return x;
+      throw new Error("Unexpected result: " + x + " /== " + y);
+    };
+  };
+  """ :: forall a. a -> a -> a
+
+(===) = eqeqeq
+infixl 4 ===
 
 getValue :: forall e. Eff (| e) Boolean
 getValue = return true
 
 main = do
   let record = { value: false }
-  record2 <- record { value = _ } <$> getValue
-  if record2.value
-    then trace "Done"
-    else error
+  record' <- record { value = _ } <$> getValue
+  print $ record'.value === true
+
+  let point = { x: 1, y: 1 }
+      x = 10
+      point' = (point { x = _, y = x }) 100
+
+  print $ point'.x === 100
+  print $ point'.y === 10

--- a/examples/passing/ObjectWildcards.purs
+++ b/examples/passing/ObjectWildcards.purs
@@ -26,6 +26,6 @@ main = do
   print obj.value
   let x = 1
   point <- { x: _, y: x } <$> return 2
-  print $ point.x === 1
-  print $ point.y === 2
+  print $ point.x === 2
+  print $ point.y === 1
   trace (mkRecord 1 "Done!").bar

--- a/examples/passing/ObjectWildcards.purs
+++ b/examples/passing/ObjectWildcards.purs
@@ -8,7 +8,24 @@ mkRecord = { foo: _, bar: _, baz: "baz" }
 getValue :: forall e. Eff (| e) Boolean
 getValue = return true
 
+foreign import eqeqeq
+  """
+  function eqeqeq(x) {
+    return function (y) {
+      if (x == y) return x;
+      throw new Error("Unexpected result: " + x + " /== " + y);
+    };
+  };
+  """ :: forall a. a -> a -> a
+
+(===) = eqeqeq
+infixl 4 ===
+
 main = do
   obj <- { value: _ } <$> getValue
   print obj.value
+  let x = 1
+  point <- { x: _, y: x } <$> return 2
+  print $ point.x === 1
+  print $ point.y === 2
   trace (mkRecord 1 "Done!").bar

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -45,6 +45,8 @@ everywhereOnValues f g h = (f', g', h')
   g' (UnaryMinus v) = g (UnaryMinus (g' v))
   g' (BinaryNoParens op v1 v2) = g (BinaryNoParens op (g' v1) (g' v2))
   g' (Parens v) = g (Parens (g' v))
+  g' (OperatorSection op (Left v)) = g (OperatorSection op (Left $ g' v))
+  g' (OperatorSection op (Right v)) = g (OperatorSection op (Right $ g' v))
   g' (ArrayLiteral vs) = g (ArrayLiteral (map g' vs))
   g' (ObjectLiteral vs) = g (ObjectLiteral (map (fmap g') vs))
   g' (ObjectConstructor vs) = g (ObjectConstructor (map (second (fmap g')) vs))
@@ -102,6 +104,8 @@ everywhereOnValuesTopDownM f g h = (f' <=< f, g' <=< g, h' <=< h)
   g' (UnaryMinus v) = UnaryMinus <$> (g v >>= g')
   g' (BinaryNoParens op v1 v2) = BinaryNoParens op <$> (g v1 >>= g') <*> (g v2 >>= g')
   g' (Parens v) = Parens <$> (g v >>= g')
+  g' (OperatorSection op (Left v)) = OperatorSection op . Left <$> (g v >>= g')
+  g' (OperatorSection op (Right v)) = OperatorSection op . Right <$> (g v >>= g')
   g' (ArrayLiteral vs) = ArrayLiteral <$> mapM (g' <=< g) vs
   g' (ObjectLiteral vs) = ObjectLiteral <$> mapM (sndM (g' <=< g)) vs
   g' (ObjectConstructor vs) = ObjectConstructor <$> mapM (sndM $ maybeM (g' <=< g)) vs
@@ -153,6 +157,8 @@ everywhereOnValuesM f g h = (f', g', h')
   g' (UnaryMinus v) = (UnaryMinus <$> g' v) >>= g
   g' (BinaryNoParens op v1 v2) = (BinaryNoParens op <$> g' v1 <*> g' v2) >>= g
   g' (Parens v) = (Parens <$> g' v) >>= g
+  g' (OperatorSection op (Left v)) = (OperatorSection op . Left <$> g' v) >>= g
+  g' (OperatorSection op (Right v)) = (OperatorSection op . Right <$> g' v) >>= g
   g' (ArrayLiteral vs) = (ArrayLiteral <$> mapM g' vs) >>= g
   g' (ObjectLiteral vs) = (ObjectLiteral <$> mapM (sndM g') vs) >>= g
   g' (ObjectConstructor vs) = (ObjectConstructor <$> mapM (sndM $ maybeM g') vs) >>= g
@@ -207,6 +213,8 @@ everythingOnValues (<>) f g h i j = (f', g', h', i', j')
   g' v@(UnaryMinus v1) = g v <> g' v1
   g' v@(BinaryNoParens _ v1 v2) = g v <> g' v1 <> g' v2
   g' v@(Parens v1) = g v <> g' v1
+  g' v@(OperatorSection _ (Left v1)) = g v <> g' v1
+  g' v@(OperatorSection _ (Right v1)) = g v <> g' v1
   g' v@(ArrayLiteral vs) = foldl (<>) (g v) (map g' vs)
   g' v@(ObjectLiteral vs) = foldl (<>) (g v) (map (g' . snd) vs)
   g' v@(ObjectConstructor vs) = foldl (<>) (g v) (map g' (mapMaybe snd vs))
@@ -272,6 +280,8 @@ everythingWithContextOnValues s0 r0 (<>) f g h i j = (f'' s0, g'' s0, h'' s0, i'
   g' s (UnaryMinus v1) = g'' s v1
   g' s (BinaryNoParens _ v1 v2) = g'' s v1 <> g'' s v2
   g' s (Parens v1) = g'' s v1
+  g' s (OperatorSection _ (Left v)) = g'' s v
+  g' s (OperatorSection _ (Right v)) = g'' s v
   g' s (ArrayLiteral vs) = foldl (<>) r0 (map (g'' s) vs)
   g' s (ObjectLiteral vs) = foldl (<>) r0 (map (g'' s . snd) vs)
   g' s (ObjectConstructor vs) = foldl (<>) r0 (map (g'' s) (mapMaybe snd vs))
@@ -340,6 +350,8 @@ everywhereWithContextOnValuesM s0 f g h i j = (f'' s0, g'' s0, h'' s0, i'' s0, j
   g' s (UnaryMinus v) = UnaryMinus <$> g'' s v
   g' s (BinaryNoParens op v1 v2) = BinaryNoParens op <$> g'' s v1 <*> g'' s v2
   g' s (Parens v) = Parens <$> g'' s v
+  g' s (OperatorSection op (Left v)) = OperatorSection op . Left <$> g'' s v
+  g' s (OperatorSection op (Right v)) = OperatorSection op . Right <$> g'' s v
   g' s (ArrayLiteral vs) = ArrayLiteral <$> mapM (g'' s) vs
   g' s (ObjectLiteral vs) = ObjectLiteral <$> mapM (sndM (g'' s)) vs
   g' s (ObjectConstructor vs) = ObjectConstructor <$> mapM (sndM $ maybeM (g'' s)) vs

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -15,6 +15,7 @@
 module Language.PureScript.AST.Traversals where
 
 import Data.Monoid (Monoid(..), mconcat)
+import Data.Maybe (mapMaybe)
 
 import Control.Applicative
 import Control.Monad
@@ -50,6 +51,7 @@ everywhereOnValues f g h = (f', g', h')
   g' (TypeClassDictionaryConstructorApp name v) = g (TypeClassDictionaryConstructorApp name (g' v))
   g' (Accessor prop v) = g (Accessor prop (g' v))
   g' (ObjectUpdate obj vs) = g (ObjectUpdate (g' obj) (map (fmap g') vs))
+  g' (ObjectUpdater obj vs) = g (ObjectUpdater (g' obj) (map (second (fmap g')) vs))
   g' (Abs name v) = g (Abs name (g' v))
   g' (App v1 v2) = g (App (g' v1) (g' v2))
   g' (IfThenElse v1 v2 v3) = g (IfThenElse (g' v1) (g' v2) (g' v3))
@@ -102,9 +104,11 @@ everywhereOnValuesTopDownM f g h = (f' <=< f, g' <=< g, h' <=< h)
   g' (Parens v) = Parens <$> (g v >>= g')
   g' (ArrayLiteral vs) = ArrayLiteral <$> mapM (g' <=< g) vs
   g' (ObjectLiteral vs) = ObjectLiteral <$> mapM (sndM (g' <=< g)) vs
+  g' (ObjectConstructor vs) = ObjectConstructor <$> mapM (sndM $ maybeM (g' <=< g)) vs
   g' (TypeClassDictionaryConstructorApp name v) = TypeClassDictionaryConstructorApp name <$> (g v >>= g')
   g' (Accessor prop v) = Accessor prop <$> (g v >>= g')
   g' (ObjectUpdate obj vs) = ObjectUpdate <$> (g obj >>= g') <*> mapM (sndM (g' <=< g)) vs
+  g' (ObjectUpdater obj vs) = ObjectUpdater <$> (g obj >>= g') <*> mapM (sndM $ maybeM (g' <=< g)) vs
   g' (Abs name v) = Abs name <$> (g v >>= g')
   g' (App v1 v2) = App <$> (g v1 >>= g') <*> (g v2 >>= g')
   g' (IfThenElse v1 v2 v3) = IfThenElse <$> (g v1 >>= g') <*> (g v2 >>= g') <*> (g v3 >>= g')
@@ -151,9 +155,11 @@ everywhereOnValuesM f g h = (f', g', h')
   g' (Parens v) = (Parens <$> g' v) >>= g
   g' (ArrayLiteral vs) = (ArrayLiteral <$> mapM g' vs) >>= g
   g' (ObjectLiteral vs) = (ObjectLiteral <$> mapM (sndM g') vs) >>= g
+  g' (ObjectConstructor vs) = (ObjectConstructor <$> mapM (sndM $ maybeM g') vs) >>= g
   g' (TypeClassDictionaryConstructorApp name v) = (TypeClassDictionaryConstructorApp name <$> g' v) >>= g
   g' (Accessor prop v) = (Accessor prop <$> g' v) >>= g
   g' (ObjectUpdate obj vs) = (ObjectUpdate <$> g' obj <*> mapM (sndM g') vs) >>= g
+  g' (ObjectUpdater obj vs) = (ObjectUpdater <$> g' obj <*> mapM (sndM $ maybeM g') vs) >>= g
   g' (Abs name v) = (Abs name <$> g' v) >>= g
   g' (App v1 v2) = (App <$> g' v1 <*> g' v2) >>= g
   g' (IfThenElse v1 v2 v3) = (IfThenElse <$> g' v1 <*> g' v2 <*> g' v3) >>= g
@@ -203,9 +209,11 @@ everythingOnValues (<>) f g h i j = (f', g', h', i', j')
   g' v@(Parens v1) = g v <> g' v1
   g' v@(ArrayLiteral vs) = foldl (<>) (g v) (map g' vs)
   g' v@(ObjectLiteral vs) = foldl (<>) (g v) (map (g' . snd) vs)
+  g' v@(ObjectConstructor vs) = foldl (<>) (g v) (map g' (mapMaybe snd vs))
   g' v@(TypeClassDictionaryConstructorApp _ v1) = g v <> g' v1
   g' v@(Accessor _ v1) = g v <> g' v1
   g' v@(ObjectUpdate obj vs) = foldl (<>) (g v <> g' obj) (map (g' . snd) vs)
+  g' v@(ObjectUpdater obj vs) = foldl (<>) (g v <> g' obj) (map g' (mapMaybe snd vs))
   g' v@(Abs _ v1) = g v <> g' v1
   g' v@(App v1 v2) = g v <> g' v1 <> g' v2
   g' v@(IfThenElse v1 v2 v3) = g v <> g' v1 <> g' v2 <> g' v3
@@ -266,9 +274,11 @@ everythingWithContextOnValues s0 r0 (<>) f g h i j = (f'' s0, g'' s0, h'' s0, i'
   g' s (Parens v1) = g'' s v1
   g' s (ArrayLiteral vs) = foldl (<>) r0 (map (g'' s) vs)
   g' s (ObjectLiteral vs) = foldl (<>) r0 (map (g'' s . snd) vs)
+  g' s (ObjectConstructor vs) = foldl (<>) r0 (map (g'' s) (mapMaybe snd vs))
   g' s (TypeClassDictionaryConstructorApp _ v1) = g'' s v1
   g' s (Accessor _ v1) = g'' s v1
   g' s (ObjectUpdate obj vs) = foldl (<>) (g'' s obj) (map (g'' s . snd) vs)
+  g' s (ObjectUpdater obj vs) = foldl (<>) (g'' s obj) (map (g'' s) (mapMaybe snd vs))
   g' s (Abs _ v1) = g'' s v1
   g' s (App v1 v2) = g'' s v1 <> g'' s v2
   g' s (IfThenElse v1 v2 v3) = g'' s v1 <> g'' s v2 <> g'' s v3
@@ -332,9 +342,11 @@ everywhereWithContextOnValuesM s0 f g h i j = (f'' s0, g'' s0, h'' s0, i'' s0, j
   g' s (Parens v) = Parens <$> g'' s v
   g' s (ArrayLiteral vs) = ArrayLiteral <$> mapM (g'' s) vs
   g' s (ObjectLiteral vs) = ObjectLiteral <$> mapM (sndM (g'' s)) vs
+  g' s (ObjectConstructor vs) = ObjectConstructor <$> mapM (sndM $ maybeM (g'' s)) vs
   g' s (TypeClassDictionaryConstructorApp name v) = TypeClassDictionaryConstructorApp name <$> g'' s v
   g' s (Accessor prop v) = Accessor prop <$> g'' s v
   g' s (ObjectUpdate obj vs) = ObjectUpdate <$> g'' s obj <*> mapM (sndM (g'' s)) vs
+  g' s (ObjectUpdater obj vs) = ObjectUpdater <$> g'' s obj <*> mapM (sndM $ maybeM (g'' s)) vs
   g' s (Abs name v) = Abs name <$> g'' s v
   g' s (App v1 v2) = App <$> g'' s v1 <*> g'' s v2
   g' s (IfThenElse v1 v2 v3) = IfThenElse <$> g'' s v1 <*> g'' s v2 <*> g'' s v3

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -55,8 +55,8 @@ import Language.PureScript.Sugar.TypeDeclarations as S
 --
 desugar :: [Module] -> SupplyT (Either ErrorStack) [Module]
 desugar = map removeSignedLiterals
-          >>> map desugarObjectConstructors
-          >>> mapM desugarDoModule
+          >>> mapM desugarObjectConstructors
+          >=> mapM desugarDoModule
           >=> desugarCasesModule
           >=> lift . (desugarTypeDeclarationsModule
                       >=> desugarImports

--- a/src/Language/PureScript/Sugar/ObjectWildcards.hs
+++ b/src/Language/PureScript/Sugar/ObjectWildcards.hs
@@ -16,35 +16,43 @@ module Language.PureScript.Sugar.ObjectWildcards (
   desugarObjectConstructors
 ) where
 
+import Control.Applicative
 import Control.Arrow (second)
 
 import Data.List (partition)
-import Data.Maybe (isJust, fromJust)
+import Data.Maybe (isJust, fromJust, catMaybes)
 
 import Language.PureScript.AST
+import Language.PureScript.Errors
 import Language.PureScript.Names
+import Language.PureScript.Supply
 
-desugarObjectConstructors :: Module -> Module
-desugarObjectConstructors (Module mn ds exts) = Module mn (map desugarDecl ds) exts
+desugarObjectConstructors :: Module -> SupplyT (Either ErrorStack) Module
+desugarObjectConstructors (Module mn ds exts) = Module mn <$> mapM desugarDecl ds <*> pure exts
   where
 
-  desugarDecl :: Declaration -> Declaration
-  (desugarDecl, _, _) = everywhereOnValues id desugarExpr id
+  desugarDecl :: Declaration -> SupplyT (Either ErrorStack) Declaration
+  (desugarDecl, _, _) = everywhereOnValuesM return desugarExpr return
 
-  desugarExpr :: Expr -> Expr
+  desugarExpr :: Expr -> SupplyT (Either ErrorStack) Expr
   desugarExpr (ObjectConstructor ps) = wrapLambda ObjectLiteral ps
   desugarExpr (ObjectUpdater obj ps) = wrapLambda (ObjectUpdate obj) ps
-  desugarExpr (ObjectGetter prop) =
-    Abs (Left (Ident "obj")) (Accessor prop (Var (Qualified Nothing (Ident "obj"))))
-  desugarExpr e = e
+  desugarExpr (ObjectGetter prop) = do
+    arg <- Ident <$> freshName
+    return $ Abs (Left arg) (Accessor prop (Var (Qualified Nothing arg)))
+  desugarExpr e = return e
 
-  wrapLambda :: ([(String, Expr)] -> Expr) -> [(String, Maybe Expr)] -> Expr
+  wrapLambda :: ([(String, Expr)] -> Expr) -> [(String, Maybe Expr)] -> SupplyT (Either ErrorStack) Expr
   wrapLambda mkVal ps =
     let (props, args) = partition (isJust . snd) ps
     in if null args
-       then mkVal $ second fromJust `map` props
-       else foldr (Abs . Left . Ident . fst) (mkVal (mkProp `map` ps)) args
+       then return . mkVal $ second fromJust `map` props
+       else do
+        (args', ps') <- unzip <$> mapM mkProp ps
+        return $ foldr (Abs . Left) (mkVal ps') (catMaybes args')
 
-  mkProp :: (String, Maybe Expr) -> (String, Expr)
-  mkProp (name, Just e) = (name, e)
-  mkProp (name, Nothing) = (name, Var (Qualified Nothing (Ident name)))
+  mkProp :: (String, Maybe Expr) -> SupplyT (Either ErrorStack) (Maybe Ident, (String, Expr))
+  mkProp (name, Just e) = return (Nothing, (name, e))
+  mkProp (name, Nothing) = do
+    arg <- Ident <$> freshName
+    return (Just arg, (name, Var (Qualified Nothing arg)))


### PR DESCRIPTION
Well that took a bit longer than expected. I hadn't implemented all the traversals the first time so it seemed to be failing randomly after changing to use the `M` traversal... anyway, sorted now, and I've added traversals for the `OperatorSection` stuff too. They'll probably never actually be reached, but I'd like to avoid anything like the problem I just had happening again.