### PR TITLE
Pass the length of arguments in as a function argument.

### DIFF
--- a/core-tests/tests/generic-deriving/Main.purs
+++ b/core-tests/tests/generic-deriving/Main.purs
@@ -4,11 +4,16 @@ import Prelude
 
 import Data.Generic
 
+data Void
+
+derive instance genericVoid :: Generic Void
+
 data A a 
   = A Number String
   | B Int
   | C (Array (A a)) 
   | D { a :: a }
+  | E Void
 
 derive instance genericA :: (Generic a) => Generic (A a)
 

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -228,8 +228,8 @@ missingAlternative env mn ca uncovered
 -- it partitions that set with the new uncovered cases, until it consumes the whole set of clauses.
 -- Then, returns the uncovered set of case alternatives.
 -- 
-checkExhaustive :: forall m. (MonadWriter MultipleErrors m) => Environment -> ModuleName -> [CaseAlternative] -> m ()
-checkExhaustive env mn cas = makeResult . first nub $ foldl' step ([initial], (pure True, [])) cas
+checkExhaustive :: forall m. (MonadWriter MultipleErrors m) => Environment -> ModuleName -> Int -> [CaseAlternative] -> m ()
+checkExhaustive env mn numArgs cas = makeResult . first nub $ foldl' step ([initialize numArgs], (pure True, [])) cas
   where
   step :: ([[Binder]], (Maybe Bool, [[Binder]])) -> CaseAlternative -> ([[Binder]], (Maybe Bool, [[Binder]]))
   step (uncovered, (nec, redundant)) ca =
@@ -239,11 +239,6 @@ checkExhaustive env mn cas = makeResult . first nub $ foldl' step ([initial], (p
                          if fromMaybe True cond then redundant else caseAlternativeBinders ca : redundant))
     where
     sequenceA = foldr (liftA2 (:)) (pure [])
-
-  initial :: [Binder]
-  initial = initialize numArgs
-    where
-    numArgs = length . caseAlternativeBinders . head $ cas 
 
   makeResult :: ([[Binder]], (Maybe Bool, [[Binder]])) -> m ()
   makeResult (bss, (_, bss')) =
@@ -274,7 +269,7 @@ checkExhaustiveDecls env mn ds =
   in mapM_ f' ds
   where
   checkExpr :: Expr -> m Expr
-  checkExpr c@(Case _ cas)  = checkExhaustive env mn cas >> return c
+  checkExpr c@(Case expr cas)  = checkExhaustive env mn (length expr) cas >> return c
   checkExpr other = return other
 
 -- |


### PR DESCRIPTION
This solves the issue #1380.

Now the error (`head empty list`) doesn't appear:

```purescript
module Main where

import Prelude
import Data.Generic

data Void
derive instance genericVoid :: Generic Void
```

and this example works fine.