### PR TITLE
Add the compiler version to psc-publish output

### DIFF
--- a/psc-publish/Main.hs
+++ b/psc-publish/Main.hs
@@ -38,6 +38,7 @@ import Web.Bower.PackageMeta (PackageMeta(..), BowerError(..), PackageName,
                               runPackageName, parsePackageName, Repository(..))
 import qualified Web.Bower.PackageMeta as Bower
 
+import qualified Language.PureScript as P (version)
 import qualified Language.PureScript.Docs as D
 import Utils
 import ErrorsWarnings
@@ -107,6 +108,7 @@ preparePackage' = do
   pkgResolvedDependencies     <- getResolvedDependencies declaredDeps
 
   let pkgUploader = D.NotYetKnown
+  let pkgCompilerVersion = P.version
 
   return D.Package{..}
 


### PR DESCRIPTION
For pursuit: to determine whether a given JSON-serialized package was
produced by a sufficiently recent compiler, so that it can fail
gracefully if necessary.

We also modify the parsers to accept an extra argument which is the
minimum allowable version. The FromJSON instance sets the minimum
allowable version to 0.0.0.0 (that is, it never fails with a
CompilerTooOld error).