### PR TITLE
fixes #1265: escape all but printable ASCII (except space) in strings

### DIFF
--- a/src/Language/PureScript/Pretty/JS.hs
+++ b/src/Language/PureScript/Pretty/JS.hs
@@ -163,6 +163,7 @@ string s = '"' : concatMap encodeChar s ++ "\""
   encodeChar '\\' = "\\\\"
   encodeChar c | fromEnum c > 0xFFF = "\\u" ++ showHex (fromEnum c) ""
   encodeChar c | fromEnum c > 0xFF = "\\u0" ++ showHex (fromEnum c) ""
+  encodeChar c | fromEnum c > 0x7E || fromEnum c < 0x20 = "\\x" ++ showHex (fromEnum c) ""
   encodeChar c = [c]
 
 conditional :: Pattern PrinterState JS ((JS, JS), JS)


### PR DESCRIPTION
Fixes #1265. Untested, since this shouldn't really be observable. Let me know what you think is the best strategy for testing this.