### PR TITLE
Remove some JS dependencies related to foreign declarations from core

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -26,7 +26,6 @@ import Language.PureScript.Names
 import Language.PureScript.Kinds
 import Language.PureScript.TypeClassDictionaries
 import Language.PureScript.Comments
-import Language.PureScript.CodeGen.JS.AST
 import Language.PureScript.Environment
 
 -- |
@@ -169,9 +168,9 @@ data Declaration
   --
   | BindingGroupDeclaration [(Ident, NameKind, Expr)]
   -- |
-  -- A foreign import declaration (type, name, optional inline Javascript, type)
+  -- A foreign import declaration (type, name, optional inline code, type)
   --
-  | ExternDeclaration ForeignImportType Ident (Maybe JS) Type
+  | ExternDeclaration ForeignImportType Ident (Maybe String) Type
   -- |
   -- A data type foreign import (name, kind)
   --

--- a/src/Language/PureScript/CodeGen.hs
+++ b/src/Language/PureScript/CodeGen.hs
@@ -21,5 +21,4 @@
 
 module Language.PureScript.CodeGen (module C) where
 
-import Language.PureScript.CodeGen.JS as C
 import Language.PureScript.CodeGen.Externs as C

--- a/src/Language/PureScript/CodeGen/Externs.hs
+++ b/src/Language/PureScript/CodeGen/Externs.hs
@@ -90,7 +90,7 @@ moduleToPs (Module _ moduleName ds (Just exts)) env = intercalate "\n" . execWri
     exportToPs (ValueRef ident) =
       case (moduleName, ident) `M.lookup` names env of
         Nothing -> error $ show ident ++ " has no type in exportToPs"
-        Just (ty, nameKind, _) | nameKind == Value || nameKind == Extern ForeignImport || nameKind == Extern InlineJavascript ->
+        Just (ty, nameKind, _) | nameKind == Value || nameKind == Extern ForeignImport || nameKind == Extern InlineForeign ->
           tell ["foreign import " ++ show ident ++ " :: " ++ prettyPrintType ty]
         _ -> return ()
     exportToPs (TypeClassRef className) =

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -71,9 +71,9 @@ data ForeignImportType
   --
   = ForeignImport
   -- |
-  -- A foreign import which contains inline Javascript as a string literal
+  -- A foreign import which contains inline foreign code as a string literal
   --
-  | InlineJavascript deriving (Show, Eq, Data, Typeable)
+  | InlineForeign deriving (Show, Eq, Data, Typeable)
 
 -- |
 -- The visibility of a name in scope

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -44,7 +44,6 @@ import Language.PureScript.Parser.Types
 import Language.PureScript.Parser.Kinds
 import Language.PureScript.Parser.Lexer
 import Language.PureScript.Names
-import Language.PureScript.CodeGen.JS.AST
 import Language.PureScript.Environment
 
 import qualified Language.PureScript.Parser.Common as C
@@ -126,9 +125,9 @@ parseExternDeclaration = P.try (reserved "foreign") *> indented *> reserved "imp
            tys <- P.many (indented *> noWildcards parseTypeAtom)
            return $ ExternInstanceDeclaration name deps className tys)
    <|> (do ident <- parseIdent
-           js <- P.optionMaybe (JSRaw <$> stringLiteral)
+           raw <- P.optionMaybe stringLiteral
            ty <- indented *> doubleColon *> noWildcards parsePolyType
-           return $ ExternDeclaration (if isJust js then InlineJavascript else ForeignImport) ident js ty))
+           return $ ExternDeclaration (if isJust raw then InlineForeign else ForeignImport) ident raw ty))
 
 parseAssociativity :: TokenParser Associativity
 parseAssociativity =


### PR DESCRIPTION
Changes due to some dependencies on JS in core that I encountered while beginning to rewrite C++ support. The use of `String` in `ExternDeclaration` might be too loose, but I'm not sure how much it matters if the FFI will change soon.