### PR TITLE
Fix psc-publish producing no modules on Windows

### DIFF
--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -43,6 +43,7 @@ import Control.Monad.Writer
 import System.Directory (doesFileExist)
 import System.Process (readProcess)
 import System.Exit (exitFailure)
+import System.FilePath (pathSeparator)
 import qualified System.FilePath.Glob as Glob
 
 import Web.Bower.PackageMeta (PackageMeta(..), BowerError(..), PackageName,
@@ -340,7 +341,7 @@ withPackageName fp = (,fp) <$> getPackageName fp
 
 getPackageName :: FilePath -> Maybe PackageName
 getPackageName fp = do
-  let xs = splitOn "/" fp
+  let xs = splitOn [pathSeparator] fp
   ys <- stripPrefix ["bower_components"] xs
   y <- headMay ys
   case Bower.mkPackageName y of

--- a/src/Language/PureScript/Publish/Utils.hs
+++ b/src/Language/PureScript/Publish/Utils.hs
@@ -2,8 +2,11 @@
 module Language.PureScript.Publish.Utils where
 
 import Data.List
-import Data.Maybe
+import Data.Either (partitionEithers)
 import System.Directory
+import System.Exit (exitFailure)
+import System.IO (hPutStrLn, stderr)
+import System.FilePath (pathSeparator)
 import qualified System.FilePath.Glob as Glob
 
 -- | Glob relative to the current directory, and produce relative pathnames.
@@ -11,7 +14,20 @@ globRelative :: Glob.Pattern -> IO [FilePath]
 globRelative pat = do
   currentDir <- getCurrentDirectory
   filesAbsolute <- Glob.globDir1 pat currentDir
-  return (mapMaybe (stripPrefix (currentDir ++ "/")) filesAbsolute)
+  let prefix = currentDir ++ [pathSeparator]
+  let (fails, paths) = partitionEithers . map (stripPrefix' prefix) $ filesAbsolute
+  if null fails
+    then return paths
+    else do
+      let p = hPutStrLn stderr
+      p "Internal error in Language.PureScript.Publish.Utils.globRelative"
+      p "Unmatched files:"
+      mapM_ p fails
+      exitFailure
+
+  where
+  stripPrefix' prefix dir =
+    maybe (Left dir) Right $ stripPrefix prefix dir
 
 -- | Glob pattern for PureScript source files.
 purescriptSourceFiles :: Glob.Pattern


### PR DESCRIPTION
Fixes #1326. Amend the globRelative function to use the OS's path
separator, and also to raise an error unless it was able to strip the
current directory prefix successfully.

@garyb would you mind testing this too please?