### PR TITLE
Modified the TypeChecker monad for supporting warnings.

### DIFF
--- a/examples/manual/passing/ShadowedName.purs
+++ b/examples/manual/passing/ShadowedName.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Prelude
+import Debug.Trace
+
+done :: String
+done = let str = "Not yet done" in
+        let str = "Done" in str
+
+main = Debug.Trace.trace done

--- a/examples/manual/passing/WildcardType.purs
+++ b/examples/manual/passing/WildcardType.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Prelude
+import Debug.Trace
+
+f1 :: (_ -> _) -> _
+f1 g = g 1
+
+f2 :: _ -> _
+f2 _ = "Done"
+
+main = Debug.Trace.trace $ f1 f2
+

--- a/psci/PSCi.hs
+++ b/psci/PSCi.hs
@@ -33,7 +33,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 import Control.Monad.Reader (MonadReader, ReaderT, runReaderT)
-import Control.Monad.Writer (MonadWriter, WriterT, runWriterT)
+import Control.Monad.Writer (MonadWriter, WriterT, runWriterT, runWriter)
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 import Control.Monad.Trans.State.Strict
@@ -411,7 +411,7 @@ handleKindOf typ = do
       case M.lookup (P.Qualified (Just mName) $ P.ProperName "IT") (P.typeSynonyms env') of
         Just (_, typ') -> do
           let chk = P.CheckState env' 0 0 (Just mName)
-              k   = L.runStateT (P.unCheck (P.kindOf mName typ')) chk
+              k   = fst . runWriter . runExceptT $ L.runStateT (P.unCheck (P.kindOf mName typ')) chk
           case k of
             Left errStack   -> PSCI . outputStrLn . P.prettyPrintMultipleErrors False $ errStack
             Right (kind, _) -> PSCI . outputStrLn . P.prettyPrintKind $ kind

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -22,9 +22,10 @@ import Data.Maybe
 import qualified Data.Map as M
 
 import Control.Applicative
-import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State
 import Control.Monad.Unify
+import Control.Monad.Writer
+import Control.Monad.Except
 
 import Language.PureScript.Environment
 import Language.PureScript.Errors
@@ -176,8 +177,8 @@ data CheckState = CheckState {
 -- |
 -- The type checking monad, which provides the state of the type checker, and error reporting capabilities
 --
-newtype Check a = Check { unCheck :: StateT CheckState (Either MultipleErrors) a }
-  deriving (Functor, Monad, Applicative, MonadState CheckState, MonadError MultipleErrors)
+newtype Check a = Check { unCheck :: StateT CheckState (ExceptT MultipleErrors (Writer MultipleErrors)) a }
+  deriving (Functor, Monad, Applicative, MonadState CheckState, MonadError MultipleErrors, MonadWriter MultipleErrors)
 
 -- |
 -- Get the current @Environment@
@@ -200,16 +201,26 @@ modifyEnv f = modify (\s -> s { checkEnv = f (checkEnv s) })
 -- |
 -- Run a computation in the Check monad, starting with an empty @Environment@
 --
-runCheck :: (MonadError MultipleErrors m) => Check a -> m (a, Environment)
+runCheck :: (MonadError MultipleErrors m, MonadWriter MultipleErrors m) => Check a -> m (a, Environment)
 runCheck = runCheck' initEnvironment
 
 -- |
 -- Run a computation in the Check monad, failing with an error, or succeeding with a return value and the final @Environment@.
 --
-runCheck' :: (MonadError MultipleErrors m) => Environment -> Check a -> m (a, Environment)
-runCheck' env c = interpretMultipleErrors $ do
-  (a, s) <- flip runStateT (CheckState env 0 0 Nothing) $ unCheck c
-  return (a, checkEnv s)
+runCheck' :: (MonadError MultipleErrors m, MonadWriter MultipleErrors m) => Environment -> Check a -> m (a, Environment)
+runCheck' env = interpretMultipleErrorsAndWarnings . unwrapCheckWithWarnings env
+  where
+  unwrapCheckWithWarnings :: Environment -> Check a -> (Either MultipleErrors (a, Environment), MultipleErrors)
+  unwrapCheckWithWarnings e =
+    (\(rc, w) -> (envCheck rc, w))
+    . runWriter
+    . runExceptT
+    . flip runStateT (CheckState e 0 0 Nothing)
+    . unCheck
+  envCheck :: Either MultipleErrors (a, CheckState) -> Either MultipleErrors (a, Environment)
+  envCheck rc = do
+    (a, s) <- rc
+    return (a, checkEnv s)
 
 -- |
 -- Make an assertion, failing with an error message
@@ -237,8 +248,18 @@ liftCheck = UnifyT . lift
 -- Run a computation in the substitution monad, generating a return value and the final substitution.
 --
 liftUnify :: (Partial t) => UnifyT t Check a -> Check (a, Substitution t)
-liftUnify unify = do
+liftUnify = liftUnifyWarnings (const id)
+
+-- |
+-- Run a computation in the substitution monad, generating a return value, the final substitution and updating warnings values.
+--
+liftUnifyWarnings :: (Partial t) => (Substitution t -> ErrorMessage -> ErrorMessage) -> UnifyT t Check a -> Check (a, Substitution t)
+liftUnifyWarnings replace unify = do
   st <- get
-  (a, ust) <- runUnify (defaultUnifyState { unifyNextVar = checkNextVar st }) unify
+  let ru = runUnify (defaultUnifyState { unifyNextVar = checkNextVar st }) unify
+  ((a, ust), w) <- censor (const mempty) . listen $ ru
   modify $ \st' -> st' { checkNextVar = unifyNextVar ust }
-  return (a, unifyCurrentSubstitution ust)
+  let uust = unifyCurrentSubstitution ust
+  tell $ onErrorMessages (replace uust) w
+  return (a, uust)
+

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -42,9 +42,9 @@ import qualified Data.Map as M
 
 import Control.Applicative
 import Control.Monad
-import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State
 import Control.Monad.Unify
+import Control.Monad.Except
 
 import Language.PureScript.AST
 import Language.PureScript.Environment
@@ -70,7 +70,7 @@ import qualified Language.PureScript.Constants as C
 --
 typesOf :: Maybe ModuleName -> ModuleName -> [(Ident, Expr)] -> Check [(Ident, (Expr, Type))]
 typesOf mainModuleName moduleName vals = do
-  tys <- fmap tidyUp . liftUnify $ do
+  tys <- fmap tidyUp . liftUnifyWarnings replace $ do
     (untyped, typed, dict, untypedDict) <- typeDictionaryForBindingGroup moduleName vals
     ds1 <- parU typed $ \e -> do
       triple@(_, (_, ty)) <- checkTypedBindingGroupElement moduleName e dict
@@ -97,6 +97,9 @@ typesOf mainModuleName moduleName vals = do
   where
   -- Apply the substitution that was returned from runUnify to both types and (type-annotated) values
   tidyUp (ts, sub) = map (\(i, (val, ty)) -> (i, (overTypes (sub $?) val, sub $? ty))) ts
+  -- Replace all the wildcards types with their inferred types
+  replace sub (WildcardInferredType ty) = WildcardInferredType (sub $? ty)
+  replace _ em = em
   -- If --main is enabled, need to check that `main` has type Eff eff a for some eff, a
   checkMain nm ty = when (Just moduleName == mainModuleName && nm == Ident C.main) $ do
     [eff, a] <- replicateM 2 fresh

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -22,7 +22,7 @@ module Language.PureScript.TypeChecker.Unify (
     unifiesWith,
     replaceVarWithUnknown,
     replaceTypeWildcards,
-    varIfUnknown
+    varIfUnknown,
 ) where
 
 import Data.List (nub, sort)
@@ -30,8 +30,9 @@ import Data.Maybe (fromMaybe)
 import qualified Data.HashMap.Strict as H
 
 import Control.Monad
-import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Unify
+import Control.Monad.Writer
+import Control.Monad.Except
 
 import Language.PureScript.Environment
 import Language.PureScript.Errors
@@ -187,6 +188,7 @@ replaceTypeWildcards = everywhereOnTypesM replace
   where
   replace TypeWildcard = do
     u <- fresh'
+    liftCheck . tell $ errorMessage . WildcardInferredType $ TUnknown u
     return $ TUnknown u
   replace other = return other
 
@@ -202,3 +204,4 @@ varIfUnknown ty =
       typeToVar (TUnknown u) = TypeVar (toName u)
       typeToVar t = t
   in mkForAll (sort . map toName $ unks) ty'
+


### PR DESCRIPTION
Wildcard types are now detected as warnings.
Also, I added some tests to manual.

Hope this is OK now :smile:

@paf31
In all, things to do:
* Add module and position information
* There's an issue when calling recursive functions (that have wildcard types). It seems like it duplicates the wildcard warnings. Perhaps for several calls to `replaceTypeWildcards`? For example, when running this test: `examples/passing/TypeWildcards.purs`