### PR TITLE
Add tested-with to Cabal file (refs #1121)

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -15,6 +15,8 @@ author: Phil Freeman <paf31@cantab.net>,
         Gary Burgess <gary.burgess@gmail.com>,
         Hardy Jones <jones3.hardy@gmail.com>
 
+tested-with: GHC==7.8
+
 extra-source-files: examples/passing/*.purs
                   , examples/failing/*.purs
 


### PR DESCRIPTION
This is a rather insignificant step towards really solving #1121, and no Haskell tooling actually does anything with this field (as far as I know). But it seems like the right thing to do.

`cabal check` gives the same result as what it previously did (i.e. it whines about -O2, but passes).