### PR TITLE
Fix psc-docs' other-modules in purescript.cabal

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -160,8 +160,9 @@ executable psc-docs
     main-is: Main.hs
     buildable: True
     hs-source-dirs: psc-docs
-    other-modules: CTags
-                   ETags
+    other-modules: Ctags
+                   Etags
+                   Tags
     ghc-options: -Wall -O2
 
 executable psc-hierarchy


### PR DESCRIPTION
It seems as though installing purescript 0.6.9.2 from hackage is not currently possible; it just failed on my machine. I think this will fix it.