### PR TITLE
Only make composition suggestion on `object . app function`

### DIFF
--- a/examples/failing/DoNotSuggestComposition.purs
+++ b/examples/failing/DoNotSuggestComposition.purs
@@ -1,0 +1,10 @@
+module DoNotSuggestComposition where
+
+import Prelude
+
+x = { y: 3 }
+
+foo :: String -> String
+foo y = y
+
+bar = foo x

--- a/examples/failing/DoNotSuggestComposition2.purs
+++ b/examples/failing/DoNotSuggestComposition2.purs
@@ -1,0 +1,3 @@
+module DoNotSuggestComposition2 where
+
+foo = let x = { y: 3 } in x 2

--- a/examples/failing/SuggestComposition.purs
+++ b/examples/failing/SuggestComposition.purs
@@ -1,0 +1,5 @@
+module SuggestComposition where
+
+import Prelude
+
+f = g . g where g = (+1)

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -214,9 +214,17 @@ tyObject = primTy "Object"
 -- Check whether a type is an object
 --
 isObject :: Type -> Bool
-isObject = (==) tyObject . extract
-  where extract (TypeApp t _) = t
-        extract t = t
+isObject = isTypeOrApplied tyObject
+
+-- |
+-- Check whether a type is a function
+--
+isFunction :: Type -> Bool
+isFunction = isTypeOrApplied tyFunction
+
+isTypeOrApplied :: Type -> Type -> Bool
+isTypeOrApplied t1 (TypeApp t2 _) = t1 == t2
+isTypeOrApplied t1 t2 = t1 == t2
 
 -- |
 -- Smart constructor for function types

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -35,7 +35,7 @@ import Control.Monad.Trans.State.Lazy
 import Control.Arrow(first)
 
 import Language.PureScript.AST
-import Language.PureScript.Environment (isObject)
+import Language.PureScript.Environment (isObject, isFunction)
 import Language.PureScript.Pretty
 import Language.PureScript.Types
 import Language.PureScript.Names
@@ -670,7 +670,7 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage <$> onTypesInError
                                              , indent . line $ "import " ++ show im ++ " hiding (" ++ nm ++ ")"
                                              ]
     suggestions' (TypesDoNotUnify t1 t2)
-      | any isObject [t1, t2] = [line "Note that function composition in PureScript is defined using (<<<)"]
+      | isObject t1 && isFunction t2 = [line "Note that function composition in PureScript is defined using (<<<)"]
       | otherwise             = []
     suggestions' _ = []
 


### PR DESCRIPTION
Seems to fix the cases given by @hdgarrood in #1272. I'm not sure it's totally done, but is more restrictive, I'd like to throw more cases at it if someone can come up some that are interesting.