### PR TITLE
Bump semigroups upper bound to <0.18

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -57,7 +57,7 @@ library
                    Glob >= 0.7 && < 0.8,
                    process >= 1.2.0 && < 1.3,
                    safe >= 0.3.9 && < 0.4,
-                   semigroups >= 0.16.2 && < 0.17
+                   semigroups >= 0.16.2 && < 0.18
 
     exposed-modules: Language.PureScript
                      Language.PureScript.AST


### PR DESCRIPTION
Related to https://github.com/fpco/stackage/issues/827