### PR TITLE
Don't require that all types are exported

### DIFF
--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -273,7 +273,6 @@ typeCheckModule (Module ss coms mn decls (Just exps)) = warnAndRethrow (addHint 
   modify (\s -> s { checkCurrentModule = Just mn })
   decls' <- typeCheckAll mn exps decls
   forM_ exps $ \e -> do
-    checkTypesAreExported e
     checkClassMembersAreExported e
     checkClassesAreExported e
   return $ Module ss coms mn decls' (Just exps)
@@ -294,17 +293,6 @@ typeCheckModule (Module ss coms mn decls (Just exps)) = warnAndRethrow (addHint 
       exports r1 (PositionedDeclarationRef _ _ r2) = exports r1 r2
       exports _ _ = False
   checkMemberExport _ _ = return ()
-
-  -- Check that all the type constructors defined in the current module that appear in member types
-  -- have also been exported from the module
-  checkTypesAreExported :: DeclarationRef -> Check ()
-  checkTypesAreExported = checkMemberExport findTcons
-    where
-    findTcons :: Type -> [DeclarationRef]
-    findTcons = everythingOnTypes (++) go
-      where
-      go (TypeConstructor (Qualified (Just mn') name)) | mn' == mn = [TypeRef name (error "Data constructors unused in checkTypesAreExported")]
-      go _ = []
 
   -- Check that all the classes defined in the current module that appear in member types have also
   -- been exported from the module


### PR DESCRIPTION
This never entirely worked properly when synyonms and the like got involved, and now we generate a decent externs format we don't need the check to prevent errors anymore either.

Also the check isn't necessary, as maybe you only want to reveal a type via synonym and then use prisms to access it or the like, so imposing that All Types Must Be Exported is a fairly arbitrary rule now that their absence won't break things.