### PR TITLE
Provide more information in `exportedDctors`

### DIFF
--- a/psci/Completion.hs
+++ b/psci/Completion.hs
@@ -218,7 +218,7 @@ dctorNames m = nubOnFst $ concatMap dctors dnames
   onlyDataDecls = (filter P.isDataDecl (P.exportedDeclarations m))
 
   dctors :: (N.ProperName, P.Declaration) -> [(N.ProperName, P.Declaration)]
-  dctors (name, decl) = map (\n -> (n, decl)) (P.exportedDctors m name)
+  dctors (name, decl) = map (\n -> (n, decl)) (map fst (P.exportedDctors m name))
 
 moduleNames :: [P.Module] -> [String]
 moduleNames ms = nub [show moduleName | P.Module _ moduleName _ _ <- ms]

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -78,12 +78,12 @@ isDctorExported ident (Just exps) ctor = test `any` exps
 -- |
 -- Return the exported data constructors for a given type.
 --
-exportedDctors :: Module -> ProperName -> [ProperName]
+exportedDctors :: Module -> ProperName -> [(ProperName, [Type])]
 exportedDctors (Module _ _ decls exps) ident =
-  filter (isDctorExported ident exps) dctors
+  filter (isDctorExported ident exps . fst) dctors
   where
   dctors = concatMap getDctors (flattenDecls decls)
-  getDctors (DataDeclaration _ _ _ ctors) = map fst ctors
+  getDctors (DataDeclaration _ _ _ ctors) = ctors
   getDctors (PositionedDeclaration _ _ d) = getDctors d
   getDctors _ = []
 


### PR DESCRIPTION
Currently, `exportedDctors` returns only a `[ProperName]` with the names
of the data constructors. This is no good if you want to know about
the arguments of each constructor. This commit fixes the issue by
changing the return type to `[(ProperName, [Type])]`.

On a related note, I wonder if the documentation for `isExported` and
`isDctorExported` should encourage you to use `exportedDecls` and
`exportedDctors`, as these are 'higher level' versions of what is really
the same function, which won't require you to pattern match (and
therefore hopefully be safer and less likely to break because of
updates).