### PR TITLE
Include more rendered code in child declarations

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -42,7 +42,7 @@ library
                    aeson >= 0.8 && < 0.9,
                    vector -any,
                    bower-json >= 0.7,
-                   aeson-better-errors >= 0.7,
+                   aeson-better-errors >= 0.8,
                    bytestring -any,
                    text -any,
                    split -any

--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -38,7 +38,7 @@ declAsMarkdown RenderedDeclaration{..} = do
   headerLevel 4 (ticks rdTitle)
   spacer
 
-  let (instances, children) = partition ((==) ChildInstance . rcdType) rdChildren
+  let (instances, children) = partition (isChildInstance . rcdInfo) rdChildren
   fencedBlock $ do
     tell' (codeToString rdCode)
     zipWithM_ (\f c -> tell' (childToString f c)) (First : repeat NotFirst) children
@@ -52,6 +52,10 @@ declAsMarkdown RenderedDeclaration{..} = do
     headerLevel 5 "Instances"
     fencedBlock $ mapM_ (tell' . childToString NotFirst) instances
     spacer
+
+  where
+  isChildInstance (ChildInstance _) = True
+  isChildInstance _ = False
 
 codeToString :: RenderedCode -> String
 codeToString = outputWith elemAsMarkdown
@@ -79,14 +83,14 @@ fixityAsMarkdown (P.Fixity associativity precedence) =
 
 childToString :: First -> RenderedChildDeclaration -> String
 childToString f RenderedChildDeclaration{..} =
-  case rcdType of
-    ChildDataConstructor ->
+  case rcdInfo of
+    ChildDataConstructor sig _ ->
       let c = if f == First then "=" else "|"
-      in  "  " ++ c ++ " " ++ codeToString rcdCode
-    ChildTypeClassMember ->
-      "  " ++ codeToString rcdCode
-    ChildInstance ->
-      codeToString rcdCode
+      in  "  " ++ c ++ " " ++ codeToString sig
+    ChildTypeClassMember ty _ ->
+      "  " ++ codeToString ty
+    ChildInstance code ->
+      codeToString code
 
 data First
   = First

--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -150,7 +150,6 @@ renderDeclaration (P.DataDeclaration dtype name args ctors) title =
   typeApp  = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
   code = keyword (show dtype) <> sp <> renderType typeApp
   children = map renderCtor ctors
-  -- TODO: Comments for data constructors?
   renderCtor (ctor', tys) =
     RenderedChildDeclaration (show ctor') Nothing Nothing (ChildDataConstructor ctorSignature ctorCode)
     where
@@ -200,7 +199,6 @@ renderDeclaration (P.TypeClassDeclaration name args implies ds) title = do
 
   children = map renderClassMember ds
 
-  -- TODO: Comments for type class members?
   renderClassMember (P.PositionedDeclaration _ _ d) = renderClassMember d
   renderClassMember (P.TypeDeclaration ident' ty) =
     RenderedChildDeclaration (show ident') Nothing Nothing (ChildTypeClassMember contextualType actualType)

--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -157,7 +157,6 @@ renderDeclaration (P.DataDeclaration dtype name args ctors) title =
     ctor'' = P.TypeConstructor (P.Qualified Nothing ctor')
     typeApp' = foldl P.TypeApp ctor'' tys
     ctorSignature = renderType typeApp'
-    -- TODO: add forall for all free type variables
     ctorCode = ident (show ctor') <> sp <> syntax "::" <> sp <> renderType ctorType
     ctorType = P.quantify $ foldr (\a b -> P.TypeApp (P.TypeApp P.tyFunction a) b) typeApp tys
 renderDeclaration (P.ExternDataDeclaration name kind') title =

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -12,7 +12,6 @@ module Language.PureScript.Docs.Types
 import Control.Arrow (first, (***))
 import Control.Applicative ((<$>), (<*>))
 import Data.Functor ((<$))
-import Data.Char
 import Data.Maybe (mapMaybe)
 import Data.Version
 import Data.Aeson ((.=))
@@ -87,27 +86,32 @@ data RenderedDeclaration = RenderedDeclaration
 data RenderedChildDeclaration = RenderedChildDeclaration
   { rcdTitle      :: String
   , rcdComments   :: Maybe String
-  , rcdCode       :: RenderedCode
   , rcdSourceSpan :: Maybe P.SourceSpan
-  , rcdType       :: RenderedChildDeclarationType
+  , rcdInfo       :: RenderedChildDeclarationInfo
   }
   deriving (Show, Eq, Ord)
 
-data RenderedChildDeclarationType
-  = ChildInstance
-  | ChildDataConstructor
-  | ChildTypeClassMember
-  deriving (Show, Eq, Ord, Bounded, Enum)
+data RenderedChildDeclarationInfo
+  = ChildInstance RenderedCode
+    -- ^ A type instance declaration. The rendered code value looks like
+    -- `instance showUnit :: Show Unit`
+  | ChildDataConstructor RenderedCode RenderedCode
+    -- ^ A data constructor, with rendered code for both how it appears in the
+    -- data declaration, and the constructor with its actual type. For example,
+    -- the constructor `Just` from the type `Maybe` might have the rendered
+    -- code values being `Just a` and `Just :: forall a. a -> Maybe a`.
+  | ChildTypeClassMember RenderedCode RenderedCode
+    -- ^ A type class member, with rendered code for its type in the context of
+    -- the parent type class declaration (that is, without a constraint), and
+    -- also for its actual type.  For example, `add` from `Semiring` might have
+    -- the rendered code values as `add :: a -> a -> a` and
+    -- `add :: forall a. (Semiring a) => a -> a -> a` respectively.
+  deriving (Show, Eq, Ord)
 
-childDeclTypeToString :: RenderedChildDeclarationType -> String
-childDeclTypeToString = withHead toLower . drop 5 . show
-  where
-  withHead f (x:xs) = f x : xs
-  withHead _ [] = []
-
-childDeclarationTypes :: [(String, RenderedChildDeclarationType)]
-childDeclarationTypes =
-  map (\t -> (childDeclTypeToString t, t)) [minBound .. maxBound]
+childDeclTypeToString :: RenderedChildDeclarationInfo -> String
+childDeclTypeToString (ChildInstance _)          = "instance"
+childDeclTypeToString (ChildDataConstructor _ _) = "dataConstructor"
+childDeclTypeToString (ChildTypeClassMember _ _) = "typeClassMember"
 
 newtype GithubUser
   = GithubUser { runGithubUser :: String }
@@ -120,7 +124,7 @@ newtype GithubRepo
 data PackageError
   = ErrorInPackageMeta BowerError
   | InvalidVersion
-  | InvalidDeclarationType
+  | InvalidChildDeclarationType String
   | InvalidRenderedCode String
   | InvalidFixity
   deriving (Show, Eq, Ord)
@@ -232,16 +236,23 @@ asRenderedChildDeclaration :: Parse PackageError RenderedChildDeclaration
 asRenderedChildDeclaration =
   RenderedChildDeclaration <$> key "title" asString
                            <*> key "comments" (perhaps asString)
-                           <*> key "code" asRenderedCode .! InvalidRenderedCode
                            <*> key "sourceSpan" (perhaps asSourceSpan)
-                           <*> key "type" asRenderedChildDeclarationType .!! InvalidDeclarationType
-  where
-  p .!! err = p .! const err
+                           <*> key "info" asRenderedChildDeclarationInfo
 
-asRenderedChildDeclarationType :: Parse PackageError RenderedChildDeclarationType
-asRenderedChildDeclarationType =
-  withString (maybe (Left InvalidDeclarationType) Right .
-                flip lookup childDeclarationTypes)
+asRenderedChildDeclarationInfo :: Parse PackageError RenderedChildDeclarationInfo
+asRenderedChildDeclarationInfo = do
+  ty <- key "declType" asString
+  case ty of
+    "instance" ->
+      ChildInstance <$> codeKey "code"
+    "dataConstructor" ->
+      ChildDataConstructor <$> codeKey "signature" <*> codeKey "type"
+    "typeClassMember" ->
+      ChildTypeClassMember <$> codeKey "contextualType" <*> codeKey "type"
+    other ->
+      throwCustomError $ InvalidChildDeclarationType other
+  where
+  codeKey k = key k asRenderedCode .! InvalidRenderedCode
 
 asSourcePos :: Parse e P.SourcePos
 asSourcePos = P.SourcePos <$> nth 0 asIntegral
@@ -317,13 +328,17 @@ instance A.ToJSON RenderedChildDeclaration where
   toJSON RenderedChildDeclaration{..} =
     A.object [ "title"      .= rcdTitle
              , "comments"   .= rcdComments
-             , "code"       .= rcdCode
              , "sourceSpan" .= rcdSourceSpan
-             , "type"       .= rcdType
+             , "info"       .= rcdInfo
              ]
 
-instance A.ToJSON RenderedChildDeclarationType where
-  toJSON = A.toJSON . childDeclTypeToString
+instance A.ToJSON RenderedChildDeclarationInfo where
+  toJSON info = A.object $ "declType" .= childDeclTypeToString info : props
+    where
+    props = case info of
+      ChildInstance code -> ["code" .= code]
+      ChildDataConstructor sig ty -> ["signature" .= sig, "type" .= ty]
+      ChildTypeClassMember cTy ty -> ["contextualType" .= cTy, "type" .= ty]
 
 instance A.ToJSON GithubUser where
   toJSON = A.toJSON . runGithubUser


### PR DESCRIPTION
The Hoogle output needs the following additional bits of rendered code
for child declarations:

* for data constructors: their name and type. For example: `Just ::
  forall a. a -> Maybe a`
* for type class members: their 'real' type, not in the context of
  the type class. For example: `add :: forall a. (Semiring a) => a -> a
  -> a` rather than just `a -> a -> a`

This commit modifies the RenderedChildDeclaration data type to
accommodate these extra bits of rendered code, as well as updating the
documentation renderer to produce these additional values.