### PR TITLE
Enhance core tests script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ cabal.sandbox.config
 .psci_modules/
 .test_modules/
 bower_components/
+node_modules
 tmp/
 .stack-work/
 tests/support/flattened/

--- a/core-tests/test-everything.sh
+++ b/core-tests/test-everything.sh
@@ -18,11 +18,10 @@ if [ "$force_reinstall" = "true" ] && [ -d "bower_components" ]; then
   rm -r bower_components
 fi
 
-if ! type bower ; then
-  npm install -g bower
-fi
+npm install bower
 
-bower i purescript-prelude \
+node_modules/.bin/bower i \
+        purescript-prelude \
         purescript-eff \
         purescript-st \
         purescript-integers \

--- a/core-tests/test-everything.sh
+++ b/core-tests/test-everything.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-npm install -g bower
+if ! type bower ; then
+  npm install -g bower
+fi
 
 bower i purescript-prelude \
         purescript-eff \

--- a/core-tests/test-everything.sh
+++ b/core-tests/test-everything.sh
@@ -2,6 +2,22 @@
 
 set -e
 
+force_recompile='false'
+force_reinstall='false'
+
+while getopts 'ci' flag; do
+  case "${flag}" in
+    c) force_recompile='true' ;;
+    i) force_reinstall='true' ;;
+    *) error "Unexpected option ${flag}" ;;
+  esac
+done
+
+if [ "$force_reinstall" = "true" ] && [ -d "bower_components" ]; then
+  echo "Reinstalling core packages..."
+  rm -r bower_components
+fi
+
 if ! type bower ; then
   npm install -g bower
 fi
@@ -51,6 +67,11 @@ bower i purescript-prelude \
         purescript-semirings \
         purescript-math \
         purescript-generics
+
+if [ "$force_recompile" = "true" ] && [ -d "output" ]; then
+  echo "Recompiling..."
+  rm -r output
+fi
 
 ../dist/build/psc/psc tests/*/*.purs \
                       'bower_components/purescript-*/src/**/*.purs' \


### PR DESCRIPTION
Update core-tests/test-everything.sh with a few small things. I hope this will improve the experience for others as well, it proved helpful to me.

* Only install bower if it's not already installed.
* Accept the newer version in case of conflicts in bower install.
* Add force recompile (-c) and force reinstall (-i) options. It's useful if you want to run it multiple times.