### PR TITLE
fix docs for (#)

### DIFF
--- a/prelude/prelude.purs
+++ b/prelude/prelude.purs
@@ -139,7 +139,7 @@ module Prelude
   -- | ```
   -- |
   -- | `(#)` is different from [`($)`](#-1) because it is left-infix instead of right, so
-  -- | `x # a # b # c # d` = `(((x a) b) c) d`
+  -- | `x # a # b # c # d` = `(((x # a) # b) # c) # d`
   -- |
   (#) :: forall a b. a -> (a -> b) -> b
   (#) x f = f x


### PR DESCRIPTION
We could alternatively write `d (c (b (a x)))` but I think this is a bit
clearer.