### PR TITLE
Fix optimizer for booleanAlgebraBoolean

### DIFF
--- a/src/Language/PureScript/CodeGen/JS/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/Inliner.hs
@@ -156,11 +156,11 @@ inlineCommonOperators = applyAll $
   , binary semigroupString (C.<>) Add
   , binary semigroupString (C.++) Add
 
-  , binary latticeBoolean (C.&&) And
-  , binary latticeBoolean (C.||) Or
-  , binaryFunction latticeBoolean C.inf And
-  , binaryFunction latticeBoolean C.sup Or
-  , unary complementedLatticeBoolean C.not Not
+  , binary booleanAlgebraBoolean (C.&&) And
+  , binary booleanAlgebraBoolean (C.||) Or
+  , binaryFunction booleanAlgebraBoolean C.conj And
+  , binaryFunction booleanAlgebraBoolean C.disj Or
+  , unary booleanAlgebraBoolean C.not Not
 
   , binary' C.dataIntBits (C..|.) BitwiseOr
   , binary' C.dataIntBits (C..&.) BitwiseAnd
@@ -307,11 +307,8 @@ semigroupString = (C.prelude, C.semigroupString)
 boundedBoolean :: (String, String)
 boundedBoolean = (C.prelude, C.boundedBoolean)
 
-latticeBoolean :: (String, String)
-latticeBoolean = (C.prelude, C.latticeBoolean)
-
-complementedLatticeBoolean :: (String, String)
-complementedLatticeBoolean = (C.prelude, C.complementedLatticeBoolean)
+booleanAlgebraBoolean :: (String, String)
+booleanAlgebraBoolean = (C.prelude, C.booleanAlgebraBoolean)
 
 semigroupoidArr :: (String, String)
 semigroupoidArr = (C.prelude, C.semigroupoidArr)

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -97,11 +97,11 @@ negate = "negate"
 not :: String
 not = "not"
 
-sup :: String
-sup = "sup"
+conj :: String
+conj = "conj"
 
-inf :: String
-inf = "inf"
+disj :: String
+disj = "disj"
 
 mod :: String
 mod = "mod"
@@ -229,11 +229,8 @@ eqBoolean = "eqBoolean"
 boundedBoolean :: String
 boundedBoolean = "boundedBoolean"
 
-latticeBoolean :: String
-latticeBoolean = "latticeBoolean"
-
-complementedLatticeBoolean :: String
-complementedLatticeBoolean = "complementedLatticeBoolean"
+booleanAlgebraBoolean :: String
+booleanAlgebraBoolean = "booleanAlgebraBoolean"
 
 semigroupString :: String
 semigroupString = "semigroupString"


### PR DESCRIPTION
Resolves #1312. Tested locally for now:

``` purescript
main = do
  print $ not $ true && false || false || true
  print $ (true `conj` not false) `disj` true
```

``` javascript
var main = function __do() {
    Control_Monad_Eff_Console.print(Prelude.showBoolean)(!(true && false || (false || true)))();
    return Control_Monad_Eff_Console.print(Prelude.showBoolean)(true && !false || true)();
};
```