### PR TITLE
Correct ConflictingImport error, add suggestion. Resolves #1088.

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -387,7 +387,7 @@ prettyPrintSingleError full e = prettyPrintErrorMessage <$> onTypesInErrorMessag
     goSimple (UnknownValue name)             = line $ "Unknown value " ++ show name
     goSimple (UnknownTypeConstructor name)   = line $ "Unknown type constructor " ++ show name
     goSimple (UnknownDataConstructor dc tc)  = line $ "Unknown data constructor " ++ show dc ++ foldMap ((" for type constructor " ++) . show) tc
-    goSimple (ConflictingImport nm mn)       = line $ "Declaration " ++ nm ++ " conflicts with import " ++ show mn 
+    goSimple (ConflictingImport nm mn)       = line $ "Cannot declare `" ++ nm ++ "` since another declaration of that name was imported from `" ++ show mn ++ "`"
     goSimple (ConflictingImports nm m1 m2)   = line $ "Conflicting imports for " ++ nm ++ " from modules " ++ show m1 ++ " and " ++ show m2
     goSimple (ConflictingTypeDecls nm)       = line $ "Conflicting type declarations for " ++ show nm
     goSimple (ConflictingCtorDecls nm)       = line $ "Conflicting data constructor declarations for " ++ show nm
@@ -540,6 +540,9 @@ prettyPrintSingleError full e = prettyPrintErrorMessage <$> onTypesInErrorMessag
   suggestions :: ErrorMessage -> [Box.Box]
   suggestions = suggestions' . unwrapErrorMessage
     where
+    suggestions' (ConflictingImport nm im) = [ line $ "Possible fix: hide `" ++ nm ++ "` when importing `" ++ show im ++ "`:"
+                                             , indent . line $ "import " ++ show im ++ " hiding (" ++ nm ++ ")"
+                                             ]
     suggestions' (TypesDoNotUnify t1 t2)
       | any isObject [t1, t2] = [line "Note that function composition in PureScript is defined using `(<<<)`"]
       | otherwise             = []

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -514,8 +514,8 @@ resolveImport currentModule importModule exps imps impQual =
     Just (Qualified Nothing _) -> error "Invalid state in updateImports"
     Just (Qualified (Just mn) _) -> throwError . errorMessage $ err
       where
-      err = if mn == currentModule || importModule == currentModule
-            then ConflictingImport (show name) mn
+      err = if currentModule `elem` [mn, importModule]
+            then ConflictingImport (show name) importModule
             else ConflictingImports (show name) mn importModule
 
   -- The available values, types, and classes in the module being imported


### PR DESCRIPTION
Here's how the output for the error in #1088 looks now:
```
Error:
Error in module ConflictingImport:
Cannot declare `id` since another declaration of that name was imported from `Prelude`
Possible fix: hide `id` when importing `Prelude`:
  import Prelude hiding (id)
See https://github.com/purescript/purescript/wiki/Error-Code-ConflictingImport for more information, or to contribute content related to this error.
```

Should I also suggest qualified imports? I believe I saw an MR about those being added.