### PR TITLE
Add missing module 'Directive' to other-modules

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -151,6 +151,7 @@ executable psci
     hs-source-dirs: psci
     other-modules: Commands
                    Parser
+                   Directive
     ghc-options: -Wall -O2
 
 executable psc-docs


### PR DESCRIPTION
I tried to install purescript 0.6.9 into my global package database, but got this:

```
psci/Parser.hs:23:18: Could not find module ‘Directive’
```

I think this is because it was missing from `other-modules` in the .cabal file. This commit hopefully will fix that.