### PR TITLE
Pretty print array literals without newlines

### DIFF
--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -40,11 +40,7 @@ literals = mkPattern' match
   match (CharLiteral c) = return $ show c
   match (BooleanLiteral True) = return "true"
   match (BooleanLiteral False) = return "false"
-  match (ArrayLiteral xs) = concat <$> sequence
-    [ return "[ "
-    , withIndent $ prettyPrintMany prettyPrintValue' xs
-    , return " ]"
-    ]
+  match (ArrayLiteral xs) = return $ "[" ++ intercalate ", " (map prettyPrintValue xs) ++ "]"
   match (ObjectLiteral ps) = prettyPrintObject' $ second Just `map` ps
   match (ObjectConstructor ps) = prettyPrintObject' ps
   match (ObjectGetter prop) = return $ "(." ++ prop ++ ")"


### PR DESCRIPTION
This is a follow-up to pull #1195.  I ran the most recent pretty-printer through some tests (https://bitbucket.org/wuzzeb/purescript-aeson-interop, although it isn't 100% working but that isn't pretty-printing problem).  There was just one issue with array literals appearing in expressions, after that the output from the pretty printer could be fed back into the compiler.