### PR TITLE
Fix functor law in prelude documentation

### DIFF
--- a/prelude/README.md
+++ b/prelude/README.md
@@ -243,7 +243,7 @@ types use the type constructor `f` to represent some computational context.
 `Functor` instances should satisfy the following laws:
 
 - Identity: `(<$>) id = id`
-- Composition: `(<$>) (f <<< g) = (<$> f) <<< (<$> g)`
+- Composition: `(<$>) (f <<< g) = (f <$>) <<< (g <$>)`
 
 
 #### `(<#>)`

--- a/prelude/prelude.purs
+++ b/prelude/prelude.purs
@@ -229,7 +229,7 @@ module Prelude
   -- | `Functor` instances should satisfy the following laws:
   -- |
   -- | - Identity: `(<$>) id = id`
-  -- | - Composition: `(<$>) (f <<< g) = (<$> f) <<< (<$> g)`
+  -- | - Composition: `(<$>) (f <<< g) = (f <$>) <<< (g <$>)`
   -- |
   class Functor f where
     (<$>) :: forall a b. (a -> b) -> f a -> f b


### PR DESCRIPTION
I just realised the arguments to `<$>` were the wrong way around while trying to write a QuickCheck property to verify well-behaved-ness of a Functor instance.