### PR TITLE
Better psci help

### DIFF
--- a/psci/Directive.hs
+++ b/psci/Directive.hs
@@ -102,12 +102,12 @@ help :: [(Directive, String, String)]
 help =
   [ (Help,   "",         "Show this help menu")
   , (Quit,   "",         "Quit PSCi")
-  , (Reset,  "",         "Reset")
-  , (Browse, "<module>", "Browse <module>")
+  , (Reset,  "",         "Discard all imported modules and declared bindings")
+  , (Browse, "<module>", "See all functions in <module>")
   , (Load,   "<file>",   "Load <file> for importing")
   , (Type,   "<expr>",   "Show the type of <expr>")
   , (Kind,   "<type>",   "Show the kind of <type>")
-  , (Show,   "import",   "Show imported modules")
-  , (Show,   "loaded",   "Show loaded modules")
+  , (Show,   "import",   "Show all imported modules")
+  , (Show,   "loaded",   "Show all loaded modules")
   ]
 

--- a/psci/PSCi.hs
+++ b/psci/PSCi.hs
@@ -138,22 +138,10 @@ helpMessage = "The following commands are available:\n\n    " ++
         , desc
         ]
 
-  extraHelp = unlines
-    [ "Once a file has been loaded, values and types in the module(s) that it"
-    , "contains are available fully qualified:"
-    , ""
-    , "    > :type Data.Function.on"
-    , "    forall a b c. (b -> b -> c) -> (a -> b) -> a -> a -> c"
-    , ""
-    , "Alternatively, you can import a loaded module in order to bring types and"
-    , "values into the current scope - then, you can use them unqualified."
-    , ""
-    , "Modules can be imported normally, as in PureScript code, eg:"
-    , ""
-    , "    > import Control.Monad"
-    , "    > import Prelude.Unsafe (unsafeIndex)"
-    , "    > import qualified Data.List as L"
-    ]
+  extraHelp =
+    "Further information is available on the PureScript wiki:\n" ++
+    " --> https://github.com/purescript/purescript/wiki/psci"
+
 
 -- |
 -- The welcome prologue.

--- a/psci/PSCi.hs
+++ b/psci/PSCi.hs
@@ -124,17 +124,36 @@ expandTilde p = return p
 --
 helpMessage :: String
 helpMessage = "The following commands are available:\n\n    " ++
-  intercalate "\n    " (map line D.help)
+  intercalate "\n    " (map line D.help) ++
+  "\n\n" ++ extraHelp
   where
-    line :: (Directive, String, String) -> String
-    line (dir, arg, desc) = intercalate " "
-          [ cmd
-          , replicate (11 - length cmd) ' '
-          , arg
-          , replicate (11 - length arg) ' '
-          , desc
-          ]
-      where cmd = ":" ++ D.stringFor dir
+  line :: (Directive, String, String) -> String
+  line (dir, arg, desc) =
+    let cmd = ':' : D.stringFor dir
+    in intercalate " "
+        [ cmd
+        , replicate (11 - length cmd) ' '
+        , arg
+        , replicate (11 - length arg) ' '
+        , desc
+        ]
+
+  extraHelp = unlines
+    [ "Once a file has been loaded, values and types in the module(s) that it"
+    , "contains are available fully qualified:"
+    , ""
+    , "    > :type Data.Function.on"
+    , "    forall a b c. (b -> b -> c) -> (a -> b) -> a -> a -> c"
+    , ""
+    , "Alternatively, you can import a loaded module in order to bring types and"
+    , "values into the current scope - then, you can use them unqualified."
+    , ""
+    , "Modules can be imported normally, as in PureScript code, eg:"
+    , ""
+    , "    > import Control.Monad"
+    , "    > import Prelude.Unsafe (unsafeIndex)"
+    , "    > import qualified Data.List as L"
+    ]
 
 -- |
 -- The welcome prologue.


### PR DESCRIPTION
Now that `:i` has been replaced with `import`, and someone asked in IRC about where `:i` had gone, I thought it might be a good idea to state it explicitly in the `:help` output. This commit also contains a couple of other small tweaks.