### PR TITLE
In error/warning link text, correctly say "error" or "warning"

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -392,7 +392,7 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage <$> onTypesInError
   prettyPrintErrorMessage em =
     paras $
       go em:suggestions em ++
-      [line $ "See " ++ wikiUri ++ " for more information, or to contribute content related to this error."]
+      [line $ "See " ++ wikiUri ++ " for more information, or to contribute content related to this " ++ levelText ++ "."]
     where
     wikiUri :: String
     wikiUri = "https://github.com/purescript/purescript/wiki/Error-Code-" ++ errorCode e
@@ -727,6 +727,11 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage <$> onTypesInError
 
   lineWithLevel :: String -> Box.Box
   lineWithLevel text = line $ show level ++ " " ++ text
+
+  levelText :: String
+  levelText = case level of
+    Error -> "error"
+    Warning -> "warning"
 
   suggestions :: ErrorMessage -> [Box.Box]
   suggestions = suggestions' . unwrapErrorMessage


### PR DESCRIPTION
Pretty simple, I got confused for a second when a warning said
> ... for more information, or to contribute content related to this error.

This change makes the text say `contribute content related to this (error|warning).` depending on the level.

e.g.
```
Error found:
Error in module Main:
Error at /home/michael/dev/contrib/purescript/Foobar.purs line 3, column 8 - line 3, column 13:
  Unknown value (+)
See https://github.com/purescript/purescript/wiki/Error-Code-UnknownValue for more information, or to contribute content related to this error.
```

and
```
Compiling Main
Warning found:
Warning in module Main:
Warning in value declaration a:
Warning at /home/michael/dev/contrib/purescript/Foobar.purs line 3, column 1 - line 3, column 8:
    Pattern could not be determined to cover all cases.
    The definition has the following uncovered cases:

    _
See https://github.com/purescript/purescript/wiki/Error-Code-NotExhaustivePattern for more information, or to contribute content related to this warning.
```