### PR TITLE
add support for building with stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cabal.sandbox.config
 .psci_modules/
 bower_components/
 tmp/
+.stack-work/

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,9 @@
+flags: {}
+packages:
+- '.'
+extra-deps:
+- aeson-better-errors-0.8.0
+- bower-json-0.7.0.0
+- boxes-0.1.4
+- pattern-arrows-0.0.2
+resolver: lts-2.15


### PR DESCRIPTION
This `stack.yaml` file makes it quicker and easier to build and install purescript using [stack](https://github.com/commercialhaskell/stack). Fewer steps than using cabal, less redundant building of dependencies. Uses the latest GHC 7.8 lts stackage resolver.

Usage:

```
stack install # or just `stack build` to not also install it to ~/.local/bin/
```
