### PR TITLE
docs: Fix display of 'where' keyword after typeclasses

### DIFF
--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -45,7 +45,9 @@ renderDeclaration Declaration{..} =
       [ keywordClass ]
       ++ maybe [] (:[]) superclasses
       ++ [renderType (typeApp declTitle args)]
-      ++ if (not (null declChildren)) then [keywordWhere] else []
+      ++ if any (isTypeClassMember . cdeclInfo) declChildren
+            then [keywordWhere]
+            else []
 
       where
       superclasses
@@ -54,6 +56,9 @@ renderDeclaration Declaration{..} =
             syntax "("
             <> mintersperse (syntax "," <> sp) (map renderConstraint implies)
             <> syntax ")" <> sp <> syntax "<="
+
+      isTypeClassMember (ChildTypeClassMember _) = True
+      isTypeClassMember _ = False
 
 renderChildDeclaration :: ChildDeclaration -> RenderedCode
 renderChildDeclaration ChildDeclaration{..} =


### PR DESCRIPTION
A 'where' should only be displayed in documentation for a type class declaration if the type class has at least one member. This commit fixes a bug introduced in #1198 where the 'where' keyword was sometimes displayed even if a type class has no members.

In #1198 I was advocating getting rid of 'where' entirely, but it turns out that doesn't work well for the output of psc-docs. Instead, I can make that change inside Pursuit rather than here.