### PR TITLE
Fix psc-publish tests

### DIFF
--- a/psc-publish/Main.hs
+++ b/psc-publish/Main.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
+module Main where
+
 import Prelude hiding (userError)
 
 import Data.Maybe

--- a/psc-publish/tests/Test.hs
+++ b/psc-publish/tests/Test.hs
@@ -57,7 +57,7 @@ getPackage = do
   pushd packageDir preparePackage
 
 data TestResult
-  = ParseFailed (ParseError PackageError)
+  = ParseFailed String
   | Mismatch ByteString ByteString -- ^ encoding before, encoding after
   | Pass ByteString
   deriving (Show)
@@ -70,10 +70,10 @@ test = roundTrip <$> getPackage
 roundTrip :: UploadedPackage -> TestResult
 roundTrip pkg =
   let before = A.encode pkg
-  in case parse asUploadedPackage before of
+  in case A.eitherDecode before of
        Left err -> ParseFailed err
        Right parsed -> do
-         let after = A.encode parsed
+         let after = A.encode (parsed :: UploadedPackage)
          if before == after
            then Pass before
            else Mismatch before after


### PR DESCRIPTION
For some reason, an explicit "module Main where" is required for other modules to be able to import things from Main.

This is a little program I wrote to test the package serialization of `psc-publish`; it downloads the current master version of `purescript-prelude`, creates a fake tag, runs `psc-publish`, and does a roundtrip to and from JSON.

Currently it's not integrated into the actual test suite, and so it only gets run manually, by me, when I change something to do with serialization. I would be happy to make this into a real test that is listed in the Cabal file (and so gets run by Travis etc).