### PR TITLE
Resolves #1276. Stop showing "Writing" and "Compiling" messages in psci

### DIFF
--- a/psc/Main.hs
+++ b/psc/Main.hs
@@ -67,7 +67,7 @@ compile (PSCMakeOptions inputGlob inputForeignGlob outputDir opts usePrefix) = d
       when (P.nonEmpty warnings) $
         hPutStrLn stderr (P.prettyPrintMultipleWarnings (P.optionsVerboseErrors opts) warnings)
       let filePathMap = M.fromList $ map (\(fp, P.Module _ mn _ _) -> (mn, fp)) ms
-          makeActions = buildMakeActions outputDir filePathMap foreigns usePrefix
+          makeActions = buildMakeActions outputDir filePathMap foreigns usePrefix formatters
       e <- runMake opts $ P.make makeActions ms
       case e of
         Left errs -> do
@@ -77,6 +77,11 @@ compile (PSCMakeOptions inputGlob inputForeignGlob outputDir opts usePrefix) = d
           when (P.nonEmpty warnings') $
             putStrLn (P.prettyPrintMultipleWarnings (P.optionsVerboseErrors opts) warnings')
           exitSuccess
+  where
+  formatters = P.OutputFormatters {
+    formatCompilingMessage = Just $ \mn -> "Compiling " ++ mn
+    , formatWritingMessage = Just $ \path -> "Writing " ++ path
+  }
 
 readInput :: InputOptions -> IO [(Either P.RebuildPolicy FilePath, String)]
 readInput InputOptions{..} = forM ioInputFiles $ \inFile -> (Right inFile, ) <$> readFile inFile

--- a/psci/PSCi.hs
+++ b/psci/PSCi.hs
@@ -262,8 +262,12 @@ make :: PSCiState -> [(Either P.RebuildPolicy FilePath, P.Module)] -> P.Make P.E
 make PSCiState{..} ms = P.make actions' (psciLoadedModules ++ ms)
     where
     filePathMap = M.fromList $ (first P.getModuleName . swap) `map` (psciLoadedModules ++ ms)
-    actions = P.buildMakeActions modulesDir filePathMap psciForeignFiles False
+    actions = P.buildMakeActions modulesDir filePathMap psciForeignFiles False formatters
     actions' = actions { P.progress = \s -> unless ("Compiling $PSCI" `isPrefixOf` s) $ liftIO . putStrLn $ s }
+    formatters = P.OutputFormatters {
+      formatCompilingMessage = Nothing
+      ,formatWritingMessage = Nothing
+    }
 
 -- |
 -- Takes a value declaration and evaluates it with the current state.

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -57,8 +57,12 @@ runTest :: Test a -> IO (Either P.MultipleErrors a)
 runTest = runExceptT . fmap fst . runWriterT . flip runReaderT P.defaultOptions . unTest
 
 makeActions :: M.Map P.ModuleName (FilePath, P.ForeignJS) -> P.MakeActions Test
-makeActions foreigns = P.MakeActions getInputTimestamp getOutputTimestamp readExterns codegen progress
+makeActions foreigns = P.MakeActions getInputTimestamp getOutputTimestamp readExterns codegen progress formatters
   where
+  formatters = P.OutputFormatters {
+    P.formatCompilingMessage = Nothing
+    ,P.formatWritingMessage = Nothing
+  }
   getInputTimestamp :: P.ModuleName -> Test (Either P.RebuildPolicy (Maybe UTCTime))
   getInputTimestamp mn 
     | isPreludeModule (P.runModuleName mn) = return (Left P.RebuildNever)


### PR DESCRIPTION
Not sure if this is the best approach (it was definitely one of the easiest that comes to mind).

Unfortunately bower's acting up for me so I'm not able to test at this very moment using `psci` (I can in half an hour or so).

It worked for `psc` using the new flag.

Thoughts?