### PR TITLE
Optimise (f <<< g $ x) as (f (g x))

### DIFF
--- a/src/Language/PureScript/CodeGen/JS/Optimizer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer.hs
@@ -77,7 +77,8 @@ optimize' js = do
     , inlineOperator (C.prelude, (C.$)) $ \f x -> JSApp f [x]
     , inlineOperator (C.prelude, (C.#)) $ \x f -> JSApp f [x]
     , inlineOperator (C.preludeUnsafe, C.unsafeIndex) $ flip JSIndexer
-    , inlineCommonOperators ]) js
+    , inlineCommonOperators
+    , inlineAppliedArrComposition ]) js
 
 untilFixedPoint :: (Eq a) => (a -> a) -> a -> a
 untilFixedPoint f = go

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -83,6 +83,9 @@ unsafeIndex = "unsafeIndex"
 (.^.) :: String
 (.^.) = ".^."
 
+(<<<) :: String
+(<<<) = "<<<"
+
 -- Functions
 
 negate :: String


### PR DESCRIPTION
When writing PureScript code like:

    not <<< not $ id true

We see a few function calls:

    Prelude["<<<"](Prelude.semigroupoidArr)
        (Prelude.not(Prelude.boolLikeBoolean))
        (Prelude.not(Prelude.boolLikeBoolean))
        (Prelude.id(Prelude.categoryArr)(
            true));

We now see something very straight forward:

    !!Prelude.id(Prelude.categoryArr)(true);

The implementation of this optimisation contains a lot of similarities
to the common binary operator inlining. We should extract some
functions out in another commit.