### PR TITLE
WIP on #421

### DIFF
--- a/examples/failing/438.purs
+++ b/examples/failing/438.purs
@@ -1,0 +1,9 @@
+module Main where
+    
+data Fix f = In (f (Fix f))
+
+instance eqFix :: (Eq (f (Fix f))) => Eq (Fix f) where
+  (==) (In f) (In g) = f == g
+  (/=) a b = not (a == b)
+  
+example = In [] == In []

--- a/examples/passing/421.purs
+++ b/examples/passing/421.purs
@@ -1,0 +1,12 @@
+module Main where
+
+class (Monad m) <= MonadBlah b m where
+  blah :: b -> m Unit
+
+example :: forall m b. (MonadBlah b m) => b -> m Unit
+example b = do
+  blah b
+  blah b
+  blah b
+
+main = Debug.Trace.trace "Done"

--- a/psc-make/Main.hs
+++ b/psc-make/Main.hs
@@ -148,6 +148,11 @@ noPrefix = switch $
   <> long "no-prefix"
   <> help "Do not include comment header"
 
+maxSearchDepth :: Parser Integer
+maxSearchDepth = option auto $
+     long "max-search-depth"
+  <> Opts.value (P.optionsMaxSearchDepth P.defaultMakeOptions)
+  <> help "The maximum depth when searching for type class instances"
 
 options :: Parser (P.Options P.Make)
 options = P.Options <$> noPrelude
@@ -157,6 +162,7 @@ options = P.Options <$> noPrelude
                     <*> noOpts
                     <*> (not <$> comments)
                     <*> verboseErrors
+                    <*> maxSearchDepth
                     <*> pure P.MakeOptions
 
 pscMakeOptions :: Parser PSCMakeOptions

--- a/psc/Main.hs
+++ b/psc/Main.hs
@@ -173,6 +173,12 @@ noPrefix = switch $
   <> long "no-prefix"
   <> help "Do not include comment header"
 
+maxSearchDepth :: Parser Integer
+maxSearchDepth = option auto $
+     long "max-search-depth"
+  <> Opts.value (P.optionsMaxSearchDepth P.defaultCompileOptions)
+  <> help "The maximum depth when searching for type class instances"
+
 options :: Parser (P.Options P.Compile)
 options = P.Options <$> noPrelude
                     <*> noTco
@@ -181,6 +187,7 @@ options = P.Options <$> noPrelude
                     <*> noOpts
                     <*> verboseErrors
                     <*> (not <$> comments)
+                    <*> maxSearchDepth
                     <*> additionalOptions
   where
   additionalOptions =

--- a/psci/Main.hs
+++ b/psci/Main.hs
@@ -337,7 +337,7 @@ completion = completeWordWithPrev Nothing " \t\n\r" findCompletions
 -- | Compilation options.
 --
 options :: P.Options P.Make
-options = P.Options False False False Nothing False False False P.MakeOptions
+options = P.defaultMakeOptions
 
 -- |
 -- PSCI monad

--- a/src/Language/PureScript/Options.hs
+++ b/src/Language/PureScript/Options.hs
@@ -73,6 +73,9 @@ data Options mode = Options {
     -- Remove the comments from the generated js
   , optionsNoComments :: Bool
     -- |
+    -- The maximum search depth when looking for type class instances
+  , optionsMaxSearchDepth :: Integer
+    -- |
     -- Specify the namespace that PureScript modules will be exported to when running in the
     -- browser.
     --
@@ -83,10 +86,10 @@ data Options mode = Options {
 -- Default compiler options
 --
 defaultCompileOptions :: Options Compile
-defaultCompileOptions = Options False False False Nothing False False False (CompileOptions "PS" [] [])
+defaultCompileOptions = Options False False False Nothing False False False 1000 (CompileOptions "PS" [] [])
 
 -- |
 -- Default make options
 --
 defaultMakeOptions :: Options Make
-defaultMakeOptions = Options False False False Nothing False False False MakeOptions
+defaultMakeOptions = Options False False False Nothing False False False 1000 MakeOptions

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -34,6 +34,7 @@ import Language.PureScript.AST
 import Language.PureScript.Errors
 import Language.PureScript.Environment
 import Language.PureScript.Names
+import Language.PureScript.Options
 import Language.PureScript.TypeChecker.Monad
 import Language.PureScript.TypeChecker.Synonyms
 import Language.PureScript.TypeChecker.Unify
@@ -45,8 +46,8 @@ import qualified Language.PureScript.Constants as C
 -- Check that the current set of type class dictionaries entail the specified type class goal, and, if so,
 -- return a type class dictionary reference.
 --
-entails :: Environment -> ModuleName -> [TypeClassDictionaryInScope] -> Constraint -> Bool -> Check Expr
-entails env moduleName context = solve (sortedNubBy canonicalizeDictionary (filter filterModule context))
+entails :: Options mode -> Environment -> ModuleName -> [TypeClassDictionaryInScope] -> Constraint -> Bool -> Check Expr
+entails opts env moduleName context = solve (sortedNubBy canonicalizeDictionary (filter filterModule context))
   where
     sortedNubBy :: (Ord k) => (v -> k) -> [v] -> [v]
     sortedNubBy f vs = M.elems (M.fromList (map (f &&& id) vs))
@@ -61,7 +62,7 @@ entails env moduleName context = solve (sortedNubBy canonicalizeDictionary (filt
       checkOverlaps $ go trySuperclasses 0 className tys
       where
       go :: Bool -> Integer -> Qualified ProperName -> [Type] -> [DictionaryValue]
-      go _ depth _ _ | depth > 1000 = []
+      go _ depth _ _ | depth > optionsMaxSearchDepth opts = []
       go trySuperclasses' depth className' tys' = 
         -- Look for regular type instances
         [ mkDictionary (canonicalizeDictionary tcd) args


### PR DESCRIPTION
This isn't ready yet, but it's close. It breaks on `RWS.Class` in `transformers` because of an infinite search. The problem is in the `typeHeadsAreEqual` function.

I think we have two options:

1. Don't use `TypeVar`, and introduce a new constructor in `Type` for "unsolved variables".
2. (I like this one because it moves us closer to something like fundeps) - allow unification of `TypeVar`s on the left during solving, but mark it as a "partial match". If all types in the instance head match, we require that at least one of them be non-partial, otherwise we fail with an "Underspecified type" error.