### PR TITLE
First stab at better imports in psci

### DIFF
--- a/psci/Commands.hs
+++ b/psci/Commands.hs
@@ -66,4 +66,13 @@ data Command
   --
   | Show String
 
+-- | All of the data that is contained by an ImportDeclaration in the AST.
+-- That is:
+--
+-- * A module name, the name of the module which is being imported
+-- * An ImportDeclarationType which specifies whether there is an explicit
+--   import list, a hiding list, or neither.
+-- * If the module is imported qualified, its qualified name in the importing
+--   module. Otherwise, Nothing.
+--
 type ImportedModule = (ModuleName, ImportDeclarationType, Maybe ModuleName)

--- a/psci/Commands.hs
+++ b/psci/Commands.hs
@@ -50,9 +50,9 @@ data Command
   --
   | Reset
   -- |
-  -- Binds a value to a name
+  -- Add some declarations to the current evaluation context.
   --
-  | Let [Declaration]
+  | Decls [Declaration]
   -- |
   -- Find the type of an expression
   --

--- a/psci/Commands.hs
+++ b/psci/Commands.hs
@@ -32,7 +32,7 @@ data Command
   -- |
   -- Import a module from a loaded file
   --
-  | Import ModuleName
+  | Import ImportedModule
   -- |
   -- Browse a module
   --
@@ -65,3 +65,5 @@ data Command
   -- Show command
   --
   | Show String
+
+type ImportedModule = (ModuleName, ImportDeclarationType, Maybe ModuleName)

--- a/psci/Directive.hs
+++ b/psci/Directive.hs
@@ -21,7 +21,6 @@ data Directive
   = Help
   | Quit
   | Reset
-  | Import
   | Browse
   | Load
   | Type
@@ -36,7 +35,6 @@ commands :: Directive -> [String]
 commands Help = ["?", "help"]
 commands Quit = ["quit"]
 commands Reset = ["reset"]
-commands Import = ["import"]
 commands Browse = ["browse"]
 commands Load = ["load", "module"]
 commands Type = ["type"]
@@ -66,7 +64,6 @@ help =
   [ (Help,   "",         "Show this help menu")
   , (Quit,   "",         "Quit PSCi")
   , (Reset,  "",         "Reset")
-  , (Import, "<module>", "Import <module> for use in PSCI")
   , (Browse, "<module>", "Browse <module>")
   , (Load,   "<file>",   "Load <file> for importing")
   , (Type,   "<expr>",   "Show the type of <expr>")

--- a/psci/Main.hs
+++ b/psci/Main.hs
@@ -113,7 +113,7 @@ updateLets ds st = st { psciLetBindings = psciLetBindings st ++ ds }
 -- Load the necessary modules.
 --
 defaultImports :: [C.ImportedModule]
-defaultImports = [(P.ModuleName [P.ProperName "Prelude"], D.Unqualified, Nothing)]
+defaultImports = [(P.ModuleName [P.ProperName "Prelude"], D.Implicit, Nothing)]
 
 -- |
 -- Locates the node executable.
@@ -476,8 +476,8 @@ handleShowImportedModules = do
       Just mn' -> "qualified " ++ N.runModuleName mn ++ " as " ++ N.runModuleName mn'
       Nothing  -> N.runModuleName mn ++ " " ++ showDeclType declType
 
-  showDeclType D.Unqualified = ""
-  showDeclType (D.Qualifying refs) = refsList refs
+  showDeclType D.Implicit = ""
+  showDeclType (D.Explicit refs) = refsList refs
   showDeclType (D.Hiding refs) = "hiding " ++ refsList refs
   refsList refs = "(" ++ commaList (map showRef refs) ++ ")"
 

--- a/psci/Main.hs
+++ b/psci/Main.hs
@@ -437,11 +437,11 @@ handleDeclaration val = do
         Nothing                        -> PSCI $ outputStrLn "Couldn't find node.js"
 
 -- |
--- Takes a let declaration and updates the environment, then run a make. If the declaration fails,
--- restore the pre-let environment.
+-- Takes a list of declarations and updates the environment, then run a make. If the declaration fails,
+-- restore the original environment.
 --
-handleLet :: [P.Declaration] -> PSCI ()
-handleLet ds = do
+handleDecls :: [P.Declaration] -> PSCI ()
+handleDecls ds = do
   st <- PSCI $ lift get
   let st' = updateLets ds st
   let m = createTemporaryModule False st' (P.ObjectLiteral [])
@@ -599,7 +599,7 @@ handleCommand :: C.Command -> PSCI ()
 handleCommand (C.Expression val) = handleDeclaration val
 handleCommand C.Help = PSCI $ outputStrLn helpMessage
 handleCommand (C.Import im) = handleImport im
-handleCommand (C.Let l) = handleLet l
+handleCommand (C.Decls l) = handleDecls l
 handleCommand (C.LoadFile filePath) = do
   absPath <- psciIO $ expandTilde filePath
   exists <- psciIO $ doesFileExist absPath

--- a/psci/Main.hs
+++ b/psci/Main.hs
@@ -72,11 +72,15 @@ data PSCiOptions = PSCiOptions
 --
 data PSCiState = PSCiState
   { psciImportedFilenames   :: [FilePath]
-  , psciImportedModuleNames :: [P.ModuleName]
+  , psciImportedModules     :: [C.ImportedModule]
   , psciLoadedModules       :: [(Either P.RebuildPolicy FilePath, P.Module)]
   , psciLetBindings         :: [P.Declaration]
   , psciNodeFlags           :: [String]
   }
+
+psciImportedModuleNames :: PSCiState -> [P.ModuleName]
+psciImportedModuleNames (PSCiState{psciImportedModules = is}) =
+  map (\(mn, _, _) -> mn) is
 
 -- State helpers
 
@@ -89,8 +93,8 @@ updateImportedFiles filename st = st { psciImportedFilenames = filename : psciIm
 -- |
 -- Updates the state to have more imported modules.
 --
-updateImports :: P.ModuleName -> PSCiState -> PSCiState
-updateImports name st = st { psciImportedModuleNames = name : psciImportedModuleNames st }
+updateImportedModules :: C.ImportedModule -> PSCiState -> PSCiState
+updateImportedModules im st = st { psciImportedModules = im : psciImportedModules st }
 
 -- |
 -- Updates the state to have more loaded files.
@@ -108,8 +112,8 @@ updateLets ds st = st { psciLetBindings = psciLetBindings st ++ ds }
 -- |
 -- Load the necessary modules.
 --
-defaultImports :: [P.ModuleName]
-defaultImports = [P.ModuleName [P.ProperName "Prelude"]]
+defaultImports :: [C.ImportedModule]
+defaultImports = [(P.ModuleName [P.ProperName "Prelude"], D.Unqualified, Nothing)]
 
 -- |
 -- Locates the node executable.
@@ -181,7 +185,7 @@ helpMessage = "The following commands are available:\n\n    " ++
           , replicate (11 - length arg) ' '
           , desc
           ]
-      where cmd = ":" ++ head (D.commands dir) 
+      where cmd = ":" ++ head (D.commands dir)
 
 -- |
 -- The welcome prologue.
@@ -370,10 +374,9 @@ mkdirp = createDirectoryIfMissing True . takeDirectory
 -- Makes a volatile module to execute the current expression.
 --
 createTemporaryModule :: Bool -> PSCiState -> P.Expr -> P.Module
-createTemporaryModule exec PSCiState{psciImportedModuleNames = imports, psciLetBindings = lets} val =
+createTemporaryModule exec PSCiState{psciImportedModules = imports, psciLetBindings = lets} val =
   let
     moduleName = P.ModuleName [P.ProperName "$PSCI"]
-    importDecl m = P.ImportDeclaration m P.Unqualified Nothing
     traceModule = P.ModuleName [P.ProperName "Debug", P.ProperName "Trace"]
     trace = P.Var (P.Qualified (Just traceModule) (P.Ident "print"))
     mainValue = P.App trace (P.Var (P.Qualified Nothing (P.Ident "it")))
@@ -388,10 +391,9 @@ createTemporaryModule exec PSCiState{psciImportedModuleNames = imports, psciLetB
 -- Makes a volatile module to hold a non-qualified type synonym for a fully-qualified data type declaration.
 --
 createTemporaryModuleForKind :: PSCiState -> P.Type -> P.Module
-createTemporaryModuleForKind PSCiState{psciImportedModuleNames = imports} typ =
+createTemporaryModuleForKind PSCiState{psciImportedModules = imports} typ =
   let
     moduleName = P.ModuleName [P.ProperName "$PSCI"]
-    importDecl m = P.ImportDeclaration m P.Unqualified Nothing
     itDecl = P.TypeSynonymDeclaration (P.ProperName "IT") [] typ
   in
     P.Module [] moduleName ((importDecl `map` imports) ++ [itDecl]) Nothing
@@ -400,12 +402,14 @@ createTemporaryModuleForKind PSCiState{psciImportedModuleNames = imports} typ =
 -- Makes a volatile module to execute the current imports.
 --
 createTemporaryModuleForImports :: PSCiState -> P.Module
-createTemporaryModuleForImports PSCiState{psciImportedModuleNames = imports} =
+createTemporaryModuleForImports PSCiState{psciImportedModules = imports} =
   let
     moduleName = P.ModuleName [P.ProperName "$PSCI"]
-    importDecl m = P.ImportDeclaration m P.Unqualified Nothing
   in
     P.Module [] moduleName (importDecl `map` imports) Nothing
+
+importDecl :: C.ImportedModule -> P.Declaration
+importDecl (mn, declType, asQ) = P.ImportDeclaration mn declType asQ
 
 modulesDir :: FilePath
 modulesDir = ".psci_modules" ++ pathSeparator : "node_modules"
@@ -463,17 +467,36 @@ handleShowLoadedModules = do
 --
 handleShowImportedModules :: PSCI ()
 handleShowImportedModules = do
-  PSCiState { psciImportedModuleNames = importedModuleNames } <- PSCI $ lift get
-  psciIO $ readModules importedModuleNames >>= putStrLn
+  PSCiState { psciImportedModules = importedModules } <- PSCI $ lift get
+  psciIO $ showModules importedModules >>= putStrLn
   return ()
-  where readModules = return . unlines . sort . map N.runModuleName
+  where
+  showModules = return . unlines . sort . map showModule
+  showModule (mn, declType, asQ) =
+    case asQ of
+      Just mn' -> "qualified " ++ N.runModuleName mn ++ " as " ++ N.runModuleName mn'
+      Nothing  -> N.runModuleName mn ++ " " ++ showDeclType declType
+  showDeclType D.Unqualified = ""
+  showDeclType (D.Qualifying refs) = refsList refs
+  showDeclType (D.Hiding refs) = "hiding " ++ refsList refs
+  refsList refs = "(" ++ commaList (map showRef refs) ++ ")"
+
+  showRef :: P.DeclarationRef -> String
+  showRef (D.TypeRef pn dctors) = show pn ++ "(" ++ maybe ".." (commaList . map N.runProperName) dctors ++ ")"
+  showRef (D.ValueRef ident) = show ident
+  showRef (D.TypeClassRef pn) = show pn
+  showRef (D.TypeInstanceRef ident) = show ident
+  showRef (D.PositionedDeclarationRef _ _ ref) = showRef ref
+
+  commaList :: [String] -> String
+  commaList = intercalate ", "
 
 -- |
 -- Imports a module, preserving the initial state on failure.
 --
-handleImport :: P.ModuleName -> PSCI ()
-handleImport moduleName = do
-   st <- updateImports moduleName <$> PSCI (lift get)
+handleImport :: C.ImportedModule -> PSCI ()
+handleImport im = do
+   st <- updateImportedModules im <$> PSCI (lift get)
    let m = createTemporaryModuleForImports st
    e <- psciIO . runMake $ P.make modulesDir (psciLoadedModules st ++ [(Left P.RebuildAlways, m)]) []
    case e of
@@ -575,7 +598,7 @@ getCommand singleLineMode = do
 handleCommand :: C.Command -> PSCI ()
 handleCommand (C.Expression val) = handleDeclaration val
 handleCommand C.Help = PSCI $ outputStrLn helpMessage
-handleCommand (C.Import moduleName) = handleImport moduleName
+handleCommand (C.Import im) = handleImport im
 handleCommand (C.Let l) = handleLet l
 handleCommand (C.LoadFile filePath) = do
   absPath <- psciIO $ expandTilde filePath
@@ -592,7 +615,7 @@ handleCommand C.Reset = do
   files <- psciImportedFilenames <$> PSCI (lift get)
   PSCI . lift . modify $ \st -> st
     { psciImportedFilenames   = files
-    , psciImportedModuleNames = defaultImports
+    , psciImportedModules     = defaultImports
     , psciLetBindings         = []
     }
   loadAllImportedModules

--- a/psci/Main.hs
+++ b/psci/Main.hs
@@ -227,7 +227,6 @@ completionContext (':' : cmd) word =
   dstr = takeWhile (not . isSpace) cmd
 
   context :: D.Directive -> Maybe CompletionContext
-  context D.Import = Just Module
   context D.Browse = Just Module
   context D.Load = Just $ FilePath word
   context D.Quit = Nothing
@@ -473,9 +472,10 @@ handleShowImportedModules = do
   where
   showModules = return . unlines . sort . map showModule
   showModule (mn, declType, asQ) =
-    case asQ of
+    "import " ++ case asQ of
       Just mn' -> "qualified " ++ N.runModuleName mn ++ " as " ++ N.runModuleName mn'
       Nothing  -> N.runModuleName mn ++ " " ++ showDeclType declType
+
   showDeclType D.Unqualified = ""
   showDeclType (D.Qualifying refs) = refsList refs
   showDeclType (D.Hiding refs) = "hiding " ++ refsList refs

--- a/psci/Parser.hs
+++ b/psci/Parser.hs
@@ -60,7 +60,7 @@ parseCommand cmdString =
       Just D.Help -> return C.Help
       Just D.Quit -> return C.Quit
       Just D.Reset -> return C.Reset
-      Just D.Import -> C.Import <$> parseRest P.moduleName arg
+      Just D.Import -> C.Import <$> parseRest P.parseImportDeclarationTail arg
       Just D.Browse -> C.Browse <$> parseRest P.moduleName arg
       Just D.Load -> return $ C.LoadFile (trim arg)
       Just D.Show -> return $ C.Show (trim arg)

--- a/psci/Parser.hs
+++ b/psci/Parser.hs
@@ -13,8 +13,8 @@
 --
 -----------------------------------------------------------------------------
 
-module Parser (
-    parseCommand
+module Parser
+  ( parseCommand
   ) where
 
 import Prelude hiding (lex)
@@ -38,53 +38,88 @@ parseCommand :: String -> Either String C.Command
 parseCommand cmdString =
   case cmdString of
     (':' : cmd) -> parseDirective cmd
-    _ -> parseRest (psciImport <|> psciLet <|> psciExpression) cmdString
+    _ -> parseRest psciCommand cmdString
+
+parseRest :: P.TokenParser a -> String -> Either String a
+parseRest p s = either (Left . show) Right $ do
+  ts <- P.lex "" s
+  P.runTokenParser "" (p <* eof) ts
+
+psciCommand :: P.TokenParser C.Command
+psciCommand = choice (map try parsers)
   where
-  parseRest :: P.TokenParser a -> String -> Either String a
-  parseRest p s = either (Left . show) Right $ do
-    ts <- P.lex "" s
-    P.runTokenParser "" (p <* eof) ts
+  parsers =
+    [ psciLet
+    , psciImport
+    , psciOtherDeclaration
+    , psciExpression
+    ]
 
-  trim :: String -> String
-  trim = trimEnd . trimStart
+trim :: String -> String
+trim = trimEnd . trimStart
 
-  trimStart :: String -> String
-  trimStart = dropWhile isSpace
+trimStart :: String -> String
+trimStart = dropWhile isSpace
 
-  trimEnd :: String -> String
-  trimEnd = reverse . trimStart . reverse
+trimEnd :: String -> String
+trimEnd = reverse . trimStart . reverse
 
-  parseDirective :: String -> Either String C.Command
-  parseDirective cmd =
-    case D.parseDirective dstr of
-      Just D.Help -> return C.Help
-      Just D.Quit -> return C.Quit
-      Just D.Reset -> return C.Reset
-      Just D.Browse -> C.Browse <$> parseRest P.moduleName arg
-      Just D.Load -> return $ C.LoadFile (trim arg)
-      Just D.Show -> return $ C.Show (trim arg)
-      Just D.Type -> C.TypeOf <$> parseRest P.parseValue arg
-      Just D.Kind -> C.KindOf <$> parseRest P.parseType arg
-      Nothing -> Left $ "Unrecognized command. Type :? for help."
-    where (dstr, arg) = break isSpace cmd
+parseDirective :: String -> Either String C.Command
+parseDirective cmd =
+  case D.parseDirective dstr of
+    Just D.Help -> return C.Help
+    Just D.Quit -> return C.Quit
+    Just D.Reset -> return C.Reset
+    Just D.Browse -> C.Browse <$> parseRest P.moduleName arg
+    Just D.Load -> return $ C.LoadFile (trim arg)
+    Just D.Show -> return $ C.Show (trim arg)
+    Just D.Type -> C.TypeOf <$> parseRest P.parseValue arg
+    Just D.Kind -> C.KindOf <$> parseRest P.parseType arg
+    Nothing -> Left $ "Unrecognized command. Type :? for help."
+  where (dstr, arg) = break isSpace cmd
 
-  -- |
-  -- Parses expressions entered at the PSCI repl.
-  --
-  psciExpression :: P.TokenParser C.Command
-  psciExpression = C.Expression <$> P.parseValue
+-- |
+-- Parses expressions entered at the PSCI repl.
+--
+psciExpression :: P.TokenParser C.Command
+psciExpression = C.Expression <$> P.parseValue
 
-  -- |
-  -- PSCI version of @let@.
-  -- This is essentially let from do-notation.
-  -- However, since we don't support the @Eff@ monad,
-  -- we actually want the normal @let@.
-  --
-  psciLet :: P.TokenParser C.Command
-  psciLet = C.Let <$> (P.reserved "let" *> P.indented *> manyDecls)
-    where
-    manyDecls :: P.TokenParser [P.Declaration]
-    manyDecls = C.mark (many1 (C.same *> P.parseDeclaration))
+-- |
+-- PSCI version of @let@.
+-- This is essentially let from do-notation.
+-- However, since we don't support the @Eff@ monad,
+-- we actually want the normal @let@.
+--
+psciLet :: P.TokenParser C.Command
+psciLet = C.Decls <$> (P.reserved "let" *> P.indented *> manyDecls)
+  where
+  manyDecls :: P.TokenParser [P.Declaration]
+  manyDecls = C.mark (many1 (C.same *> P.parseLocalDeclaration))
 
-  psciImport :: P.TokenParser C.Command
-  psciImport = C.Import <$> P.parseImportDeclaration'
+-- | Imports must be handled separately from other declarations, so that
+-- :show import works, for example.
+psciImport :: P.TokenParser C.Command
+psciImport = C.Import <$> P.parseImportDeclaration'
+
+-- | Any other declaration that we don't need a 'special case' parser for
+-- (like let or import declarations).
+psciOtherDeclaration :: P.TokenParser C.Command
+psciOtherDeclaration = C.Decls . (:[]) <$> do
+  decl <- discardPositionInfo <$> P.parseDeclaration
+  if acceptable decl
+    then return decl
+    else fail "this kind of declaration is not supported in psci"
+
+discardPositionInfo :: P.Declaration -> P.Declaration
+discardPositionInfo (P.PositionedDeclaration _ _ d) = d
+discardPositionInfo d = d
+
+acceptable :: P.Declaration -> Bool
+acceptable (P.DataDeclaration _ _ _ _) = True
+acceptable (P.TypeSynonymDeclaration _ _ _) = True
+acceptable (P.ExternDeclaration _ _ _ _) = True
+acceptable (P.ExternDataDeclaration _ _) = True
+acceptable (P.ExternInstanceDeclaration _ _ _ _) = True
+acceptable (P.TypeClassDeclaration _ _ _ _) = True
+acceptable (P.TypeInstanceDeclaration _ _ _ _ _) = True
+acceptable _ = False

--- a/psci/Parser.hs
+++ b/psci/Parser.hs
@@ -38,7 +38,7 @@ parseCommand :: String -> Either String C.Command
 parseCommand cmdString =
   case cmdString of
     (':' : cmd) -> parseDirective cmd
-    _ -> parseRest (psciLet <|> psciExpression) cmdString
+    _ -> parseRest (psciImport <|> psciLet <|> psciExpression) cmdString
   where
   parseRest :: P.TokenParser a -> String -> Either String a
   parseRest p s = either (Left . show) Right $ do
@@ -60,7 +60,6 @@ parseCommand cmdString =
       Just D.Help -> return C.Help
       Just D.Quit -> return C.Quit
       Just D.Reset -> return C.Reset
-      Just D.Import -> C.Import <$> parseRest P.parseImportDeclarationTail arg
       Just D.Browse -> C.Browse <$> parseRest P.moduleName arg
       Just D.Load -> return $ C.LoadFile (trim arg)
       Just D.Show -> return $ C.Show (trim arg)
@@ -86,3 +85,6 @@ parseCommand cmdString =
     where
     manyDecls :: P.TokenParser [P.Declaration]
     manyDecls = C.mark (many1 (C.same *> P.parseDeclaration))
+
+  psciImport :: P.TokenParser C.Command
+  psciImport = C.Import <$> P.parseImportDeclaration'

--- a/src/Language/PureScript.hs
+++ b/src/Language/PureScript.hs
@@ -257,7 +257,7 @@ reverseDependencies g = combine [ (dep, mn) | (mn, deps) <- g, dep <- deps ]
 addDefaultImport :: ModuleName -> Module -> Module
 addDefaultImport toImport m@(Module coms mn decls exps)  =
   if isExistingImport `any` decls || mn == toImport then m
-  else Module coms mn (ImportDeclaration toImport Unqualified Nothing : decls) exps
+  else Module coms mn (ImportDeclaration toImport Implicit Nothing : decls) exps
   where
   isExistingImport (ImportDeclaration mn' _ _) | mn' == toImport = True
   isExistingImport (PositionedDeclaration _ _ d) = isExistingImport d

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -127,15 +127,15 @@ instance Eq DeclarationRef where
 --
 data ImportDeclarationType
   -- |
-  -- Unqualified import
+  -- An import with no explicit list: `import M`
   --
-  = Unqualified
+  = Implicit
   -- |
-  -- Qualified import with a list of references to import
+  -- An import with an explicit list of references to import: `import M (foo)`
   --
-  | Qualifying [DeclarationRef]
+  | Explicit [DeclarationRef]
   -- |
-  -- Import with hiding clause with a list of references to hide
+  -- An import with a list of references to hide: `import M hiding (foo)`
   --
   | Hiding [DeclarationRef]
   deriving (Show, D.Data, D.Typeable)

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -24,7 +24,7 @@ module Language.PureScript.Parser.Declarations (
     parseGuard,
     parseBinder,
     parseBinderNoParens,
-    parseImportDeclarationTail,
+    parseImportDeclaration',
 ) where
 
 import Prelude hiding (lex)
@@ -147,15 +147,13 @@ parseFixityDeclaration = do
 
 parseImportDeclaration :: TokenParser Declaration
 parseImportDeclaration = do
-  reserved "import"
-  indented
-  (mn, declType, asQ) <- parseImportDeclarationTail
+  (mn, declType, asQ) <- parseImportDeclaration'
   return $ ImportDeclaration mn declType asQ
 
--- |
--- The part of an import statement following the 'import'.
-parseImportDeclarationTail :: TokenParser (ModuleName, ImportDeclarationType, (Maybe ModuleName))
-parseImportDeclarationTail =
+parseImportDeclaration' :: TokenParser (ModuleName, ImportDeclarationType, (Maybe ModuleName))
+parseImportDeclaration' = do
+  reserved "import"
+  indented
   qualImport <|> stdImport
   where
   stdImport = do

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -25,6 +25,7 @@ module Language.PureScript.Parser.Declarations (
     parseBinder,
     parseBinderNoParens,
     parseImportDeclaration',
+    parseLocalDeclaration
 ) where
 
 import Prelude hiding (lex)

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -165,19 +165,19 @@ parseImportDeclaration' = do
       declType <- importDeclarationType Hiding
       return (mn, declType, Nothing)
     stdImportQualifying mn = do
-      declType <- importDeclarationType Qualifying
+      declType <- importDeclarationType Explicit
       return (mn, declType, Nothing)
   qualImport = do
     reserved "qualified"
     indented
     moduleName' <- moduleName
-    declType <- importDeclarationType Qualifying
+    declType <- importDeclarationType Explicit
     reserved "as"
     asQ <- moduleName
     return (moduleName', declType, Just asQ)
   importDeclarationType expectedType = do
     idents <- P.optionMaybe $ indented *> (parens $ commaSep parseDeclarationRef)
-    return $ fromMaybe Unqualified (expectedType <$> idents)
+    return $ fromMaybe Implicit (expectedType <$> idents)
 
 
 parseDeclarationRef :: TokenParser DeclarationRef

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -1,7 +1,7 @@
 -----------------------------------------------------------------------------
 --
 -- Module      :  Language.PureScript.Pretty.Values
--- Copyright   :  Kinds.hs(c) Phil Freeman 2013
+-- Copyright   :  (c) Phil Freeman 2013
 -- License     :  MIT
 --
 -- Maintainer  :  Phil Freeman <paf31@cantab.net>

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -199,7 +199,7 @@ elaborateImports (Module coms mn decls exps) = Module coms mn decls' exps
   fqValues (Var (Qualified (Just mn') _)) = [mn']
   fqValues _ = []
   mkImport :: ModuleName -> Declaration
-  mkImport mn' = ImportDeclaration mn' (Qualifying []) Nothing
+  mkImport mn' = ImportDeclaration mn' (Explicit []) Nothing
 
 -- |
 -- Replaces all local names with qualified names within a module and checks that all existing
@@ -417,7 +417,7 @@ resolveImports env (Module _ currentModule decls _) =
   -- module (where Nothing indicates everything is to be imported), and optionally a qualified name
   -- for the module
   scope :: M.Map ModuleName (Maybe SourceSpan, ImportDeclarationType, Maybe ModuleName)
-  scope = M.insert currentModule (Nothing, Unqualified, Nothing) (findImports decls)
+  scope = M.insert currentModule (Nothing, Implicit, Nothing) (findImports decls)
 
   resolveImport' :: ImportEnvironment -> (ModuleName, (Maybe SourceSpan, ImportDeclarationType, Maybe ModuleName)) -> m ImportEnvironment
   resolveImport' imp (mn, (pos, typ, impQual)) = do
@@ -437,8 +437,8 @@ resolveImport currentModule importModule exps imps impQual =
   where
 
   resolveByType :: ImportDeclarationType -> m ImportEnvironment
-  resolveByType Unqualified = importAll importExplicit
-  resolveByType (Qualifying explImports) = (checkedRefs >=> foldM importExplicit imps) explImports
+  resolveByType Implicit = importAll importExplicit
+  resolveByType (Explicit explImports) = (checkedRefs >=> foldM importExplicit imps) explImports
   resolveByType (Hiding hiddenImports) = do
     hiddenImports' <- checkedRefs hiddenImports
     importAll (importNonHidden hiddenImports')


### PR DESCRIPTION
refs #753 
Issues:

* [ ] What happens if the same module is imported multiple times? Do we want to include an :unimport command?
* [ ] This probably needs some kind of refactoring (in particular, it feels a bit wrong having `parseImportDeclaration'` in the export list)
* [ ] Completion needs some work
* [x] Fails silently in some situations, eg `:import Prelude.Unsafe hiding (doesNotExist)`
* [ ] `:browse Q` after doing `import qualified M as Q` should work
* [x] Disallow `let import ...` and any other declarations that shouldn't really follow 'let'
* [x] Allow bare declarations where sensible to make up for `let import ...` etc being disallowed

But importing qualified modules, as well as importing modules with explicit import or hiding lists seems to work :) Some feedback at this stage would be nice.