### PR TITLE
Check source distributions during Travis builds

### DIFF
--- a/travis-script.sh
+++ b/travis-script.sh
@@ -9,3 +9,9 @@ fi
 
 cabal build
 cabal test
+
+# Check that a source distribution can be successfully generated, and that
+# the generated source distribution can be installed
+cabal sdist
+SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")


### PR DESCRIPTION
This commit adds a step in travis-script.sh to generate a source
distribution and then check that the source distribution can be built.
Hopefully this will stop things like #980 from happening again.

the idea comes from here:
https://github.com/hvr/multi-ghc-travis/blob/master/.travis.yml#L98-L103