### PR TITLE
Scoped type variables #347

### DIFF
--- a/examples/passing/ScopedTypeVariables.purs
+++ b/examples/passing/ScopedTypeVariables.purs
@@ -6,4 +6,16 @@ test1 f x = g (g x)
   g :: a -> a
   g y = f (f y)
 
+test2 :: forall a. (a -> a) -> a -> a
+test2 = h
+  where
+  h :: forall b. (b -> b) -> b -> b
+  h f x = g (g x)
+    where
+    g :: b -> b
+    g y = f (f y)
+
+test3 :: Number 
+test3 = ((\b -> b :: b) :: forall b. b -> b) 0
+
 main = Debug.Trace.trace "Done"

--- a/examples/passing/ScopedTypeVariables.purs
+++ b/examples/passing/ScopedTypeVariables.purs
@@ -18,4 +18,17 @@ test2 = h
 test3 :: Number 
 test3 = ((\b -> b :: b) :: forall b. b -> b) 0
 
+test4 :: forall a. (a -> a) -> a -> a
+test4 = h
+  where
+  h :: forall b. (b -> b) -> b -> b
+  h f x = g (g x)
+    where
+    g :: b -> b
+    g y = j (f (f y))
+      where
+      j :: forall b. b -> b
+      j x = x
+
+
 main = Debug.Trace.trace "Done"

--- a/examples/passing/ScopedTypeVariables.purs
+++ b/examples/passing/ScopedTypeVariables.purs
@@ -1,0 +1,9 @@
+module Main where
+
+test1 :: forall a. (a -> a) -> a -> a
+test1 f x = g (g x)
+  where
+  g :: a -> a
+  g y = f (f y)
+
+main = Debug.Trace.trace "Done"

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -136,7 +136,12 @@ data TypeKind
   -- |
   -- A local type variable
   --
-  | LocalTypeVariable deriving (Show, Eq, Data, Typeable)
+  | LocalTypeVariable
+  -- |
+  -- A scoped type variable
+  --
+  | ScopedTypeVar Type
+   deriving (Show, Eq, Data, Typeable)
 
 -- |
 -- The type ('data' or 'newtype') of a data type declaration

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -140,7 +140,7 @@ data TypeKind
   -- |
   -- A scoped type variable
   --
-  | ScopedTypeVar Type
+  | ScopedTypeVar
    deriving (Show, Eq, Data, Typeable)
 
 -- |

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -60,7 +60,7 @@ bindTypes newNames action = do
 -- Temporarily bind a collection of names to types
 --
 withScopedTypeVars :: (Functor m, MonadState CheckState m) => ModuleName -> [(String, Kind)] -> m a -> m a
-withScopedTypeVars mn ks = bindTypes (M.fromList (map (\(name, k) -> (Qualified (Just mn) (ProperName name), (k, ScopedTypeVar (TypeVar name)))) ks))
+withScopedTypeVars mn ks = bindTypes (M.fromList (map (\(name, k) -> (Qualified (Just mn) (ProperName name), (k, ScopedTypeVar))) ks))
 
 -- |
 -- Temporarily make a collection of type class dictionaries available

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -57,6 +57,12 @@ bindTypes newNames action = do
   return a
 
 -- |
+-- Temporarily bind a collection of names to types
+--
+withScopedTypeVars :: (Functor m, MonadState CheckState m) => ModuleName -> [(String, Kind)] -> m a -> m a
+withScopedTypeVars mn ks = bindTypes (M.fromList (map (\(name, k) -> (Qualified (Just mn) (ProperName name), (k, ScopedTypeVar (TypeVar name)))) ks))
+
+-- |
 -- Temporarily make a collection of type class dictionaries available
 --
 withTypeClassDictionaries :: (MonadState CheckState m) => [TypeClassDictionaryInScope] -> m a -> m a

--- a/src/Language/PureScript/TypeChecker/Skolems.hs
+++ b/src/Language/PureScript/TypeChecker/Skolems.hs
@@ -71,6 +71,7 @@ skolemizeTypesInValue :: String -> Int -> SkolemScope -> Expr -> Expr
 skolemizeTypesInValue ident sko scope = let (_, f, _) = everywhereOnValues id go id in f
   where
   go (SuperClassDictionary c ts) = SuperClassDictionary c (map (skolemize ident sko scope) ts)
+  go (TypedValue check val ty) = TypedValue check val (skolemize ident sko scope ty)
   go other = other
 
 -- |

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -134,7 +134,7 @@ checkTypedBindingGroupElement mn (ident, (val', ty, checkType)) dict = do
   ty' <- replaceTypeWildcards ty
   -- Kind check
   (kind, args) <- liftCheck $ kindOfWithScopedVars ty
-  guardWith (strMsg $ "Expected type of kind *, was " ++ prettyPrintKind kind) $ kind == Star
+  checkTypeKind kind
   -- Check the type with the new names in scope
   ty'' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty'
   val'' <- if checkType
@@ -183,10 +183,8 @@ replaceTypeClassDictionaries mn =
 -- |
 -- Check the kind of a type, failing if it is not of kind *.
 --
-checkTypeKind :: ModuleName -> Type -> UnifyT t Check ()
-checkTypeKind moduleName ty = do
-  kind <- liftCheck $ kindOf moduleName ty
-  guardWith (strMsg $ "Expected type of kind *, was " ++ prettyPrintKind kind) $ kind == Star
+checkTypeKind :: Kind -> UnifyT t Check ()
+checkTypeKind kind = guardWith (strMsg $ "Expected type of kind *, was " ++ prettyPrintKind kind) $ kind == Star
 
 -- |
 -- Remove any ForAlls and ConstrainedType constructors in a type by introducing new unknowns
@@ -293,9 +291,10 @@ infer' (SuperClassDictionary className tys) = do
   return $ TypeClassDictionary False (className, tys) dicts
 infer' (TypedValue checkType val ty) = do
   Just moduleName <- checkCurrentModule <$> get
-  checkTypeKind moduleName ty
+  (kind, args) <- liftCheck $ kindOfWithScopedVars ty
+  checkTypeKind kind
   ty' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty
-  val' <- if checkType then check val ty' else return val
+  val' <- if checkType then withScopedTypeVars moduleName args (check val ty') else return val
   return $ TypedValue True val' ty'
 infer' (PositionedValue pos _ val) = rethrowWithPosition pos $ infer' val
 infer' _ = error "Invalid argument to infer"
@@ -304,10 +303,11 @@ inferLetBinding :: [Declaration] -> [Declaration] -> Expr -> (Expr -> UnifyT Typ
 inferLetBinding seen [] ret j = (,) seen <$> makeBindingGroupVisible (j ret)
 inferLetBinding seen (ValueDeclaration ident nameKind [] (Right (tv@(TypedValue checkType val ty))) : rest) ret j = do
   Just moduleName <- checkCurrentModule <$> get
-  checkTypeKind moduleName ty
+  (kind, args) <- liftCheck $ kindOfWithScopedVars ty
+  checkTypeKind kind
   let dict = M.singleton (moduleName, ident) (ty, nameKind, Undefined)
   ty' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty
-  TypedValue _ val' ty'' <- if checkType then bindNames dict (check val ty') else return tv
+  TypedValue _ val' ty'' <- if checkType then withScopedTypeVars moduleName args (bindNames dict (check val ty')) else return tv
   bindNames (M.singleton (moduleName, ident) (ty'', nameKind, Defined)) $ inferLetBinding (seen ++ [ValueDeclaration ident nameKind [] (Right (TypedValue checkType val' ty''))]) rest ret j
 inferLetBinding seen (ValueDeclaration ident nameKind [] (Right val) : rest) ret j = do
   valTy <- fresh
@@ -507,14 +507,15 @@ check' (SuperClassDictionary className tys) _ = do
   return $ TypeClassDictionary False (className, tys) dicts
 check' (TypedValue checkType val ty1) ty2 = do
   Just moduleName <- checkCurrentModule <$> get
-  checkTypeKind moduleName ty1
+  (kind, args) <- liftCheck $ kindOfWithScopedVars ty1
+  checkTypeKind kind
   ty1' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty1
   ty2' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty2
   val' <- subsumes (Just val) ty1' ty2'
   case val' of
     Nothing -> throwError . strMsg $ "Unable to check type subsumption"
     Just val'' -> do
-      val''' <- if checkType then check val'' ty2' else return val''
+      val''' <- if checkType then withScopedTypeVars moduleName args (check val'' ty2') else return val''
       return $ TypedValue checkType (TypedValue True val''' ty1') ty2'
 check' (Case vals binders) ret = do
   vals' <- mapM infer vals
@@ -562,7 +563,7 @@ check' val ty | containsTypeSynonyms ty = do
   ty' <- introduceSkolemScope <=< expandAllTypeSynonyms <=< replaceTypeWildcards $ ty
   check val ty'
 check' val kt@(KindedType ty kind) = do
-  guardWith (strMsg $ "Expected type of kind *, was " ++ prettyPrintKind kind) $ kind == Star
+  checkTypeKind kind
   val' <- check' val ty
   return $ TypedValue True val' kt
 check' (PositionedValue pos _ val) ty =


### PR DESCRIPTION
@garyb @joneshf Would you please review this?

High level overview:

- Kind inference updated to peel off top-level `forall`s and return the kinds of their bound variables.
- Skolems can now have their kind inferred, by using the handily stored type variable name they originated from.
- `withScopedTypeVars` brings scoped type variable kinds into scope.
- `skolemizeTypesInValue` updated to skolemize type annotations.

Still TODO:

- [x] Remove `Type` from `ScopedTypeVar` constructor.
- [x] Handle scoped type vars in `let` bindings.