### PR TITLE
Expand type synonyms eagerly

### DIFF
--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -166,7 +166,6 @@ convertDeclaration (P.TypeInstanceDeclaration _ constraints className tys _) tit
   unQual x = let (P.Qualified _ y) = x in P.runProperName y
 
   extractProperNames (P.TypeConstructor n) = [unQual n]
-  extractProperNames (P.SaturatedTypeSynonym n _) = [unQual n]
   extractProperNames _ = []
 
   childDecl = ChildDeclaration title Nothing Nothing (ChildInstance constraints classApp)

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -170,11 +170,11 @@ make MakeActions{..} ms = do
   go :: Environment -> [(Bool, Module)] -> SupplyT m Environment
   go env [] = return env
   go env ((False, m) : ms') = do
-    (_, env') <- lift . runCheck' env $ typeCheckModule Nothing m
+    (_, env') <- lift . runCheck' env $ typeCheckModule m
     go env' ms'
   go env ((True, m@(Module ss coms moduleName' _ exps)) : ms') = do
     lift . progress $ CompilingModule moduleName'
-    (checked@(Module _ _ _ elaborated _), env') <- lift . runCheck' env $ typeCheckModule Nothing m
+    (checked@(Module _ _ _ elaborated _), env') <- lift . runCheck' env $ typeCheckModule m
     checkExhaustiveModule env' checked
     regrouped <- createBindingGroups moduleName' . collapseBindingGroups $ elaborated
     let mod' = Module ss coms moduleName' regrouped exps

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -42,7 +42,6 @@ typeLiterals = mkPattern match
   match (TUnknown u) = Just $ '_' : show u
   match (Skolem name s _) = Just $ name ++ show s
   match (ConstrainedType deps ty) = Just $ "(" ++ intercalate ", " (map (\(pn, ty') -> showQualified runProperName pn ++ " " ++ unwords (map prettyPrintTypeAtom ty')) deps) ++ ") => " ++ prettyPrintType ty
-  match (SaturatedTypeSynonym name args) = Just $ showQualified runProperName name ++ "<" ++ intercalate "," (map prettyPrintTypeAtom args) ++ ">"
   match REmpty = Just "()"
   match row@RCons{} = Just $ '(' : prettyPrintRow row ++ ")"
   match _ = Nothing

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -171,7 +171,6 @@ renameInModule env imports (Module ss coms mn decls exps) =
     where
     updateType :: Type -> m Type
     updateType (TypeConstructor name) = TypeConstructor <$> updateTypeName name pos
-    updateType (SaturatedTypeSynonym name tys) = SaturatedTypeSynonym <$> updateTypeName name pos <*> pure tys
     updateType (ConstrainedType cs t) = ConstrainedType <$> updateConstraints pos cs <*> pure t
     updateType t = return t
 

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -132,8 +132,8 @@ checkTypeSynonyms = void . replaceAllTypeSynonyms
 --
 --  * Process module imports
 --
-typeCheckAll :: Maybe ModuleName -> ModuleName -> [DeclarationRef] -> [Declaration] -> Check [Declaration]
-typeCheckAll mainModuleName moduleName _ ds = mapM go ds <* mapM_ checkOrphanFixities ds
+typeCheckAll :: ModuleName -> [DeclarationRef] -> [Declaration] -> Check [Declaration]
+typeCheckAll moduleName _ ds = mapM go ds <* mapM_ checkOrphanFixities ds
   where
   go :: Declaration -> Check Declaration
   go (DataDeclaration dtype name args dctors) = do
@@ -181,7 +181,7 @@ typeCheckAll mainModuleName moduleName _ ds = mapM go ds <* mapM_ checkOrphanFix
   go (ValueDeclaration name nameKind [] (Right val)) =
     warnAndRethrow (onErrorMessages (ErrorInValueDeclaration name)) $ do
       valueIsNotDefined moduleName name
-      [(_, (val', ty))] <- typesOf mainModuleName moduleName [(name, val)]
+      [(_, (val', ty))] <- typesOf moduleName [(name, val)]
       addValue moduleName name ty nameKind
       return $ ValueDeclaration name nameKind [] $ Right val'
   go (ValueDeclaration{}) = error "Binders were not desugared"
@@ -189,7 +189,7 @@ typeCheckAll mainModuleName moduleName _ ds = mapM go ds <* mapM_ checkOrphanFix
     warnAndRethrow (onErrorMessages (ErrorInBindingGroup (map (\(ident, _, _) -> ident) vals))) $ do
       forM_ (map (\(ident, _, _) -> ident) vals) $ \name ->
         valueIsNotDefined moduleName name
-      tys <- typesOf mainModuleName moduleName $ map (\(ident, _, ty) -> (ident, ty)) vals
+      tys <- typesOf moduleName $ map (\(ident, _, ty) -> (ident, ty)) vals
       vals' <- forM [ (name, val, nameKind, ty)
                     | (name, nameKind, _) <- vals
                     , (name', (val, ty)) <- tys
@@ -272,11 +272,11 @@ typeCheckAll mainModuleName moduleName _ ds = mapM go ds <* mapM_ checkOrphanFix
 -- Type check an entire module and ensure all types and classes defined within the module that are
 -- required by exported members are also exported.
 --
-typeCheckModule :: Maybe ModuleName -> Module -> Check Module
-typeCheckModule _ (Module _ _ _ _ Nothing) = error "exports should have been elaborated"
-typeCheckModule mainModuleName (Module ss coms mn decls (Just exps)) = warnAndRethrow (onErrorMessages (ErrorInModule mn)) $ do
+typeCheckModule :: Module -> Check Module
+typeCheckModule (Module _ _ _ _ Nothing) = error "exports should have been elaborated"
+typeCheckModule (Module ss coms mn decls (Just exps)) = warnAndRethrow (onErrorMessages (ErrorInModule mn)) $ do
   modify (\s -> s { checkCurrentModule = Just mn })
-  decls' <- typeCheckAll mainModuleName mn exps decls
+  decls' <- typeCheckAll mn exps decls
   forM_ exps $ \e -> do
     checkTypesAreExported e
     checkClassMembersAreExported e

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -41,7 +41,6 @@ import Language.PureScript.Errors
 import Language.PureScript.Environment
 import Language.PureScript.Names
 import Language.PureScript.TypeChecker.Monad
-import Language.PureScript.TypeChecker.Synonyms
 import Language.PureScript.TypeChecker.Unify
 import Language.PureScript.TypeClassDictionaries
 import Language.PureScript.Types

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -145,9 +145,6 @@ typeHeadsAreEqual _ _ t                    (TypeVar v)                     = Jus
 typeHeadsAreEqual _ _ (TypeConstructor c1) (TypeConstructor c2) | c1 == c2 = Just []
 typeHeadsAreEqual m e (TypeApp h1 t1)      (TypeApp h2 t2)                 = (++) <$> typeHeadsAreEqual m e h1 h2
                                                                                   <*> typeHeadsAreEqual m e t1 t2
-typeHeadsAreEqual m e (SaturatedTypeSynonym name args) t2 = case expandTypeSynonym' e name args of
-  Left  _  -> Nothing
-  Right t1 -> typeHeadsAreEqual m e t1 t2
 typeHeadsAreEqual _ _ REmpty REmpty = Just []
 typeHeadsAreEqual m e r1@(RCons _ _ _) r2@(RCons _ _ _) =
   let (s1, r1') = rowToList r1

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -38,7 +38,6 @@ import Control.Monad.Writer.Class (tell)
 
 import Language.PureScript.AST
 import Language.PureScript.Errors
-import Language.PureScript.Environment
 import Language.PureScript.Names
 import Language.PureScript.TypeChecker.Monad
 import Language.PureScript.TypeChecker.Unify
@@ -50,8 +49,8 @@ import qualified Language.PureScript.Constants as C
 -- Check that the current set of type class dictionaries entail the specified type class goal, and, if so,
 -- return a type class dictionary reference.
 --
-entails :: Environment -> ModuleName -> M.Map (Maybe ModuleName) (M.Map (Qualified ProperName) (M.Map (Qualified Ident) TypeClassDictionaryInScope)) -> Constraint -> Check Expr
-entails env moduleName context = solve
+entails :: ModuleName -> M.Map (Maybe ModuleName) (M.Map (Qualified ProperName) (M.Map (Qualified Ident) TypeClassDictionaryInScope)) -> Constraint -> Check Expr
+entails moduleName context = solve
   where
     forClassName :: Qualified ProperName -> [TypeClassDictionaryInScope]
     forClassName cn = findDicts cn Nothing ++ findDicts cn (Just moduleName)
@@ -70,7 +69,7 @@ entails env moduleName context = solve
         let instances = do
               tcd <- forClassName className'
               -- Make sure the type unifies with the type in the type instance definition
-              subst <- maybeToList . (>>= verifySubstitution) . fmap concat $ zipWithM (typeHeadsAreEqual moduleName env) tys' (tcdInstanceTypes tcd)
+              subst <- maybeToList . (>>= verifySubstitution) . fmap concat $ zipWithM (typeHeadsAreEqual moduleName) tys' (tcdInstanceTypes tcd)
               return (subst, tcd)
         (subst, tcd) <- unique instances
         -- Solve any necessary subgoals
@@ -128,7 +127,7 @@ entails env moduleName context = solve
       verifySubstitution :: [(String, Type)] -> Maybe [(String, Type)]
       verifySubstitution subst = do
         let grps = groupBy ((==) `on` fst) . sortBy (compare `on` fst) $ subst
-        guard (all (pairwise (unifiesWith env) . map snd) grps)
+        guard (all (pairwise unifiesWith . map snd) grps)
         return $ map head grps
 
     valUndefined :: Expr
@@ -138,21 +137,21 @@ entails env moduleName context = solve
 -- Check whether the type heads of two types are equal (for the purposes of type class dictionary lookup),
 -- and return a substitution from type variables to types which makes the type heads unify.
 --
-typeHeadsAreEqual :: ModuleName -> Environment -> Type -> Type -> Maybe [(String, Type)]
-typeHeadsAreEqual _ _ (Skolem _ s1 _)      (Skolem _ s2 _)      | s1 == s2 = Just []
-typeHeadsAreEqual _ _ t                    (TypeVar v)                     = Just [(v, t)]
-typeHeadsAreEqual _ _ (TypeConstructor c1) (TypeConstructor c2) | c1 == c2 = Just []
-typeHeadsAreEqual m e (TypeApp h1 t1)      (TypeApp h2 t2)                 = (++) <$> typeHeadsAreEqual m e h1 h2
-                                                                                  <*> typeHeadsAreEqual m e t1 t2
-typeHeadsAreEqual _ _ REmpty REmpty = Just []
-typeHeadsAreEqual m e r1@(RCons _ _ _) r2@(RCons _ _ _) =
+typeHeadsAreEqual :: ModuleName -> Type -> Type -> Maybe [(String, Type)]
+typeHeadsAreEqual _ (Skolem _ s1 _)      (Skolem _ s2 _)      | s1 == s2 = Just []
+typeHeadsAreEqual _ t                    (TypeVar v)                     = Just [(v, t)]
+typeHeadsAreEqual _ (TypeConstructor c1) (TypeConstructor c2) | c1 == c2 = Just []
+typeHeadsAreEqual m (TypeApp h1 t1)      (TypeApp h2 t2)                 = (++) <$> typeHeadsAreEqual m h1 h2
+                                                                                <*> typeHeadsAreEqual m t1 t2
+typeHeadsAreEqual _ REmpty REmpty = Just []
+typeHeadsAreEqual m r1@RCons{} r2@RCons{} =
   let (s1, r1') = rowToList r1
       (s2, r2') = rowToList r2
 
       int = [ (t1, t2) | (name, t1) <- s1, (name', t2) <- s2, name == name' ]
       sd1 = [ (name, t1) | (name, t1) <- s1, name `notElem` map fst s2 ]
       sd2 = [ (name, t2) | (name, t2) <- s2, name `notElem` map fst s1 ]
-  in (++) <$> foldMap (\(t1, t2) -> typeHeadsAreEqual m e t1 t2) int
+  in (++) <$> foldMap (uncurry (typeHeadsAreEqual m)) int
           <*> go sd1 r1' sd2 r2'
   where
   go :: [(String, Type)] -> Type -> [(String, Type)] -> Type -> Maybe [(String, Type)]
@@ -162,7 +161,7 @@ typeHeadsAreEqual m e r1@(RCons _ _ _) r2@(RCons _ _ _) =
   go [] (Skolem _ s1 _) [] (Skolem _ s2 _) | s1 == s2 = Just []
   go sd r               [] (TypeVar v)     = Just [(v, rowFromList (sd, r))]
   go _  _               _  _               = Nothing
-typeHeadsAreEqual _ _ _ _ = Nothing
+typeHeadsAreEqual _ _ _ = Nothing
 
 -- |
 -- Check all values in a list pairwise match a predicate

--- a/src/Language/PureScript/TypeChecker/Rows.hs
+++ b/src/Language/PureScript/TypeChecker/Rows.hs
@@ -46,7 +46,6 @@ checkDuplicateLabels =
     where
     checkDups :: Type -> Check ()
     checkDups (TypeApp t1 t2) = checkDups t1 >> checkDups t2
-    checkDups (SaturatedTypeSynonym _ ts) = mapM_ checkDups ts
     checkDups (ForAll _ t _) = checkDups t
     checkDups (ConstrainedType args t) = do
       mapM_ checkDups $ concatMap snd args

--- a/src/Language/PureScript/TypeChecker/Subsumption.hs
+++ b/src/Language/PureScript/TypeChecker/Subsumption.hs
@@ -57,12 +57,6 @@ subsumes' val (TypeApp (TypeApp f1 arg1) ret1) (TypeApp (TypeApp f2 arg2) ret2) 
   _ <- subsumes Nothing arg2 arg1
   _ <- subsumes Nothing ret1 ret2
   return val
-subsumes' val (SaturatedTypeSynonym name tyArgs) ty2 = do
-  ty1 <- introduceSkolemScope <=< expandTypeSynonym name $ tyArgs
-  subsumes val ty1 ty2
-subsumes' val ty1 (SaturatedTypeSynonym name tyArgs) = do
-  ty2 <- introduceSkolemScope <=< expandTypeSynonym name $ tyArgs
-  subsumes val ty1 ty2
 subsumes' val (KindedType ty1 _) ty2 =
   subsumes val ty1 ty2
 subsumes' val ty1 (KindedType ty2 _) =

--- a/src/Language/PureScript/TypeChecker/Subsumption.hs
+++ b/src/Language/PureScript/TypeChecker/Subsumption.hs
@@ -20,7 +20,6 @@ module Language.PureScript.TypeChecker.Subsumption (
 import Data.List (sortBy)
 import Data.Ord (comparing)
 
-import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Unify
 
@@ -29,7 +28,6 @@ import Language.PureScript.Environment
 import Language.PureScript.Errors
 import Language.PureScript.TypeChecker.Monad
 import Language.PureScript.TypeChecker.Skolems
-import Language.PureScript.TypeChecker.Synonyms
 import Language.PureScript.TypeChecker.Unify
 import Language.PureScript.Types
 

--- a/src/Language/PureScript/TypeChecker/Synonyms.hs
+++ b/src/Language/PureScript/TypeChecker/Synonyms.hs
@@ -9,22 +9,18 @@
 -- Portability :
 --
 -- |
--- Functions for replacing fully applied type synonyms with the @SaturatedTypeSynonym@ data constructor
+-- Functions for replacing fully applied type synonyms
 --
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE CPP #-}
 
 module Language.PureScript.TypeChecker.Synonyms (
-    saturateAllTypeSynonyms,
-    desaturateAllTypeSynonyms,
-    replaceAllTypeSynonyms,
-    expandAllTypeSynonyms,
-    expandTypeSynonym,
-    expandTypeSynonym'
+    replaceAllTypeSynonyms
 ) where
 
 import Data.Maybe (fromMaybe)
@@ -38,73 +34,31 @@ import Control.Monad.State
 
 import Language.PureScript.Environment
 import Language.PureScript.Errors
-import Language.PureScript.Names
 import Language.PureScript.TypeChecker.Monad
 import Language.PureScript.Types
 
 -- |
--- Build a type substitution for a type synonym
+-- Replace fully applied type synonyms.
 --
-buildTypeSubstitution :: M.Map (Qualified ProperName) Int -> Type -> Either ErrorMessage (Maybe Type)
-buildTypeSubstitution m = go 0 []
+replaceAllTypeSynonyms' :: Environment -> Type -> Either MultipleErrors Type
+replaceAllTypeSynonyms' env = everywhereOnTypesTopDownM try
   where
-  go :: Int -> [Type] -> Type -> Either ErrorMessage (Maybe Type)
-  go c args (TypeConstructor ctor) | M.lookup ctor m == Just c = return (Just $ SaturatedTypeSynonym ctor args)
-  go c _    (TypeConstructor ctor) | M.lookup ctor m >  Just c = throwError $ SimpleErrorWrapper $ PartiallyAppliedSynonym ctor
-  go c args (TypeApp f arg) = go (c + 1) (arg:args) f
+  try :: Type -> Either MultipleErrors Type
+  try t = fromMaybe t <$> go 0 [] t
+
+  go :: Int -> [Type] -> Type -> Either MultipleErrors (Maybe Type)
+  go c args (TypeConstructor ctor)
+    | Just (synArgs, body) <- M.lookup ctor (typeSynonyms env)
+    , c == length synArgs
+    = let repl = replaceAllTypeVars (zip (map fst synArgs) args) body
+      in Just <$> try repl
+    | Just (synArgs, _) <- M.lookup ctor (typeSynonyms env)
+    , length synArgs > c
+    = throwError . errorMessage $ PartiallyAppliedSynonym ctor
+  go c args (TypeApp f arg) = go (c + 1) (arg : args) f
   go _ _ _ = return Nothing
-
--- |
--- Replace all type synonyms with the @SaturatedTypeSynonym@ data constructor
---
-saturateAllTypeSynonyms :: M.Map (Qualified ProperName) Int -> Type -> Either ErrorMessage Type
-saturateAllTypeSynonyms syns = everywhereOnTypesTopDownM replace
-  where
-  replace t = fromMaybe t <$> buildTypeSubstitution syns t
-
--- |
--- \"Desaturate\" @SaturatedTypeSynonym@s
---
-desaturateAllTypeSynonyms :: Type -> Type
-desaturateAllTypeSynonyms = everywhereOnTypes replaceSaturatedTypeSynonym
-  where
-  replaceSaturatedTypeSynonym (SaturatedTypeSynonym name args) = foldl TypeApp (TypeConstructor name) args
-  replaceSaturatedTypeSynonym t = t
-
--- |
--- Replace fully applied type synonyms with the @SaturatedTypeSynonym@ data constructor, which helps generate
--- better error messages during unification.
---
-replaceAllTypeSynonyms' :: Environment -> Type -> Either ErrorMessage Type
-replaceAllTypeSynonyms' env d =
-  let
-    syns = length . fst <$> typeSynonyms env
-  in
-    saturateAllTypeSynonyms syns d
 
 replaceAllTypeSynonyms :: (e ~ MultipleErrors, Functor m, Monad m, MonadState CheckState m, MonadError e m) => Type -> m Type
 replaceAllTypeSynonyms d = do
   env <- getEnv
-  either (throwError . singleError) return $ replaceAllTypeSynonyms' env d
-
--- |
--- Replace a type synonym and its arguments with the aliased type
---
-expandTypeSynonym' :: Environment -> Qualified ProperName -> [Type] -> Either ErrorMessage Type
-expandTypeSynonym' env name args =
-  case M.lookup name (typeSynonyms env) of
-    Just (synArgs, body) -> do
-      let repl = replaceAllTypeVars (zip (map fst synArgs) args) body
-      replaceAllTypeSynonyms' env repl
-    Nothing -> error "Type synonym was not defined"
-
-expandTypeSynonym :: (e ~ MultipleErrors, Functor m, Monad m, MonadState CheckState m, MonadError e m) => Qualified ProperName -> [Type] -> m Type
-expandTypeSynonym name args = do
-  env <- getEnv
-  either (throwError . singleError) return $ expandTypeSynonym' env name args
-
-expandAllTypeSynonyms :: (e ~ MultipleErrors, Functor m, Applicative m, Monad m, MonadState CheckState m, MonadError e m) => Type -> m Type
-expandAllTypeSynonyms = everywhereOnTypesTopDownM go
-  where
-  go (SaturatedTypeSynonym name args) = expandTypeSynonym name args
-  go other = return other
+  either throwError return $ replaceAllTypeSynonyms' env d

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -167,9 +167,7 @@ replaceTypeClassDictionaries mn =
   let (_, f, _) = everywhereOnValuesTopDownM return go return
   in f
   where
-  go (TypeClassDictionary constraint dicts) = do
-    env <- getEnv
-    entails env mn dicts constraint
+  go (TypeClassDictionary constraint dicts) = entails mn dicts constraint
   go other = return other
 
 -- |

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -40,7 +40,6 @@ import Language.PureScript.Environment
 import Language.PureScript.Errors
 import Language.PureScript.TypeChecker.Monad
 import Language.PureScript.TypeChecker.Skolems
-import Language.PureScript.TypeChecker.Synonyms
 import Language.PureScript.Types
 
 instance Partial Type where

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -66,10 +66,6 @@ data Type
   --
   | TypeApp Type Type
   -- |
-  -- A type synonym which is \"saturated\", i.e. fully applied
-  --
-  | SaturatedTypeSynonym (Qualified ProperName) [Type]
-  -- |
   -- Forall quantifier
   --
   | ForAll String Type (Maybe SkolemScope)
@@ -161,7 +157,6 @@ replaceAllTypeVars = go []
       Just r -> r
       Nothing -> TypeVar v
   go bs m (TypeApp t1 t2) = TypeApp (go bs m t1) (go bs m t2)
-  go bs m (SaturatedTypeSynonym name' ts) = SaturatedTypeSynonym name' $ map (go bs m) ts
   go bs m f@(ForAll v t sco) | v `elem` keys = go bs (filter ((/= v) . fst) m) f
                              | v `elem` usedVars =
                                let v' = genName v (keys ++ bs ++ usedVars)
@@ -200,7 +195,6 @@ freeTypeVariables = nub . go []
   go :: [String] -> Type -> [String]
   go bound (TypeVar v) | v `notElem` bound = [v]
   go bound (TypeApp t1 t2) = go bound t1 ++ go bound t2
-  go bound (SaturatedTypeSynonym _ ts) = concatMap (go bound) ts
   go bound (ForAll v t _) = go (v : bound) t
   go bound (ConstrainedType cs t) = concatMap (concatMap (go bound) . snd) cs ++ go bound t
   go bound (RCons _ t r) = go bound t ++ go bound r
@@ -247,7 +241,6 @@ everywhereOnTypes :: (Type -> Type) -> Type -> Type
 everywhereOnTypes f = go
   where
   go (TypeApp t1 t2) = f (TypeApp (go t1) (go t2))
-  go (SaturatedTypeSynonym name tys) = f (SaturatedTypeSynonym name (map go tys))
   go (ForAll arg ty sco) = f (ForAll arg (go ty) sco)
   go (ConstrainedType cs ty) = f (ConstrainedType (map (fmap (map go)) cs) (go ty))
   go (RCons name ty rest) = f (RCons name (go ty) (go rest))
@@ -261,7 +254,6 @@ everywhereOnTypesTopDown :: (Type -> Type) -> Type -> Type
 everywhereOnTypesTopDown f = go . f
   where
   go (TypeApp t1 t2) = TypeApp (go (f t1)) (go (f t2))
-  go (SaturatedTypeSynonym name tys) = SaturatedTypeSynonym name (map (go . f) tys)
   go (ForAll arg ty sco) = ForAll arg (go (f ty)) sco
   go (ConstrainedType cs ty) = ConstrainedType (map (fmap (map (go . f))) cs) (go (f ty))
   go (RCons name ty rest) = RCons name (go (f ty)) (go (f rest))
@@ -275,7 +267,6 @@ everywhereOnTypesM :: (Functor m, Applicative m, Monad m) => (Type -> m Type) ->
 everywhereOnTypesM f = go
   where
   go (TypeApp t1 t2) = (TypeApp <$> go t1 <*> go t2) >>= f
-  go (SaturatedTypeSynonym name tys) = (SaturatedTypeSynonym name <$> mapM go tys) >>= f
   go (ForAll arg ty sco) = (ForAll arg <$> go ty <*> pure sco) >>= f
   go (ConstrainedType cs ty) = (ConstrainedType <$> mapM (sndM (mapM go)) cs <*> go ty) >>= f
   go (RCons name ty rest) = (RCons name <$> go ty <*> go rest) >>= f
@@ -289,7 +280,6 @@ everywhereOnTypesTopDownM :: (Functor m, Applicative m, Monad m) => (Type -> m T
 everywhereOnTypesTopDownM f = go <=< f
   where
   go (TypeApp t1 t2) = TypeApp <$> (f t1 >>= go) <*> (f t2 >>= go)
-  go (SaturatedTypeSynonym name tys) = SaturatedTypeSynonym name <$> mapM (go <=< f) tys
   go (ForAll arg ty sco) = ForAll arg <$> (f ty >>= go) <*> pure sco
   go (ConstrainedType cs ty) = ConstrainedType <$> mapM (sndM (mapM (go <=< f))) cs <*> (f ty >>= go)
   go (RCons name ty rest) = RCons name <$> (f ty >>= go) <*> (f rest >>= go)
@@ -303,7 +293,6 @@ everythingOnTypes :: (r -> r -> r) -> (Type -> r) -> Type -> r
 everythingOnTypes (<>) f = go
   where
   go t@(TypeApp t1 t2) = f t <> go t1 <> go t2
-  go t@(SaturatedTypeSynonym _ tys) = foldl (<>) (f t) (map go tys)
   go t@(ForAll _ ty _) = f t <> go ty
   go t@(ConstrainedType cs ty) = foldl (<>) (f t) (map go $ concatMap snd cs) <> go ty
   go t@(RCons _ ty rest) = f t <> go ty <> go rest
@@ -318,7 +307,6 @@ everythingWithContextOnTypes s0 r0 (<>) f = go' s0
   where
   go' s t = let (s', r) = f s t in r <> go s' t
   go s (TypeApp t1 t2) = go' s t1 <> go' s t2
-  go s (SaturatedTypeSynonym _ tys) = foldl (<>) r0 (map (go' s) tys)
   go s (ForAll _ ty _) = go' s ty
   go s (ConstrainedType cs ty) = foldl (<>) r0 (map (go' s) $ concatMap snd cs) <> go' s ty
   go s (RCons _ ty rest) = go' s ty <> go' s rest


### PR DESCRIPTION
/cc @garyb 

Tested on Halogen master.

I think this makes things quite a bit simpler, which I like. The only possible issue is error messages, but I think in practice, it's not so much of a concern. In many cases, you actually want to expand synonyms in errors, for example when dealing with `lens` for example. And in most cases, getting to the root of a type issue often requires looking under synonyms anyway.

Thoughts?