### PR TITLE
Preserve binding names a bit better in functions

### DIFF
--- a/src/Language/PureScript/Sugar/CaseDeclarations.hs
+++ b/src/Language/PureScript/Sugar/CaseDeclarations.hs
@@ -119,27 +119,32 @@ toTuple _ = error "Not a value declaration"
 
 makeCaseDeclaration :: (Functor m, Applicative m, MonadSupply m, MonadError MultipleErrors m) => Ident -> [([Binder], Either [(Guard, Expr)] Expr)] -> m Declaration
 makeCaseDeclaration ident alternatives = do
-  let argPattern = length . fst . head $ alternatives
-  args <- mapM argName (foldl1 (zipWith resolveIdents) namedArgs)
+  let namedArgs = map findName . fst <$> alternatives
+  args <- mapM argName $ foldl1 resolveNames namedArgs
   let
     vars = map (Var . Qualified Nothing) args
     binders = [ CaseAlternative bs result | (bs, result) <- alternatives ]
     value = foldr (Abs . Left) (Case vars binders) args
   return $ ValueDeclaration ident Value [] (Right value)
   where
-  namedArgs = findNames . fst <$> alternatives
-  findNames names = findName <$> names
+  findName :: Binder -> Maybe Ident
   findName (VarBinder name) = Just name
+  findName (PositionedBinder _ _ binder) = findName binder
   findName _ = Nothing
 
+  argName :: (MonadSupply m) => Maybe Ident -> m Ident
   argName (Just name) = return name
   argName Nothing = do
     name <- freshName
     return (Ident name)
 
-  resolveIdents (Just a) (Just b)
+  resolveNames :: [Maybe Ident] -> [Maybe Ident] -> [Maybe Ident]
+  resolveNames = zipWith resolveName
+
+  resolveName :: Maybe Ident -> Maybe Ident -> Maybe Ident
+  resolveName (Just a) (Just b)
     | a == b = Just a
     | otherwise = Nothing
-  resolveIdents Nothing Nothing = Nothing
-  resolveIdents (Just a) Nothing = Just a
-  resolveIdents Nothing (Just b) = Just b
+  resolveName Nothing Nothing = Nothing
+  resolveName (Just a) Nothing = Just a
+  resolveName Nothing (Just b) = Just b


### PR DESCRIPTION
This change is intended to improve generated code a bit by keeping binding names in functions, where possible. For example, currently this PureScript code:
```PureScript
fib :: Number -> Number
fib 0 = 0
fib 1 = 1
fib n = fib (n - 2) + fib (n - 1)
```
produces this JavaScript code:
```JavaScript
var fib = function (_29) {
    if (_29 === 0) {
        return 0;
    };
    if (_29 === 1) {
        return 1;
    };
    return fib(_29 - 2) + fib(_29 - 1);
};
```
With this change, it will instead produce:
```JavaScript
var fib = function (n) {
    if (n === 0) {
        return 0;
    };
    if (n === 1) {
        return 1;
    };
    return fib(n - 2) + fib(n - 1);
};
```
In cases where the binding names are inconsistent (they don't all match), it will fallback to the generated names. For example:
```PureScript
fib :: Number -> Number
fib 0 = 0
fib 1 = 1
fib q | q == 2 = 2
fib n = fib (n - 2) + fib (n - 1)
```
results in:
```JavaScript
var fib = function (_25) {
    if (_25 === 0) {
        return 0;
    };
    if (_25 === 1) {
        return 1;
    };
    if (_25 === 2) {
        return 2;
    };
        return fib(_25 - 2) + fib(_25 - 1);
};
```

Tests all pass, but please let me know if you see any problems or a better way to do this!
