### PR TITLE
Fix Docs Render compilation with GHC 7.10.1

### DIFF
--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -101,6 +101,7 @@ addDefaultFixity rd@RenderedDeclaration{..}
   | isOp rdTitle && isNothing rdFixity = rd { rdFixity = Just defaultFixity }
   | otherwise                          = rd
   where
+  isOp :: String -> Bool
   isOp str = "(" `isPrefixOf` str && ")" `isSuffixOf` str
   defaultFixity = P.Fixity P.Infixl (-1)
 


### PR DESCRIPTION
GHC 7.10.1 infers this type for `isOp`:

    (Eq a, Data.String.IsString [a]) => [a] -> Bool

Just needed [a] to be fixed to String.