### PR TITLE
Needs GHC >= 7.8 due to Traversable (,) a instance

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -26,7 +26,7 @@ source-repository head
     location: https://github.com/purescript/purescript.git
 
 library
-    build-depends: base >=4.6 && <5,
+    build-depends: base >=4.7 && <5,
                    containers -any,
                    unordered-containers -any,
                    dlist -any,


### PR DESCRIPTION
This only applies to the 0.7.0.0 release. I've revised it (http://hackage.haskell.org/package/purescript/revisions/) so a new release is only necessary if you want to restore backwards compatibility.

```
src/Language/PureScript/CodeGen/JS/AST.hs:297:59:
    Could not deduce (Data.Traversable.Traversable ((,) String))
      arising from a use of `traverse'
    from the context (Applicative m, Monad m)
      bound by the type signature for
                 everywhereOnJSTopDownM :: (Applicative m, Monad m) =>
                                           (JS -> m JS) -> JS -> m JS
      at src/Language/PureScript/CodeGen/JS/AST.hs:289:27-80
    Possible fix:
      add an instance declaration for
      (Data.Traversable.Traversable ((,) String))
    In the first argument of `traverse', namely `(traverse f')'
    In the second argument of `(<$>)', namely
      `traverse (traverse f') js'
    In the expression: JSObjectLiteral <$> traverse (traverse f') js
```
