### PR TITLE
Add mod name to constraint dict names and pass type information to IsTagOf

### DIFF
--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -149,8 +149,8 @@ moduleToCoreFn env (A.Module coms mn decls (Just exps)) =
   binderToCoreFn ss com (A.VarBinder name) =
     VarBinder (ss, com, Nothing, Nothing) name
   binderToCoreFn ss com (A.ConstructorBinder dctor@(Qualified mn' _) bs) =
-    let (_, tctor, _, _) = lookupConstructor env dctor
-    in ConstructorBinder (ss, com, Nothing, Just $ getConstructorMeta dctor) (Qualified mn' tctor) dctor (map (binderToCoreFn ss []) bs)
+    let (_, tctor, ty, _) = lookupConstructor env dctor
+    in ConstructorBinder (ss, com, Just ty, Just $ getConstructorMeta dctor) (Qualified mn' tctor) dctor (map (binderToCoreFn ss []) bs)
   binderToCoreFn ss com (A.ObjectBinder bs) =
     LiteralBinder (ss, com, Nothing, Nothing) (ObjectLiteral $ map (second (binderToCoreFn ss [])) bs)
   binderToCoreFn ss com (A.ArrayBinder bs) =

--- a/src/Language/PureScript/CoreImp/Desugar.hs
+++ b/src/Language/PureScript/CoreImp/Desugar.hs
@@ -126,11 +126,11 @@ moduleToCoreImp (Module coms mn imps exps externs decls) =
     return $ Decl (VarDecl nullAnn ident (var varName)) : done
   binder varName done (CF.ConstructorBinder (_, _, _, Just IsNewtype) _ _ [b]) =
     binder varName done b
-  binder varName done (CF.ConstructorBinder (_, _, _, Just (IsConstructor ctorType fields)) _ ctor bs) = do
+  binder varName done (CF.ConstructorBinder (_, _, ty, Just (IsConstructor ctorType fields)) _ ctor bs) = do
     stmnts <- go (zip fields bs) done
     return $ case ctorType of
       ProductType -> stmnts
-      SumType -> [IfElse nullAnn (IsTagOf nullAnn ctor (var varName)) stmnts Nothing]
+      SumType -> [IfElse nullAnn (IsTagOf (Nothing, [], ty, Nothing) ctor (var varName)) stmnts Nothing]
     where
     go :: [(Ident, CF.Binder Ann)] -> [Statement Ann] -> m [Statement Ann]
     go [] done' = return done'

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -439,9 +439,9 @@ check' val (ForAll ident ty _) = do
   val' <- check skVal sk
   return $ TypedValue True val' (ForAll ident ty (Just scope))
 check' val t@(ConstrainedType constraints ty) = do
-  dictNames <- forM constraints $ \(Qualified _ (ProperName className), _) -> do
+  dictNames <- forM constraints $ \(Qualified mn' (ProperName className), _) -> do
     n <- liftCheck freshDictionaryName
-    return $ Ident $ "__dict_" ++ className ++ "_" ++ show n
+    return $ Ident $ "__dict_" ++ (maybe "" ((++ ".") . runModuleName) mn') ++ className ++ "_" ++ show n
   val' <- makeBindingGroupVisible $ withTypeClassDictionaries (zipWith (\name (className, instanceTy) ->
     TypeClassDictionaryInScope name className instanceTy Nothing TCDRegular False) (map (Qualified Nothing) dictNames)
       constraints) $ check val ty


### PR DESCRIPTION
Needed by the refactored C++11 backend. This obviously isn't the ideal mechanism to get this information to the backend, but it's very simple, doesn't affect anything else, and works for now. Even providing the module name in the proper place (within the outgoing qualified name) causes some problems in PureScript/JS. I'd definitely like to revisit this when time permits.