### PR TITLE
Line numbers for `ShadowedName` warnings.

### DIFF
--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -53,7 +53,12 @@ lint (Module _ mn ds _) = censor (onErrorMessages (ErrorInModule mn)) $ mapM_ li
   lintDeclaration :: Declaration -> m ()
   lintDeclaration d =
     let (f, _, _, _, _) = everythingWithContextOnValues moduleNames mempty mappend stepD stepE stepB def def
-    in tell (f d)
+
+        f' :: Declaration -> MultipleErrors
+        f' (PositionedDeclaration pos _ dec) = onErrorMessages (PositionedError pos) (f' dec)
+        f' dec = f dec
+
+    in tell (f' d)
     where
     def s _ = (s, mempty)
 


### PR DESCRIPTION
As @garyb said, the problem was `ShadowedName` warnings. #1165

Now we can see this kind of warnings:

```haskell
module Main where
f _ = let f _ = 0 in f
g _ = let g _ = 0 in g
```

```
Multiple warnings:
  Warning in module Main:
  Warning at /dev/stdin line 2, column 1 - line 3, column 1:
    Name 'f' was shadowed.
  See https://github.com/purescript/purescript/wiki/Error-Code-ShadowedName for more information, or to contribute content related to this error.

  Warning in module Main:
  Warning at /dev/stdin line 3, column 1 - line 3, column 22:
    Name 'g' was shadowed.
  See https://github.com/purescript/purescript/wiki/Error-Code-ShadowedName for more information, or to contribute content related to this error.
```