### PR TITLE
Expose version at runtime

### DIFF
--- a/src/Language/PureScript.hs
+++ b/src/Language/PureScript.hs
@@ -27,6 +27,7 @@ module Language.PureScript
   , MonadMake(..)
   , make
   , prelude
+  , version
   ) where
 
 import Data.FileEmbed (embedFile)
@@ -34,6 +35,7 @@ import Data.Function (on)
 import Data.List (sortBy, groupBy, intercalate)
 import Data.Maybe (fromMaybe)
 import Data.Time.Clock
+import Data.Version (Version)
 import qualified Data.Traversable as T (traverse)
 import qualified Data.ByteString.UTF8 as BU
 import qualified Data.Map as M
@@ -65,6 +67,8 @@ import Language.PureScript.TypeChecker as P
 import Language.PureScript.Types as P
 import qualified Language.PureScript.CoreFn as CoreFn
 import qualified Language.PureScript.Constants as C
+
+import qualified Paths_purescript as Paths
 
 -- |
 -- Compile a collection of modules
@@ -267,3 +271,6 @@ importPrelude = addDefaultImport (ModuleName [ProperName C.prelude])
 
 prelude :: String
 prelude = BU.toString $(embedFile "prelude/prelude.purs")
+
+version :: Version
+version = Paths.version


### PR DESCRIPTION
This commit allows programs that depend on `purescript` to ask what
version of it they've got at runtime. This was motivated by Pursuit,
where we want to show which version of a particular package is being
used. Specifically, we want to be able to say things like "this is the
documentation for the prelude in PureScript 0.6.8".

refs purescript/pursuit#34