### PR TITLE
Integrate some of the work done in psc-pages

### DIFF
--- a/psc-docs/Main.hs
+++ b/psc-docs/Main.hs
@@ -15,13 +15,11 @@
 module Main where
 
 import Control.Applicative
-import Control.Monad
 import Control.Monad.Writer
 import Control.Arrow (first)
 import Data.List
 import Data.Maybe (fromMaybe)
 import Data.Version (showVersion)
-import Data.Foldable (traverse_)
 
 import Options.Applicative
 
@@ -32,6 +30,7 @@ import System.IO (hPutStrLn, stderr)
 
 import Etags
 import Ctags
+import Language.PureScript.Docs.AsMarkdown
 
 -- Available output formats
 data Format = Markdown -- Output documentation in Markdown format
@@ -52,7 +51,7 @@ docgen (PSCDocsOptions fmt input) = do
       exitFailure
     Right ms -> do
       case fmt of
-       Markdown -> putStrLn . runDocs $ renderModules (map snd ms)
+       Markdown -> putStrLn $ renderModulesAsMarkdown $ map snd ms
        Etags -> ldump $ dumpEtags $ pairs ms
        Ctags -> ldump $ dumpCtags $ pairs ms
       exitSuccess
@@ -63,175 +62,6 @@ docgen (PSCDocsOptions fmt input) = do
     
 parseFile :: FilePath -> IO (FilePath, String)
 parseFile input = (,) input <$> readFile input
-
-type Docs = Writer [String] ()
-
-runDocs :: Docs -> String
-runDocs = unlines . execWriter
-
-spacer :: Docs
-spacer = tell [""]
-
-headerLevel :: Int -> String -> Docs
-headerLevel level hdr = tell [replicate level '#' ++ ' ' : hdr]
-
-withIndent :: Int -> Docs -> Docs
-withIndent indent = censor (map (replicate indent ' ' ++ ))
-
-atIndent :: Int -> String -> Docs
-atIndent indent text =
-  let ls = lines text in
-  withIndent indent (tell ls)
-
-fenced :: String -> Docs
-fenced text = fencedBlock (tell $ lines text)
-
-fencedBlock :: Docs -> Docs
-fencedBlock inner = do
-  tell ["``` purescript"]
-  inner
-  tell ["```"]
-
-ticks :: String -> String
-ticks = ("`" ++) . (++ "`")
-
-renderModules :: [P.Module] -> Docs
-renderModules ms = do
-  headerLevel 1 "Module Documentation"
-  spacer
-  mapM_ renderModule ms
-
-renderModule :: P.Module -> Docs
-renderModule mdl@(P.Module coms moduleName _ exps) = do
-    headerLevel 2 $ "Module " ++ P.runModuleName moduleName
-    spacer
-    unless (null coms) $ do
-      renderComments coms
-      spacer
-    renderTopLevel exps (P.exportedDeclarations mdl)
-    spacer
-
-renderTopLevel :: Maybe [P.DeclarationRef] -> [P.Declaration] -> Docs
-renderTopLevel exps decls = forM_ decls $ \decl ->
-  when (canRenderDecl decl) $ do
-    traverse_ (headerLevel 4) (ticks `fmap` getDeclarationTitle decl)
-    spacer
-    renderDeclaration exps decl
-    spacer
-
-renderTypeclassImage :: P.ModuleName -> Docs
-renderTypeclassImage name =
-  let name' = P.runModuleName name
-  in tell ["![" ++ name' ++ "](images/" ++ name' ++ ".png)"]
-
-getDeclarationTitle :: P.Declaration -> Maybe String
-getDeclarationTitle (P.TypeDeclaration name _)                      = Just (show name)
-getDeclarationTitle (P.ExternDeclaration _ name _ _)                = Just (show name)
-getDeclarationTitle (P.DataDeclaration _ name _ _)                  = Just (show name)
-getDeclarationTitle (P.ExternDataDeclaration name _)                = Just (show name)
-getDeclarationTitle (P.TypeSynonymDeclaration name _ _)             = Just (show name)
-getDeclarationTitle (P.TypeClassDeclaration name _ _ _)   = Just (show name)
-getDeclarationTitle (P.TypeInstanceDeclaration name _ _ _ _)        = Just (show name)
-getDeclarationTitle (P.PositionedDeclaration _ _ d)                 = getDeclarationTitle d
-getDeclarationTitle _                                               = Nothing
-
-renderDeclaration :: Maybe [P.DeclarationRef] -> P.Declaration -> Docs
-renderDeclaration _ (P.TypeDeclaration ident ty) =
-  fenced $ show ident ++ " :: " ++ prettyPrintType' ty
-renderDeclaration _ (P.ExternDeclaration _ ident _ ty) =
-  fenced $ show ident ++ " :: " ++ prettyPrintType' ty
-renderDeclaration exps (P.DataDeclaration dtype name args ctors) = do
-  let
-    typeApp  = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
-    typeName = prettyPrintType' typeApp
-    exported = filter (P.isDctorExported name exps . fst) ctors
-  fencedBlock $ do
-    tell [show dtype ++ " " ++ typeName]
-    zipWithM_ (\isFirst (ctor, tys) ->
-                atIndent 2 $ (if isFirst then "= " else "| ") ++ P.runProperName ctor ++ " " ++ unwords (map P.prettyPrintTypeAtom tys))
-              (True : repeat False) exported
-renderDeclaration _ (P.ExternDataDeclaration name kind) =
-  fenced $ "data " ++ P.runProperName name ++ " :: " ++ P.prettyPrintKind kind
-renderDeclaration _ (P.TypeSynonymDeclaration name args ty) = do
-  let
-    typeApp  = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
-    typeName = prettyPrintType' typeApp
-  fenced $ "type " ++ typeName ++ " = " ++ prettyPrintType' ty
-renderDeclaration _ (P.TypeClassDeclaration name args implies ds) = do
-  let impliesText = case implies of
-                      [] -> ""
-                      is -> "(" ++ intercalate ", " (map (\(pn, tys') -> show pn ++ " " ++ unwords (map P.prettyPrintTypeAtom tys')) is) ++ ") <= "
-      classApp  = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
-      className = prettyPrintType' classApp
-  fencedBlock $ do
-    tell ["class " ++ impliesText ++ className ++ " where"]
-    mapM_ renderClassMember ds
-  where
-    renderClassMember (P.PositionedDeclaration _ _ d) = renderClassMember d
-    renderClassMember (P.TypeDeclaration ident ty) = atIndent 2 $ show ident ++ " :: " ++ prettyPrintType' ty
-    renderClassMember _ = error "Invalid argument to renderClassMember."
-renderDeclaration _ (P.TypeInstanceDeclaration name constraints className tys _) = do
-  let constraintsText = case constraints of
-                          [] -> ""
-                          cs -> "(" ++ intercalate ", " (map (\(pn, tys') -> show pn ++ " " ++ unwords (map P.prettyPrintTypeAtom tys')) cs) ++ ") => "
-  fenced $ "instance " ++ show name ++ " :: " ++ constraintsText ++ show className ++ " " ++ unwords (map P.prettyPrintTypeAtom tys)
-renderDeclaration exps (P.PositionedDeclaration _ com d) = do
-  renderDeclaration exps d
-  renderComments com
-renderDeclaration _ _ = return ()
-
-renderComments :: [P.Comment] -> Docs
-renderComments cs = do
-  let raw = concatMap toLines cs
-  when (all hasPipe raw) $ do
-    spacer
-    atIndent 0 . unlines . map stripPipes $ raw
-  where
-
-  toLines (P.LineComment s) = [s]
-  toLines (P.BlockComment s) = lines s
-
-  hasPipe s = case dropWhile (== ' ') s of { ('|':_) -> True; _ -> False }
-
-  stripPipes = dropPipe . dropWhile (== ' ')
-
-  dropPipe ('|':' ':s) = s
-  dropPipe ('|':s) = s
-  dropPipe s = s
-
-toTypeVar :: (String, Maybe P.Kind) -> P.Type
-toTypeVar (s, Nothing) = P.TypeVar s
-toTypeVar (s, Just k) = P.KindedType (P.TypeVar s) k
-
-prettyPrintType' :: P.Type -> String
-prettyPrintType' = P.prettyPrintType . P.everywhereOnTypes dePrim
-  where
-  dePrim ty@(P.TypeConstructor (P.Qualified _ name))
-    | ty == P.tyBoolean || ty == P.tyNumber || ty == P.tyString =
-      P.TypeConstructor $ P.Qualified Nothing name
-  dePrim other = other
-
-getName :: P.Declaration -> String
-getName (P.TypeDeclaration ident _) = show ident
-getName (P.ExternDeclaration _ ident _ _) = show ident
-getName (P.DataDeclaration _ name _ _) = P.runProperName name
-getName (P.ExternDataDeclaration name _) = P.runProperName name
-getName (P.TypeSynonymDeclaration name _ _) = P.runProperName name
-getName (P.TypeClassDeclaration name _ _ _) = P.runProperName name
-getName (P.TypeInstanceDeclaration name _ _ _ _) = show name
-getName (P.PositionedDeclaration _ _ d) = getName d
-getName _ = error "Invalid argument to getName"
-
-canRenderDecl :: P.Declaration -> Bool
-canRenderDecl P.TypeDeclaration{} = True
-canRenderDecl P.ExternDeclaration{} = True
-canRenderDecl P.DataDeclaration{} = True
-canRenderDecl P.ExternDataDeclaration{} = True
-canRenderDecl P.TypeSynonymDeclaration{} = True
-canRenderDecl P.TypeClassDeclaration{} = True
-canRenderDecl P.TypeInstanceDeclaration{} = True
-canRenderDecl (P.PositionedDeclaration _ _ d) = canRenderDecl d
-canRenderDecl _ = False
 
 inputFile :: Parser FilePath
 inputFile = strArgument $

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -112,9 +112,19 @@ library
                      Language.PureScript.TypeClassDictionaries
                      Language.PureScript.Types
 
+                     Language.PureScript.Docs
+                     Language.PureScript.Docs.Render
+                     Language.PureScript.Docs.Types
+                     Language.PureScript.Docs.RenderedCode
+                     Language.PureScript.Docs.RenderedCode.Types
+                     Language.PureScript.Docs.RenderedCode.Render
+                     Language.PureScript.Docs.MonoidExtras
+                     Language.PureScript.Docs.AsMarkdown
+
                      Control.Monad.Unify
                      Control.Monad.Supply
                      Control.Monad.Supply.Class
+
     exposed: True
     buildable: True
     hs-source-dirs: src
@@ -159,7 +169,8 @@ executable psci
 
 executable psc-docs
     build-depends: base >=4 && <5, purescript -any,
-                   optparse-applicative >= 0.10.0, process -any, mtl -any
+                   optparse-applicative >= 0.10.0, process -any, mtl -any,
+                   pattern-arrows -any
     main-is: Main.hs
     buildable: True
     hs-source-dirs: psc-docs

--- a/src/Language/PureScript/Docs.hs
+++ b/src/Language/PureScript/Docs.hs
@@ -1,0 +1,12 @@
+
+-- | Data types and functions for rendering generated documentation from
+-- PureScript code, in a variety of formats.
+
+module Language.PureScript.Docs (
+  module Docs
+) where
+
+import Language.PureScript.Docs.Types as Docs
+import Language.PureScript.Docs.RenderedCode.Types as Docs
+import Language.PureScript.Docs.RenderedCode.Render as Docs
+

--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Language.PureScript.Docs.AsMarkdown (
+  renderModulesAsMarkdown
+) where
+
+import Control.Monad.Writer
+import Data.Foldable (for_)
+import Data.List (partition)
+
+import qualified Language.PureScript as P
+
+import Language.PureScript.Docs.Types
+import Language.PureScript.Docs.RenderedCode
+import qualified Language.PureScript.Docs.Render as Render
+
+-- |
+-- Take a list of modules and render them all in order, returning a single
+-- Markdown-formatted String.
+--
+renderModulesAsMarkdown :: [P.Module] -> String
+renderModulesAsMarkdown =
+  runDocs . modulesAsMarkdown . map Render.renderModule
+
+modulesAsMarkdown :: [RenderedModule] -> Docs
+modulesAsMarkdown ms = do
+  headerLevel 1 "Module Documentation"
+  spacer
+  mapM_ moduleAsMarkdown ms
+
+moduleAsMarkdown :: RenderedModule -> Docs
+moduleAsMarkdown RenderedModule{..} = do
+  headerLevel 2 $ "Module " ++ rmName
+  spacer
+  for_ rmComments tell'
+  mapM_ declAsMarkdown rmDeclarations
+  spacer
+
+declAsMarkdown :: RenderedDeclaration -> Docs
+declAsMarkdown RenderedDeclaration{..} = do
+  headerLevel 4 (ticks rdTitle)
+  spacer
+
+  let (instances, children) = partition ((==) ChildInstance . rcdType) rdChildren
+  fencedBlock $ do
+    tell' (codeToString rdCode)
+    zipWithM_ (\f c -> tell' (childToString f c)) (True : repeat False) children
+  spacer
+
+  unless (null instances) $ do
+    headerLevel 5 "Instances"
+    fencedBlock $ do
+      mapM_ (tell' . childToString False) instances
+    spacer
+
+  for_ rdComments tell'
+
+codeToString :: RenderedCode -> String
+codeToString = outputWith elemAsMarkdown
+  where
+  elemAsMarkdown (Syntax x)  = x
+  elemAsMarkdown (Ident x)   = x
+  elemAsMarkdown (Ctor x _)  = x
+  elemAsMarkdown (Kind x)    = x
+  elemAsMarkdown (Keyword x) = x
+  elemAsMarkdown Space       = " "
+
+childToString :: Bool -> RenderedChildDeclaration -> String
+childToString isFirst RenderedChildDeclaration{..} =
+  case rcdType of
+    ChildDataConstructor ->
+      let c = if isFirst then "=" else "|"
+      in  "  " ++ c ++ " " ++ codeToString rcdCode
+    ChildTypeClassMember ->
+      "  " ++ codeToString rcdCode
+    ChildInstance ->
+      codeToString rcdCode
+
+type Docs = Writer [String] ()
+
+runDocs :: Docs -> String
+runDocs = unlines . execWriter
+
+tell' :: String -> Docs
+tell' = tell . (:[])
+
+spacer :: Docs
+spacer = tell' ""
+
+headerLevel :: Int -> String -> Docs
+headerLevel level hdr = tell' (replicate level '#' ++ ' ' : hdr)
+
+fencedBlock :: Docs -> Docs
+fencedBlock inner = do
+  tell' "``` purescript"
+  inner
+  tell' "```"
+
+ticks :: String -> String
+ticks = ("`" ++) . (++ "`")

--- a/src/Language/PureScript/Docs/MonoidExtras.hs
+++ b/src/Language/PureScript/Docs/MonoidExtras.hs
@@ -1,0 +1,9 @@
+module Language.PureScript.Docs.MonoidExtras where
+
+import Data.Monoid
+
+mintersperse :: (Monoid m) => m -> [m] -> m
+mintersperse _ []       = mempty
+mintersperse _ [x]      = x
+mintersperse sep (x:xs) = x <> sep <> mintersperse sep xs
+

--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -1,0 +1,238 @@
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- | Functions for rendering documentation generated from PureScript code.
+
+module Language.PureScript.Docs.Render (
+  renderPackage,
+  renderModule
+) where
+
+import Control.Monad
+import Data.Either
+import Data.Version (Version)
+import Data.Monoid ((<>))
+import Data.Maybe (mapMaybe)
+import Data.List (nub)
+
+import qualified Language.PureScript as P
+
+import Language.PureScript.Docs.MonoidExtras
+import Language.PureScript.Docs.RenderedCode
+import Language.PureScript.Docs.Types
+
+-- |
+-- Render a Package, given its name, its current version, and a list of
+-- contained modules.
+--
+renderPackage :: String -> Version -> [P.Module] -> RenderedPackage
+renderPackage name vers mods =
+  RenderedPackage name vers (map renderModule mods)
+
+-- |
+-- Render a single Module.
+--
+renderModule :: P.Module -> RenderedModule
+renderModule m@(P.Module coms moduleName  _ exps) =
+  RenderedModule (show moduleName) comments declarations
+  where
+  comments = renderComments coms
+  declarations = groupChildren declarationsWithChildren
+  declarationsWithChildren = mapMaybe go (P.exportedDeclarations m)
+  go decl = getDeclarationTitle decl
+             >>= renderDeclaration exps decl
+
+-- | An intermediate stage which we go through during rendering.
+--
+-- In the first pass, we take all top level declarations in the module, and
+-- render those which should appear at the top level in the output, as well as
+-- those which should appear as children of other declarations in the output.
+--
+-- In the second pass, we move all children under their respective parents,
+-- or discard them if none are found.
+--
+-- This two-pass system is only necessary for type instance declarations, since
+-- they appear at the top level in the AST, and since they might need to appear
+-- as children in two places (for example, if a data type defined in a module
+-- is an instance of a type class also defined in that module).
+--
+-- This data type is used as an intermediate type between the two stages. The
+-- Left case is a child declaration, together with a list of parent declaration
+-- titles which this may appear as a child of.
+--
+-- The Right case is a top level declaration which should pass straight through
+-- the second stage; the only way it might change is if child declarations are
+-- added to it.
+type IntermediateDeclaration
+  = Either ([String], RenderedChildDeclaration) RenderedDeclaration
+
+-- | Move child declarations into their respective parents; the second pass.
+-- See the comments under the type synonym IntermediateDeclaration for more
+-- information.
+groupChildren :: [IntermediateDeclaration] -> [RenderedDeclaration]
+groupChildren (partitionEithers -> (children, toplevels)) =
+  foldl go toplevels children
+  where
+  go ds (parentTitles, child) =
+    map (\d ->
+      if rdTitle d `elem` parentTitles
+        then d { rdChildren = rdChildren d ++ [child] }
+        else d) ds
+
+getDeclarationTitle :: P.Declaration -> Maybe String
+getDeclarationTitle (P.TypeDeclaration name _)               = Just (show name)
+getDeclarationTitle (P.ExternDeclaration _ name _ _)         = Just (show name)
+getDeclarationTitle (P.DataDeclaration _ name _ _)           = Just (show name)
+getDeclarationTitle (P.ExternDataDeclaration name _)         = Just (show name)
+getDeclarationTitle (P.TypeSynonymDeclaration name _ _)      = Just (show name)
+getDeclarationTitle (P.TypeClassDeclaration name _ _ _)      = Just (show name)
+getDeclarationTitle (P.TypeInstanceDeclaration name _ _ _ _) = Just (show name)
+getDeclarationTitle (P.PositionedDeclaration _ _ d)          = getDeclarationTitle d
+getDeclarationTitle _                                        = Nothing
+
+basicDeclaration :: String -> RenderedCode -> Maybe IntermediateDeclaration
+basicDeclaration title code = Just (Right (RenderedDeclaration title Nothing code Nothing []))
+
+renderDeclaration :: Maybe [P.DeclarationRef] -> P.Declaration -> String -> Maybe IntermediateDeclaration
+renderDeclaration _ (P.TypeDeclaration ident' ty) title =
+  basicDeclaration title code
+  where
+  code = ident (show ident')
+          <> sp <> syntax "::" <> sp
+          <> renderType ty
+renderDeclaration _ (P.ExternDeclaration _ ident' _ ty) title =
+  basicDeclaration title code
+  where
+  code = ident (show ident')
+          <> sp <> syntax "::" <> sp
+          <> renderType ty
+renderDeclaration exps (P.DataDeclaration dtype name args ctors) title =
+  Just (Right (RenderedDeclaration title Nothing code Nothing children))
+  where
+  typeApp  = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
+  exported = filter (P.isDctorExported name exps . fst) ctors
+  code = keyword (show dtype) <> sp <> renderType typeApp
+  children = map renderCtor exported
+  -- TODO: Comments for data constructors?
+  renderCtor (ctor', tys) =
+          let typeApp' = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing ctor')) tys
+              childCode = renderType typeApp'
+          in  RenderedChildDeclaration (show ctor') Nothing childCode Nothing ChildDataConstructor
+renderDeclaration _ (P.ExternDataDeclaration name kind') title =
+  basicDeclaration title code
+  where
+  code = keywordData <> sp
+          <> renderType (P.TypeConstructor (P.Qualified Nothing name))
+          <> sp <> syntax "::" <> sp
+          <> renderKind kind'
+renderDeclaration _ (P.TypeSynonymDeclaration name args ty) title =
+  basicDeclaration title code
+  where
+  typeApp = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
+  code = mintersperse sp
+          [ keywordType
+          , renderType typeApp
+          , syntax "="
+          , renderType ty
+          ]
+renderDeclaration _ (P.TypeClassDeclaration name args implies ds) title = do
+  Just (Right (RenderedDeclaration title Nothing code Nothing children))
+  where
+  code = mintersperse sp $
+           [keywordClass]
+            ++ maybe [] (:[]) superclasses
+            ++ [renderType classApp]
+            ++ if (not (null ds)) then [keywordWhere] else []
+
+  superclasses
+    | null implies = Nothing
+    | otherwise = Just $
+        syntax "("
+         <> mintersperse (syntax "," <> sp) (map renderImplies implies)
+         <> syntax ") <="
+
+  renderImplies (pn, tys) =
+    let supApp = foldl P.TypeApp (P.TypeConstructor pn) tys
+    in renderType supApp
+
+  classApp = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
+
+  children = map renderClassMember ds
+
+  -- TODO: Comments for type class members
+  renderClassMember (P.PositionedDeclaration _ _ d) = renderClassMember d
+  renderClassMember (P.TypeDeclaration ident' ty) =
+    let childCode =
+          mintersperse sp
+            [ ident (show ident')
+            , syntax "::"
+            , renderType ty
+            ]
+    in  RenderedChildDeclaration (show ident') Nothing childCode Nothing ChildTypeClassMember
+  renderClassMember _ = error "Invalid argument to renderClassMember."
+renderDeclaration _ (P.TypeInstanceDeclaration name constraints className tys _) title = do
+  Just (Left (classNameString : typeNameStrings, childDecl))
+  where
+  classNameString = unQual className
+  typeNameStrings = nub (concatMap (P.everythingOnTypes (++) extractProperNames) tys)
+  unQual x = let (P.Qualified _ y) = x in show y
+
+  extractProperNames (P.TypeConstructor n) = [unQual n]
+  extractProperNames (P.SaturatedTypeSynonym n _) = [unQual n]
+  extractProperNames _ = []
+
+  childDecl = RenderedChildDeclaration title Nothing code Nothing ChildInstance
+
+  code =
+    mintersperse sp $
+      [ keywordInstance
+      , ident (show name)
+      , syntax "::"
+      ] ++ maybe [] (:[]) constraints'
+        ++ [ renderType classApp ]
+
+  constraints'
+    | null constraints = Nothing
+    | otherwise = Just (syntax "(" <> renderedConstraints <> syntax ") =>")
+
+  renderedConstraints = mintersperse (syntax "," <> sp) (map renderConstraint constraints)
+
+  renderConstraint (pn, tys') =
+    let supApp = foldl P.TypeApp (P.TypeConstructor pn) tys'
+    in renderType supApp
+
+  classApp = foldl P.TypeApp (P.TypeConstructor className) tys
+renderDeclaration exps (P.PositionedDeclaration srcSpan com d') title =
+  fmap (addComments . addSourceSpan) (renderDeclaration exps d' title)
+  where
+  addComments (Left (t, d)) = Left (t, d { rcdComments = renderComments com })
+  addComments (Right d) = Right (d { rdComments = renderComments com })
+
+  addSourceSpan (Left (t, d)) = Left (t, d { rcdSourceSpan = Just srcSpan })
+  addSourceSpan (Right d) = Right (d { rdSourceSpan = Just srcSpan })
+renderDeclaration _ _ _ = Nothing
+
+renderComments :: [P.Comment] -> Maybe String
+renderComments cs = do
+  let raw = concatMap toLines cs
+  guard (all hasPipe raw && not (null raw))
+  return (go raw)
+  where
+  go = unlines . map stripPipes
+
+  toLines (P.LineComment s) = [s]
+  toLines (P.BlockComment s) = lines s
+
+  hasPipe s = case dropWhile (== ' ') s of { ('|':_) -> True; _ -> False }
+
+  stripPipes = dropPipe . dropWhile (== ' ')
+
+  dropPipe ('|':' ':s) = s
+  dropPipe ('|':s) = s
+  dropPipe s = s
+
+toTypeVar :: (String, Maybe P.Kind) -> P.Type
+toTypeVar (s, Nothing) = P.TypeVar s
+toTypeVar (s, Just k) = P.KindedType (P.TypeVar s) k

--- a/src/Language/PureScript/Docs/RenderedCode.hs
+++ b/src/Language/PureScript/Docs/RenderedCode.hs
@@ -1,0 +1,11 @@
+
+-- | Data types and functions for representing a simplified form of PureScript
+-- code, intended for use in e.g. HTML documentation.
+
+module Language.PureScript.Docs.RenderedCode (
+  module RenderedCode
+) where
+
+import Language.PureScript.Docs.RenderedCode.Types as RenderedCode
+import Language.PureScript.Docs.RenderedCode.Render as RenderedCode
+

--- a/src/Language/PureScript/Docs/RenderedCode/Render.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Render.hs
@@ -1,0 +1,172 @@
+
+-- | Functions for producing RenderedCode values from PureScript Type values.
+
+module Language.PureScript.Docs.RenderedCode.Render (
+    renderType,
+    renderTypeAtom,
+    renderRow,
+    renderKind
+) where
+
+import Data.Monoid ((<>), mconcat, mempty)
+import Data.Maybe (fromMaybe)
+
+import Control.Arrow ((<+>))
+import Control.PatternArrows
+
+import Language.PureScript.Names
+import Language.PureScript.Types
+import Language.PureScript.Kinds
+import Language.PureScript.Pretty.Kinds
+import Language.PureScript.Environment
+
+import Language.PureScript.Docs.MonoidExtras
+import Language.PureScript.Docs.RenderedCode.Types
+
+typeLiterals :: Pattern () Type RenderedCode
+typeLiterals = mkPattern match
+  where
+  match TypeWildcard =
+    Just (syntax "_")
+  match (TypeVar var) =
+    Just (ident var)
+  match (PrettyPrintObject row) =
+    Just $ mintersperse sp
+              [ syntax "{"
+              , renderRow row
+              , syntax "}"
+              ]
+  match (PrettyPrintArray ty) =
+    Just $ mconcat
+              [ syntax "["
+              , renderType ty
+              , syntax "]"
+              ]
+  match (TypeConstructor (Qualified mn name)) =
+    Just (ctor (show name) (toContainingModule mn))
+  match (ConstrainedType deps ty) =
+    Just $ mintersperse sp
+            [ syntax "(" <> constraints <> syntax ")"
+            , syntax "=>"
+            , renderType ty
+            ]
+    where
+    constraints = mintersperse (syntax "," <> sp) (map renderDep deps)
+    renderDep (pn, tys) =
+        let instApp = foldl TypeApp (TypeConstructor pn) tys
+        in  renderType instApp
+  match REmpty =
+    Just (syntax "()")
+  match row@RCons{} =
+    Just (syntax "(" <> renderRow row <> syntax ")")
+  match _ =
+    Nothing
+
+-- |
+-- Render code representing a Row
+--
+renderRow :: Type -> RenderedCode
+renderRow = uncurry renderRow' . rowToList
+  where
+  renderRow' h t = renderHead h <> renderTail t
+
+renderHead :: [(String, Type)] -> RenderedCode
+renderHead = mintersperse (syntax "," <> sp) . map renderLabel
+
+renderLabel :: (String, Type) -> RenderedCode
+renderLabel (label, ty) =
+  mintersperse sp
+    [ ident label
+    , syntax "::"
+    , renderType ty
+    ]
+
+renderTail :: Type -> RenderedCode
+renderTail REmpty = mempty
+renderTail other = sp <> syntax "|" <> sp <> renderType other
+
+typeApp :: Pattern () Type (Type, Type)
+typeApp = mkPattern match
+  where
+  match (TypeApp f x) = Just (f, x)
+  match _ = Nothing
+
+appliedFunction :: Pattern () Type (Type, Type)
+appliedFunction = mkPattern match
+  where
+  match (PrettyPrintFunction arg ret) = Just (arg, ret)
+  match _ = Nothing
+
+kinded :: Pattern () Type (Kind, Type)
+kinded = mkPattern match
+  where
+  match (KindedType t k) = Just (k, t)
+  match _ = Nothing
+
+matchTypeAtom :: Pattern () Type RenderedCode
+matchTypeAtom = typeLiterals <+> fmap parens matchType
+  where
+  parens x = syntax "(" <> x <> syntax ")"
+
+matchType :: Pattern () Type RenderedCode
+matchType = buildPrettyPrinter operators matchTypeAtom
+  where
+  operators :: OperatorTable () Type RenderedCode
+  operators =
+    OperatorTable [ [ AssocL typeApp $ \f x -> f <> sp <> x ]
+                  , [ AssocR appliedFunction $ \arg ret -> mintersperse sp [arg, syntax "->", ret] ]
+                  , [ Wrap forall_ $ \idents ty -> mconcat [syntax "forall", sp, mintersperse sp (map ident idents), syntax ".", sp, ty] ]
+                  , [ Wrap kinded $ \k ty -> mintersperse sp [ty, syntax "::", renderKind k] ]
+                  ]
+
+forall_ :: Pattern () Type ([String], Type)
+forall_ = mkPattern match
+  where
+  match (PrettyPrintForAll idents ty) = Just (idents, ty)
+  match _ = Nothing
+
+insertPlaceholders :: Type -> Type
+insertPlaceholders =
+  everywhereOnTypesTopDown convertForAlls . everywhereOnTypes convert
+
+dePrim :: Type -> Type
+dePrim ty@(TypeConstructor (Qualified _ name))
+  | ty == tyBoolean || ty == tyNumber || ty == tyString =
+    TypeConstructor $ Qualified Nothing name
+dePrim other = other
+
+convert :: Type -> Type
+convert (TypeApp (TypeApp f arg) ret) | f == tyFunction = PrettyPrintFunction arg ret
+convert (TypeApp a el) | a == tyArray = PrettyPrintArray el
+convert (TypeApp o r) | o == tyObject = PrettyPrintObject r
+convert other = other
+
+convertForAlls :: Type -> Type
+convertForAlls (ForAll i ty _) = go [i] ty
+  where
+  go idents (ForAll ident' ty' _) = go (ident' : idents) ty'
+  go idents other = PrettyPrintForAll idents other
+convertForAlls other = other
+
+preprocessType :: Type -> Type
+preprocessType = dePrim . insertPlaceholders
+
+-- |
+-- Render code representing a Kind
+--
+renderKind :: Kind -> RenderedCode
+renderKind = kind . prettyPrintKind
+
+-- |
+-- Render code representing a Type, as it should appear inside parentheses
+--
+renderTypeAtom :: Type -> RenderedCode
+renderTypeAtom = fromMaybe (error "Incomplete pattern") . pattern matchTypeAtom () . preprocessType
+
+
+-- |
+-- Render code representing a Type
+--
+renderType :: Type -> RenderedCode
+renderType = fromMaybe (error "Incomplete pattern") . pattern matchType () . preprocessType
+

--- a/src/Language/PureScript/Docs/RenderedCode/Types.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Types.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- | Data types and functions for representing a simplified form of PureScript
+-- code, intended for use in e.g. HTML documentation.
+
+module Language.PureScript.Docs.RenderedCode.Types
+ ( RenderedCodeElement(..)
+ , ContainingModule(..)
+ , toContainingModule
+ , fromContainingModule
+ , RenderedCode
+ , outputWith
+ , sp
+ , syntax
+ , ident
+ , ctor
+ , kind
+ , keyword
+ , keywordForall
+ , keywordData
+ , keywordNewtype
+ , keywordType
+ , keywordClass
+ , keywordInstance
+ , keywordWhere
+ ) where
+
+import Data.Foldable
+import Data.Monoid
+
+import qualified Language.PureScript as P
+
+-- |
+-- A single element in a rendered code fragment. The intention is to support
+-- multiple output formats. For example, plain text, or highlighted HTML.
+--
+data RenderedCodeElement
+  = Syntax String
+  | Ident String
+  | Ctor String ContainingModule
+  | Kind String
+  | Keyword String
+  | Space
+  deriving (Show, Eq, Ord)
+
+-- |
+-- This type is isomorphic to 'Maybe' 'P.ModuleName'. It makes code a bit easier
+-- to read, as the meaning is more explicit.
+--
+data ContainingModule
+  = ThisModule
+  | OtherModule P.ModuleName
+  deriving (Show, Eq, Ord)
+
+-- |
+-- Convert a 'Maybe' 'P.ModuleName' to a 'ContainingModule', using the obvious
+-- isomorphism.
+--
+toContainingModule :: Maybe P.ModuleName -> ContainingModule
+toContainingModule Nothing = ThisModule
+toContainingModule (Just mn) = OtherModule mn
+
+-- |
+-- A version of 'fromMaybe' for 'ContainingModule' values.
+--
+fromContainingModule :: P.ModuleName -> ContainingModule -> P.ModuleName
+fromContainingModule def ThisModule = def
+fromContainingModule _ (OtherModule mn) = mn
+
+-- |
+-- A type representing a highly simplified version of PureScript code, intended
+-- for use in output formats like plain text or HTML.
+--
+newtype RenderedCode
+  = RC { unRC :: [RenderedCodeElement] }
+  deriving (Show, Eq, Ord, Monoid)
+
+-- |
+-- This function allows conversion of a 'RenderedCode' value into a value of
+-- some other type (for example, plain text, or HTML). The first argument
+-- is a function specifying how each individual 'RenderedCodeElement' should be
+-- rendered.
+--
+outputWith :: Monoid a => (RenderedCodeElement -> a) -> RenderedCode -> a
+outputWith f = foldMap f . unRC
+
+-- |
+-- A 'RenderedCode' fragment representing a space.
+--
+sp :: RenderedCode
+sp = RC [Space]
+
+syntax :: String -> RenderedCode
+syntax x = RC [Syntax x]
+
+ident :: String -> RenderedCode
+ident x = RC [Ident x]
+
+ctor :: String -> ContainingModule -> RenderedCode
+ctor x m = RC [Ctor x m]
+
+kind :: String -> RenderedCode
+kind x = RC [Kind x]
+
+keyword :: String -> RenderedCode
+keyword kw = RC [Keyword kw]
+
+keywordForall :: RenderedCode
+keywordForall = keyword "forall"
+
+keywordData :: RenderedCode
+keywordData = keyword "data"
+
+keywordNewtype :: RenderedCode
+keywordNewtype = keyword "newtype"
+
+keywordType :: RenderedCode
+keywordType = keyword "type"
+
+keywordClass :: RenderedCode
+keywordClass = keyword "class"
+
+keywordInstance :: RenderedCode
+keywordInstance = keyword "instance"
+
+keywordWhere :: RenderedCode
+keywordWhere = keyword "where"

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -1,0 +1,49 @@
+
+module Language.PureScript.Docs.Types
+  ( module Language.PureScript.Docs.Types
+  , module ReExports
+  )
+  where
+
+import Data.Version
+import qualified Language.PureScript as P
+
+import Language.PureScript.Docs.RenderedCode as ReExports (RenderedCode, ContainingModule(..))
+
+data RenderedPackage = RenderedPackage
+  { rpName    :: String
+  , rpVersion :: Version
+  , rpModules :: [RenderedModule]
+  }
+  deriving (Show)
+
+data RenderedModule = RenderedModule
+  { rmName         :: String
+  , rmComments     :: Maybe String
+  , rmDeclarations :: [RenderedDeclaration]
+  }
+  deriving (Show)
+
+data RenderedDeclaration = RenderedDeclaration
+  { rdTitle      :: String
+  , rdComments   :: Maybe String
+  , rdCode       :: RenderedCode
+  , rdSourceSpan :: Maybe P.SourceSpan
+  , rdChildren   :: [RenderedChildDeclaration]
+  }
+  deriving (Show)
+
+data RenderedChildDeclaration = RenderedChildDeclaration
+  { rcdTitle      :: String
+  , rcdComments   :: Maybe String
+  , rcdCode       :: RenderedCode
+  , rcdSourceSpan :: Maybe P.SourceSpan
+  , rcdType       :: RenderedChildDeclarationType
+  }
+  deriving (Show)
+
+data RenderedChildDeclarationType
+  = ChildInstance
+  | ChildDataConstructor
+  | ChildTypeClassMember
+  deriving (Show, Eq, Ord)


### PR DESCRIPTION
Some context:

* We want to be able to render documentation in at least 3 different forms: Markdown (`psc-docs`), HTML (`psc-pages`), and as an input file for Hoogle (not really "documentation", but the process is very similar). The code I recently contributed to psc-pages splits the rendering into two stages, which makes it easy to render documentation in different forms in this way. In fact psc-pages can currently produce both HTML and ~~Markdown~~ Hoogle.
* We want to fix bugs like #747, and also only have to do it once.
* We eventually want users to be able to run a tool locally which will generate HTML documentation and Hoogle input files, and then publish the results on the web.

It seems like the best way of accomplishing these 3 goals is to start looking at moving chunks of `psc-pages` into the library part of the `purescript` package. This PR is a step in this direction.

One small change I've made in this code that's not in the current `psc-pages` code, or even in the code in the open PR I have on `psc-pages`, is that the `RenderedDeclaration` etc types now have comments as `String` rather than `Html` - the code is the same, it just omits the final step transforming the comments into an HTML element. This allows us to output comments as Markdown, like `psc-docs` currently does, or as HTML.

Also, I decided to base off of `0.7-dev`, since #747 is marked for 0.7.0, but I can change this easily if you'd like.