### PR TITLE
A simple attempt at operator aliases, fix #806

### DIFF
--- a/examples/passing/OperatorAlias.purs
+++ b/examples/passing/OperatorAlias.purs
@@ -1,0 +1,17 @@
+module Main where
+
+data Maybe a = Nothing | Just a
+
+infixl 4 ? as orElse
+
+(?) :: forall a. Maybe a -> a -> a
+(?) Nothing a = a
+(?) (Just a) _ = a
+
+test1 x = x ? 0
+
+test2 x = x ? 0
+  where
+  (?) _ y = y
+
+main = Debug.Trace.trace "Done"

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -180,9 +180,9 @@ data Declaration
   --
   | ExternInstanceDeclaration Ident [Constraint] (Qualified ProperName) [Type]
   -- |
-  -- A fixity declaration (fixity data, operator name)
+  -- A fixity declaration (fixity data, operator name, replacement)
   --
-  | FixityDeclaration Fixity String
+  | FixityDeclaration Fixity String (Maybe String)
   -- |
   -- A module import (module name, qualified/unqualified/hiding, optional "qualified as" name)
   --

--- a/src/Language/PureScript/CodeGen/Externs.hs
+++ b/src/Language/PureScript/CodeGen/Externs.hs
@@ -45,10 +45,10 @@ moduleToPs (Module moduleName ds (Just exts)) env = intercalate "\n" . execWrite
 
     declToPs :: Declaration -> Writer [String] ()
     declToPs (ImportDeclaration mn _ _) = tell ["import " ++ show mn ++ " ()"]
-    declToPs (FixityDeclaration (Fixity assoc prec) op) =
+    declToPs (FixityDeclaration (Fixity assoc prec) op repl) =
       case find exportsOp exts of
         Nothing -> return ()
-        Just _ -> tell [ unwords [ show assoc, show prec, op ] ]
+        Just _ -> tell [ unwords $ [ show assoc, show prec, op ] ++ maybe [] (\s -> [ "as", s ]) repl ]
       where
       exportsOp :: DeclarationRef -> Bool
       exportsOp (PositionedDeclarationRef _ _ r) = exportsOp r

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -142,7 +142,11 @@ parseFixityDeclaration = do
   fixity <- parseFixity
   indented
   name <- symbol
-  return $ FixityDeclaration fixity name
+  repl <- P.optionMaybe $ do
+    indented
+    reserved "as"
+    identifier
+  return $ FixityDeclaration fixity name repl
 
 parseImportDeclaration :: TokenParser Declaration
 parseImportDeclaration = do

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -31,13 +31,16 @@ import Language.PureScript.Names
 import Language.PureScript.Supply
 
 import Control.Applicative
-import Control.Monad.State
+import Control.Monad
 import Control.Monad.Error.Class
 
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Monoid ((<>))
 import Data.Function (on)
 import Data.Functor.Identity
 import Data.List (groupBy, sortBy)
+
+import qualified Data.Map as M
 
 import qualified Text.Parsec as P
 import qualified Text.Parsec.Pos as P
@@ -45,15 +48,125 @@ import qualified Text.Parsec.Expr as P
 
 import qualified Language.PureScript.Constants as C
 
+type Chain = [Either Expr Expr]
+
 -- |
 -- Remove explicit parentheses and reorder binary operator applications
 --
 rebracket :: [Module] -> Either ErrorStack [Module]
 rebracket ms = do
   let fixities = concatMap collectFixities ms
-  ensureNoDuplicates $ map (\(i, pos, _) -> (i, pos)) fixities
-  let opTable = customOperatorTable $ map (\(i, _, f) -> (i, f)) fixities
-  mapM (rebracketModule opTable) ms
+  ensureNoDuplicates $ map (\(i, pos, _, _) -> (i, pos)) fixities
+  let aliases = M.fromList $ mapMaybe (\(i, _, _, r) -> (,) i <$> r) fixities
+  let opTable = customOperatorTable $ map (\(i, _, f, r) -> (i, f, r)) fixities
+  mapM (rebracketModule aliases opTable) ms
+  where
+      
+  collectFixities :: Module -> [(Qualified Ident, SourceSpan, Fixity, Maybe Ident)]
+  collectFixities (Module moduleName ds _) = concatMap collect ds
+    where
+    collect :: Declaration -> [(Qualified Ident, SourceSpan, Fixity, Maybe Ident)]
+    collect (PositionedDeclaration pos _ (FixityDeclaration fixity name repl)) = 
+      [(Qualified (Just moduleName) (Op name), pos, fixity, Ident <$> repl)]
+    collect FixityDeclaration{} = error "Fixity without srcpos info"
+    collect _ = []
+
+  ensureNoDuplicates :: [(Qualified Ident, SourceSpan)] -> Either ErrorStack ()
+  ensureNoDuplicates m = go $ sortBy (compare `on` fst) m
+    where
+    go [] = return ()
+    go [_] = return ()
+    go ((x@(Qualified (Just mn) name), _) : (y, pos) : _) | x == y =
+      rethrow (strMsg ("Error in module " ++ show mn) <>) $
+        rethrowWithPosition pos $
+          throwError $ mkErrorStack ("Redefined fixity for " ++ show name) Nothing
+    go (_ : rest) = go rest
+  
+  customOperatorTable :: [(Qualified Ident, Fixity, Maybe Ident)] -> [[(Qualified Ident, Expr -> Expr -> Expr, Associativity)]]
+  customOperatorTable fixities =
+    let
+      applyUserOp ident t1 = App (App (Var ident) t1)
+      userOps = map (\(name@(Qualified mn name'), Fixity a p, repl) -> (name, applyUserOp (Qualified mn (fromMaybe name' repl)), p, a)) fixities
+      sorted = sortBy (flip compare `on` (\(_, _, p, _) -> p)) userOps
+      groups = groupBy ((==) `on` (\(_, _, p, _) -> p)) sorted
+    in
+      map (map (\(name, f, _, a) -> (name, f, a))) groups
+
+  rebracketModule :: M.Map (Qualified Ident) Ident -> [[(Qualified Ident, Expr -> Expr -> Expr, Associativity)]] -> Module -> Either ErrorStack Module
+  rebracketModule aliases opTable (Module mn ds exts) =
+    let (f, _, _) = everywhereOnValuesTopDownM return matchOperators return
+    in Module mn <$> (map (removeParens . replaceFunctionNames) <$> parU ds f) <*> pure (map updateExports <$> exts)
+    where
+    removeParens :: Declaration -> Declaration
+    removeParens =
+      let (f, _, _) = everywhereOnValues id go id
+      in f
+      where
+      go (Parens val) = val
+      go val = val
+      
+    updateExports :: DeclarationRef -> DeclarationRef
+    updateExports (ValueRef ident) = let ident' = M.lookup (Qualified (Just mn) ident) aliases 
+                                     in ValueRef (fromMaybe ident ident')
+    updateExports (PositionedDeclarationRef ss com ref) = PositionedDeclarationRef ss com (updateExports ref)
+    updateExports other = other
+    
+    replaceFunctionNames :: Declaration -> Declaration
+    replaceFunctionNames (TypeDeclaration ident ty) =
+      let ident' = M.lookup (Qualified (Just mn) ident) aliases
+      in TypeDeclaration (fromMaybe ident ident') ty
+    replaceFunctionNames (ValueDeclaration ident a b c) =
+      let ident' = M.lookup (Qualified (Just mn) ident) aliases
+      in ValueDeclaration (fromMaybe ident ident') a b c
+    replaceFunctionNames (PositionedDeclaration ss com d) = 
+      PositionedDeclaration ss com (replaceFunctionNames d)
+    replaceFunctionNames other = other
+    
+    matchOperators :: Expr -> Either ErrorStack Expr
+    matchOperators = parseChains
+      where
+      parseChains :: Expr -> Either ErrorStack Expr
+      parseChains b@BinaryNoParens{} = bracketChain (extendChain b)
+      parseChains other = return other
+      
+      extendChain :: Expr -> Chain
+      extendChain (BinaryNoParens op l r) = Left l : Right op : extendChain r
+      extendChain other = [Left other]
+      
+      bracketChain :: Chain -> Either ErrorStack Expr
+      bracketChain = either (Left . (`mkErrorStack` Nothing) . show) Right . P.parse (P.buildExpressionParser ops parseValue <* P.eof) "operator expression"
+      
+      ops = [P.Infix (P.try (parseTicks >>= \op -> return (\t1 t2 -> App (App op t1) t2))) P.AssocLeft]
+            : map (map (\(name, f, a) -> P.Infix (P.try (matchOp name) >> return f) (toAssoc a))) opTable
+            ++ [[ P.Infix (P.try (parseOp >>= \ident -> return (\t1 t2 -> App (App (Var ident) t1) t2))) P.AssocLeft ]]
+    
+      toAssoc :: Associativity -> P.Assoc
+      toAssoc Infixl = P.AssocLeft
+      toAssoc Infixr = P.AssocRight
+      toAssoc Infix  = P.AssocNone
+      
+      token :: (P.Stream s Identity t, Show t) => (t -> Maybe a) -> P.Parsec s u a
+      token = P.token show (const (P.initialPos ""))
+      
+      parseValue :: P.Parsec Chain () Expr
+      parseValue = token (either Just (const Nothing)) P.<?> "expression"
+      
+      parseOp :: P.Parsec Chain () (Qualified Ident)
+      parseOp = token (either (const Nothing) fromOp) P.<?> "operator"
+        where
+        fromOp (Var q@(Qualified _ (Op _))) = Just q
+        fromOp _ = Nothing
+      
+      parseTicks :: P.Parsec Chain () Expr
+      parseTicks = token (either (const Nothing) fromOther) P.<?> "infix function"
+        where
+        fromOther (Var (Qualified _ (Op _))) = Nothing
+        fromOther v = Just v
+      
+      matchOp :: Qualified Ident -> P.Parsec Chain () ()
+      matchOp op = do
+        ident <- parseOp
+        guard $ ident == op
 
 removeSignedLiterals :: Module -> Module
 removeSignedLiterals (Module mn ds exts) = Module mn (map f' ds) exts
@@ -62,93 +175,6 @@ removeSignedLiterals (Module mn ds exts) = Module mn (map f' ds) exts
 
   go (UnaryMinus val) = App (Var (Qualified (Just (ModuleName [ProperName C.prelude])) (Ident C.negate))) val
   go other = other
-
-rebracketModule :: [[(Qualified Ident, Expr -> Expr -> Expr, Associativity)]] -> Module -> Either ErrorStack Module
-rebracketModule opTable (Module mn ds exts) =
-  let (f, _, _) = everywhereOnValuesTopDownM return (matchOperators opTable) return
-  in Module mn <$> (map removeParens <$> parU ds f) <*> pure exts
-
-removeParens :: Declaration -> Declaration
-removeParens =
-  let (f, _, _) = everywhereOnValues id go id
-  in f
-  where
-  go (Parens val) = val
-  go val = val
-
-collectFixities :: Module -> [(Qualified Ident, SourceSpan, Fixity)]
-collectFixities (Module moduleName ds _) = concatMap collect ds
-  where
-  collect :: Declaration -> [(Qualified Ident, SourceSpan, Fixity)]
-  collect (PositionedDeclaration pos _ (FixityDeclaration fixity name)) = [(Qualified (Just moduleName) (Op name), pos, fixity)]
-  collect FixityDeclaration{} = error "Fixity without srcpos info"
-  collect _ = []
-
-ensureNoDuplicates :: [(Qualified Ident, SourceSpan)] -> Either ErrorStack ()
-ensureNoDuplicates m = go $ sortBy (compare `on` fst) m
-  where
-  go [] = return ()
-  go [_] = return ()
-  go ((x@(Qualified (Just mn) name), _) : (y, pos) : _) | x == y =
-    rethrow (strMsg ("Error in module " ++ show mn) <>) $
-      rethrowWithPosition pos $
-        throwError $ mkErrorStack ("Redefined fixity for " ++ show name) Nothing
-  go (_ : rest) = go rest
-
-customOperatorTable :: [(Qualified Ident, Fixity)] -> [[(Qualified Ident, Expr -> Expr -> Expr, Associativity)]]
-customOperatorTable fixities =
-  let
-    applyUserOp ident t1 = App (App (Var ident) t1)
-    userOps = map (\(name, Fixity a p) -> (name, applyUserOp name, p, a)) fixities
-    sorted = sortBy (flip compare `on` (\(_, _, p, _) -> p)) userOps
-    groups = groupBy ((==) `on` (\(_, _, p, _) -> p)) sorted
-  in
-    map (map (\(name, f, _, a) -> (name, f, a))) groups
-
-type Chain = [Either Expr Expr]
-
-matchOperators :: [[(Qualified Ident, Expr -> Expr -> Expr, Associativity)]] -> Expr -> Either ErrorStack Expr
-matchOperators ops = parseChains
-  where
-  parseChains :: Expr -> Either ErrorStack Expr
-  parseChains b@BinaryNoParens{} = bracketChain (extendChain b)
-  parseChains other = return other
-  extendChain :: Expr -> Chain
-  extendChain (BinaryNoParens op l r) = Left l : Right op : extendChain r
-  extendChain other = [Left other]
-  bracketChain :: Chain -> Either ErrorStack Expr
-  bracketChain = either (Left . (`mkErrorStack` Nothing) . show) Right . P.parse (P.buildExpressionParser opTable parseValue <* P.eof) "operator expression"
-  opTable = [P.Infix (P.try (parseTicks >>= \op -> return (\t1 t2 -> App (App op t1) t2))) P.AssocLeft]
-            : map (map (\(name, f, a) -> P.Infix (P.try (matchOp name) >> return f) (toAssoc a))) ops
-            ++ [[ P.Infix (P.try (parseOp >>= \ident -> return (\t1 t2 -> App (App (Var ident) t1) t2))) P.AssocLeft ]]
-
-toAssoc :: Associativity -> P.Assoc
-toAssoc Infixl = P.AssocLeft
-toAssoc Infixr = P.AssocRight
-toAssoc Infix  = P.AssocNone
-
-token :: (P.Stream s Identity t, Show t) => (t -> Maybe a) -> P.Parsec s u a
-token = P.token show (const (P.initialPos ""))
-
-parseValue :: P.Parsec Chain () Expr
-parseValue = token (either Just (const Nothing)) P.<?> "expression"
-
-parseOp :: P.Parsec Chain () (Qualified Ident)
-parseOp = token (either (const Nothing) fromOp) P.<?> "operator"
-  where
-  fromOp (Var q@(Qualified _ (Op _))) = Just q
-  fromOp _ = Nothing
-
-parseTicks :: P.Parsec Chain () Expr
-parseTicks = token (either (const Nothing) fromOther) P.<?> "infix function"
-  where
-  fromOther (Var (Qualified _ (Op _))) = Nothing
-  fromOther v = Just v
-
-matchOp :: Qualified Ident -> P.Parsec Chain () ()
-matchOp op = do
-  ident <- parseOp
-  guard $ ident == op
 
 desugarOperatorSections :: Module -> SupplyT (Either ErrorStack) Module
 desugarOperatorSections (Module mn ds exts) = Module mn <$> mapM goDecl ds <*> pure exts

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -31,6 +31,7 @@ import Data.Monoid ((<>))
 import Data.Foldable (for_)
 import qualified Data.Map as M
 
+import Control.Applicative
 import Control.Monad.State
 import Control.Monad.Error
 
@@ -217,10 +218,10 @@ typeCheckAll mainModuleName moduleName exps = go
         Nothing -> putEnv (env { names = M.insert (moduleName, name) (ty, Extern importTy, Defined) (names env) })
     ds <- go rest
     return $ d : ds
-  go (d@(FixityDeclaration _ name) : rest) = do
+  go (d@(FixityDeclaration _ name repl) : rest) = do
     ds <- go rest
     env <- getEnv
-    guardWith (strMsg ("Fixity declaration with no binding: " ++ name)) $ M.member (moduleName, Op name) $ names env
+    guardWith (strMsg ("Fixity declaration with no binding: " ++ name)) $ M.member (moduleName, fromMaybe (Op name) (Ident <$> repl)) $ names env
     return $ d : ds
   go (d@(ImportDeclaration importedModule _ _) : rest) = do
     tcds <- getTypeClassDictionaries


### PR DESCRIPTION
This doesn't implement the spec that I wrote out in #806, but it allows us to give aliases for top-level fixity declarations, which is a start. They are neither required, nor supported in `where` clauses.

Fully implementing the spec laid out in the issue could be quite difficult, so I'm going to try to do it in stages.

I also tidied up the `Operators` module a bit.

@garyb @joneshf Thoughts?
