### PR TITLE
Redundancy Checker

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -121,6 +121,7 @@ data SimpleErrorMessage
   | ShadowedName Ident
   | WildcardInferredType Type
   | NotExhaustivePattern [[Binder]] Bool
+  | OverlappingPattern [[Binder]] Bool
   | ClassOperator ProperName Ident
   deriving (Show)
 
@@ -231,6 +232,7 @@ errorCode em = case unwrapErrorMessage em of
   (ShadowedName _)              -> "ShadowedName"
   (WildcardInferredType _)      -> "WildcardInferredType"
   (NotExhaustivePattern _ _)    -> "NotExhaustivePattern"
+  (OverlappingPattern _ _)      -> "OverlappingPattern"
   (ClassOperator _ _)           -> "ClassOperator"
 
 -- |
@@ -564,6 +566,11 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage <$> onTypesInError
     goSimple (NotExhaustivePattern bs b) =
       indent $ paras $ [ line "Pattern could not be determined to cover all cases."
               , line $ "The definition has the following uncovered cases:\n"
+              , Box.hsep 1 Box.left (map (paras . map (line . prettyPrintBinderAtom)) (transpose bs))
+              ] ++ if not b then [line "..."] else []
+    goSimple (OverlappingPattern bs b) =
+      indent $ paras $ [ line "Redundant cases have been detected."
+              , line $ "The definition has the following redundant cases:\n"
               , Box.hsep 1 Box.left (map (paras . map (line . prettyPrintBinderAtom)) (transpose bs))
               ] ++ if not b then [line "..."] else []
     go (NotYetDefined names err) =


### PR DESCRIPTION
Written on top of the exhaustivity checker, it checks for the existence of overlapping patterns.

Example:
```haskell
module Main where
f true true = 0
f true false = 0
f true true = 0
```
It throws:
```
 Warning in module Main:
 Warning in value declaration f:
 Warning at /dev/stdin line 2, column 1 - line 3, column 1:
      Redundant cases has been detected.
      The definitions has the following redundant cases:

      true true
```
TODO:
- Support for arrays and literals