### PR TITLE
Fix the haddock for the Language.PureScript.Bundle module

### DIFF
--- a/src/Language/PureScript/Bundle.hs
+++ b/src/Language/PureScript/Bundle.hs
@@ -10,6 +10,9 @@
 --
 -- | Bundles compiled PureScript modules for the browser.
 --
+-- This module takes as input the individual generated modules from 'Language.PureScript.Make' and
+-- performs dead code elimination, filters empty modules,
+-- and generates the final Javascript bundle.
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE PatternGuards #-}
@@ -18,11 +21,6 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE RecordWildCards #-}
 
--- | Bundle javascript for use in the browser.
---
--- This module takes as input the individual generated modules from 'Language.PureScript.Make' and
--- performs dead code elimination, filters empty modules,
--- and generates the final Javascript bundle.
 module Language.PureScript.Bundle (
      bundle
    , ModuleIdentifier(..)


### PR DESCRIPTION
The bundle module has two haddock comments for the module itself, which resulted in a build error:

https://hackage.haskell.org/package/purescript-0.7.1.0/reports/1

This fixes it by changing the module to only have one comment.  When I moved the code, I didn't see the haddock comment that was already there.  I did test with `stack haddock` and the haddocks build now after this commit.