### PR TITLE
Resolves #1097. "Reading ..." error output is only shown when passed …

### DIFF
--- a/psc-make/Main.hs
+++ b/psc-make/Main.hs
@@ -68,9 +68,11 @@ instance P.MonadMake Make where
   getTimestamp path = makeIO (const (P.SimpleErrorWrapper $ P.CannotGetFileInfo path)) $ do
     exists <- doesFileExist path
     traverse (const $ getModificationTime path) $ guard exists
-  readTextFile path = makeIO (const (P.SimpleErrorWrapper $ P.CannotReadFile path)) $ do
-    putStrLn $ "Reading " ++ path
-    readFile path
+  readTextFile path = do
+    verboseErrorsEnabled <- asks P.optionsVerboseErrors
+    makeIO (const (P.SimpleErrorWrapper $ P.CannotReadFile path)) $ do
+      when verboseErrorsEnabled $ putStrLn $ "Reading " ++ path
+      readFile path
   writeTextFile path text = makeIO (const (P.SimpleErrorWrapper $ P.CannotWriteFile path)) $ do
     mkdirp path
     putStrLn $ "Writing " ++ path


### PR DESCRIPTION
…flag.

Uses the --verbose-errors flag to hide some "Reading ..." errors. See #1097.

Thank you @paf31  and @hdgarrood for the help. This should resolve the errors when the flag is given. Here are two example commands:

**With Flag**
> ~/.cabal/bin/psc-make --verbose-errors ~/tmp/bower_components/purescript-prelude/src/Prelude.purs ConflictingImport.purs 
Reading output/Prelude/externs.purs
Error:
Error in module ConflictingImport:
Cannot declare `id` since another declaration of that name was imported from `Prelude`
Possible fix: hide `id` when importing `Prelude`:
  import Prelude hiding (id)
See https://github.com/purescript/purescript/wiki/Error-Code-ConflictingImport for more information, or to contribute content related to this error.

**Without flag**
> ~/.cabal/bin/psc-make ~/tmp/bower_components/purescript-prelude/src/Prelude.purs ConflictingImport.purs 
Error:
Error in module ConflictingImport:
Cannot declare `id` since another declaration of that name was imported from `Prelude`
Possible fix: hide `id` when importing `Prelude`:
  import Prelude hiding (id)
See https://github.com/purescript/purescript/wiki/Error-Code-ConflictingImport for more information, or to contribute content related to this error.
