### PR TITLE
Improve performance of module dictionary collection

### DIFF
--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -84,8 +84,8 @@ getTypeClassDictionaries = fmap M.elems . typeClassDictionaries . checkEnv <$> g
 -- |
 -- Lookup type class dictionaries in a module.
 --
-lookupTypeClassDictionaries :: (Functor m, MonadState CheckState m) => Maybe ModuleName -> m [TypeClassDictionaryInScope]
-lookupTypeClassDictionaries mn = maybe [] M.elems . M.lookup mn . typeClassDictionaries . checkEnv <$> get
+lookupTypeClassDictionaries :: (Functor m, MonadState CheckState m) => Maybe ModuleName -> m (M.Map (Qualified Ident) TypeClassDictionaryInScope)
+lookupTypeClassDictionaries mn = fromMaybe M.empty . M.lookup mn . typeClassDictionaries . checkEnv <$> get
 
 -- |
 -- Temporarily bind a collection of names to local variables


### PR DESCRIPTION
    benchmarking unpatched
    time                 20.60 s    (20.26 s .. 21.37 s)
                         1.000 R²   (NaN R² .. 1.000 R²)
    mean                 19.93 s    (19.79 s .. 20.01 s)
    std dev              123.3 ms   (0.0 s .. 136.6 ms)
    variance introduced by outliers: 19% (moderately inflated)

    benchmarking patched
    time                 13.90 s    (10.16 s .. 15.90 s)
                         0.991 R²   (0.981 R² .. 1.000 R²)
    mean                 13.31 s    (12.50 s .. 13.82 s)
    std dev              766.5 ms   (0.0 s .. 880.3 ms)
    variance introduced by outliers: 19% (moderately inflated)