### PR TITLE
Improve error message formatting for tool interop

### DIFF
--- a/src/Language/PureScript/AST/SourcePos.hs
+++ b/src/Language/PureScript/AST/SourcePos.hs
@@ -36,8 +36,7 @@ data SourcePos = SourcePos
 
 displaySourcePos :: SourcePos -> String
 displaySourcePos sp =
-  "line " ++ show (sourcePosLine sp) ++
-    ", column " ++ show (sourcePosColumn sp)
+  show (sourcePosLine sp) ++ ":" ++ show (sourcePosColumn sp)
 
 instance A.ToJSON SourcePos where
   toJSON SourcePos{..} =
@@ -62,6 +61,10 @@ displaySourceSpan sp =
   spanName sp ++ " " ++
     displaySourcePos (spanStart sp) ++ " - " ++
     displaySourcePos (spanEnd sp)
+
+displaySourceSpanStart :: SourceSpan -> String
+displaySourceSpanStart sp =
+  spanName sp ++ ":" ++ displaySourcePos (spanStart sp)
 
 instance A.ToJSON SourceSpan where
   toJSON SourceSpan{..} =

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -651,8 +651,10 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage <$> onTypesInError
       paras [ lineWithLevel $ "in foreign import " ++ show nm ++ ":"
             , go err
             ]
+
+    -- Format follows gcc: "/path/to/file.purs:line:col:level:"
     go (PositionedError srcSpan err) =
-      paras [ lineWithLevel $ "at " ++ displaySourceSpan srcSpan ++ ":"
+      paras [ lineWithLevelSuffix $ displaySourceSpanStart srcSpan ++ ":"
             , indent $ go err
             ]
     go (SimpleErrorWrapper sem) = goSimple sem
@@ -662,6 +664,9 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage <$> onTypesInError
 
   lineWithLevel :: String -> Box.Box
   lineWithLevel text = line $ show level ++ " " ++ text
+
+  lineWithLevelSuffix :: String -> Box.Box
+  lineWithLevelSuffix text = line $ text ++ show level ++ ":"
 
   suggestions :: ErrorMessage -> [Box.Box]
   suggestions = suggestions' . unwrapErrorMessage

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -740,13 +740,13 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage <$> onTypesInError
 -- Pretty print multiple errors
 --
 prettyPrintMultipleErrors :: Bool -> MultipleErrors -> String
-prettyPrintMultipleErrors full = flip evalState M.empty . prettyPrintMultipleErrorsWith Error "Error:" "Multiple errors:" full
+prettyPrintMultipleErrors full = flip evalState M.empty . prettyPrintMultipleErrorsWith Error "Error found:" "Multiple errors found:" full
 
 -- |
 -- Pretty print multiple warnings
 --
 prettyPrintMultipleWarnings :: Bool -> MultipleErrors ->  String
-prettyPrintMultipleWarnings full = flip evalState M.empty . prettyPrintMultipleErrorsWith Warning "Warning:" "Multiple warnings:" full
+prettyPrintMultipleWarnings full = flip evalState M.empty . prettyPrintMultipleErrorsWith Warning "Warning found:" "Multiple warnings found:" full
 
 prettyPrintMultipleErrorsWith :: Level -> String -> String -> Bool -> MultipleErrors -> State UnknownMap String
 prettyPrintMultipleErrorsWith level intro _ full  (MultipleErrors [e]) = do


### PR DESCRIPTION
Improve editor interop by printing compiler errors in a format like that of gcc, ghc, javac, etc.

The new format allows editors like emacs to highlight errors and warnings correctly, and in such a way that the highlighting depends on the error level. Additionally, (emacs) features like 'go to error line' and 'go to next error' now work (more) correctly. See also #1098.

Changes:

- The headings ``Error:`` and ``Warning:`` at the top of the error list are interpreted by emacs as proper errors, which causes problem with highlighting and with jumping to the error line, because it doesn't exist. Fix: replace ``Error:`` by ``Error found:`` and so on. The introduction of a space character fixes the problem.

- ``PositionErrors`` are now formatted like ``/path/to/File.purs:3:5:warning:Some descriptive message``, following gcc. This allows emacs to parse the source position and error loevel correctly.

- The ending positions of the span are no longer printed. They are still available in the JSON format.

Before:

    Error:
    Error in module Foo:
    Error at /Users/erik/dev/ex/examples-purescript/purescript-0.7-project/error-msg-formats/bla.purs line 3, column 1 - line 4, column 1:
      Orphan type declaration for f

After:

    Error found:
    Error in module Foo:
    /Users/erik/dev/ex/examples-purescript/purescript-0.7-project/error-msg-formats/bla.purs:3:1:Error:
      Orphan type declaration for f
