### PR TITLE
Tune GHC parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,14 @@ install:
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - travis_retry cabal update
   - cabal sandbox init
+  # Run with limited concurrency
+  # Travis container infrastructure seems to expose all host CPUs (16?), thus
+  # cabal and ghc tries to use them all. Which is bad idea on a shared box.
+  # See also: https://ghc.haskell.org/trac/ghc/ticket/9221
+  #
+  # We probably want to be running with larger heap sizes when there are lots
+  # of cores, to counteract the synchronization overhead of stop-the-world GC
+  # across many cores. e.g. +RTS -A32m at least.
   - cabal install --only-dependencies --enable-tests -j2 --ghc-options='+RTS -A32m -RTS'
   - cabal install hpc-coveralls -j2
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ install:
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - travis_retry cabal update
   - cabal sandbox init
-  - cabal install --only-dependencies --enable-tests
-  - cabal install hpc-coveralls
+  - cabal install --only-dependencies --enable-tests -j2 --ghc-options='+RTS -A32m -RTS'
+  - cabal install hpc-coveralls -j2
 script:
   - ./travis/configure.sh
-  - cabal build
+  - cabal build -j2 --ghc-options='+RTS -A32m -RTS'
   - cabal test
   - ./travis/test-install.sh
 after_script:

--- a/travis/test-install.sh
+++ b/travis/test-install.sh
@@ -8,5 +8,5 @@ then
   mkdir -p ../install-test
   cd ../install-test
   cabal sandbox init
-  cabal install "$SRC_TGZ"
+  cabal install -j2 --ghc-options='+RTS -A32m -RTS' "$SRC_TGZ"
 fi


### PR DESCRIPTION
`-j2` actually decreases parallellism, which on shared travis containers cause bad performance. See https://ghc.haskell.org/trac/ghc/ticket/9221