### PR TITLE
Relax lower bound of transformers to 0.3.0.0

### DIFF
--- a/psc-make/Main.hs
+++ b/psc-make/Main.hs
@@ -17,7 +17,9 @@
 module Main where
 
 import Control.Applicative
-import Control.Monad.Except
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Trans.Except
 import Control.Monad.Reader
 
 import Data.Version (showVersion)

--- a/psc/Main.hs
+++ b/psc/Main.hs
@@ -17,7 +17,7 @@
 module Main where
 
 import Control.Applicative
-import Control.Monad.Except
+import Control.Monad
 import Control.Monad.Reader
 
 import Data.Maybe (fromMaybe)

--- a/psci/PSCi.hs
+++ b/psci/PSCi.hs
@@ -30,8 +30,8 @@ import qualified Data.Map as M
 import Control.Applicative
 import Control.Monad
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Error.Class (throwError)
-import Control.Monad.Except (ExceptT(..), MonadError, runExceptT)
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 import Control.Monad.Reader (MonadReader, ReaderT, runReaderT)
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -31,7 +31,8 @@ library
                    filepath -any,
                    mtl >= 2.1.0 && < 2.3.0,
                    parsec -any,
-                   transformers >= 0.4.0 && < 0.5,
+                   transformers >= 0.3.0 && < 0.5,
+                   transformers-compat >= 0.3.0,
                    utf8-string >= 1 && < 2,
                    pattern-arrows >= 0.0.2 && < 0.1,
                    file-embed >= 0.0.7 && < 0.0.8,
@@ -133,7 +134,7 @@ executable psc
 executable psc-make
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any,
                    mtl -any, optparse-applicative >= 0.10.0, parsec -any, purescript -any,
-                   transformers -any
+                   transformers -any, transformers-compat -any
     main-is: Main.hs
     buildable: True
     hs-source-dirs: psc-make
@@ -144,7 +145,7 @@ executable psci
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any,
                    mtl -any, optparse-applicative >= 0.10.0, parsec -any,
                    haskeline >= 0.7.0.0, purescript -any, transformers -any,
-                   process -any
+                   transformers-compat -any, process -any
 
     main-is: Main.hs
     buildable: True
@@ -189,7 +190,7 @@ test-suite psci-tests
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any,
                    mtl -any, optparse-applicative >= 0.10.0, parsec -any,
                    haskeline >= 0.7.0.0, purescript -any, transformers -any,
-                   process -any, HUnit -any
+                   transformers-compat -any, process -any, HUnit -any
     type: exitcode-stdio-1.0
     main-is: Main.hs
     buildable: True

--- a/src/Control/Monad/Supply.hs
+++ b/src/Control/Monad/Supply.hs
@@ -21,7 +21,7 @@ import Data.Functor.Identity
 
 import Control.Applicative
 import Control.Monad.State
-import Control.Monad.Except
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Reader
 import Control.Monad.Writer
 

--- a/src/Control/Monad/Unify.hs
+++ b/src/Control/Monad/Unify.hs
@@ -27,7 +27,7 @@ import Data.Monoid
 
 import Control.Applicative
 import Control.Monad.State
-import Control.Monad.Error.Class
+import Control.Monad.Error.Class (MonadError(..))
 
 import Data.HashMap.Strict as M
 

--- a/src/Language/PureScript.hs
+++ b/src/Language/PureScript.hs
@@ -43,7 +43,8 @@ import qualified Data.Set as S
 
 import Control.Applicative
 import Control.Arrow ((&&&))
-import Control.Monad.Except
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Reader
 
 import System.FilePath ((</>))

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -23,7 +23,8 @@ import Data.List (intercalate)
 import Data.Monoid
 import Data.Foldable (fold, foldMap)
 
-import Control.Monad.Except
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Unify
 import Control.Applicative ((<$>))
 

--- a/src/Language/PureScript/ModuleDependencies.hs
+++ b/src/Language/PureScript/ModuleDependencies.hs
@@ -19,7 +19,7 @@ module Language.PureScript.ModuleDependencies (
   ModuleGraph
 ) where
 
-import Control.Monad.Except
+import Control.Monad.Error.Class (MonadError(..))
 
 import Data.Graph
 import Data.List (nub)

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -20,7 +20,7 @@ module Language.PureScript.Sugar (desugar, module S) where
 import Control.Monad
 import Control.Category ((>>>))
 import Control.Applicative
-import Control.Monad.Error.Class
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Supply.Class
 
 import Language.PureScript.AST

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -28,7 +28,7 @@ import Data.List (nub, intersect)
 import Data.Maybe (isJust, mapMaybe)
 import Control.Applicative
 import Control.Monad ((<=<))
-import Control.Monad.Error.Class
+import Control.Monad.Error.Class (MonadError(..))
 
 import qualified Data.Set as S
 

--- a/src/Language/PureScript/Sugar/CaseDeclarations.hs
+++ b/src/Language/PureScript/Sugar/CaseDeclarations.hs
@@ -26,8 +26,7 @@ import Data.List (nub, groupBy)
 
 import Control.Applicative
 import Control.Monad ((<=<), forM, replicateM, join, unless)
-import Control.Monad.Except (throwError)
-import Control.Monad.Error.Class (MonadError)
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Supply.Class
 
 import Language.PureScript.Names

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -28,7 +28,7 @@ import Language.PureScript.Errors
 import qualified Language.PureScript.Constants as C
 
 import Control.Applicative
-import Control.Monad.Error.Class
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Supply.Class
 
 -- |

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -23,7 +23,8 @@ import Data.List (nub)
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
 
 import Control.Applicative (Applicative(..), (<$>), (<*>))
-import Control.Monad.Except
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
 
 import qualified Data.Map as M
 

--- a/src/Language/PureScript/Sugar/ObjectWildcards.hs
+++ b/src/Language/PureScript/Sugar/ObjectWildcards.hs
@@ -21,7 +21,7 @@ module Language.PureScript.Sugar.ObjectWildcards (
 
 import Control.Applicative
 import Control.Arrow (second)
-import Control.Monad.Error.Class
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Supply.Class
 
 import Data.List (partition)

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -33,7 +33,7 @@ import Language.PureScript.Names
 
 import Control.Applicative
 import Control.Monad.State
-import Control.Monad.Except
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Supply.Class
 
 import Data.Function (on)

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -35,7 +35,7 @@ import qualified Language.PureScript.Constants as C
 
 import Control.Applicative
 import Control.Arrow (first, second)
-import Control.Monad.Except
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State
 import Data.List ((\\), find, sortBy)
 import Data.Maybe (catMaybes, mapMaybe, isJust)

--- a/src/Language/PureScript/Sugar/TypeDeclarations.hs
+++ b/src/Language/PureScript/Sugar/TypeDeclarations.hs
@@ -23,8 +23,7 @@ module Language.PureScript.Sugar.TypeDeclarations (
 
 import Control.Applicative
 import Control.Monad (forM)
-import Control.Monad.Except (throwError)
-import Control.Monad.Error.Class (MonadError)
+import Control.Monad.Error.Class (MonadError(..))
 
 import Language.PureScript.AST
 import Language.PureScript.Names

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -32,7 +32,7 @@ import Data.Foldable (for_)
 import qualified Data.Map as M
 
 import Control.Monad.State
-import Control.Monad.Except
+import Control.Monad.Error.Class (MonadError(..))
 
 import Language.PureScript.Types
 import Language.PureScript.Names

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -25,7 +25,8 @@ import qualified Data.Map as M
 
 import Control.Applicative
 import Control.Arrow (Arrow(..))
-import Control.Monad.Except
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
 
 import Language.PureScript.AST
 import Language.PureScript.Errors

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -30,7 +30,8 @@ import qualified Data.Map as M
 
 import Control.Arrow (second)
 import Control.Applicative
-import Control.Monad.Except
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State
 import Control.Monad.Unify
 

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -22,7 +22,7 @@ import Data.Maybe
 import qualified Data.Map as M
 
 import Control.Applicative
-import Control.Monad.Except
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State
 import Control.Monad.Unify
 

--- a/src/Language/PureScript/TypeChecker/Rows.hs
+++ b/src/Language/PureScript/TypeChecker/Rows.hs
@@ -19,7 +19,8 @@ module Language.PureScript.TypeChecker.Rows (
 
 import Data.List
 
-import Control.Monad.Except
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
 
 import Language.PureScript.AST
 import Language.PureScript.Errors

--- a/src/Language/PureScript/TypeChecker/Skolems.hs
+++ b/src/Language/PureScript/TypeChecker/Skolems.hs
@@ -26,7 +26,7 @@ import Data.List (nub, (\\))
 import Data.Monoid
 
 import Control.Applicative
-import Control.Monad.Except
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Unify
 
 import Language.PureScript.AST

--- a/src/Language/PureScript/TypeChecker/Subsumption.hs
+++ b/src/Language/PureScript/TypeChecker/Subsumption.hs
@@ -20,7 +20,8 @@ module Language.PureScript.TypeChecker.Subsumption (
 import Data.List (sortBy)
 import Data.Ord (comparing)
 
-import Control.Monad.Except
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Unify
 
 import Language.PureScript.AST

--- a/src/Language/PureScript/TypeChecker/Synonyms.hs
+++ b/src/Language/PureScript/TypeChecker/Synonyms.hs
@@ -28,7 +28,8 @@ import Data.Maybe (fromMaybe)
 import qualified Data.Map as M
 
 import Control.Applicative
-import Control.Monad.Except
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State
 
 import Language.PureScript.Environment

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -41,7 +41,8 @@ import Data.Maybe (fromMaybe)
 import qualified Data.Map as M
 
 import Control.Applicative
-import Control.Monad.Except
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State
 import Control.Monad.Unify
 

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -29,7 +29,8 @@ import Data.List (nub, sort)
 import Data.Maybe (fromMaybe)
 import qualified Data.HashMap.Strict as H
 
-import Control.Monad.Except
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Unify
 
 import Language.PureScript.Environment


### PR DESCRIPTION
These commits do 3 things:

* Replace all occurrences of `Control.Monad.Except` with one or more of `Control.Monad`, `Control.Monad.Error.Class (MonadError(..))`, and `Control.Monad.Trans.Except`, since `Control.Monad.Except` seems to just re-export all of these. This is necessary in the case where we are using `transformers==0.3.*`, because `transformers-compat` doesn't have `Control.Monad.Except` (not sure why). I think this is worth doing anyway; I don't like how `Control.Monad.Except` re-exports so much stuff.
* Add an explicit dependency on `transformers-compat`. purescript was previously bringing it in as a transitive dependency, so the only effect that this should have is allowing the importing of its modules where necessary.
* Relax `transformers` lower bound to 0.3.\*; now that we have `transformers-compat`, purescript can compile with `transformers==0.3.*`. I tested this by doing:

```
cabal sandbox delete
cabal sandbox init
cabal install --only-dependencies --enable-tests --constraint='transformers ==0.3.*'
cabal build
cabal test
```

The effect of this is that you can now easily install `yesod-bin` together with `purescript` in a sandbox. Also, it is still possible to get  `transformers==0.4.*` when resolving constraints - these changes appear to have no effect on the versions selected in those cases which currently can be resolved.