### PR TITLE
Make module imports relative.

### DIFF
--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -80,7 +80,7 @@ moduleToJs (Module coms mn imps exps foreigns decls) = do
   importToJs mn' = do
     additional <- asks optionsAdditional
     let moduleBody = case additional of
-          MakeOptions -> JSApp (JSVar "require") [JSStringLiteral (runModuleName mn')]
+          MakeOptions -> JSApp (JSVar "require") [JSStringLiteral ("../" ++ runModuleName mn')]
           CompileOptions ns _ _ -> JSAccessor (moduleNameToJs mn') (JSVar ns)
     return $ JSVariableIntroduction (moduleNameToJs mn') (Just moduleBody)
 


### PR DESCRIPTION
This pull request addresses the issue described in https://github.com/purescript/purescript/issues/352#issuecomment-68677435.

This means that modules can be `require`d without setting `process.env.NODE_PATH` or renaming the output directory to `node_modules`.