### PR TITLE
Minor fixes to pretty printer

### DIFF
--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -55,10 +55,17 @@ currentIndent = do
 -- Print many lines
 --
 prettyPrintMany :: (a -> StateT PrinterState Maybe String) -> [a] -> StateT PrinterState Maybe String
-prettyPrintMany f xs = do
+prettyPrintMany = prettyPrintMany' ""
+
+-- |
+-- Print many lines, intercalating a string at the end of every line except the final line.
+-- This is primarily useful to add a comma to the end of each line except the final line.
+--
+prettyPrintMany' :: String -> (a -> StateT PrinterState Maybe String) -> [a] -> StateT PrinterState Maybe String
+prettyPrintMany' postfix f xs = do
   ss <- mapM f xs
   indentString <- currentIndent
-  return $ intercalate "\n" $ map (indentString ++) ss
+  return $ intercalate (postfix ++ "\n") $ map (indentString ++) ss
 
 -- |
 -- Prints an object key, escaping reserved names.

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -124,7 +124,7 @@ prettyPrintDoNotationElement (DoNotationBind binder val) =
     ]
 prettyPrintDoNotationElement (DoNotationLet ds) =
   concat <$> sequence
-    [ return "let "
+    [ return "let\n"
     , withIndent $ prettyPrintMany prettyPrintDeclaration ds
     ]
 prettyPrintDoNotationElement (PositionedDoNotationElement _ _ el) = prettyPrintDoNotationElement el
@@ -133,7 +133,7 @@ prettyPrintObject' :: [(String, Maybe Expr)] -> StateT PrinterState Maybe String
 prettyPrintObject' [] = return "{}"
 prettyPrintObject' ps = concat <$> sequence
   [ return "{\n"
-  , withIndent $ prettyPrintMany prettyPrintObjectProperty ps
+  , withIndent $ prettyPrintMany' "," prettyPrintObjectProperty ps
   , return "\n"
   , currentIndent
   , return "}"

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -13,6 +13,7 @@
 --
 -----------------------------------------------------------------------------
 
+{-# LANGUAGE TupleSections #-}
 module Language.PureScript.Pretty.Values (
     prettyPrintValue,
     prettyPrintBinder
@@ -41,9 +42,11 @@ literals = mkPattern' match
   match (BooleanLiteral True) = return "true"
   match (BooleanLiteral False) = return "false"
   match (ArrayLiteral xs) = concat <$> sequence
-    [ return "[ "
-    , withIndent $ prettyPrintMany prettyPrintValue' xs
-    , return " ]"
+    [ return "[\n"
+    , withIndent $ prettyPrintMany' "," prettyPrintValue' xs
+    , return "\n"
+    , currentIndent
+    , return "]"
     ]
   match (ObjectLiteral ps) = prettyPrintObject' $ second Just `map` ps
   match (ObjectConstructor ps) = prettyPrintObject' ps
@@ -60,6 +63,14 @@ literals = mkPattern' match
     , return " of\n"
     , withIndent $ prettyPrintMany prettyPrintCaseAlternative binders
     , currentIndent
+    ]
+  match (Let [d] val) = concat <$> sequence
+    [ return "let "
+    , withIndent $ prettyPrintDeclaration d
+    , return "\n"
+    , currentIndent
+    , return "in "
+    , withIndent $ prettyPrintValue' val
     ]
   match (Let ds val) = concat <$> sequence
     [ return "let\n"
@@ -159,10 +170,10 @@ objectUpdate = mkPattern match
   match _ = Nothing
 
 app :: Pattern PrinterState Expr (String, Expr)
-app = mkPattern match
+app = mkPattern' match
   where
-  match (App val arg) = Just (prettyPrintValue arg, val)
-  match _ = Nothing
+  match (App val arg) = (,val) <$> prettyPrintValue' arg
+  match _ = mzero
 
 lam :: Pattern PrinterState Expr (String, Expr)
 lam = mkPattern match


### PR DESCRIPTION
Here are a couple more improvements to the pretty printer.  There is one bug that I found but did not fix in this pull, since it is a more complicated bug.

If you have an expression like `App something (ObjectLiteral ...)` which is common for example when something is a data constructor, the indentation is not correct.  The bug is that in the `app` function in Pretty/Values.hs, it just prints the argument starting from zero indentation level.  My first guess is that changing app in Values.hs to the following...
```
app :: Pattern PrinterState Expr (String, Expr)
app = mkPattern' match
  where
  match (App val arg) = (,val) <$> prettyPrintValue' arg
  match _ = mzero
```

The above does prettyprint `App something (ObjectLiteral ...)` correctly, but I am not sure if it breaks anything else.