### PR TITLE
docs: Separate conversion and rendering stages

### DIFF
--- a/psc-publish/Main.hs
+++ b/psc-publish/Main.hs
@@ -109,14 +109,14 @@ preparePackage' = do
 
   return D.Package{..}
 
-getModulesAndBookmarks :: PrepareM ([D.Bookmark], [D.RenderedModule])
+getModulesAndBookmarks :: PrepareM ([D.Bookmark], [D.Module])
 getModulesAndBookmarks = do
   (inputFiles, depsFiles) <- liftIO getInputAndDepsFiles
   liftIO (D.parseAndDesugar inputFiles depsFiles renderModules)
     >>= either (userError . ParseAndDesugarError) return
   where
   renderModules bookmarks modules =
-    return (bookmarks, map D.renderModule modules)
+    return (bookmarks, map D.convertModule modules)
 
 getVersionFromGitTag :: PrepareM (String, Version)
 getVersionFromGitTag = do

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -125,6 +125,7 @@ library
                      Language.PureScript.Types
 
                      Language.PureScript.Docs
+                     Language.PureScript.Docs.Convert
                      Language.PureScript.Docs.Render
                      Language.PureScript.Docs.Types
                      Language.PureScript.Docs.RenderedCode

--- a/src/Language/PureScript/Docs.hs
+++ b/src/Language/PureScript/Docs.hs
@@ -9,5 +9,6 @@ module Language.PureScript.Docs (
 import Language.PureScript.Docs.Types as Docs
 import Language.PureScript.Docs.RenderedCode.Types as Docs
 import Language.PureScript.Docs.RenderedCode.Render as Docs
+import Language.PureScript.Docs.Convert as Docs
 import Language.PureScript.Docs.Render as Docs
 import Language.PureScript.Docs.ParseAndDesugar as Docs

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- | Functions for converting PureScript ASTs into values of the data types
+-- from Language.PureScript.Docs.
+
+module Language.PureScript.Docs.Convert
+  ( convertModule
+  , collectBookmarks
+  ) where
+
+import Control.Monad
+import Control.Category ((>>>))
+import Data.Either
+import Data.Maybe (mapMaybe, isNothing)
+import Data.List (nub, isPrefixOf, isSuffixOf)
+
+import qualified Language.PureScript as P
+
+import Language.PureScript.Docs.Types
+
+-- |
+-- Convert a single Module.
+--
+convertModule :: P.Module -> Module
+convertModule m@(P.Module coms moduleName  _ _) =
+  Module (show moduleName) comments (declarations m)
+  where
+  comments = convertComments coms
+  declarations =
+    P.exportedDeclarations
+    >>> mapMaybe (\d -> getDeclarationTitle d >>= convertDeclaration d)
+    >>> augmentDeclarations
+    >>> map addDefaultFixity
+
+-- | The data type for an intermediate stage which we go through during
+-- converting.
+--
+-- In the first pass, we take all top level declarations in the module, and
+-- collect other information which will later be used to augment the top level
+-- declarations. These two situation correspond to the Right and Left
+-- constructors, respectively.
+--
+-- In the second pass, we go over all of the Left values and augment the
+-- relevant declarations, leaving only the augmented Right values.
+--
+-- Note that in the Left case, we provide a [String] as well as augment
+-- information. The [String] value should be a list of titles of declarations
+-- that the augmentation should apply to. For example, for a type instance
+-- declaration, that would be any types or type classes mentioned in the
+-- instance. For a fixity declaration, it would be just the relevant operator's
+-- name.
+type IntermediateDeclaration
+  = Either ([String], DeclarationAugment) Declaration
+
+-- | Some data which will be used to augment a Declaration in the
+-- output.
+--
+-- The AugmentChild constructor allows us to move all children under their
+-- respective parents. It is only necessary for type instance declarations,
+-- since they appear at the top level in the AST, and since they might need to
+-- appear as children in two places (for example, if a data type defined in a
+-- module is an instance of a type class also defined in that module).
+--
+-- The AugmentFixity constructor allows us to augment operator definitions
+-- with their associativity and precedence.
+data DeclarationAugment
+  = AugmentChild ChildDeclaration
+  | AugmentFixity P.Fixity
+
+-- | Augment top-level declarations; the second pass. See the comments under
+-- the type synonym IntermediateDeclaration for more information.
+augmentDeclarations :: [IntermediateDeclaration] -> [Declaration]
+augmentDeclarations (partitionEithers -> (augments, toplevels)) =
+  foldl go toplevels augments
+  where
+  go ds (parentTitles, a) =
+    map (\d ->
+      if declTitle d `elem` parentTitles
+        then augmentWith a d
+        else d) ds
+
+  augmentWith a d =
+    case a of
+      AugmentChild child ->
+        d { declChildren = declChildren d ++ [child] }
+      AugmentFixity fixity ->
+        d { declFixity = Just fixity }
+
+-- | Add the default operator fixity for operators which do not have associated
+-- fixity declarations.
+--
+-- TODO: This may no longer be necessary after issue 806 is resolved, hopefully
+-- in 0.8.
+addDefaultFixity :: Declaration -> Declaration
+addDefaultFixity decl@Declaration{..}
+  | isOp declTitle && isNothing declFixity =
+        decl { declFixity = Just defaultFixity }
+  | otherwise =
+        decl
+  where
+  isOp :: String -> Bool
+  isOp str = "(" `isPrefixOf` str && ")" `isSuffixOf` str
+  defaultFixity = P.Fixity P.Infixl (-1)
+
+getDeclarationTitle :: P.Declaration -> Maybe String
+getDeclarationTitle (P.TypeDeclaration name _)               = Just (show name)
+getDeclarationTitle (P.ExternDeclaration name _)             = Just (show name)
+getDeclarationTitle (P.DataDeclaration _ name _ _)           = Just (show name)
+getDeclarationTitle (P.ExternDataDeclaration name _)         = Just (show name)
+getDeclarationTitle (P.TypeSynonymDeclaration name _ _)      = Just (show name)
+getDeclarationTitle (P.TypeClassDeclaration name _ _ _)      = Just (show name)
+getDeclarationTitle (P.TypeInstanceDeclaration name _ _ _ _) = Just (show name)
+getDeclarationTitle (P.FixityDeclaration _ name)             = Just ("(" ++ name ++ ")")
+getDeclarationTitle (P.PositionedDeclaration _ _ d)          = getDeclarationTitle d
+getDeclarationTitle _                                        = Nothing
+
+-- | Create a basic Declaration value.
+mkDeclaration :: String -> DeclarationInfo -> Declaration
+mkDeclaration title info =
+  Declaration { declTitle      = title
+              , declComments   = Nothing
+              , declSourceSpan = Nothing
+              , declChildren   = []
+              , declFixity     = Nothing
+              , declInfo       = info
+              }
+
+basicDeclaration :: String -> DeclarationInfo -> Maybe IntermediateDeclaration
+basicDeclaration title info = Just $ Right $ mkDeclaration title info
+
+convertDeclaration :: P.Declaration -> String -> Maybe IntermediateDeclaration
+convertDeclaration (P.TypeDeclaration _ ty) title =
+  basicDeclaration title (ValueDeclaration ty)
+convertDeclaration (P.ExternDeclaration _ ty) title =
+  basicDeclaration title (ValueDeclaration ty)
+convertDeclaration (P.DataDeclaration dtype _ args ctors) title =
+  Just (Right (mkDeclaration title info) { declChildren = children })
+  where
+  info = DataDeclaration dtype args
+  children = map convertCtor ctors
+  convertCtor (ctor', tys) =
+    ChildDeclaration (show ctor') Nothing Nothing (ChildDataConstructor tys)
+convertDeclaration (P.ExternDataDeclaration _ kind') title =
+  basicDeclaration title (ExternDataDeclaration kind')
+convertDeclaration (P.TypeSynonymDeclaration _ args ty) title =
+  basicDeclaration title (TypeSynonymDeclaration args ty)
+convertDeclaration (P.TypeClassDeclaration _ args implies ds) title = do
+  Just (Right (mkDeclaration title info) { declChildren = children })
+  where
+  info = TypeClassDeclaration args implies
+  children = map convertClassMember ds
+  convertClassMember (P.PositionedDeclaration _ _ d) =
+    convertClassMember d
+  convertClassMember (P.TypeDeclaration ident' ty) =
+    ChildDeclaration (show ident') Nothing Nothing (ChildTypeClassMember ty)
+  convertClassMember _ =
+    error "Invalid argument to convertClassMember."
+convertDeclaration (P.TypeInstanceDeclaration _ constraints className tys _) title = do
+  Just (Left (classNameString : typeNameStrings, AugmentChild childDecl))
+  where
+  classNameString = unQual className
+  typeNameStrings = nub (concatMap (P.everythingOnTypes (++) extractProperNames) tys)
+  unQual x = let (P.Qualified _ y) = x in show y
+
+  extractProperNames (P.TypeConstructor n) = [unQual n]
+  extractProperNames (P.SaturatedTypeSynonym n _) = [unQual n]
+  extractProperNames _ = []
+
+  childDecl = ChildDeclaration title Nothing Nothing (ChildInstance constraints classApp)
+  classApp = foldl P.TypeApp (P.TypeConstructor className) tys
+convertDeclaration (P.FixityDeclaration fixity _) title =
+  Just (Left ([title], AugmentFixity fixity))
+convertDeclaration (P.PositionedDeclaration srcSpan com d') title =
+  fmap (addComments . addSourceSpan) (convertDeclaration d' title)
+  where
+  addComments (Right d) =
+    Right (d { declComments = convertComments com })
+  addComments (Left augment) =
+    Left (withAugmentChild (\d -> d { cdeclComments = convertComments com })
+                           augment)
+
+  addSourceSpan (Right d) =
+    Right (d { declSourceSpan = Just srcSpan })
+  addSourceSpan (Left augment) =
+    Left (withAugmentChild (\d -> d { cdeclSourceSpan = Just srcSpan })
+                           augment)
+
+  withAugmentChild f (t, a) =
+    case a of
+      AugmentChild d -> (t, AugmentChild (f d))
+      _              -> (t, a)
+convertDeclaration _ _ = Nothing
+
+convertComments :: [P.Comment] -> Maybe String
+convertComments cs = do
+  let raw = concatMap toLines cs
+  guard (all hasPipe raw && not (null raw))
+  return (go raw)
+  where
+  go = unlines . map stripPipes
+
+  toLines (P.LineComment s) = [s]
+  toLines (P.BlockComment s) = lines s
+
+  hasPipe s = case dropWhile (== ' ') s of { ('|':_) -> True; _ -> False }
+
+  stripPipes = dropPipe . dropWhile (== ' ')
+
+  dropPipe ('|':' ':s) = s
+  dropPipe ('|':s) = s
+  dropPipe s = s
+
+-- | Go through a PureScript module and extract a list of Bookmarks; references
+-- to data types or values, to be used as a kind of index. These are used for
+-- generating links in the HTML documentation, for example.
+collectBookmarks :: InPackage P.Module -> [Bookmark]
+collectBookmarks (Local m) = map Local (collectBookmarks' m)
+collectBookmarks (FromDep pkg m) = map (FromDep pkg) (collectBookmarks' m)
+
+collectBookmarks' :: P.Module -> [(P.ModuleName, String)]
+collectBookmarks' m =
+  map (P.getModuleName m, )
+      (mapMaybe getDeclarationTitle
+                (P.exportedDeclarations m))
+

--- a/src/Language/PureScript/Docs/ParseAndDesugar.hs
+++ b/src/Language/PureScript/Docs/ParseAndDesugar.hs
@@ -19,7 +19,7 @@ import Web.Bower.PackageMeta (PackageName)
 import qualified Language.PureScript as P
 import qualified Language.PureScript.Constants as C
 import Language.PureScript.Docs.Types
-import Language.PureScript.Docs.Render
+import Language.PureScript.Docs.Convert (collectBookmarks)
 
 data ParseDesugarError
   = ParseError P.MultipleErrors

--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -1,299 +1,104 @@
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns #-}
 
--- | Functions for rendering documentation generated from PureScript code.
+-- | Functions for creating `RenderedCode` values from data types in
+-- Language.PureScript.Docs.Types.
+--
+-- These functions are the ones that are used in markdown/html documentation
+-- generation, but the intention is that you are able to supply your own
+-- instead if necessary. For example, the Hoogle input file generator
+-- substitutes some of these
 
-module Language.PureScript.Docs.Render
-  ( renderModule
-  , collectBookmarks
-  ) where
+module Language.PureScript.Docs.Render where
 
-import Control.Monad
-import Control.Category ((>>>))
-import Data.Either
 import Data.Monoid ((<>))
-import Data.Maybe (mapMaybe, isNothing)
-import Data.List (nub, isPrefixOf, isSuffixOf)
-
 import qualified Language.PureScript as P
 
-import Language.PureScript.Docs.RenderedCode
 import Language.PureScript.Docs.Types
+import Language.PureScript.Docs.RenderedCode
 import Language.PureScript.Docs.Utils.MonoidExtras
 
--- |
--- Render a single Module.
---
-renderModule :: P.Module -> RenderedModule
-renderModule m@(P.Module coms moduleName  _ _) =
-  RenderedModule (show moduleName) comments (declarations m)
-  where
-  comments = renderComments coms
-  declarations =
-    P.exportedDeclarations
-    >>> mapMaybe (\d -> getDeclarationTitle d >>= renderDeclaration d)
-    >>> augmentDeclarations
-    >>> map addDefaultFixity
+renderDeclaration :: Declaration -> RenderedCode
+renderDeclaration Declaration{..} =
+  mintersperse sp $ case declInfo of
+    ValueDeclaration ty ->
+      [ ident declTitle
+      , syntax "::"
+      , renderType ty
+      ]
+    DataDeclaration dtype args ->
+      [ keyword (show dtype)
+      , renderType (typeApp declTitle args)
+      ]
+    ExternDataDeclaration kind' ->
+      [ keywordData
+      , renderType (P.TypeConstructor (notQualified declTitle))
+      , syntax "::"
+      , renderKind kind'
+      ]
+    TypeSynonymDeclaration args ty ->
+      [ keywordType
+      , renderType (typeApp declTitle args)
+      , syntax "="
+      , renderType ty
+      ]
+    TypeClassDeclaration args implies ->
+      [ keywordClass ]
+      ++ maybe [] (:[]) superclasses
+      ++ [renderType (typeApp declTitle args)]
+      ++ if (not (null declChildren)) then [keywordWhere] else []
 
--- | The data type for an intermediate stage which we go through during
--- rendering.
---
--- In the first pass, we take all top level declarations in the module, and
--- collect other information which will later be used to augment the top level
--- declarations. These two situation correspond to the Right and Left
--- constructors, respectively.
---
--- In the second pass, we go over all of the Left values and augment the
--- relevant declarations, leaving only the augmented Right values.
---
--- Note that in the Left case, we provide a [String] as well as augment
--- information. The [String] value should be a list of titles of declarations
--- that the augmentation should apply to. For example, for a type instance
--- declaration, that would be any types or type classes mentioned in the
--- instance. For a fixity declaration, it would be just the relevant operator's
--- name.
-type IntermediateDeclaration
-  = Either ([String], DeclarationAugment) RenderedDeclaration
+      where
+      superclasses
+        | null implies = Nothing
+        | otherwise = Just $
+            syntax "("
+            <> mintersperse (syntax "," <> sp) (map renderConstraint implies)
+            <> syntax ")" <> sp <> syntax "<="
 
--- | Some data which will be used to augment a RenderedDeclaration in the
--- output.
---
--- The AugmentChild constructor allows us to move all children under their
--- respective parents. It is only necessary for type instance declarations,
--- since they appear at the top level in the AST, and since they might need to
--- appear as children in two places (for example, if a data type defined in a
--- module is an instance of a type class also defined in that module).
---
--- The AugmentFixity constructor allows us to augment operator definitions
--- with their associativity and precedence.
-data DeclarationAugment
-  = AugmentChild RenderedChildDeclaration
-  | AugmentFixity P.Fixity
-
--- | Augment top-level declarations; the second pass. See the comments under
--- the type synonym IntermediateDeclaration for more information.
-augmentDeclarations :: [IntermediateDeclaration] -> [RenderedDeclaration]
-augmentDeclarations (partitionEithers -> (augments, toplevels)) =
-  foldl go toplevels augments
-  where
-  go ds (parentTitles, a) =
-    map (\d ->
-      if rdTitle d `elem` parentTitles
-        then augmentWith a d
-        else d) ds
-
-  augmentWith a d =
-    case a of
-      AugmentChild child ->
-        d { rdChildren = rdChildren d ++ [child] }
-      AugmentFixity fixity ->
-        d { rdFixity = Just fixity }
-
--- | Add the default operator fixity for operators which do not have associated
--- fixity declarations.
---
--- TODO: This may no longer be necessary after issue 806 is resolved, hopefully
--- in 0.8.
-addDefaultFixity :: RenderedDeclaration -> RenderedDeclaration
-addDefaultFixity rd@RenderedDeclaration{..}
-  | isOp rdTitle && isNothing rdFixity = rd { rdFixity = Just defaultFixity }
-  | otherwise                          = rd
-  where
-  isOp :: String -> Bool
-  isOp str = "(" `isPrefixOf` str && ")" `isSuffixOf` str
-  defaultFixity = P.Fixity P.Infixl (-1)
-
-getDeclarationTitle :: P.Declaration -> Maybe String
-getDeclarationTitle (P.TypeDeclaration name _)               = Just (show name)
-getDeclarationTitle (P.ExternDeclaration name _)             = Just (show name)
-getDeclarationTitle (P.DataDeclaration _ name _ _)           = Just (show name)
-getDeclarationTitle (P.ExternDataDeclaration name _)         = Just (show name)
-getDeclarationTitle (P.TypeSynonymDeclaration name _ _)      = Just (show name)
-getDeclarationTitle (P.TypeClassDeclaration name _ _ _)      = Just (show name)
-getDeclarationTitle (P.TypeInstanceDeclaration name _ _ _ _) = Just (show name)
-getDeclarationTitle (P.FixityDeclaration _ name)             = Just ("(" ++ name ++ ")")
-getDeclarationTitle (P.PositionedDeclaration _ _ d)          = getDeclarationTitle d
-getDeclarationTitle _                                        = Nothing
-
--- | Create a basic RenderedDeclaration value.
-mkDeclaration :: String -> RenderedCode -> RenderedDeclaration
-mkDeclaration title code =
-  RenderedDeclaration { rdTitle      = title
-                      , rdComments   = Nothing
-                      , rdCode       = code
-                      , rdSourceSpan = Nothing
-                      , rdChildren   = []
-                      , rdFixity     = Nothing
-                      }
-
-basicDeclaration :: String -> RenderedCode -> Maybe IntermediateDeclaration
-basicDeclaration title code = Just $ Right $ mkDeclaration title code
-
-renderDeclaration :: P.Declaration -> String -> Maybe IntermediateDeclaration
-renderDeclaration (P.TypeDeclaration ident' ty) title =
-  basicDeclaration title code
-  where
-  code = ident (show ident')
-          <> sp <> syntax "::" <> sp
-          <> renderType ty
-renderDeclaration (P.ExternDeclaration ident' ty) title =
-  basicDeclaration title code
-  where
-  code = ident (show ident')
-          <> sp <> syntax "::" <> sp
-          <> renderType ty
-renderDeclaration (P.DataDeclaration dtype name args ctors) title =
-  Just (Right (mkDeclaration title code) { rdChildren = children })
-  where
-  typeApp  = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
-  code = keyword (show dtype) <> sp <> renderType typeApp
-  children = map renderCtor ctors
-  renderCtor (ctor', tys) =
-    RenderedChildDeclaration (show ctor') Nothing Nothing (ChildDataConstructor ctorSignature ctorCode)
-    where
-    ctor'' = P.TypeConstructor (P.Qualified Nothing ctor')
-    typeApp' = foldl P.TypeApp ctor'' tys
-    ctorSignature = renderType typeApp'
-    ctorCode = ident (show ctor') <> sp <> syntax "::" <> sp <> renderType ctorType
-    ctorType = P.quantify $ foldr (\a b -> P.TypeApp (P.TypeApp P.tyFunction a) b) typeApp tys
-renderDeclaration (P.ExternDataDeclaration name kind') title =
-  basicDeclaration title code
-  where
-  code = keywordData <> sp
-          <> renderType (P.TypeConstructor (P.Qualified Nothing name))
-          <> sp <> syntax "::" <> sp
-          <> renderKind kind'
-renderDeclaration (P.TypeSynonymDeclaration name args ty) title =
-  basicDeclaration title code
-  where
-  typeApp = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
-  code = mintersperse sp
-          [ keywordType
-          , renderType typeApp
-          , syntax "="
-          , renderType ty
-          ]
-renderDeclaration (P.TypeClassDeclaration name args implies ds) title = do
-  Just (Right (mkDeclaration title code) { rdChildren = children })
-  where
-  code = mintersperse sp $
-           [keywordClass]
-            ++ maybe [] (:[]) superclasses
-            ++ [renderType classApp]
-            ++ if (not (null ds)) then [keywordWhere] else []
-
-  superclasses
-    | null implies = Nothing
-    | otherwise = Just $
-        syntax "("
-         <> mintersperse (syntax "," <> sp) (map renderImplies implies)
-         <> syntax ") <="
-
-  renderImplies (pn, tys) =
-    let supApp = foldl P.TypeApp (P.TypeConstructor pn) tys
-    in renderType supApp
-
-  classApp = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
-
-  children = map renderClassMember ds
-
-  renderClassMember (P.PositionedDeclaration _ _ d) = renderClassMember d
-  renderClassMember (P.TypeDeclaration ident' ty) =
-    RenderedChildDeclaration (show ident') Nothing Nothing (ChildTypeClassMember contextualType actualType)
-    where
-    begin               = ident (show ident') <> sp <> syntax "::" <> sp
-    contextualType      = begin <> renderType ty
-    actualType          = begin <> renderType (addConstraint classConstraint ty)
-    classConstraint     = (P.Qualified Nothing name, map toTypeVar args)
-    addConstraint c ty' = P.moveQuantifiersToFront (P.quantify (P.ConstrainedType [c] ty'))
-  renderClassMember _ = error "Invalid argument to renderClassMember."
-renderDeclaration (P.TypeInstanceDeclaration name constraints className tys _) title = do
-  Just (Left (classNameString : typeNameStrings, AugmentChild childDecl))
-  where
-  classNameString = unQual className
-  typeNameStrings = nub (concatMap (P.everythingOnTypes (++) extractProperNames) tys)
-  unQual x = let (P.Qualified _ y) = x in show y
-
-  extractProperNames (P.TypeConstructor n) = [unQual n]
-  extractProperNames (P.SaturatedTypeSynonym n _) = [unQual n]
-  extractProperNames _ = []
-
-  childDecl = RenderedChildDeclaration title Nothing Nothing (ChildInstance code)
-
-  code =
-    mintersperse sp $
+renderChildDeclaration :: ChildDeclaration -> RenderedCode
+renderChildDeclaration ChildDeclaration{..} =
+  mintersperse sp $ case cdeclInfo of
+    ChildInstance constraints ty ->
       [ keywordInstance
-      , ident (show name)
+      , ident cdeclTitle
       , syntax "::"
       ] ++ maybe [] (:[]) constraints'
-        ++ [ renderType classApp ]
+        ++ [ renderType ty ]
+      where
+      constraints'
+        | null constraints = Nothing
+        | otherwise = Just $
+              syntax "("
+              <> renderedConstraints
+              <> syntax ")" <> sp <> syntax "=>"
 
-  constraints'
-    | null constraints = Nothing
-    | otherwise = Just (syntax "(" <> renderedConstraints <> syntax ") =>")
+      renderedConstraints = mintersperse (syntax "," <> sp)
+                                         (map renderConstraint constraints)
+    ChildDataConstructor args ->
+      [ renderType typeApp' ]
+      where
+      typeApp' = foldl P.TypeApp ctor' args
+      ctor' = P.TypeConstructor (notQualified cdeclTitle)
 
-  renderedConstraints = mintersperse (syntax "," <> sp) (map renderConstraint constraints)
+    ChildTypeClassMember ty ->
+      [ ident cdeclTitle
+      , syntax "::"
+      , renderType ty
+      ]
 
-  renderConstraint (pn, tys') =
-    let supApp = foldl P.TypeApp (P.TypeConstructor pn) tys'
-    in renderType supApp
+renderConstraint :: (P.Qualified P.ProperName, [P.Type]) -> RenderedCode
+renderConstraint (pn, tys) =
+  renderType $ foldl P.TypeApp (P.TypeConstructor pn) tys
 
-  classApp = foldl P.TypeApp (P.TypeConstructor className) tys
-renderDeclaration (P.FixityDeclaration fixity _) title =
-  Just (Left ([title], AugmentFixity fixity))
-renderDeclaration (P.PositionedDeclaration srcSpan com d') title =
-  fmap (addComments . addSourceSpan) (renderDeclaration d' title)
-  where
-  addComments (Right d) =
-    Right (d { rdComments = renderComments com })
-  addComments (Left augment) =
-    Left (withAugmentChild (\d -> d { rcdComments = renderComments com })
-                           augment)
+notQualified :: String -> P.Qualified P.ProperName
+notQualified = P.Qualified Nothing . P.ProperName
 
-  addSourceSpan (Right d) =
-    Right (d { rdSourceSpan = Just srcSpan })
-  addSourceSpan (Left augment) =
-    Left (withAugmentChild (\d -> d { rcdSourceSpan = Just srcSpan })
-                           augment)
-
-  withAugmentChild f (t, a) =
-    case a of
-      AugmentChild d -> (t, AugmentChild (f d))
-      _              -> (t, a)
-renderDeclaration _ _ = Nothing
-
-renderComments :: [P.Comment] -> Maybe String
-renderComments cs = do
-  let raw = concatMap toLines cs
-  guard (all hasPipe raw && not (null raw))
-  return (go raw)
-  where
-  go = unlines . map stripPipes
-
-  toLines (P.LineComment s) = [s]
-  toLines (P.BlockComment s) = lines s
-
-  hasPipe s = case dropWhile (== ' ') s of { ('|':_) -> True; _ -> False }
-
-  stripPipes = dropPipe . dropWhile (== ' ')
-
-  dropPipe ('|':' ':s) = s
-  dropPipe ('|':s) = s
-  dropPipe s = s
+typeApp :: String -> [(String, Maybe P.Kind)] -> P.Type
+typeApp title typeArgs =
+  foldl P.TypeApp
+        (P.TypeConstructor (notQualified title))
+        (map toTypeVar typeArgs)
 
 toTypeVar :: (String, Maybe P.Kind) -> P.Type
 toTypeVar (s, Nothing) = P.TypeVar s
 toTypeVar (s, Just k) = P.KindedType (P.TypeVar s) k
-
-collectBookmarks :: InPackage P.Module -> [Bookmark]
-collectBookmarks (Local m) = map Local (collectBookmarks' m)
-collectBookmarks (FromDep pkg m) = map (FromDep pkg) (collectBookmarks' m)
-
-collectBookmarks' :: P.Module -> [(P.ModuleName, String)]
-collectBookmarks' m =
-  map (P.getModuleName m, )
-      (mapMaybe getDeclarationTitle
-                (P.exportedDeclarations m))
-

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -13,12 +13,15 @@
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Language.PureScript.Environment where
 
 import Data.Data
 import Data.Maybe (fromMaybe)
 import qualified Data.Map as M
+import qualified Data.Text as T
+import qualified Data.Aeson as A
 
 import Language.PureScript.Kinds
 import Language.PureScript.Names
@@ -136,6 +139,16 @@ data DataDeclType
 instance Show DataDeclType where
   show Data = "data"
   show Newtype = "newtype"
+
+instance A.ToJSON DataDeclType where
+  toJSON = A.toJSON . show
+
+instance A.FromJSON DataDeclType where
+  parseJSON = A.withText "DataDeclType" $ \str ->
+    case str of
+      "data" -> return Data
+      "newtype" -> return Newtype
+      other -> fail $ "invalid type: '" ++ T.unpack other ++ "'"
 
 -- |
 -- Construct a ProperName in the Prim module

--- a/src/Language/PureScript/Kinds.hs
+++ b/src/Language/PureScript/Kinds.hs
@@ -13,10 +13,12 @@
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Language.PureScript.Kinds where
 
 import Data.Data
+import qualified Data.Aeson.TH as A
 
 import Control.Applicative
 import Control.Monad.Unify (Unknown)
@@ -44,7 +46,9 @@ data Kind
   -- |
   -- Function kinds
   --
-  | FunKind Kind Kind deriving (Show, Eq, Data, Typeable)
+  | FunKind Kind Kind deriving (Show, Eq, Ord, Data, Typeable)
+
+$(A.deriveJSON A.defaultOptions ''Kind)
 
 everywhereOnKinds :: (Kind -> Kind) -> Kind -> Kind
 everywhereOnKinds f = go

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -14,11 +14,15 @@
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Language.PureScript.Types where
 
 import Data.Data
 import Data.List (nub)
+import qualified Data.Aeson as A
+import qualified Data.Aeson.TH as A
 
 import Control.Monad.Unify
 import Control.Arrow (second)
@@ -32,7 +36,7 @@ import Language.PureScript.Traversals
 -- |
 -- An identifier for the scope of a skolem variable
 --
-newtype SkolemScope = SkolemScope { runSkolemScope :: Int } deriving (Show, Eq, Ord, Data, Typeable)
+newtype SkolemScope = SkolemScope { runSkolemScope :: Int } deriving (Show, Eq, Ord, Data, Typeable, A.ToJSON, A.FromJSON)
 
 -- |
 -- The type of types
@@ -98,12 +102,14 @@ data Type
   -- |
   -- A placeholder used in pretty printing
   --
-  | PrettyPrintForAll [String] Type deriving (Show, Eq, Data, Typeable)
+  | PrettyPrintForAll [String] Type deriving (Show, Eq, Ord, Data, Typeable)
 
 -- |
 -- A typeclass constraint
 --
 type Constraint = (Qualified ProperName, [Type])
+
+$(A.deriveJSON A.defaultOptions ''Type)
 
 -- |
 -- Convert a row to a list of pairs of labels and types


### PR DESCRIPTION
* Modify the data types in Language.PureScript.Docs.Types so that they
  no longer contain any RenderedCode values, but rather values of the
  types Language.PureScript.Type or Language.PureScript.Kind, in order
  to preserve more structure
* Rename Language.PureScript.Docs.Render to
  Language.PureScript.Docs.Convert, and remove all the code related to
  producing RenderedCode values
* Add a new module Language.PureScript.Docs.Render with code
  rendering functions (extracted from what was previously
  Language.PureScript.Docs.Render), to be used in markdown/html docs

These changes mean that information about the real types and kinds are stored in the JSON-serialized packages that pursuit works with, meaning that pursuit now has access to this information. This enables us to do the transformations necessary for Hoogle input files, and gives us more flexibility with regard to how we work around differences in PureScript's and Haskell's type systems (with respect to, eg, rows).

Also, as a bonus, the old renderDeclaration function (now split into the functions convertDeclaration, renderDeclaration, and renderChildDeclaration) is significantly simpler (resulting from concerns being better separated).