### PR TITLE
Flexible row syntax

### DIFF
--- a/examples/failing/RowConstructors1.purs
+++ b/examples/failing/RowConstructors1.purs
@@ -1,0 +1,6 @@
+module Main where
+
+data Foo = Bar
+type Baz = { | Foo }
+
+main = Debug.Trace.trace "Done"

--- a/examples/failing/RowConstructors2.purs
+++ b/examples/failing/RowConstructors2.purs
@@ -1,0 +1,6 @@
+module Main where
+
+type Foo r = (x :: Number | r)
+type Bar = { | Foo }
+
+main = Debug.Trace.trace "Done"

--- a/examples/failing/RowConstructors3.purs
+++ b/examples/failing/RowConstructors3.purs
@@ -1,0 +1,6 @@
+module Main where
+
+type Foo = { x :: Number }
+type Bar = { | Foo }
+
+main = Debug.Trace.trace "Done"

--- a/examples/passing/RowConstructors.purs
+++ b/examples/passing/RowConstructors.purs
@@ -22,4 +22,19 @@ bar' = id' bar
 baz :: Baz
 baz = { x: 0, y: 0, z: 0, w: 0 }
 
+type Quux r = (q :: Number | r)
+type Norf r = (q' :: Number | Quux r)
+
+quux :: { f :: { | Foo } | Quux Bar }
+quux = { f: foo', x: 0, y: 0, z: 0, q: 0 }
+
+quux' :: { | Norf Bar }
+quux' = { x: 0, y: 0, z: 0, q: 0, q': 0 }
+
+wildcard :: { w :: Number | _ } -> Baz
+wildcard { w: w } = { x: w, y: w, z: w, w: w }
+
+wildcard' :: { | Quux _ } -> Number
+wildcard' { q: q } = q
+
 main = Debug.Trace.trace "Done"

--- a/examples/passing/RowConstructors.purs
+++ b/examples/passing/RowConstructors.purs
@@ -1,0 +1,25 @@
+module Main where
+
+type Foo = (x :: Number | (y :: Number | (z :: Number)))
+type Bar = (x :: Number, y :: Number, z :: Number)
+type Baz = { w :: Number | Bar }
+
+foo :: { | Foo }
+foo = { x: 0, y: 0, z: 0 }
+
+bar :: { | Bar }
+bar = { x: 0, y: 0, z: 0 }
+
+id' :: Object Foo -> Object Bar
+id' = id
+
+foo' :: { | Foo }
+foo' = id' foo
+
+bar' :: { | Bar }
+bar' = id' bar
+
+baz :: Baz
+baz = { x: 0, y: 0, z: 0, w: 0 }
+
+main = Debug.Trace.trace "Done"

--- a/src/Language/PureScript/Parser/Types.hs
+++ b/src/Language/PureScript/Parser/Types.hs
@@ -126,11 +126,7 @@ parseNameAndType :: TokenParser t -> TokenParser (String, t)
 parseNameAndType p = (,) <$> (indented *> (lname <|> stringLiteral) <* indented <* doubleColon) <*> p
 
 parseRowEnding :: TokenParser Type
-parseRowEnding = P.option REmpty $ indented *> pipe *> indented *> P.choice  (map P.try
-            [ parseTypeWildcard
-            , TypeVar <$> identifier
-            , parseTypeConstructor
-            , parens parseRow ])
+parseRowEnding = P.option REmpty $ indented *> pipe *> indented *> parseType
 
 parseRow :: TokenParser Type
 parseRow = (curry rowFromList <$> commaSep (parseNameAndType parsePolyType) <*> parseRowEnding) P.<?> "row"

--- a/src/Language/PureScript/Parser/Types.hs
+++ b/src/Language/PureScript/Parser/Types.hs
@@ -128,7 +128,9 @@ parseNameAndType p = (,) <$> (indented *> (lname <|> stringLiteral) <* indented 
 parseRowEnding :: TokenParser Type
 parseRowEnding = P.option REmpty $ indented *> pipe *> indented *> P.choice  (map P.try
             [ parseTypeWildcard
-            , TypeVar <$> identifier ])
+            , TypeVar <$> identifier
+            , parseTypeConstructor
+            , parens parseRow ])
 
 parseRow :: TokenParser Type
 parseRow = (curry rowFromList <$> commaSep (parseNameAndType parsePolyType) <*> parseRowEnding) P.<?> "row"


### PR DESCRIPTION
As discussed in #973, I made row syntax more flexible. That is, now constructs such as `(foo :: Number | (bar :: Number))` and `(foo :: Number | Bar)` (where `Bar` is some row) are supported. In particular, this causes `Object Foo` and `{ | Foo }` to be the same thing and thus fixes #931 also making #973 obsolete.

Turned out that only tiny changes to the parser were required and everything type checks just fine, although it would be nice if someone more familiar with type checker could confirm that it is not just coincidence. Generally, this improvement should be backwards compatible.