### PR TITLE
Restrict record type pretty printer

### DIFF
--- a/examples/passing/Objects.purs
+++ b/examples/passing/Objects.purs
@@ -15,6 +15,11 @@ module Main where
   typed :: { foo :: Number }
   typed = { foo: 0 }
 
+  type Foo = (foo :: Number)
+
+  typed2 :: Object Foo
+  typed2 = { foo: 0 }
+
   test2 = \x -> x."!@#"
 
   test3 = typed."foo"

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -93,6 +93,9 @@ insertPlaceholders = everywhereOnTypesTopDown convertForAlls . everywhereOnTypes
     go idents other = PrettyPrintForAll idents other
   convertForAlls other = other
 
+  -- Object type application should be sugared into record syntax. However,
+  -- this may produce illegal code when object is applied to non-trivial row
+  -- (e.g. type alias). This function checks whether row is of sugarable form.
   prettyRow :: Type -> Bool
   prettyRow (RCons _ _ r) = prettyRow r
   prettyRow REmpty = True

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -85,13 +85,19 @@ insertPlaceholders = everywhereOnTypesTopDown convertForAlls . everywhereOnTypes
   where
   convert (TypeApp (TypeApp f arg) ret) | f == tyFunction = PrettyPrintFunction arg ret
   convert (TypeApp a el) | a == tyArray = PrettyPrintArray el
-  convert (TypeApp o r) | o == tyObject = PrettyPrintObject r
+  convert (TypeApp o r) | o == tyObject && prettyRow r = PrettyPrintObject r
   convert other = other
   convertForAlls (ForAll ident ty _) = go [ident] ty
     where
     go idents (ForAll ident' ty' _) = go (ident' : idents) ty'
     go idents other = PrettyPrintForAll idents other
   convertForAlls other = other
+
+  prettyRow :: Type -> Bool
+  prettyRow (RCons _ _ r) = prettyRow r
+  prettyRow REmpty = True
+  prettyRow (TypeVar _) = True
+  prettyRow _ = False
 
 matchTypeAtom :: Pattern () Type String
 matchTypeAtom = typeLiterals <+> fmap parens matchType


### PR DESCRIPTION
This is my attempt at solving #931. Simplifying provided example mentioned in the issue:

    type Foo = (foo :: Number)

    bar :: Object Foo
    bar = { foo: 0 }

yields `foreign import bar :: {  | Foo }` in generated `externs.purs` file which is not accepted by the compiler. This happens because pretty printer has a rule to turn all `Object row` expressions to neatly printed records. However, pretty printer is not aware of aliases, thus yields this incorrect statement.

So I figured out three solutions:

1. Restrict pretty printer to output record syntax only with *pretty rows* (most straightforward, implemented in this PR).
2. Make pretty printer expand type aliases (which is bad because it would output ugly code in some cases and would require massive pretty printer refactoring).
3. Just support `foo :: { | Foo }` syntax. I don't know if this is by design but I see no charm in making it valid syntax. Actually, I was confused as why PureScript allows only type variable after the `|` and not row in any kind of form (e.g. `foo :: { x :: Number | (y :: Number, z : Number) }`).

So, for now pretty printing type of bar from the provided example would yield `Object Foo`. If there are no objections I can also work on the third option - adding syntax support should be quite easy, I am not sure what adjustments would be required in type checker though. 