### PR TITLE
Require base >= 4.7

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -26,7 +26,7 @@ source-repository head
     location: https://github.com/purescript/purescript.git
 
 library
-    build-depends: base >=4.6 && <5,
+    build-depends: base >=4.7 && <5,
                    containers -any,
                    unordered-containers -any,
                    dlist -any,


### PR DESCRIPTION
GHC 7.6 and earlier is not supported. Any attempt to build purescript
with GHC 7.6 or earlier will now fail at the `cabal configure` step,
instead of giving a compile error which is impossible to understand for
people not familiar with the compiler internals.

Refs #1121