### PR TITLE
Avoid 'WARNING - If this if/for/while really shouldn't have a body, use ...

### DIFF
--- a/prelude/prelude.purs
+++ b/prelude/prelude.purs
@@ -1304,7 +1304,7 @@ module Control.Monad.Eff
     """
     function untilE(f) {
       return function() {
-        while (!f());
+        while (!f()) {};
         return {};
       };
     }


### PR DESCRIPTION
...{}' when using the Closure Compiler.