### PR TITLE
Make error list heading emacs-friendly

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -740,13 +740,13 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage <$> onTypesInError
 -- Pretty print multiple errors
 --
 prettyPrintMultipleErrors :: Bool -> MultipleErrors -> String
-prettyPrintMultipleErrors full = flip evalState M.empty . prettyPrintMultipleErrorsWith Error "Error:" "Multiple errors:" full
+prettyPrintMultipleErrors full = flip evalState M.empty . prettyPrintMultipleErrorsWith Error "Error found:" "Multiple errors found:" full
 
 -- |
 -- Pretty print multiple warnings
 --
 prettyPrintMultipleWarnings :: Bool -> MultipleErrors ->  String
-prettyPrintMultipleWarnings full = flip evalState M.empty . prettyPrintMultipleErrorsWith Warning "Warning:" "Multiple warnings:" full
+prettyPrintMultipleWarnings full = flip evalState M.empty . prettyPrintMultipleErrorsWith Warning "Warning found:" "Multiple warnings found:" full
 
 prettyPrintMultipleErrorsWith :: Level -> String -> String -> Bool -> MultipleErrors -> State UnknownMap String
 prettyPrintMultipleErrorsWith level intro _ full  (MultipleErrors [e]) = do


### PR DESCRIPTION
Reworded the text here to introduce a space, so that emacs no longer incorrectly interprets the lines with `Error:` and `Warning:` as proper errors. This fixes  error highlighting and 'jump to next error' and similar functionality in the case of a single warning/error.

These changes were also a part of https://github.com/purescript/purescript/pull/1285.