### PR TITLE
Fix #1534

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -142,7 +142,7 @@ data SimpleErrorMessage
   | ShadowedTypeVar String
   | UnusedTypeVar String
   | WildcardInferredType Type
-  | MissingTypeDeclaration Ident
+  | MissingTypeDeclaration Ident Type
   | NotExhaustivePattern [[Binder]] Bool
   | OverlappingPattern [[Binder]] Bool
   | IncompleteExhaustivityCheck
@@ -666,11 +666,11 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
       paras [ line "The wildcard type definition has the inferred type "
             , indent $ typeAsBox ty
             ]
-    renderSimpleErrorMessage (MissingTypeDeclaration ident) =
+    renderSimpleErrorMessage (MissingTypeDeclaration ident ty) =
       paras [ line $ "No type declaration was provided for the top-level declaration of " ++ showIdent ident ++ "."
             , line "It is good practice to provide type declarations as a form of documentation."
-            , line "Consider using a type wildcard to display the inferred type:"
-            , indent $ line $ showIdent ident ++ " :: _"
+            , line $ "The inferred type of " ++ showIdent ident ++ " was:"
+            , indent $ typeAsBox ty
             ]
     renderSimpleErrorMessage (NotExhaustivePattern bs b) =
       paras $ [ line "A case expression could not be determined to cover all inputs."

--- a/src/Language/PureScript/Sugar/TypeDeclarations.hs
+++ b/src/Language/PureScript/Sugar/TypeDeclarations.hs
@@ -25,9 +25,8 @@ module Language.PureScript.Sugar.TypeDeclarations (
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
 #endif
-import Control.Monad (forM, when)
+import Control.Monad (forM)
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Writer.Class (MonadWriter(tell))
 
 import Language.PureScript.AST
 import Language.PureScript.Names
@@ -38,7 +37,7 @@ import Language.PureScript.Traversals
 -- |
 -- Replace all top level type declarations in a module with type annotations
 --
-desugarTypeDeclarationsModule :: forall m. (Functor m, Applicative m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) => [Module] -> m [Module]
+desugarTypeDeclarationsModule :: forall m. (Functor m, Applicative m, MonadError MultipleErrors m) => [Module] -> m [Module]
 desugarTypeDeclarationsModule ms = forM ms $ \(Module ss coms name ds exps) ->
   rethrow (addHint (ErrorInModule name)) $
     Module ss coms name <$> desugarTypeDeclarations ds <*> pure exps

--- a/src/Language/PureScript/Sugar/TypeDeclarations.hs
+++ b/src/Language/PureScript/Sugar/TypeDeclarations.hs
@@ -41,16 +41,16 @@ import Language.PureScript.Traversals
 desugarTypeDeclarationsModule :: forall m. (Functor m, Applicative m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) => [Module] -> m [Module]
 desugarTypeDeclarationsModule ms = forM ms $ \(Module ss coms name ds exps) ->
   rethrow (addHint (ErrorInModule name)) $
-    Module ss coms name <$> desugarTypeDeclarations True ds <*> pure exps
+    Module ss coms name <$> desugarTypeDeclarations ds <*> pure exps
   where
 
-  desugarTypeDeclarations :: Bool -> [Declaration] -> m [Declaration]
-  desugarTypeDeclarations reqd (PositionedDeclaration pos com d : ds) = do
-    (d' : ds') <- rethrowWithPosition pos $ desugarTypeDeclarations reqd (d : ds)
+  desugarTypeDeclarations :: [Declaration] -> m [Declaration]
+  desugarTypeDeclarations (PositionedDeclaration pos com d : ds) = do
+    (d' : ds') <- rethrowWithPosition pos $ desugarTypeDeclarations (d : ds)
     return (PositionedDeclaration pos com d' : ds')
-  desugarTypeDeclarations reqd (TypeDeclaration name ty : d : rest) = do
+  desugarTypeDeclarations (TypeDeclaration name ty : d : rest) = do
     (_, nameKind, val) <- fromValueDeclaration d
-    desugarTypeDeclarations reqd (ValueDeclaration name nameKind [] (Right (TypedValue True val ty)) : rest)
+    desugarTypeDeclarations (ValueDeclaration name nameKind [] (Right (TypedValue True val ty)) : rest)
     where
     fromValueDeclaration :: Declaration -> m (Ident, NameKind, Expr)
     fromValueDeclaration (ValueDeclaration name' nameKind [] (Right val)) | name == name' = return (name', nameKind, val)
@@ -58,19 +58,14 @@ desugarTypeDeclarationsModule ms = forM ms $ \(Module ss coms name ds exps) ->
       (ident, nameKind, val) <- rethrowWithPosition pos $ fromValueDeclaration d'
       return (ident, nameKind, PositionedValue pos com val)
     fromValueDeclaration _ = throwError . errorMessage $ OrphanTypeDeclaration name
-  desugarTypeDeclarations _ [TypeDeclaration name _] = throwError . errorMessage $ OrphanTypeDeclaration name
-  desugarTypeDeclarations reqd (ValueDeclaration name nameKind bs val : rest) = do
-    -- At the top level, match a type signature or emit a warning.
-    when reqd $ case val of
-                  Right TypedValue{} -> return ()
-                  Left _ -> error "desugarTypeDeclarations: cases were not desugared"
-                  _ -> tell (addHint (ErrorInValueDeclaration name) $ errorMessage $ MissingTypeDeclaration name)
+  desugarTypeDeclarations [TypeDeclaration name _] = throwError . errorMessage $ OrphanTypeDeclaration name
+  desugarTypeDeclarations (ValueDeclaration name nameKind bs val : rest) = do
     let (_, f, _) = everywhereOnValuesTopDownM return go return
         f' (Left gs) = Left <$> mapM (pairM return f) gs
         f' (Right v) = Right <$> f v
-    (:) <$> (ValueDeclaration name nameKind bs <$> f' val) <*> desugarTypeDeclarations reqd rest
+    (:) <$> (ValueDeclaration name nameKind bs <$> f' val) <*> desugarTypeDeclarations rest
     where
-    go (Let ds val') = Let <$> desugarTypeDeclarations False ds <*> pure val'
+    go (Let ds val') = Let <$> desugarTypeDeclarations ds <*> pure val'
     go other = return other
-  desugarTypeDeclarations reqd (d:ds) = (:) d <$> desugarTypeDeclarations reqd ds
-  desugarTypeDeclarations _ [] = return []
+  desugarTypeDeclarations (d:ds) = (:) d <$> desugarTypeDeclarations ds
+  desugarTypeDeclarations [] = return []


### PR DESCRIPTION
/cc @garyb 

New warning (from `TypedBinders.purs`):

```text
Warning 2 of 3:

  Warning in value declaration runState:
  Warning in module Main:
  No type declaration was provided for the top-level declaration of runState.
  It is good practice to provide type declarations as a form of documentation.
  The inferred type of runState was:

    forall t29 t30. t30 -> State t30 t29 -> Tuple t30 t29

Warning 3 of 3:

  Warning in value declaration main:
  Warning in module Main:
  No type declaration was provided for the top-level declaration of main.
  It is good practice to provide type declarations as a form of documentation.
  The inferred type of main was:

    forall t112. Eff ( console :: CONSOLE
                     | t112
                     )
                 Unit
```

Much nicer, I think.