### PR TITLE
Remove poor performing entails.filterModule

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -17,6 +17,7 @@
 module Language.PureScript.AST.Declarations where
 
 import qualified Data.Data as D
+import qualified Data.Map as M
 
 import Language.PureScript.AST.Binders
 import Language.PureScript.AST.Operators
@@ -360,7 +361,7 @@ data Expr
   -- at superclass implementations when searching for a dictionary, the type class name and
   -- instance type, and the type class dictionaries in scope.
   --
-  | TypeClassDictionary Bool Constraint [TypeClassDictionaryInScope]
+  | TypeClassDictionary Bool Constraint (M.Map (Maybe ModuleName) [TypeClassDictionaryInScope])
   -- |
   -- A typeclass dictionary accessor, the implementation is left unspecified until CoreFn desugaring.
   --

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -76,10 +76,10 @@ withTypeClassDictionaries entries action = do
   return a
 
 -- |
--- Get the currently available list of type class dictionaries
+-- Get the currently available map of type class dictionaries
 --
-getTypeClassDictionaries :: (Functor m, MonadState CheckState m) => m [TypeClassDictionaryInScope]
-getTypeClassDictionaries = (>>= M.elems) . M.elems . typeClassDictionaries . checkEnv <$> get
+getTypeClassDictionaries :: (Functor m, MonadState CheckState m) => m (M.Map (Maybe ModuleName) [TypeClassDictionaryInScope])
+getTypeClassDictionaries = fmap M.elems . typeClassDictionaries . checkEnv <$> get
 
 -- |
 -- Lookup type class dictionaries in a module.


### PR DESCRIPTION
Turns out this was the last thing using the getTypeClassDictionaries
list, but was also filtering down to the module. Changed to using the
underlying Map, which provides quick indexing of the module.

Some more numbers:

    benchmarking unpatched
    time                 59.75 s    (51.44 s .. 67.70 s)
                         0.998 R²   (NaN R² .. 1.000 R²)
    mean                 59.01 s    (57.54 s .. 60.14 s)
    std dev              1.737 s    (0.0 s .. 1.954 s)
    variance introduced by outliers: 19% (moderately inflated)

    benchmarking patched
    time                 32.53 s    (25.64 s .. 39.85 s)
                         0.994 R²   (0.977 R² .. 1.000 R²)
    mean                 33.09 s    (31.42 s .. 34.06 s)
    std dev              1.496 s    (0.0 s .. 1.670 s)
    variance introduced by outliers: 19% (moderately inflated)

I have no idea why Criterion gives a NaN...