### PR TITLE
Stackage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - cabal --version
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - travis_retry cabal update
+  - ./travis-stackage.sh
   - cabal install --only-dependencies --enable-tests --enable-benchmarks
 script:
   - ./travis-script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ env:
   - CABALVER=1.22 GHCVER=7.8.3 COVERAGE_SUITE=psci-tests
   - CABALVER=1.22 GHCVER=7.6.3
   - CABALVER=1.22 GHCVER=7.10.1
+  - CABALVER=1.22 GHCVER=7.10.1 STACKAGE=nightly
+  - CABALVER=1.22 GHCVER=7.8.3 STACKAGE=lts
 before_install:
   - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
   - travis_retry sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,17 @@
+sudo: false
 env:
   - CABALVER=1.22 GHCVER=7.8.3 COVERAGE_SUITE=tests
   - CABALVER=1.22 GHCVER=7.8.3 COVERAGE_SUITE=psci-tests
   - CABALVER=1.22 GHCVER=7.6.3
   - CABALVER=1.22 GHCVER=7.10.1
   - CABALVER=1.22 GHCVER=7.10.1 STACKAGE=nightly
-  - CABALVER=1.22 GHCVER=7.8.3 STACKAGE=lts
+  - CABALVER=1.22 GHCVER=7.8.3 STACKAGE=lts # Here is 7.8.3, yet stackage is build with 7.8.4
 before_install:
-  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
-  - travis_retry sudo apt-get update
-  - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
-  - export PATH="/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH"
+  - export PATH="/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:/opt/alex/3.1.4/bin:/opt/happy/1.19.5/bin:$PATH"
 install:
   - cabal --version
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - travis_retry cabal update
-  - cabal install alex happy
   - cabal install --only-dependencies --enable-tests --enable-benchmarks
 script:
   - ./travis-script.sh
@@ -33,3 +30,14 @@ deploy:
   on:
     all_branches: true
     tags: true
+addons:
+  apt:
+    sources:
+    - hvr-ghc
+    packages:
+    - ghc-7.6.3
+    - ghc-7.8.3
+    - ghc-7.10.1
+    - cabal-install-1.22
+    - alex-3.1.4
+    - happy-1.19.5

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -2,8 +2,7 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-- aeson-better-errors-0.8.0
 - bower-json-0.7.0.0
 - boxes-0.1.4
 - pattern-arrows-0.0.2
-resolver: lts-2.18
+resolver: nightly-2015-07-12

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -1,5 +1,10 @@
 set -e
 
+if [ -n "$STACKAGE" ]
+then
+  curl -O https://www.stackage.org/$STACKAGE/cabal.config
+fi
+
 if [ -z $( git describe --tags --exact-match 2>/dev/null ) && -n "$COVERAGE_SUITE" ]
 then
   cabal configure --enable-tests --enable-coverage -v2

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -1,10 +1,5 @@
 set -e
 
-if [ -n "$STACKAGE" ]
-then
-  curl -O https://www.stackage.org/$STACKAGE/cabal.config
-fi
-
 if [ -z $( git describe --tags --exact-match 2>/dev/null ) && -n "$COVERAGE_SUITE" ]
 then
   cabal configure --enable-tests --enable-coverage -v2

--- a/travis-stackage.sh
+++ b/travis-stackage.sh
@@ -1,0 +1,7 @@
+set -e
+
+if [ -n "$STACKAGE" ]
+then
+  curl -LO https://www.stackage.org/$STACKAGE/cabal.config
+  head -n 1 cabal.config
+fi


### PR DESCRIPTION
Update travis scripts. Update to use [container infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/). Builds seems to start faster, but also to take longer (maybe it's the time of the day though).

This is motivated by https://github.com/purescript/purescript/issues/684 issue. I don't see any problems of adding purescript to stackage.