### PR TITLE
Support ctags/etags generation

### DIFF
--- a/psc-docs/Ctags.hs
+++ b/psc-docs/Ctags.hs
@@ -1,0 +1,13 @@
+module Ctags (dumpCtags) where
+
+import qualified Language.PureScript as P
+import Tags
+import Data.List (sort)
+
+dumpCtags :: [(String, P.Module)] -> [String]
+dumpCtags = sort . concat . (map renderModCtags)
+
+renderModCtags :: (String, P.Module) -> [String]
+renderModCtags (path, mdl) = sort tagLines
+  where tagLines = map tagLine $ tags mdl
+        tagLine (name, line) = name ++ "\t" ++ path ++ "\t" ++ show line

--- a/psc-docs/Etags.hs
+++ b/psc-docs/Etags.hs
@@ -1,0 +1,15 @@
+module Etags (dumpEtags) where
+
+import qualified Language.PureScript as P
+import Tags
+
+dumpEtags :: [(String, P.Module)] -> [String]
+dumpEtags = concat . (map renderModEtags)
+
+renderModEtags :: (String, P.Module) -> [String]
+renderModEtags (path, mdl) = ["\x0c", path ++ "," ++ show tagsLen] ++ tagLines
+  where tagsLen = sum $ map length tagLines
+        tagLines = map tagLine $ tags mdl
+        tagLine (name, line) = "\x7f" ++ name ++ "\x01" ++ show line ++ ","
+
+

--- a/psc-docs/Main.hs
+++ b/psc-docs/Main.hs
@@ -30,21 +30,37 @@ import qualified Paths_purescript as Paths
 import System.Exit (exitSuccess, exitFailure)
 import System.IO (hPutStrLn, stderr)
 
+import Etags
+import Ctags
+
+-- Available output formats
+data Format = Markdown -- Output documentation in Markdown format
+               | Ctags -- Output ctags symbol index suitable for use with vi
+               | Etags -- Output etags symbol index suitable for use with emacs
+
 data PSCDocsOptions = PSCDocsOptions
-  { pscdInputFiles  :: [FilePath]
+  { pscdFormat :: Format
+  , pscdInputFiles  :: [FilePath]
   }
 
 docgen :: PSCDocsOptions -> IO ()
-docgen (PSCDocsOptions input) = do
+docgen (PSCDocsOptions fmt input) = do
   e <- P.parseModulesFromFiles (fromMaybe "") <$> mapM (fmap (first Just) . parseFile) (nub input)
   case e of
     Left err -> do
       hPutStrLn stderr $ show err
       exitFailure
     Right ms -> do
-      putStrLn . runDocs $ renderModules (map snd ms)
+      case fmt of
+       Markdown -> putStrLn . runDocs $ renderModules (map snd ms)
+       Etags -> ldump $ dumpEtags $ pairs ms
+       Ctags -> ldump $ dumpCtags $ pairs ms
       exitSuccess
-
+  where pairs :: [(Maybe String, m)] -> [(String, m)]
+        pairs = map (\(k,m) -> (fromMaybe "" k,m))
+        ldump :: [String] -> IO ()
+        ldump = mapM_ putStrLn
+    
 parseFile :: FilePath -> IO (FilePath, String)
 parseFile input = (,) input <$> readFile input
 
@@ -222,8 +238,20 @@ inputFile = strArgument $
      metavar "FILE"
   <> help "The input .purs file(s)"
 
+instance Read Format where
+    readsPrec _ "etags" = [(Etags, "")]
+    readsPrec _ "ctags" = [(Ctags, "")]
+    readsPrec _ "markdown" = [(Markdown, "")]
+    readsPrec _ _ = []    
+
+format :: Parser Format
+format = option auto $ value Markdown
+         <> long "format"
+         <> metavar "FORMAT"
+         <> help "Set output FORMAT (markdown | etags | ctags)"  
+
 pscDocsOptions :: Parser PSCDocsOptions
-pscDocsOptions = PSCDocsOptions <$> many inputFile
+pscDocsOptions = PSCDocsOptions <$> format <*> many inputFile
 
 main :: IO ()
 main = execParser opts >>= docgen

--- a/psc-docs/Tags.hs
+++ b/psc-docs/Tags.hs
@@ -1,0 +1,18 @@
+module Tags where
+
+import qualified Language.PureScript as P
+
+tags :: P.Module -> [(String, Int)]
+tags = concatMap dtags . P.exportedDeclarations
+  where dtags (P.PositionedDeclaration sp _ d) = map tag $ names d
+          where tag name = (name, line)
+                line = P.sourcePosLine $ P.spanStart sp
+        dtags _ = []
+        names (P.DataDeclaration _ name _ dcons) = P.runProperName name : consNames
+          where consNames = map (\(cname, _) -> P.runProperName cname) dcons
+        names (P.TypeDeclaration ident _) = [show ident]
+        names (P.ExternDeclaration _ ident _ _) = [show ident]
+        names (P.TypeSynonymDeclaration name _ _) = [P.runProperName name]
+        names (P.TypeClassDeclaration name _ _ _) = [P.runProperName name]
+        names (P.TypeInstanceDeclaration name _ _ _ _) = [show name]
+        names _ = []


### PR DESCRIPTION
This is my attempt at #890.

To try it with vi:

    psc-docs --format ctags `find bower_components src test -name \*.purs -not -name externs.purs` `find bower_components src test -name externs.purs`  > tags
vi src/Main.purs
position the cursor on top of a symbol and press CTRL+], go back with CTRL+T.

With emacs:

    psc-docs --format etags `find bower_components src test -name \*.purs -not -name externs.purs` `find bower_components src test -name externs.purs`  > TAGS
emacs src/Main.purs
position the cursor on top of a symbol and press ALT+.