### PR TITLE
foreign -> foreign_

### DIFF
--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -55,14 +55,14 @@ import System.FilePath.Posix ((</>))
 --
 moduleToJs :: forall m. (Applicative m, Monad m, MonadReader Options m, MonadSupply m)
            => Module Ann -> Maybe JS -> m [JS]
-moduleToJs (Module coms mn imps exps foreigns decls) foreign = do
+moduleToJs (Module coms mn imps exps foreigns decls) foreign_ = do
   jsImports <- T.traverse importToJs . delete (ModuleName [ProperName C.prim]) . (\\ [mn]) $ imps
   jsDecls <- mapM bindToJs decls
   optimized <- T.traverse (T.traverse optimize) jsDecls
   comments <- not <$> asks optionsNoComments
   let strict = JSStringLiteral "use strict"
   let header = if comments && not (null coms) then JSComment coms strict else strict
-  let foreign' = [JSVariableIntroduction "$foreign" foreign | not $ null foreigns || foreign == Nothing]
+  let foreign' = [JSVariableIntroduction "$foreign" foreign_ | not $ null foreigns || foreign_ == Nothing]
   let moduleBody = header : foreign' ++ jsImports ++ concat optimized
   let foreignExps = exps `intersect` (fst `map` foreigns)
   let standardExps = exps \\ foreignExps


### PR DESCRIPTION
`foreign` is a keyword and it's better not to use it as a name to avoid parser errors.

Interestingly it was causing an error only when in ghci (7.10.2).