### PR TITLE
[#765] - allow binary operators to be defined infix.

### DIFF
--- a/examples/failing/TooManyArgsInInfixOperatorDecl.purs
+++ b/examples/failing/TooManyArgsInInfixOperatorDecl.purs
@@ -1,0 +1,6 @@
+module Main where
+
+(<!!>) :: Number -> Number -> String -> String
+num1 num2 <!!> str = show num1 ++ str
+
+main = Debug.Trace.trace "Done"

--- a/examples/passing/InfixOperatorDecl.purs
+++ b/examples/passing/InfixOperatorDecl.purs
@@ -1,0 +1,10 @@
+module Main where
+
+(<!!>) :: Number -> String -> String
+num <!!> str = show num ++ str
+
+(<!!!>) :: Number -> String -> String
+num <!!!> str | num == 0 = (<!!>) 100 str
+num <!!!> str | otherwise = num <!!> str
+ 
+main = Debug.Trace.trace "Done"

--- a/src/Language/PureScript/Parser/Common.hs
+++ b/src/Language/PureScript/Parser/Common.hs
@@ -60,6 +60,12 @@ parseIdent :: TokenParser Ident
 parseIdent = (Ident <$> identifier) <|> (Op <$> parens symbol)
 
 -- |
+-- Parse an operator without parameters
+--
+parseOp :: TokenParser Ident
+parseOp = Op <$> symbol
+
+-- |
 -- Run the first parser, then match the second if possible, applying the specified function on a successful match
 --
 augment :: P.Stream s m t => P.ParsecT s u m a -> P.ParsecT s u m b -> (a -> b -> a) -> P.ParsecT s u m a


### PR DESCRIPTION
I couldn't find starter-kit (as mentioned in the guidelines for contributing) so I didn't run it.

The error message if an infix operator is defined with not exactly two parameters is not very nice. Otherwise it seems to work. 
It's my first attempt at touching compiler code, and I'm no Haskell expert, so I'd be interested to know what's wrong with this PR, and I'd hope learn to contribute.