### PR TITLE
Small improvements to the pretty printer

### DIFF
--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -71,7 +71,7 @@ literals = mkPattern' match
     ]
   match (Var ident) = return $ show ident
   match (Do els) = concat <$> sequence
-    [ return "do "
+    [ return "do\n"
     , withIndent $ prettyPrintMany prettyPrintDoNotationElement els
     , currentIndent
     ]
@@ -99,7 +99,10 @@ prettyPrintCaseAlternative (CaseAlternative binders result) =
     , prettyPrintResult result
     ]
   where
-  prettyPrintResult (Left gs) = concat <$> mapM prettyPrintGuardedValue gs
+  prettyPrintResult (Left gs) = concat <$> sequence
+      [ return "\n"
+      , withIndent $ prettyPrintMany prettyPrintGuardedValue gs
+      ]
   prettyPrintResult (Right v) = (" -> " ++) <$> prettyPrintValue' v
 
   prettyPrintGuardedValue (grd, val) =
@@ -108,7 +111,6 @@ prettyPrintCaseAlternative (CaseAlternative binders result) =
       , prettyPrintValue' grd
       , return " -> "
       , prettyPrintValue' val
-      , return "\n"
       ]
 
 prettyPrintDoNotationElement :: DoNotationElement -> StateT PrinterState Maybe String


### PR DESCRIPTION
- A do block had the first statement on the same line as the do block itself
  which caused later lines to not be indented properly.  Instead, add a newline
  after the do so that all statements in the do block are indented properly.

- The guards in a case expression were not indented at all, appearing on the
  very first character of the line.  Instead, use withIndent and prettyPrintMany
  to properly indent each guard of a case expression.