### PR TITLE
Print type errors using boxes library, #929

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node_modules
 tmp/
 .stack-work/
 tests/support/flattened/
+output

--- a/psci/PSCi.hs
+++ b/psci/PSCi.hs
@@ -464,7 +464,7 @@ handleCommand (LoadFile filePath) = whenFileExists filePath $ \absPath -> do
     Right mods -> PSCI . lift $ modify (updateModules (map ((,) (Right absPath)) mods))
 handleCommand (LoadForeign filePath) = whenFileExists filePath $ \absPath -> do
   foreignsOrError <- psciIO . runMake $ do
-    foreignFile <- makeIO (const (P.SimpleErrorWrapper $ P.CannotReadFile absPath)) (readFile absPath)
+    foreignFile <- makeIO (const (P.ErrorMessage [] $ P.CannotReadFile absPath)) (readFile absPath)
     P.parseForeignModulesFromFiles [(absPath, foreignFile)]
   case foreignsOrError of
     Left err -> PSCI $ outputStrLn $ P.prettyPrintMultipleErrors False err
@@ -533,7 +533,7 @@ loop PSCiOptions{..} = do
       historyFilename <- getHistoryFilename
       let settings = defaultSettings { historyFile = Just historyFilename }
       foreignsOrError <- runMake $ do
-        foreignFilesContent <- forM foreignFiles (\inFile -> (inFile,) <$> makeIO (const (P.SimpleErrorWrapper $ P.CannotReadFile inFile)) (readFile inFile))
+        foreignFilesContent <- forM foreignFiles (\inFile -> (inFile,) <$> makeIO (const (P.ErrorMessage [] $ P.CannotReadFile inFile)) (readFile inFile))
         P.parseForeignModulesFromFiles foreignFilesContent
       case foreignsOrError of
         Left errs -> putStrLn (P.prettyPrintMultipleErrors False errs) >> exitFailure

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -40,7 +40,7 @@ import Language.PureScript.Linter.Exhaustive as L
 -- |
 -- | Right now, this pass only performs a shadowing check.
 lint :: forall m. (Applicative m, MonadWriter MultipleErrors m) => Module -> m ()
-lint (Module _ _ mn ds _) = censor (onErrorMessages (ErrorInModule mn)) $ mapM_ lintDeclaration ds
+lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDeclaration ds
   where
   moduleNames :: S.Set Ident
   moduleNames = S.fromList (nub (mapMaybe getDeclIdent ds))
@@ -58,9 +58,9 @@ lint (Module _ _ mn ds _) = censor (onErrorMessages (ErrorInModule mn)) $ mapM_ 
     let (f, _, _, _, _) = everythingWithContextOnValues moduleNames mempty mappend stepD stepE stepB def def
 
         f' :: Declaration -> MultipleErrors
-        f' (PositionedDeclaration pos _ dec) = onErrorMessages (PositionedError pos) (f' dec)
-        f' dec@(ValueDeclaration name _ _ _) = onErrorMessages (ErrorInValueDeclaration name) (f dec <> checkTypeVarsInDecl dec)
-        f' (TypeDeclaration name ty) = onErrorMessages (ErrorInTypeDeclaration name) (checkTypeVars ty)
+        f' (PositionedDeclaration pos _ dec) = addHint (PositionedError pos) (f' dec)
+        f' dec@(ValueDeclaration name _ _ _) = addHint (ErrorInValueDeclaration name) (f dec <> checkTypeVarsInDecl dec)
+        f' (TypeDeclaration name ty) = addHint (ErrorInTypeDeclaration name) (checkTypeVars ty)
         f' dec = f dec <> checkTypeVarsInDecl dec
 
     in tell (f' d)

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -46,8 +46,6 @@ import Language.PureScript.Kinds
 import Language.PureScript.Types as P
 import Language.PureScript.Errors
 
-import Language.PureScript.AST.Traversals (everywhereOnValuesTopDownM)
-
 -- | There are two modes of failure for the redudancy check:
 --
 -- 1. Exhaustivity was incomeplete due to too many cases, so we couldn't determine redundancy.
@@ -273,28 +271,39 @@ checkExhaustive env mn numArgs cas = makeResult . first nub $ foldl' step ([init
 -- Exhaustivity checking over a list of declarations
 --
 checkExhaustiveDecls :: forall m. (Applicative m, MonadWriter MultipleErrors m) => Environment -> ModuleName -> [Declaration] -> m ()
-checkExhaustiveDecls env mn ds =
-  let (f, _, _) = everywhereOnValuesTopDownM return checkExpr return
-
-      f' :: Declaration -> m Declaration
-      f' d@(BindingGroupDeclaration bs) = mapM_ (f' . convert) bs >> return d
-        where
-        convert :: (Ident, NameKind, Expr) -> Declaration
-        convert (name, nk, e) = ValueDeclaration name nk [] (Right e)
-      f' d@(ValueDeclaration name _ _ _) = censor (onErrorMessages (ErrorInValueDeclaration name)) $ f d
-      f' (PositionedDeclaration pos com dec) = PositionedDeclaration pos com <$> censor (onErrorMessages (PositionedError pos)) (f' dec)
-      -- Don't generate two warnings for desugared dictionaries.
-      f' d@TypeInstanceDeclaration{} = return d
-      f' d = f d
-
-  in mapM_ f' ds
+checkExhaustiveDecls env mn = mapM_ onDecl
   where
-  checkExpr :: Expr -> m Expr
-  checkExpr c@(Case expr cas)  = checkExhaustive env mn (length expr) cas >> return c
-  checkExpr other = return other
+  onDecl :: Declaration -> m ()
+  onDecl (BindingGroupDeclaration bs) = mapM_ (onDecl . convert) bs
+    where
+    convert :: (Ident, NameKind, Expr) -> Declaration
+    convert (name, nk, e) = ValueDeclaration name nk [] (Right e)
+  onDecl (ValueDeclaration name _ _ (Right e)) = censor (addHint (ErrorInValueDeclaration name)) (onExpr e)
+  onDecl (PositionedDeclaration pos _ dec) = censor (addHint (PositionedError pos)) (onDecl dec)
+  onDecl _ = return ()
+
+  onExpr :: Expr -> m ()
+  onExpr (UnaryMinus e) = onExpr e
+  onExpr (ArrayLiteral es) = mapM_ onExpr es
+  onExpr (ObjectLiteral es) = mapM_ (onExpr . snd) es
+  onExpr (TypeClassDictionaryConstructorApp _ e) = onExpr e
+  onExpr (Accessor _ e) = onExpr e
+  onExpr (ObjectUpdate o es) = onExpr o >> mapM_ (onExpr . snd) es
+  onExpr (Abs _ e) = onExpr e
+  onExpr (App e1 e2) = onExpr e1 >> onExpr e2
+  onExpr (IfThenElse e1 e2 e3) = onExpr e1 >> onExpr e2 >> onExpr e3
+  onExpr (Case es cas) = checkExhaustive env mn (length es) cas >> mapM_ onExpr es >> mapM_ onCaseAlternative cas
+  onExpr (TypedValue _ e _) = onExpr e
+  onExpr (Let ds e) = mapM_ onDecl ds >> onExpr e
+  onExpr (PositionedValue pos _ e) = censor (addHint (PositionedError pos)) (onExpr e)
+  onExpr _ = return ()
+
+  onCaseAlternative :: CaseAlternative -> m ()
+  onCaseAlternative (CaseAlternative _ (Left es)) = mapM_ (\(e, g) -> onExpr e >> onExpr g) es
+  onCaseAlternative (CaseAlternative _ (Right e)) = onExpr e
 
 -- |
 -- Exhaustivity checking over a single module
 --
 checkExhaustiveModule :: forall m. (Applicative m, MonadWriter MultipleErrors m) => Environment -> Module -> m ()
-checkExhaustiveModule env (Module _ _ mn ds _) = censor (onErrorMessages (ErrorInModule mn)) $ checkExhaustiveDecls env mn ds
+checkExhaustiveModule env (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ checkExhaustiveDecls env mn ds

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -305,15 +305,15 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
   requiresForeign = not . null . CF.moduleForeign
 
   getTimestamp :: FilePath -> Make (Maybe UTCTime)
-  getTimestamp path = makeIO (const (SimpleErrorWrapper $ CannotGetFileInfo path)) $ do
+  getTimestamp path = makeIO (const (ErrorMessage [] $ CannotGetFileInfo path)) $ do
     exists <- doesFileExist path
     traverse (const $ getModificationTime path) $ guard exists
 
   readTextFile :: FilePath -> Make B.ByteString
-  readTextFile path = makeIO (const (SimpleErrorWrapper $ CannotReadFile path)) $ B.readFile path
+  readTextFile path = makeIO (const (ErrorMessage [] $ CannotReadFile path)) $ B.readFile path
 
   writeTextFile :: FilePath -> B.ByteString -> Make ()
-  writeTextFile path text = makeIO (const (SimpleErrorWrapper $ CannotWriteFile path)) $ do
+  writeTextFile path text = makeIO (const (ErrorMessage [] $ CannotWriteFile path)) $ do
     mkdirp path
     B.writeFile path text
     where

--- a/src/Language/PureScript/Names.hs
+++ b/src/Language/PureScript/Names.hs
@@ -104,6 +104,10 @@ qualify _ (Qualified (Just m) a) = (m, a)
 mkQualified :: a -> ModuleName -> Qualified a
 mkQualified name mn = Qualified (Just mn) name
 
+-- | Remove the module name from a qualified name
+disqualify :: Qualified a -> a
+disqualify (Qualified _ a) = a
+
 -- |
 -- Checks whether a qualified value is actually qualified with a module reference
 --

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -293,7 +293,7 @@ parseModulesFromFiles toFilePath input = do
   collect vss = [ (k, v) | (k, vs) <- vss, v <- vs ]
 
 toPositionedError :: P.ParseError -> ErrorMessage
-toPositionedError perr = PositionedError (SourceSpan name start end) (SimpleErrorWrapper (ErrorParsingModule perr))
+toPositionedError perr = ErrorMessage [ PositionedError (SourceSpan name start end) ] (ErrorParsingModule perr)
   where
   name   = (P.sourceName . P.errorPos) perr
   start  = (toSourcePos  . P.errorPos) perr

--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -17,7 +17,10 @@ module Language.PureScript.Pretty.Common where
 
 import Control.Monad.State
 import Data.List (intercalate)
+
 import Language.PureScript.Parser.Lexer (reservedPsNames, opChars)
+
+import Text.PrettyPrint.Boxes
 
 -- |
 -- Wrap a string in parentheses
@@ -67,3 +70,11 @@ prettyPrintObjectKey :: String -> String
 prettyPrintObjectKey s | s `elem` reservedPsNames = show s
                        | any (`elem` opChars) s = show s
                        | otherwise = s
+
+-- | Place a box before another, vertically when the first box takes up multiple lines.
+before :: Box -> Box -> Box
+before b1 b2 | rows b1 > 1 = b1 // b2
+             | otherwise = b1 <> b2
+
+beforeWithSpace :: Box -> Box -> Box
+beforeWithSpace b1 = before (b1 <> text " ")

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -14,13 +14,15 @@
 -----------------------------------------------------------------------------
 
 module Language.PureScript.Pretty.Types (
+    typeAsBox,
     prettyPrintType,
+    typeAtomAsBox,
     prettyPrintTypeAtom,
+    prettyPrintRowWith,
     prettyPrintRow
 ) where
 
 import Data.Maybe (fromMaybe)
-import Data.List (intercalate)
 
 import Control.Arrow ((<+>))
 import Control.PatternArrows
@@ -32,35 +34,53 @@ import Language.PureScript.Pretty.Common
 import Language.PureScript.Pretty.Kinds
 import Language.PureScript.Environment
 
-typeLiterals :: Pattern () Type String
+import Text.PrettyPrint.Boxes hiding ((<+>))
+
+typeLiterals :: Pattern () Type Box
 typeLiterals = mkPattern match
   where
-  match TypeWildcard = Just "_"
-  match (TypeVar var) = Just var
-  match (PrettyPrintObject row) = Just $ "{ " ++ prettyPrintRow row ++ " }"
-  match (TypeConstructor ctor) = Just $ showQualified runProperName ctor
-  match (TUnknown u) = Just $ '_' : show u
-  match (Skolem name s _) = Just $ name ++ show s
-  match (ConstrainedType deps ty) = Just $ "(" ++ intercalate ", " (map (\(pn, ty') -> showQualified runProperName pn ++ " " ++ unwords (map prettyPrintTypeAtom ty')) deps) ++ ") => " ++ prettyPrintType ty
-  match (SaturatedTypeSynonym name args) = Just $ showQualified runProperName name ++ "<" ++ intercalate "," (map prettyPrintTypeAtom args) ++ ">"
-  match REmpty = Just "()"
-  match row@RCons{} = Just $ '(' : prettyPrintRow row ++ ")"
+  match TypeWildcard = Just $ text "_"
+  match (TypeVar var) = Just $ text var
+  match (PrettyPrintObject row) = Just $ prettyPrintRowWith '{' '}' row
+  match (TypeConstructor ctor) = Just $ text $ runProperName $ disqualify ctor
+  match (TUnknown u) = Just $ text $ '_' : show u
+  match (Skolem name s _) = Just $ text $ name ++ show s
+  match (ConstrainedType deps ty) = Just $ constraintsAsBox deps `before` (text ") => " <> typeAsBox ty)
+  match REmpty = Just $ text "()"
+  match row@RCons{} = Just $ prettyPrintRowWith '(' ')' row
   match _ = Nothing
+
+constraintsAsBox :: [(Qualified ProperName, [Type])] -> Box
+constraintsAsBox = vcat left . zipWith (\i (pn, tys) -> text (if i == 0 then "( " else ", ") <> constraintAsBox pn tys) [0 :: Int ..]
+  where
+  constraintAsBox pn tys = hsep 1 left (text (runProperName (disqualify pn)) : map typeAtomAsBox tys)
 
 -- |
 -- Generate a pretty-printed string representing a Row
 --
-prettyPrintRow :: Type -> String
-prettyPrintRow = (\(tys, rest) -> intercalate ", " (map (uncurry nameAndTypeToPs) tys) ++ tailToPs rest) . toList []
+prettyPrintRowWith :: Char -> Char -> Type -> Box
+prettyPrintRowWith open close = uncurry listToBox . toList []
   where
-  nameAndTypeToPs :: String -> Type -> String
-  nameAndTypeToPs name ty = prettyPrintObjectKey name ++ " :: " ++ prettyPrintType ty
-  tailToPs :: Type -> String
-  tailToPs REmpty = ""
-  tailToPs other = " | " ++ prettyPrintType other
+  nameAndTypeToPs :: Char -> String -> Type -> Box
+  nameAndTypeToPs start name ty = text (start : ' ' : prettyPrintObjectKey name ++ " :: ") <> typeAsBox ty
+
+  tailToPs :: Type -> Box
+  tailToPs REmpty = nullBox
+  tailToPs other = text "| " <> typeAsBox other
+
+  listToBox :: [(String, Type)] -> Type -> Box
+  listToBox [] REmpty = text [open, close]
+  listToBox [] rest = text [ open, ' ' ] <> tailToPs rest <> text [ ' ', close ]
+  listToBox ts rest = vcat left $
+    zipWith (\(nm, ty) i -> nameAndTypeToPs (if i == 0 then open else ',') nm ty) ts [0 :: Int ..] ++
+    [ tailToPs rest, text [close] ]
+
   toList :: [(String, Type)] -> Type -> ([(String, Type)], Type)
   toList tys (RCons name ty row) = toList ((name, ty):tys) row
   toList tys r = (tys, r)
+
+prettyPrintRow :: Type -> String
+prettyPrintRow = render . prettyPrintRowWith '(' ')'
 
 typeApp :: Pattern () Type (Type, Type)
 typeApp = mkPattern match
@@ -92,19 +112,19 @@ insertPlaceholders = everywhereOnTypesTopDown convertForAlls . everywhereOnTypes
     go idents other = PrettyPrintForAll idents other
   convertForAlls other = other
 
-matchTypeAtom :: Pattern () Type String
-matchTypeAtom = typeLiterals <+> fmap parens matchType
+matchTypeAtom :: Pattern () Type Box
+matchTypeAtom = typeLiterals <+> fmap ((`before` text ")") . (text "(" <>)) matchType
 
-matchType :: Pattern () Type String
+matchType :: Pattern () Type Box
 matchType = buildPrettyPrinter operators matchTypeAtom
   where
-  operators :: OperatorTable () Type String
+  operators :: OperatorTable () Type Box
   operators =
-    OperatorTable [ [ AssocL typeApp $ \f x -> f ++ " " ++ x ]
-                  , [ AssocR appliedFunction $ \arg ret -> arg ++ " -> " ++ ret
+    OperatorTable [ [ AssocL typeApp $ \f x -> f `beforeWithSpace` x ]
+                  , [ AssocR appliedFunction $ \arg ret -> (arg <> text " ") `before` (text "-> " <> ret)
                     ]
-                  , [ Wrap forall_ $ \idents ty -> "forall " ++ unwords idents ++ ". " ++ ty ]
-                  , [ Wrap kinded $ \k ty -> ty ++ " :: " ++ prettyPrintKind k ]
+                  , [ Wrap forall_ $ \idents ty -> text ("forall " ++ unwords idents ++ ". ") <> ty ]
+                  , [ Wrap kinded $ \k ty -> ty `before` (text " :: " <> kindAsBox k) ]
                   ]
 
 forall_ :: Pattern () Type ([String], Type)
@@ -113,15 +133,16 @@ forall_ = mkPattern match
   match (PrettyPrintForAll idents ty) = Just (idents, ty)
   match _ = Nothing
 
--- |
--- Generate a pretty-printed string representing a Type, as it should appear inside parentheses
---
+typeAtomAsBox :: Type -> Box
+typeAtomAsBox = fromMaybe (error "Incomplete pattern") . pattern matchTypeAtom () . insertPlaceholders
+
+-- | Generate a pretty-printed string representing a Type, as it should appear inside parentheses
 prettyPrintTypeAtom :: Type -> String
-prettyPrintTypeAtom = fromMaybe (error "Incomplete pattern") . pattern matchTypeAtom () . insertPlaceholders
+prettyPrintTypeAtom = render . typeAtomAsBox
 
+typeAsBox :: Type -> Box
+typeAsBox = fromMaybe (error "Incomplete pattern") . pattern matchType () . insertPlaceholders
 
--- |
--- Generate a pretty-printed string representing a Type
---
+-- | Generate a pretty-printed string representing a Type
 prettyPrintType :: Type -> String
-prettyPrintType = fromMaybe (error "Incomplete pattern") . pattern matchType () . insertPlaceholders
+prettyPrintType = render . typeAsBox

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -70,6 +70,7 @@ prettyPrintValue (Do els) =
   text "do " <> vcat left (map prettyPrintDoNotationElement els)
 prettyPrintValue (TypeClassDictionary (name, tys) _) = foldl1 beforeWithSpace $ text ("#dict " ++ runProperName (disqualify name)) : map typeAtomAsBox tys
 prettyPrintValue (SuperClassDictionary name _) = text $ "#dict " ++ runProperName (disqualify name)
+prettyPrintValue (TypedValue _ val _) = prettyPrintValue val
 prettyPrintValue (PositionedValue _ _ val) = prettyPrintValue val
 prettyPrintValue expr = prettyPrintValueAtom expr
 
@@ -88,7 +89,7 @@ prettyPrintValueAtom (Constructor name) = text $ runProperName (disqualify name)
 prettyPrintValueAtom (Var ident) = text $ showIdent (disqualify ident)
 prettyPrintValueAtom (OperatorSection op (Right val)) = ((text "(" <> prettyPrintValue op) `beforeWithSpace` prettyPrintValue val) `before` text ")"
 prettyPrintValueAtom (OperatorSection op (Left val)) = ((text "(" <> prettyPrintValue val) `beforeWithSpace` prettyPrintValue op) `before` text ")"
-prettyPrintValueAtom (TypedValue _ val _) = prettyPrintValue val
+prettyPrintValueAtom (TypedValue _ val _) = prettyPrintValueAtom val
 prettyPrintValueAtom (PositionedValue _ _ val) = prettyPrintValueAtom val
 prettyPrintValueAtom expr = (text "(" <> prettyPrintValue expr) `before` text ")"
 

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -184,7 +184,7 @@ toBindingGroup moduleName (CyclicSCC ds') =
   cycleError :: (MonadError MultipleErrors m) => Declaration -> [Declaration] -> m a
   cycleError (PositionedDeclaration p _ d) ds = rethrowWithPosition p $ cycleError d ds
   cycleError (ValueDeclaration n _ _ (Right _)) [] = throwError . errorMessage $ CycleInDeclaration n
-  cycleError d ds@(_:_) = rethrow (onErrorMessages (NotYetDefined (map getIdent ds))) $ cycleError d []
+  cycleError d ds@(_:_) = rethrow (addHint (NotYetDefined (map getIdent ds))) $ cycleError d []
   cycleError _ _ = error "Expected ValueDeclaration"
 
 toDataBindingGroup :: (MonadError MultipleErrors m) => SCC Declaration -> m Declaration

--- a/src/Language/PureScript/Sugar/CaseDeclarations.hs
+++ b/src/Language/PureScript/Sugar/CaseDeclarations.hs
@@ -50,7 +50,7 @@ isLeft (Right _) = False
 --
 desugarCasesModule :: (Functor m, Applicative m, MonadSupply m, MonadError MultipleErrors m) => [Module] -> m [Module]
 desugarCasesModule ms = forM ms $ \(Module ss coms name ds exps) ->
-  rethrow (onErrorMessages (ErrorInModule name)) $
+  rethrow (addHint (ErrorInModule name)) $
     Module ss coms name <$> (desugarCases <=< desugarAbs $ ds) <*> pure exps
 
 desugarAbs :: (Functor m, Applicative m, MonadSupply m, MonadError MultipleErrors m) => [Declaration] -> m [Declaration]

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -98,7 +98,7 @@ desugarImports externs modules = do
 
   renameInModule' :: Env -> Module -> m Module
   renameInModule' env m@(Module _ _ mn _ _) =
-    rethrow (onErrorMessages (ErrorInModule mn)) $ do
+    rethrow (addHint (ErrorInModule mn)) $ do
       let (_, imps, exps) = fromMaybe (error "Module is missing in renameInModule'") $ M.lookup mn env
       elaborateImports imps <$> renameInModule env imps (elaborateExports exps m)
 

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -43,7 +43,7 @@ import Language.PureScript.Sugar.Names.Env
 --
 findExportable :: forall m. (Applicative m, MonadError MultipleErrors m) => Module -> m Exports
 findExportable (Module _ _ mn ds _) =
-  rethrow (onErrorMessages (ErrorInModule mn)) $ foldM updateExports nullExports ds
+  rethrow (addHint (ErrorInModule mn)) $ foldM updateExports nullExports ds
   where
   updateExports :: Exports -> Declaration -> m Exports
   updateExports exps (TypeClassDeclaration tcn _ _ ds') = do
@@ -67,7 +67,7 @@ findExportable (Module _ _ mn ds _) =
 --
 resolveExports :: forall m. (Applicative m, MonadError MultipleErrors m) => Env -> ModuleName -> Imports -> Exports -> [DeclarationRef] -> m Exports
 resolveExports env mn imps exps refs =
-  rethrow (onErrorMessages (ErrorInModule mn)) $ do
+  rethrow (addHint (ErrorInModule mn)) $ do
     filtered <- filterModule mn exps refs
     foldM elaborateModuleExports filtered refs
 

--- a/src/Language/PureScript/Sugar/Names/Imports.hs
+++ b/src/Language/PureScript/Sugar/Names/Imports.hs
@@ -64,7 +64,7 @@ findImports = foldM (go Nothing) M.empty
 --
 resolveImports :: (Applicative m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) => Env -> Module -> m Imports
 resolveImports env (Module _ _ currentModule decls _) =
-  censor (onErrorMessages (ErrorInModule currentModule)) $ do
+  censor (addHint (ErrorInModule currentModule)) $ do
     scope <- M.insert currentModule [(Nothing, Implicit, Nothing)] <$> findImports decls
     foldM (resolveModuleImport currentModule env) nullImports (M.toList scope)
 

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -102,7 +102,7 @@ ensureNoDuplicates m = go $ sortBy (compare `on` fst) m
   go [] = return ()
   go [_] = return ()
   go ((x@(Qualified (Just mn) name), _) : (y, pos) : _) | x == y =
-    rethrow (onErrorMessages (ErrorInModule mn)) $
+    rethrow (addHint (ErrorInModule mn)) $
       rethrowWithPosition pos $
         throwError . errorMessage $ MultipleFixities name
   go (_ : rest) = go rest

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -243,7 +243,7 @@ unit = TypeApp tyObject REmpty
 
 typeInstanceDictionaryDeclaration :: (Functor m, Applicative m, MonadSupply m, MonadError MultipleErrors m) => Ident -> ModuleName -> [Constraint] -> Qualified ProperName -> [Type] -> [Declaration] -> Desugar m Declaration
 typeInstanceDictionaryDeclaration name mn deps className tys decls =
-  rethrow (onErrorMessages (ErrorInInstance className tys)) $ do
+  rethrow (addHint (ErrorInInstance className tys)) $ do
   m <- get
 
   -- Lookup the type arguments and member types for the type class

--- a/src/Language/PureScript/Sugar/TypeDeclarations.hs
+++ b/src/Language/PureScript/Sugar/TypeDeclarations.hs
@@ -15,18 +15,19 @@
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE CPP #-}
 
 module Language.PureScript.Sugar.TypeDeclarations (
-    desugarTypeDeclarations,
     desugarTypeDeclarationsModule
 ) where
 
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
 #endif
-import Control.Monad (forM)
+import Control.Monad (forM, when)
 import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Writer.Class (MonadWriter(tell))
 
 import Language.PureScript.AST
 import Language.PureScript.Names
@@ -37,36 +38,39 @@ import Language.PureScript.Traversals
 -- |
 -- Replace all top level type declarations in a module with type annotations
 --
-desugarTypeDeclarationsModule :: (Functor m, Applicative m, MonadError MultipleErrors m) => [Module] -> m [Module]
+desugarTypeDeclarationsModule :: forall m. (Functor m, Applicative m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) => [Module] -> m [Module]
 desugarTypeDeclarationsModule ms = forM ms $ \(Module ss coms name ds exps) ->
-  rethrow (onErrorMessages (ErrorInModule name)) $
-    Module ss coms name <$> desugarTypeDeclarations ds <*> pure exps
+  rethrow (addHint (ErrorInModule name)) $
+    Module ss coms name <$> desugarTypeDeclarations True ds <*> pure exps
+  where
 
--- |
--- Replace all top level type declarations with type annotations
---
-desugarTypeDeclarations :: (Functor m, Applicative m, MonadError MultipleErrors m) => [Declaration] -> m [Declaration]
-desugarTypeDeclarations (PositionedDeclaration pos com d : ds) = do
-  (d' : ds') <- rethrowWithPosition pos $ desugarTypeDeclarations (d : ds)
-  return (PositionedDeclaration pos com d' : ds')
-desugarTypeDeclarations (TypeDeclaration name ty : d : rest) = do
-  (_, nameKind, val) <- fromValueDeclaration d
-  desugarTypeDeclarations (ValueDeclaration name nameKind [] (Right (TypedValue True val ty)) : rest)
-  where
-  fromValueDeclaration :: (Functor m, Applicative m, MonadError MultipleErrors m) => Declaration -> m (Ident, NameKind, Expr)
-  fromValueDeclaration (ValueDeclaration name' nameKind [] (Right val)) | name == name' = return (name', nameKind, val)
-  fromValueDeclaration (PositionedDeclaration pos com d') = do
-    (ident, nameKind, val) <- rethrowWithPosition pos $ fromValueDeclaration d'
-    return (ident, nameKind, PositionedValue pos com val)
-  fromValueDeclaration _ = throwError . errorMessage $ OrphanTypeDeclaration name
-desugarTypeDeclarations [TypeDeclaration name _] = throwError . errorMessage $ OrphanTypeDeclaration name
-desugarTypeDeclarations (ValueDeclaration name nameKind bs val : rest) = do
-  let (_, f, _) = everywhereOnValuesTopDownM return go return
-      f' (Left gs) = Left <$> mapM (pairM return f) gs
-      f' (Right v) = Right <$> f v
-  (:) <$> (ValueDeclaration name nameKind bs <$> f' val) <*> desugarTypeDeclarations rest
-  where
-  go (Let ds val') = Let <$> desugarTypeDeclarations ds <*> pure val'
-  go other = return other
-desugarTypeDeclarations (d:ds) = (:) d <$> desugarTypeDeclarations ds
-desugarTypeDeclarations [] = return []
+  desugarTypeDeclarations :: Bool -> [Declaration] -> m [Declaration]
+  desugarTypeDeclarations reqd (PositionedDeclaration pos com d : ds) = do
+    (d' : ds') <- rethrowWithPosition pos $ desugarTypeDeclarations reqd (d : ds)
+    return (PositionedDeclaration pos com d' : ds')
+  desugarTypeDeclarations reqd (TypeDeclaration name ty : d : rest) = do
+    (_, nameKind, val) <- fromValueDeclaration d
+    desugarTypeDeclarations reqd (ValueDeclaration name nameKind [] (Right (TypedValue True val ty)) : rest)
+    where
+    fromValueDeclaration :: Declaration -> m (Ident, NameKind, Expr)
+    fromValueDeclaration (ValueDeclaration name' nameKind [] (Right val)) | name == name' = return (name', nameKind, val)
+    fromValueDeclaration (PositionedDeclaration pos com d') = do
+      (ident, nameKind, val) <- rethrowWithPosition pos $ fromValueDeclaration d'
+      return (ident, nameKind, PositionedValue pos com val)
+    fromValueDeclaration _ = throwError . errorMessage $ OrphanTypeDeclaration name
+  desugarTypeDeclarations _ [TypeDeclaration name _] = throwError . errorMessage $ OrphanTypeDeclaration name
+  desugarTypeDeclarations reqd (ValueDeclaration name nameKind bs val : rest) = do
+    -- At the top level, match a type signature or emit a warning.
+    when reqd $ case val of
+                  Right TypedValue{} -> return ()
+                  Left _ -> error "desugarTypeDeclarations: cases were not desugared"
+                  _ -> tell (addHint (ErrorInValueDeclaration name) $ errorMessage $ MissingTypeDeclaration name)
+    let (_, f, _) = everywhereOnValuesTopDownM return go return
+        f' (Left gs) = Left <$> mapM (pairM return f) gs
+        f' (Right v) = Right <$> f v
+    (:) <$> (ValueDeclaration name nameKind bs <$> f' val) <*> desugarTypeDeclarations reqd rest
+    where
+    go (Let ds val') = Let <$> desugarTypeDeclarations False ds <*> pure val'
+    go other = return other
+  desugarTypeDeclarations reqd (d:ds) = (:) d <$> desugarTypeDeclarations reqd ds
+  desugarTypeDeclarations _ [] = return []

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -51,7 +51,7 @@ addDataType moduleName dtype name args dctors ctorKind = do
   env <- getEnv
   putEnv $ env { types = M.insert (Qualified (Just moduleName) name) (ctorKind, DataType args dctors) (types env) }
   forM_ dctors $ \(dctor, tys) ->
-    warnAndRethrow (onErrorMessages (ErrorInDataConstructor dctor)) $
+    warnAndRethrow (addHint (ErrorInDataConstructor dctor)) $
       addDataConstructor moduleName dtype name (map fst args) dctor tys
 
 addDataConstructor :: ModuleName -> DataDeclType -> ProperName -> [String] -> ProperName -> [Type] -> Check ()
@@ -137,7 +137,7 @@ typeCheckAll mainModuleName moduleName _ ds = mapM go ds <* mapM_ checkOrphanFix
   where
   go :: Declaration -> Check Declaration
   go (DataDeclaration dtype name args dctors) = do
-    warnAndRethrow (onErrorMessages (ErrorInTypeConstructor name)) $ do
+    warnAndRethrow (addHint (ErrorInTypeConstructor name)) $ do
       when (dtype == Newtype) $ checkNewtype dctors
       checkDuplicateTypeArguments $ map fst args
       ctorKind <- kindsOf True moduleName name args (concatMap snd dctors)
@@ -150,7 +150,7 @@ typeCheckAll mainModuleName moduleName _ ds = mapM go ds <* mapM_ checkOrphanFix
     checkNewtype [(_, _)] = throwError . errorMessage $ InvalidNewtype
     checkNewtype _ = throwError . errorMessage $ InvalidNewtype
   go (d@(DataBindingGroupDeclaration tys)) = do
-    warnAndRethrow (onErrorMessages ErrorInDataBindingGroup) $ do
+    warnAndRethrow (addHint ErrorInDataBindingGroup) $ do
       let syns = mapMaybe toTypeSynonym tys
       let dataDecls = mapMaybe toDataDecl tys
       (syn_ks, data_ks) <- kindsOfAll moduleName syns (map (\(_, name, args, dctors) -> (name, args, concatMap snd dctors)) dataDecls)
@@ -171,7 +171,7 @@ typeCheckAll mainModuleName moduleName _ ds = mapM go ds <* mapM_ checkOrphanFix
     toDataDecl (PositionedDeclaration _ _ d') = toDataDecl d'
     toDataDecl _ = Nothing
   go (TypeSynonymDeclaration name args ty) = do
-    warnAndRethrow (onErrorMessages (ErrorInTypeSynonym name)) $ do
+    warnAndRethrow (addHint (ErrorInTypeSynonym name)) $ do
       checkDuplicateTypeArguments $ map fst args
       kind <- kindsOf False moduleName name args [ty]
       let args' = args `withKinds` kind
@@ -179,14 +179,14 @@ typeCheckAll mainModuleName moduleName _ ds = mapM go ds <* mapM_ checkOrphanFix
     return $ TypeSynonymDeclaration name args ty
   go (TypeDeclaration{}) = error "Type declarations should have been removed"
   go (ValueDeclaration name nameKind [] (Right val)) =
-    warnAndRethrow (onErrorMessages (ErrorInValueDeclaration name)) $ do
+    warnAndRethrow (addHint (ErrorInValueDeclaration name)) $ do
       valueIsNotDefined moduleName name
       [(_, (val', ty))] <- typesOf mainModuleName moduleName [(name, val)]
       addValue moduleName name ty nameKind
       return $ ValueDeclaration name nameKind [] $ Right val'
   go (ValueDeclaration{}) = error "Binders were not desugared"
   go (BindingGroupDeclaration vals) =
-    warnAndRethrow (onErrorMessages (ErrorInBindingGroup (map (\(ident, _, _) -> ident) vals))) $ do
+    warnAndRethrow (addHint (ErrorInBindingGroup (map (\(ident, _, _) -> ident) vals))) $ do
       forM_ (map (\(ident, _, _) -> ident) vals) $ \name ->
         valueIsNotDefined moduleName name
       tys <- typesOf mainModuleName moduleName $ map (\(ident, _, ty) -> (ident, ty)) vals
@@ -203,7 +203,7 @@ typeCheckAll mainModuleName moduleName _ ds = mapM go ds <* mapM_ checkOrphanFix
     putEnv $ env { types = M.insert (Qualified (Just moduleName) name) (kind, ExternData) (types env) }
     return d
   go (d@(ExternDeclaration name ty)) = do
-    warnAndRethrow (onErrorMessages (ErrorInForeignImport name)) $ do
+    warnAndRethrow (addHint (ErrorInForeignImport name)) $ do
       env <- getEnv
       kind <- kindOf moduleName ty
       guardWith (errorMessage (ExpectedType ty kind)) $ kind == Star
@@ -269,7 +269,7 @@ typeCheckAll mainModuleName moduleName _ ds = mapM go ds <* mapM_ checkOrphanFix
 --
 typeCheckModule :: Maybe ModuleName -> Module -> Check Module
 typeCheckModule _ (Module _ _ _ _ Nothing) = error "exports should have been elaborated"
-typeCheckModule mainModuleName (Module ss coms mn decls (Just exps)) = warnAndRethrow (onErrorMessages (ErrorInModule mn)) $ do
+typeCheckModule mainModuleName (Module ss coms mn decls (Just exps)) = warnAndRethrow (addHint (ErrorInModule mn)) $ do
   modify (\s -> s { checkCurrentModule = Just mn })
   decls' <- typeCheckAll mainModuleName mn exps decls
   forM_ exps $ \e -> do

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -83,7 +83,7 @@ kindOf _ ty = fst <$> kindOfWithScopedVars ty
 --
 kindOfWithScopedVars :: Type -> Check (Kind, [(String, Kind)])
 kindOfWithScopedVars ty =
-  rethrow (onErrorMessages (ErrorCheckingKind ty)) $
+  rethrow (addHint (ErrorCheckingKind ty)) $
     fmap tidyUp . liftUnify $ infer ty
   where
   tidyUp ((k, args), sub) = ( starIfUnknown (sub $? k)
@@ -161,7 +161,7 @@ starIfUnknown k = k
 -- Infer a kind for a type
 --
 infer :: Type -> UnifyT Kind Check (Kind, [(String, Kind)])
-infer ty = rethrow (onErrorMessages (ErrorCheckingKind ty)) $ infer' ty
+infer ty = rethrow (addHint (ErrorCheckingKind ty)) $ infer' ty
 
 infer' :: Type -> UnifyT Kind Check (Kind, [(String, Kind)])
 infer' (ForAll ident ty _) = do

--- a/src/Language/PureScript/TypeChecker/Skolems.hs
+++ b/src/Language/PureScript/TypeChecker/Skolems.hs
@@ -92,7 +92,7 @@ skolemEscapeCheck root@TypedValue{} =
   let (_, f, _, _, _) = everythingWithContextOnValues [] [] (++) def go def def def
   in case f root of
        [] -> return ()
-       ((binding, val) : _) -> throwError . singleError $ ErrorInExpression val $ SimpleErrorWrapper $ EscapedSkolem binding
+       ((binding, val) : _) -> throwError . singleError $ ErrorMessage [ ErrorInExpression val ] $ EscapedSkolem binding
   where
   def s _ = (s, [])
 

--- a/src/Language/PureScript/TypeChecker/Subsumption.hs
+++ b/src/Language/PureScript/TypeChecker/Subsumption.hs
@@ -37,7 +37,7 @@ import Language.PureScript.Types
 -- Check whether one type subsumes another, rethrowing errors to provide a better error message
 --
 subsumes :: Maybe Expr -> Type -> Type -> UnifyT Type Check (Maybe Expr)
-subsumes val ty1 ty2 = rethrow (onErrorMessages (ErrorInSubsumption ty1 ty2)) $ subsumes' val ty1 ty2
+subsumes val ty1 ty2 = rethrow (addHint (ErrorInSubsumption ty1 ty2)) $ subsumes' val ty1 ty2
 
 -- |
 -- Check whether one type subsumes another

--- a/src/Language/PureScript/TypeChecker/Synonyms.hs
+++ b/src/Language/PureScript/TypeChecker/Synonyms.hs
@@ -50,7 +50,7 @@ buildTypeSubstitution m = go 0 []
   where
   go :: Int -> [Type] -> Type -> Either ErrorMessage (Maybe Type)
   go c args (TypeConstructor ctor) | M.lookup ctor m == Just c = return (Just $ SaturatedTypeSynonym ctor args)
-  go c _    (TypeConstructor ctor) | M.lookup ctor m >  Just c = throwError $ SimpleErrorWrapper $ PartiallyAppliedSynonym ctor
+  go c _    (TypeConstructor ctor) | M.lookup ctor m >  Just c = throwError $ ErrorMessage [] $ PartiallyAppliedSynonym ctor
   go c args (TypeApp f arg) = go (c + 1) (arg:args) f
   go _ _ _ = return Nothing
 

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -63,7 +63,7 @@ instance Unifiable Check Type where
 -- Unify two types, updating the current substitution
 --
 unifyTypes :: Type -> Type -> UnifyT Type Check ()
-unifyTypes t1 t2 = rethrow (onErrorMessages (ErrorUnifyingTypes t1 t2)) $
+unifyTypes t1 t2 = rethrow (addHint (ErrorUnifyingTypes t1 t2)) $
   unifyTypes' t1 t2
   where
   unifyTypes' (TUnknown u1) (TUnknown u2) | u1 == u2 = return ()


### PR DESCRIPTION
@garyb Look ok?

This just tidies up row errors right now:

```text
Error checking that value
  {}
has type
  { foo :: _1
  | _0
  }
```

but we could generate nicer errors for other types later.

After this, I'd like to use `boxes` for values and maybe even codegen before closing #929. 