### PR TITLE
Inline semigroupoidArr composition

### DIFF
--- a/src/Language/PureScript/CodeGen/JS/AST.hs
+++ b/src/Language/PureScript/CodeGen/JS/AST.hs
@@ -17,6 +17,8 @@
 
 module Language.PureScript.CodeGen.JS.AST where
 
+import Control.Monad ((>=>))
+import Control.Monad.Identity
 import Data.Data
 
 import Language.PureScript.Comments
@@ -281,31 +283,34 @@ everywhereOnJS f = go
   go other = f other
 
 everywhereOnJSTopDown :: (JS -> JS) -> JS -> JS
-everywhereOnJSTopDown f = go . f
+everywhereOnJSTopDown f = runIdentity . everywhereOnJSTopDownM (Identity . f)
+
+everywhereOnJSTopDownM :: (Monad m) => (JS -> m JS) -> JS -> m JS
+everywhereOnJSTopDownM f = f >=> go
   where
-  go :: JS -> JS
-  go (JSUnary op j) = JSUnary op (go (f j))
-  go (JSBinary op j1 j2) = JSBinary op (go (f j1)) (go (f j2))
-  go (JSArrayLiteral js) = JSArrayLiteral (map (go . f) js)
-  go (JSIndexer j1 j2) = JSIndexer (go (f j1)) (go (f j2))
-  go (JSObjectLiteral js) = JSObjectLiteral (map (fmap (go . f)) js)
-  go (JSAccessor prop j) = JSAccessor prop (go (f j))
-  go (JSFunction name args j) = JSFunction name args (go (f j))
-  go (JSApp j js) = JSApp (go (f j)) (map (go . f) js)
-  go (JSConditional j1 j2 j3) = JSConditional (go (f j1)) (go (f j2)) (go (f j3))
-  go (JSBlock js) = JSBlock (map (go . f) js)
-  go (JSVariableIntroduction name j) = JSVariableIntroduction name (fmap (go . f) j)
-  go (JSAssignment j1 j2) = JSAssignment (go (f j1)) (go (f j2))
-  go (JSWhile j1 j2) = JSWhile (go (f j1)) (go (f j2))
-  go (JSFor name j1 j2 j3) = JSFor name (go (f j1)) (go (f j2)) (go (f j3))
-  go (JSForIn name j1 j2) = JSForIn name (go (f j1)) (go (f j2))
-  go (JSIfElse j1 j2 j3) = JSIfElse (go (f j1)) (go (f j2)) (fmap (go . f) j3)
-  go (JSReturn j) = JSReturn (go (f j))
-  go (JSThrow j) = JSThrow (go (f j))
-  go (JSTypeOf j) = JSTypeOf (go (f j))
-  go (JSLabel name j) = JSLabel name (go (f j))
-  go (JSInstanceOf j1 j2) = JSInstanceOf (go (f j1)) (go (f j2))
-  go (JSComment com j) = JSComment com (go (f j))
+  f' = f >=> go
+  go (JSUnary op j) = JSUnary op <$> f' j
+  go (JSBinary op j1 j2) = JSBinary op <$> f' j1 <*> f' j2
+  go (JSArrayLiteral js) = JSArrayLiteral <$> traverse f' js
+  go (JSIndexer j1 j2) = JSIndexer <$> f' j1 <*> f' j2
+  go (JSObjectLiteral js) = JSObjectLiteral <$> traverse (traverse f') js
+  go (JSAccessor prop j) = JSAccessor prop <$> f' j
+  go (JSFunction name args j) = JSFunction name args <$> f' j
+  go (JSApp j js) = JSApp <$> f' j <*> traverse f' js
+  go (JSConditional j1 j2 j3) = JSConditional <$> f' j1 <*> f' j2 <*> f' j3
+  go (JSBlock js) = JSBlock <$> traverse f' js
+  go (JSVariableIntroduction name j) = JSVariableIntroduction name <$> traverse f' j
+  go (JSAssignment j1 j2) = JSAssignment <$> f' j1 <*> f' j2
+  go (JSWhile j1 j2) = JSWhile <$> f' j1 <*> f' j2
+  go (JSFor name j1 j2 j3) = JSFor name <$> f' j1 <*> f' j2 <*> f' j3
+  go (JSForIn name j1 j2) = JSForIn name <$> f' j1 <*> f' j2
+  go (JSIfElse j1 j2 j3) = JSIfElse <$> f' j1 <*> f' j2 <*> traverse f' j3
+  go (JSReturn j) = JSReturn <$> f' j
+  go (JSThrow j) = JSThrow <$> f' j
+  go (JSTypeOf j) = JSTypeOf <$> f' j
+  go (JSLabel name j) = JSLabel name <$> f' j
+  go (JSInstanceOf j1 j2) = JSInstanceOf <$> f' j1 <*> f' j2
+  go (JSComment com j) = JSComment com <$> f' j
   go other = f other
 
 everythingOnJS :: (r -> r -> r) -> (JS -> r) -> JS -> r

--- a/src/Language/PureScript/CodeGen/JS/AST.hs
+++ b/src/Language/PureScript/CodeGen/JS/AST.hs
@@ -17,9 +17,10 @@
 
 module Language.PureScript.CodeGen.JS.AST where
 
-import Control.Monad ((>=>))
+import Control.Applicative (Applicative, (<$>), (<*>))
 import Control.Monad.Identity
 import Data.Data
+import Data.Traversable (traverse)
 
 import Language.PureScript.Comments
 
@@ -285,7 +286,7 @@ everywhereOnJS f = go
 everywhereOnJSTopDown :: (JS -> JS) -> JS -> JS
 everywhereOnJSTopDown f = runIdentity . everywhereOnJSTopDownM (Identity . f)
 
-everywhereOnJSTopDownM :: (Monad m) => (JS -> m JS) -> JS -> m JS
+everywhereOnJSTopDownM :: (Applicative m, Monad m) => (JS -> m JS) -> JS -> m JS
 everywhereOnJSTopDownM f = f >=> go
   where
   f' = f >=> go

--- a/src/Language/PureScript/CodeGen/JS/Optimizer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer.hs
@@ -78,7 +78,8 @@ optimize' js = do
     , inlineOperator (C.prelude, (C.#)) $ \x f -> JSApp f [x]
     , inlineOperator (C.preludeUnsafe, C.unsafeIndex) $ flip JSIndexer
     , inlineCommonOperators
-    , inlineAppliedArrComposition ]) js
+    , inlineAppliedArrComposition
+    , inlineAppliedVars ]) js
 
 untilFixedPoint :: (Monad m, Eq a) => (a -> m a) -> a -> m a
 untilFixedPoint f = go

--- a/src/Language/PureScript/CodeGen/JS/Optimizer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer.hs
@@ -61,7 +61,7 @@ optimize js = do
 optimize' :: (Monad m, MonadReader (Options mode) m) => JS -> m JS
 optimize' js = do
   opts <- ask
-  return $ untilFixedPoint (applyAll
+  untilFixedPoint (return . applyAll
     [ collapseNestedBlocks
     , collapseNestedIfs
     , tco opts
@@ -80,8 +80,9 @@ optimize' js = do
     , inlineCommonOperators
     , inlineAppliedArrComposition ]) js
 
-untilFixedPoint :: (Eq a) => (a -> a) -> a -> a
+untilFixedPoint :: (Monad m, Eq a) => (a -> m a) -> a -> m a
 untilFixedPoint f = go
   where
-  go a = let a' = f a in
-          if a' == a then a' else go a'
+  go a = do
+   a' <- f a
+   if a' == a then return a' else go a'

--- a/src/Language/PureScript/CodeGen/JS/Optimizer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer.hs
@@ -37,6 +37,7 @@ module Language.PureScript.CodeGen.JS.Optimizer (
     optimize
 ) where
 
+import Control.Applicative (Applicative)
 import Control.Monad.Reader (MonadReader, ask, asks)
 import Control.Monad.Supply.Class (MonadSupply)
 
@@ -54,12 +55,12 @@ import Language.PureScript.CodeGen.JS.Optimizer.Blocks
 -- |
 -- Apply a series of optimizer passes to simplified Javascript code
 --
-optimize :: (Monad m, MonadReader (Options mode) m, MonadSupply m) => JS -> m JS
+optimize :: (Monad m, MonadReader (Options mode) m, Applicative m, MonadSupply m) => JS -> m JS
 optimize js = do
   noOpt <- asks optionsNoOptimizations
   if noOpt then return js else optimize' js
 
-optimize' :: (Monad m, MonadReader (Options mode) m, MonadSupply m) => JS -> m JS
+optimize' :: (Monad m, MonadReader (Options mode) m, Applicative m, MonadSupply m) => JS -> m JS
 optimize' js = do
   opts <- ask
   untilFixedPoint (inlineArrComposition . applyAll

--- a/src/Language/PureScript/CodeGen/JS/Optimizer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer.hs
@@ -38,6 +38,7 @@ module Language.PureScript.CodeGen.JS.Optimizer (
 ) where
 
 import Control.Monad.Reader (MonadReader, ask, asks)
+import Control.Monad.Supply.Class (MonadSupply)
 
 import Language.PureScript.CodeGen.JS.AST
 import Language.PureScript.Options
@@ -53,15 +54,15 @@ import Language.PureScript.CodeGen.JS.Optimizer.Blocks
 -- |
 -- Apply a series of optimizer passes to simplified Javascript code
 --
-optimize :: (Monad m, MonadReader (Options mode) m) => JS -> m JS
+optimize :: (Monad m, MonadReader (Options mode) m, MonadSupply m) => JS -> m JS
 optimize js = do
   noOpt <- asks optionsNoOptimizations
   if noOpt then return js else optimize' js
 
-optimize' :: (Monad m, MonadReader (Options mode) m) => JS -> m JS
+optimize' :: (Monad m, MonadReader (Options mode) m, MonadSupply m) => JS -> m JS
 optimize' js = do
   opts <- ask
-  untilFixedPoint (return . applyAll
+  untilFixedPoint (inlineArrComposition . applyAll
     [ collapseNestedBlocks
     , collapseNestedIfs
     , tco opts

--- a/src/Language/PureScript/CodeGen/JS/Optimizer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer.hs
@@ -79,8 +79,7 @@ optimize' js = do
     , inlineOperator (C.prelude, (C.$)) $ \f x -> JSApp f [x]
     , inlineOperator (C.prelude, (C.#)) $ \x f -> JSApp f [x]
     , inlineOperator (C.preludeUnsafe, C.unsafeIndex) $ flip JSIndexer
-    , inlineCommonOperators
-    , inlineAppliedVars ]) js
+    , inlineCommonOperators ]) js
 
 untilFixedPoint :: (Monad m, Eq a) => (a -> m a) -> a -> m a
 untilFixedPoint f = go

--- a/src/Language/PureScript/CodeGen/JS/Optimizer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer.hs
@@ -79,7 +79,6 @@ optimize' js = do
     , inlineOperator (C.prelude, (C.#)) $ \x f -> JSApp f [x]
     , inlineOperator (C.preludeUnsafe, C.unsafeIndex) $ flip JSIndexer
     , inlineCommonOperators
-    , inlineAppliedArrComposition
     , inlineAppliedVars ]) js
 
 untilFixedPoint :: (Monad m, Eq a) => (a -> m a) -> a -> m a

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/Inliner.hs
@@ -19,6 +19,7 @@ module Language.PureScript.CodeGen.JS.Optimizer.Inliner (
   inlineOperator,
   inlineCommonOperators,
   inlineAppliedArrComposition,
+  inlineAppliedVars,
   etaConvert,
   unThunk,
   evaluateIifes
@@ -244,6 +245,13 @@ inlineAppliedArrComposition = everywhereOnJS convert
   where
   convert :: JS -> JS
   convert (JSApp (JSApp (JSApp (JSApp fn [dict']) [x]) [y]) [z]) | isDict semigroupoidArr dict' && isPreludeFn (C.<<<) fn = JSApp x [JSApp y [z]]
+  convert other = other
+
+inlineAppliedVars :: JS -> JS
+inlineAppliedVars = everywhereOnJS convert
+  where
+  convert :: JS -> JS
+  convert (JSApp (JSFunction Nothing [a] (JSBlock [JSReturn b])) [JSVar x]) = replaceIdent a (JSVar x) b
   convert other = other
 
 isDict :: (String, String) -> JS -> Bool

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/Inliner.hs
@@ -18,7 +18,6 @@ module Language.PureScript.CodeGen.JS.Optimizer.Inliner (
   inlineValues,
   inlineOperator,
   inlineCommonOperators,
-  inlineAppliedArrComposition,
   inlineAppliedVars,
   inlineArrComposition,
   etaConvert,
@@ -241,14 +240,6 @@ inlineCommonOperators = applyAll $
     go m acc (JSApp lhs [arg]) = go (m - 1) (arg : acc) lhs
     go _ _   _ = Nothing
 
--- (f << g $ x) = f (g x)
-inlineAppliedArrComposition :: JS -> JS
-inlineAppliedArrComposition = everywhereOnJS convert
-  where
-  convert :: JS -> JS
-  convert (JSApp (JSApp (JSApp (JSApp fn [dict']) [x]) [y]) [z]) | isDict semigroupoidArr dict' && isPreludeFn (C.<<<) fn = JSApp x [JSApp y [z]]
-  convert other = other
-
 inlineAppliedVars :: JS -> JS
 inlineAppliedVars = everywhereOnJS convert
   where
@@ -256,14 +247,20 @@ inlineAppliedVars = everywhereOnJS convert
   convert (JSApp (JSFunction Nothing [a] (JSBlock [JSReturn b])) [JSVar x]) = replaceIdent a (JSVar x) b
   convert other = other
 
+-- (f <<< g $ x) = f (g x)
+-- (f <<< g)     = \x -> f (g x)
 inlineArrComposition :: (MonadSupply m) => JS -> m JS
-inlineArrComposition js = everywhereOnJSTopDownM convert js
+inlineArrComposition = everywhereOnJSTopDownM convert
   where
   convert :: (MonadSupply m) => JS -> m JS
-  convert (JSApp (JSApp (JSApp fn [dict']) [x]) [y]) | isDict semigroupoidArr dict' && isPreludeFn (C.<<<) fn = do
+  convert (JSApp (JSApp (JSApp (JSApp fn [dict']) [x]) [y]) [z]) | isArrCompose dict' fn =
+    return $ JSApp x [JSApp y [z]]
+  convert (JSApp (JSApp (JSApp fn [dict']) [x]) [y]) | isArrCompose dict' fn = do
     arg <- freshName
     return $ JSFunction Nothing [arg] (JSBlock [JSReturn $ JSApp x [JSApp y [JSVar arg]]])
   convert other = return other
+  isArrCompose :: JS -> JS -> Bool
+  isArrCompose dict' fn = isDict semigroupoidArr dict' && isPreludeFn (C.<<<) fn
 
 isDict :: (String, String) -> JS -> Bool
 isDict (moduleName, dictName) (JSAccessor x (JSVar y)) = x == dictName && y == moduleName

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/Inliner.hs
@@ -25,6 +25,7 @@ module Language.PureScript.CodeGen.JS.Optimizer.Inliner (
   evaluateIifes
 ) where
 
+import Control.Applicative (Applicative)
 import Control.Monad.Supply.Class (MonadSupply, freshName)
 import Data.Maybe (fromMaybe)
 
@@ -249,7 +250,7 @@ inlineAppliedVars = everywhereOnJS convert
 
 -- (f <<< g $ x) = f (g x)
 -- (f <<< g)     = \x -> f (g x)
-inlineArrComposition :: (MonadSupply m) => JS -> m JS
+inlineArrComposition :: (Applicative m, MonadSupply m) => JS -> m JS
 inlineArrComposition = everywhereOnJSTopDownM convert
   where
   convert :: (MonadSupply m) => JS -> m JS

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/Inliner.hs
@@ -18,7 +18,6 @@ module Language.PureScript.CodeGen.JS.Optimizer.Inliner (
   inlineValues,
   inlineOperator,
   inlineCommonOperators,
-  inlineAppliedVars,
   inlineArrComposition,
   etaConvert,
   unThunk,
@@ -240,13 +239,6 @@ inlineCommonOperators = applyAll $
     go 0 acc (JSApp runFnN [fn]) | isNFn C.runFn n runFnN && length acc == n = Just (JSApp fn acc)
     go m acc (JSApp lhs [arg]) = go (m - 1) (arg : acc) lhs
     go _ _   _ = Nothing
-
-inlineAppliedVars :: JS -> JS
-inlineAppliedVars = everywhereOnJS convert
-  where
-  convert :: JS -> JS
-  convert (JSApp (JSFunction Nothing [a] (JSBlock [JSReturn b])) [JSVar x]) = replaceIdent a (JSVar x) b
-  convert other = other
 
 -- (f <<< g $ x) = f (g x)
 -- (f <<< g)     = \x -> f (g x)


### PR DESCRIPTION
An example of the changes:

```purescript
g :: Boolean
g = not <<< not $ true

f :: Boolean -> Boolean
f = not <<< not <<< not <<< not

f' x = (\y -> f y) x
```

```js
var g = !!true;

var f = function (_44) {
    return !!!!_44;
};

var f$prime = function (x) {
    return f(x);
};
```

I did the following:

1. Allowed `everywhereOnJSTopDown` to work in a `Monad`, default is `Identity`.
2. Made `untiFixedPoint` work on a `Monad`.
3. Added `inlineAppliedVars` optimisation, turning `(\x -> f x) y` into `f y`.
4. Added `inlineArrComposition` optimisation, turning `a >>> b` into `(\x -> a (b x))`.

What are the drawbacks?

Should fix #1066.