### PR TITLE
Clarify ExtraneousClassMember vs. MissingClassMember

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -107,6 +107,7 @@ data SimpleErrorMessage
   | ArgListLengthsDiffer Ident
   | OverlappingArgNames (Maybe Ident)
   | MissingClassMember Ident
+  | ExtraneousClassMember Ident
   | ExpectedType Kind
   | IncorrectConstructorArity (Qualified ProperName)
   | SubsumptionCheckFailed
@@ -215,6 +216,7 @@ errorCode em = case unwrapErrorMessage em of
   (ArgListLengthsDiffer _)      -> "ArgListLengthsDiffer"
   (OverlappingArgNames _)       -> "OverlappingArgNames"
   (MissingClassMember _)        -> "MissingClassMember"
+  (ExtraneousClassMember _)     -> "ExtraneousClassMember"
   (ExpectedType _)              -> "ExpectedType"
   (IncorrectConstructorArity _) -> "IncorrectConstructorArity"
   SubsumptionCheckFailed        -> "SubsumptionCheckFailed"
@@ -513,6 +515,8 @@ prettyPrintSingleError full e = prettyPrintErrorMessage <$> onTypesInErrorMessag
       line $ "Overlapping names in function/binder" ++ foldMap ((" in declaration" ++) . show) ident
     goSimple (MissingClassMember ident) =
       line $ "Member " ++ show ident ++ " has not been implemented"
+    goSimple (ExtraneousClassMember ident) =
+      line $ "Member " ++ show ident ++ " is not a member of the class being instantiated"
     goSimple (ExpectedType kind) =
       line $ "Expected type of kind *, was " ++ prettyPrintKind kind
     goSimple (IncorrectConstructorArity nm) =

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -277,7 +277,7 @@ typeInstanceDictionaryDeclaration name mn deps className tys decls =
 
   memberToValue :: (Functor m, Applicative m, MonadSupply m, MonadError MultipleErrors m) => [(Ident, Type)] -> Declaration -> Desugar m Expr
   memberToValue tys' (ValueDeclaration ident _ [] (Right val)) = do
-    _ <- maybe (throwError . errorMessage $ MissingClassMember ident) return $ lookup ident tys'
+    _ <- maybe (throwError . errorMessage $ ExtraneousClassMember ident) return $ lookup ident tys'
     return val
   memberToValue tys' (PositionedDeclaration pos com d) = rethrowWithPosition pos $ do
     val <- memberToValue tys' d


### PR DESCRIPTION
Resolves #1142.

Example showing correctness of existing "missing class member":
```
module Foobar where

class Foobarable m where
  foobar :: m
  oops :: m

data Blah = Beanz | Spaz

newtype Fooample = Fooample Blah

instance foobarableFooample :: Foobarable Fooample where
  foobar = Fooample Beanz
```

Errors with:
> Error:
Error in type class instance Foobar.Foobarable Foobar.Fooample:
Error at /home/michael/dev/contrib/Foobar.purs line 11, column 1 - line 12, column 21:
  Member oops has not been implemented
See https://github.com/purescript/purescript/wiki/Error-Code-MissingClassMember for more information, or to contribute content related to this error.

Example showing new error:
```
module Foobar where

class Foobarable m where
  foobar :: m

data Blah = Beanz | Spaz

newtype Fooample = Fooample Blah

instance foobarableFooample :: Foobarable Fooample where
  foobar = Fooample Beanz
  oops = Fooample Spaz
```

Errors with:
> Error:
Error in type class instance Foobar.Foobarable Foobar.Fooample:
Error at /home/michael/dev/contrib/Foobar.purs line 12, column 3 - line 12, column 19:
  Member oops does not belong to the class being instantiated
See https://github.com/purescript/purescript/wiki/Error-Code-ExtraneousClassMember for more information, or to contribute content related to this error.