### PR TITLE
Show comments before instances in generated docs

### DIFF
--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -44,13 +44,12 @@ declAsMarkdown RenderedDeclaration{..} = do
     zipWithM_ (\f c -> tell' (childToString f c)) (First : repeat NotFirst) children
   spacer
 
+  for_ rdComments tell'
+
   unless (null instances) $ do
     headerLevel 5 "Instances"
-    fencedBlock $ do
-      mapM_ (tell' . childToString NotFirst) instances
+    fencedBlock $ mapM_ (tell' . childToString NotFirst) instances
     spacer
-
-  for_ rdComments tell'
 
 codeToString :: RenderedCode -> String
 codeToString = outputWith elemAsMarkdown


### PR DESCRIPTION
Currently if there are a lot of instances for a type you get this less than ideal situation:

https://github.com/purescript/purescript-maybe/blob/f207b2f09e620b938976f201f6fc61e2a557b59e/docs/Data.Maybe.md