### PR TITLE
Use strict writers to avoid leaking memory

### DIFF
--- a/psc/Main.hs
+++ b/psc/Main.hs
@@ -22,7 +22,7 @@ module Main where
 import Control.Applicative
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Writer
+import Control.Monad.Writer.Strict
 
 import Data.Version (showVersion)
 import qualified Data.Map as M

--- a/psci/PSCi.hs
+++ b/psci/PSCi.hs
@@ -36,7 +36,7 @@ import Control.Monad.Trans.Except (runExceptT)
 import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 import Control.Monad.Trans.State.Strict
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Writer (runWriter)
+import Control.Monad.Writer.Strict (runWriter)
 import qualified Control.Monad.Trans.State.Lazy as L
 
 import Options.Applicative as Opts

--- a/psci/tests/Main.hs
+++ b/psci/tests/Main.hs
@@ -5,7 +5,7 @@ module Main where
 import Control.Monad.Trans.State.Strict (runStateT)
 import Control.Monad (when, forM)
 import Control.Applicative
-import Control.Monad.Writer (runWriterT)
+import Control.Monad.Writer.Strict (runWriterT)
 import Control.Monad.Trans.Except (runExceptT)
 
 import Data.List (sort)

--- a/src/Language/PureScript/Docs/ParseAndDesugar.hs
+++ b/src/Language/PureScript/Docs/ParseAndDesugar.hs
@@ -11,7 +11,7 @@ import Control.Monad
 import Control.Applicative
 
 import Control.Monad.Trans.Except
-import Control.Monad.Writer (WriterT(), runWriterT)
+import Control.Monad.Writer.Strict (WriterT(), runWriterT)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.IO.Class (MonadIO(..))
 

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -41,7 +41,7 @@ import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Trans.Except
 import Control.Monad.Reader
-import Control.Monad.Writer
+import Control.Monad.Writer.Strict
 import Control.Monad.Supply
 
 import Data.Function (on)

--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -39,7 +39,7 @@ import Control.Exception (catch, try)
 import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 import Control.Monad.Trans.Except
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Writer
+import Control.Monad.Writer.Strict
 
 import System.Directory (doesFileExist, findExecutable)
 import System.Process (readProcess)

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -24,7 +24,7 @@ import qualified Data.Map as M
 import Control.Applicative
 import Control.Monad.State
 import Control.Monad.Unify
-import Control.Monad.Writer
+import Control.Monad.Writer.Strict
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Trans.Except
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -53,7 +53,7 @@ import Control.Applicative
 import Control.Arrow ((>>>))
 
 import Control.Monad.Reader
-import Control.Monad.Writer
+import Control.Monad.Writer.Strict
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Except
 import Control.Monad.Error.Class


### PR DESCRIPTION
Part of #1297, there may be a round 2 yet.

An unscientific test of compiling `SlamData` from scratch and eyeballing the process monitor with these changes applied reduces the peak memory usage from ~12.5gb to ~2.5gb. Also compilation time is reduced from ~68s to ~37s.

:boom::boom::boom: