### PR TITLE
Friendlier errors

### DIFF
--- a/psci/PSCi.hs
+++ b/psci/PSCi.hs
@@ -71,7 +71,7 @@ supportModule :: P.Module
 supportModule =
   case P.parseModulesFromFiles id [("", code)] of
     Right [(_, P.Module ss cs _ ds exps)] -> P.Module ss cs supportModuleName ds exps
-    _ -> error "Support module could not be parsed"
+    _ -> P.internalError "Support module could not be parsed"
   where
   code :: String
   code = unlines
@@ -390,7 +390,7 @@ printModuleSignatures moduleName env =
         findType envNames m@(_, mIdent) = (mIdent, M.lookup m envNames)
         showType :: (P.Ident, Maybe (P.Type, P.NameKind, P.NameVisibility)) -> String
         showType (mIdent, Just (mType, _, _)) = show mIdent ++ " :: " ++ P.prettyPrintType mType
-        showType _ = error "The impossible happened in printModuleSignatures."
+        showType _ = P.internalError "The impossible happened in printModuleSignatures."
 
 -- |
 -- Browse a module and displays its signature (if module exists).
@@ -482,7 +482,7 @@ handleCommand (KindOf typ) = handleKindOf typ
 handleCommand (BrowseModule moduleName) = handleBrowse moduleName
 handleCommand (ShowInfo QueryLoaded) = handleShowLoadedModules
 handleCommand (ShowInfo QueryImport) = handleShowImportedModules
-handleCommand QuitPSCi = error "`handleCommand QuitPSCi` was called. This is a bug."
+handleCommand QuitPSCi = P.internalError "`handleCommand QuitPSCi` was called. This is a bug."
 
 whenFileExists :: FilePath -> (FilePath -> PSCI ()) -> PSCI ()
 whenFileExists filePath f = do

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -79,6 +79,7 @@ library
                      Language.PureScript.AST.Traversals
                      Language.PureScript.AST.Exported
                      Language.PureScript.Bundle
+                     Language.PureScript.Crash
                      Language.PureScript.Externs
                      Language.PureScript.CodeGen
                      Language.PureScript.CodeGen.JS

--- a/src/Language/PureScript.hs
+++ b/src/Language/PureScript.hs
@@ -26,6 +26,7 @@ module Language.PureScript
 import Data.Version (Version)
 
 import Language.PureScript.AST as P
+import Language.PureScript.Crash as P
 import Language.PureScript.Comments as P
 import Language.PureScript.Environment as P
 import Language.PureScript.Errors as P hiding (indent)

--- a/src/Language/PureScript/AST/Operators.hs
+++ b/src/Language/PureScript/AST/Operators.hs
@@ -21,6 +21,8 @@ import qualified Data.Data as D
 import Data.Aeson ((.=))
 import qualified Data.Aeson as A
 
+import Language.PureScript.Crash
+
 -- |
 -- A precedence level for an infix operator
 --
@@ -40,7 +42,7 @@ readAssoc :: String -> Associativity
 readAssoc "infixl" = Infixl
 readAssoc "infixr" = Infixr
 readAssoc "infix"  = Infix
-readAssoc _ = error "readAssoc: no parse"
+readAssoc _ = internalError "readAssoc: no parse"
 
 instance A.ToJSON Associativity where
   toJSON = A.toJSON . showAssoc

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -38,6 +38,7 @@ import Control.Monad (replicateM, forM)
 import Control.Monad.Reader (MonadReader, asks)
 import Control.Monad.Supply.Class
 
+import Language.PureScript.Crash
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.CodeGen.JS.AST as AST
 import Language.PureScript.CodeGen.JS.Common as Common
@@ -272,7 +273,7 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ = do
       go (v:vs) done' (b:bs) = do
         done'' <- go vs done' bs
         binderToJs v done'' b
-      go _ _ _ = error "Invalid arguments to bindersToJs"
+      go _ _ _ = internalError "Invalid arguments to bindersToJs"
 
       failedPatternError :: [String] -> JS
       failedPatternError names = JSUnary JSNew $ JSApp (JSVar "Error") [JSBinary Add (JSStringLiteral errorMessage) (JSArrayLiteral $ zipWith valueError names vals)]
@@ -322,7 +323,7 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ = do
       js <- binderToJs argVar done'' binder
       return (JSVariableIntroduction argVar (Just (JSAccessor (identToJs field) (JSVar varName))) : js)
   binderToJs _ _ ConstructorBinder{} =
-    error "binderToJs: Invalid ConstructorBinder in binderToJs"
+    internalError "binderToJs: Invalid ConstructorBinder in binderToJs"
   binderToJs varName done (NamedBinder _ ident binder) = do
     js <- binderToJs varName done binder
     return (JSVariableIntroduction (identToJs ident) (Just (JSVar varName)) : js)

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/Common.hs
@@ -17,6 +17,7 @@ module Language.PureScript.CodeGen.JS.Optimizer.Common where
 
 import Data.Maybe (fromMaybe)
 
+import Language.PureScript.Crash
 import Language.PureScript.CodeGen.JS.AST
 
 applyAll :: [a -> a] -> a -> a
@@ -63,7 +64,7 @@ targetVariable :: JS -> String
 targetVariable (JSVar var) = var
 targetVariable (JSAccessor _ tgt) = targetVariable tgt
 targetVariable (JSIndexer _ tgt) = targetVariable tgt
-targetVariable _ = error "Invalid argument to targetVariable"
+targetVariable _ = internalError "Invalid argument to targetVariable"
 
 isUpdated :: String -> JS -> Bool
 isUpdated var1 = everythingOnJS (||) check

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -21,6 +21,7 @@ import qualified Data.Map as M
 
 import Control.Arrow (second, (***))
 
+import Language.PureScript.Crash
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.AST.Traversals
 import Language.PureScript.CoreFn.Ann
@@ -41,7 +42,7 @@ import qualified Language.PureScript.AST as A
 --
 moduleToCoreFn :: Environment -> A.Module -> Module Ann
 moduleToCoreFn _ (A.Module _ _ _ _ Nothing) =
-  error "Module exports were not elaborated before moduleToCoreFn"
+  internalError "Module exports were not elaborated before moduleToCoreFn"
 moduleToCoreFn env (A.Module _ coms mn decls (Just exps)) =
   let imports = nub $ mapMaybe importToCoreFn decls ++ findQualModules decls
       exps' = nub $ concatMap exportToCoreFn exps
@@ -98,7 +99,7 @@ moduleToCoreFn env (A.Module _ coms mn decls (Just exps)) =
   exprToCoreFn ss com ty (A.Abs (Left name) v) =
     Abs (ss, com, ty, Nothing) name (exprToCoreFn ss [] Nothing v)
   exprToCoreFn _ _ _ (A.Abs _ _) =
-    error "Abs with Binder argument was not desugared before exprToCoreFn mn"
+    internalError "Abs with Binder argument was not desugared before exprToCoreFn mn"
   exprToCoreFn ss com ty (A.App v1 v2) =
     App (ss, com, ty, Nothing) (exprToCoreFn ss [] Nothing v1) (exprToCoreFn ss [] Nothing v2)
   exprToCoreFn ss com ty (A.Var ident) =
@@ -193,7 +194,7 @@ moduleToCoreFn env (A.Module _ coms mn decls (Just exps)) =
     numConstructors ty = length $ filter (((==) `on` typeConstructor) ty) $ M.toList $ dataConstructors env
     typeConstructor :: (Qualified ProperName, (DataDeclType, ProperName, Type, [Ident])) -> (ModuleName, ProperName)
     typeConstructor (Qualified (Just mn') _, (_, tyCtor, _, _)) = (mn', tyCtor)
-    typeConstructor _ = error "Invalid argument to typeConstructor"
+    typeConstructor _ = internalError "Invalid argument to typeConstructor"
 
 -- |
 -- Find module names from qualified references to values. This is used to

--- a/src/Language/PureScript/Crash.hs
+++ b/src/Language/PureScript/Crash.hs
@@ -1,0 +1,9 @@
+module Language.PureScript.Crash where
+
+-- | Exit with an error message and a crash report link.
+internalError :: String -> a
+internalError =
+  error
+  . ("An internal error ocurred during compilation: " ++)
+  . (++ "\nPlease report this at https://github.com/purescript/purescript/issues")
+  . show

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -157,7 +157,7 @@ convertDeclaration (P.TypeClassDeclaration _ args implies ds) title =
   convertClassMember (P.TypeDeclaration ident' ty) =
     ChildDeclaration (P.showIdent ident') Nothing Nothing (ChildTypeClassMember ty)
   convertClassMember _ =
-    error "Invalid argument to convertClassMember."
+    P.internalError "convertDeclaration: Invalid argument to convertClassMember."
 convertDeclaration (P.TypeInstanceDeclaration _ constraints className tys _) title =
   Just (Left (classNameString : typeNameStrings, AugmentChild childDecl))
   where

--- a/src/Language/PureScript/Docs/RenderedCode/Render.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Render.hs
@@ -22,6 +22,7 @@ import Data.Maybe (fromMaybe)
 import Control.Arrow ((<+>))
 import Control.PatternArrows
 
+import Language.PureScript.Crash
 import Language.PureScript.Names
 import Language.PureScript.Types
 import Language.PureScript.Kinds
@@ -163,7 +164,7 @@ renderKind = kind . prettyPrintKind
 --
 renderTypeAtom :: Type -> RenderedCode
 renderTypeAtom =
-  fromMaybe (error "Incomplete pattern") . pattern matchTypeAtom () . preprocessType defaultRenderTypeOptions
+  fromMaybe (internalError "Incomplete pattern") . pattern matchTypeAtom () . preprocessType defaultRenderTypeOptions
 
 
 -- |
@@ -181,4 +182,4 @@ defaultRenderTypeOptions = RenderTypeOptions { prettyPrintObjects = True }
 
 renderTypeWithOptions :: RenderTypeOptions -> Type -> RenderedCode
 renderTypeWithOptions opts =
-  fromMaybe (error "Incomplete pattern") . pattern matchType () . preprocessType opts
+  fromMaybe (internalError "Incomplete pattern") . pattern matchType () . preprocessType opts

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -25,6 +25,7 @@ import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Aeson as A
 
+import Language.PureScript.Crash
 import Language.PureScript.Kinds
 import Language.PureScript.Names
 import Language.PureScript.TypeClassDictionaries
@@ -252,7 +253,7 @@ primTypes = M.fromList [ (primName "Function" , (FunKind Star (FunKind Star Star
 --
 lookupConstructor :: Environment -> Qualified ProperName -> (DataDeclType, ProperName, Type, [Ident])
 lookupConstructor env ctor =
-  fromMaybe (error "Data constructor not found") $ ctor `M.lookup` dataConstructors env
+  fromMaybe (internalError "Data constructor not found") $ ctor `M.lookup` dataConstructors env
 
 -- |
 -- Checks whether a data constructor is for a newtype.

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -411,7 +411,7 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
             , prettyPrintParseError err
             ]
     renderSimpleErrorMessage (MissingFFIModule mn) =
-      paras [ line $ "Missing foreign module implementation for module " ++ runModuleName mn
+      paras [ line $ "The foreign module implementation for module " ++ runModuleName mn ++ " is missing."
             , line $ "Provide your foreign module implementation using the --ffi command line option, and ensure that your module contains the following module header:"
             , indent . line $ "// module " ++ runModuleName mn
             ]
@@ -496,13 +496,13 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
     renderSimpleErrorMessage (ConflictingCtorDecls nm) =
       line $ "Conflicting data constructor declarations for " ++ runProperName nm
     renderSimpleErrorMessage (TypeConflictsWithClass nm) =
-      line $ "The type " ++ runProperName nm ++ " conflicts with type class declaration of the same name."
+      line $ "The type " ++ runProperName nm ++ " conflicts with a type class declaration of the same name."
     renderSimpleErrorMessage (CtorConflictsWithClass nm) =
-      line $ "The data constructor " ++ runProperName nm ++ " conflicts with type class declaration of the same name."
+      line $ "The data constructor " ++ runProperName nm ++ " conflicts with a type class declaration of the same name."
     renderSimpleErrorMessage (ClassConflictsWithType nm) =
-      line $ "The type class " ++ runProperName nm ++ " conflicts with type declaration of the same name."
+      line $ "The type class " ++ runProperName nm ++ " conflicts with a type declaration of the same name."
     renderSimpleErrorMessage (ClassConflictsWithCtor nm) =
-      line $ "The type class " ++ runProperName nm ++ " conflicts with data constructor declaration of the same name."
+      line $ "The type class " ++ runProperName nm ++ " conflicts with a data constructor declaration of the same name."
     renderSimpleErrorMessage (DuplicateModuleName mn) =
       line $ "The module " ++ runModuleName mn ++ " has been defined multiple times."
     renderSimpleErrorMessage (DuplicateClassExport nm) =

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -457,19 +457,19 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
     renderSimpleErrorMessage (UnknownDataConstructor dc tc) =
       line $ "Unknown data constructor " ++ showQualified runProperName dc ++ foldMap ((" for type constructor " ++) . showQualified runProperName) tc
     renderSimpleErrorMessage (UnknownImportType mn name) =
-      paras [ line $ "Cannot import the type " ++ runProperName name ++ " from module " ++ runModuleName mn
+      paras [ line $ "Cannot import type " ++ runProperName name ++ " from module " ++ runModuleName mn
             , line "It either does not exist or the module does not export it."
             ]
     renderSimpleErrorMessage (UnknownExportType name) =
       line $ "Cannot export unknown type " ++ runProperName name
     renderSimpleErrorMessage (UnknownImportTypeClass mn name) =
-      paras [ line $ "Cannot import the type class " ++ runProperName name ++ " from module " ++ runModuleName mn
+      paras [ line $ "Cannot import type class " ++ runProperName name ++ " from module " ++ runModuleName mn
             , line "It either does not exist or the module does not export it."
             ]
     renderSimpleErrorMessage (UnknownExportTypeClass name) =
       line $ "Cannot export unknown type class " ++ runProperName name
     renderSimpleErrorMessage (UnknownImportValue mn name) =
-      paras [ line $ "Cannot import the value " ++ showIdent name ++ " from module " ++ runModuleName mn
+      paras [ line $ "Cannot import value " ++ showIdent name ++ " from module " ++ runModuleName mn
             , line "It either does not exist or the module does not export it."
             ]
     renderSimpleErrorMessage (UnknownExportValue name) =
@@ -483,7 +483,7 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
     renderSimpleErrorMessage (UnknownExportDataConstructor tcon dcon) =
       line $ "Cannot export data constructor " ++ runProperName dcon ++ " for type " ++ runProperName tcon ++ ", as it has not been declared."
     renderSimpleErrorMessage (ConflictingImport nm mn) =
-      paras [ line $ "Cannot declare " ++ show nm ++ ", since another declaration of that name was imported from the module " ++ runModuleName mn
+      paras [ line $ "Cannot declare " ++ show nm ++ ", since another declaration of that name was imported from module " ++ runModuleName mn
             , line $ "Consider hiding " ++ show nm ++ " when importing " ++ runModuleName mn ++ ":"
             , indent . line $ "import " ++ runModuleName mn ++ " hiding (" ++ nm ++ ")"
             ]
@@ -494,15 +494,15 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
     renderSimpleErrorMessage (ConflictingCtorDecls nm) =
       line $ "Conflicting data constructor declarations for " ++ runProperName nm
     renderSimpleErrorMessage (TypeConflictsWithClass nm) =
-      line $ "The type " ++ runProperName nm ++ " conflicts with a type class declaration of the same name."
+      line $ "Type " ++ runProperName nm ++ " conflicts with a type class declaration with the same name."
     renderSimpleErrorMessage (CtorConflictsWithClass nm) =
-      line $ "The data constructor " ++ runProperName nm ++ " conflicts with a type class declaration of the same name."
+      line $ "Data constructor " ++ runProperName nm ++ " conflicts with a type class declaration with the same name."
     renderSimpleErrorMessage (ClassConflictsWithType nm) =
-      line $ "The type class " ++ runProperName nm ++ " conflicts with a type declaration of the same name."
+      line $ "Type class " ++ runProperName nm ++ " conflicts with a type declaration with the same name."
     renderSimpleErrorMessage (ClassConflictsWithCtor nm) =
-      line $ "The type class " ++ runProperName nm ++ " conflicts with a data constructor declaration of the same name."
+      line $ "Type class " ++ runProperName nm ++ " conflicts with a data constructor declaration with the same name."
     renderSimpleErrorMessage (DuplicateModuleName mn) =
-      line $ "The module " ++ runModuleName mn ++ " has been defined multiple times."
+      line $ "Module " ++ runModuleName mn ++ " has been defined multiple times."
     renderSimpleErrorMessage (DuplicateClassExport nm) =
       line $ "Duplicate export declaration for type class " ++ runProperName nm
     renderSimpleErrorMessage (DuplicateValueExport nm) =
@@ -510,20 +510,22 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
     renderSimpleErrorMessage (CycleInDeclaration nm) =
       line $ "The value of " ++ showIdent nm ++ " is undefined here, so this reference is not allowed."
     renderSimpleErrorMessage (CycleInModules mns) =
-      line $ "There is a cycle in the module dependencies: " ++ intercalate ", " (map runModuleName mns)
+      paras [ line $ "There is a cycle in module dependencies in these modules: "
+            , indent $ paras (map (line . runModuleName) mns)
+            ]
     renderSimpleErrorMessage (CycleInTypeSynonym name) =
       paras [ line $ case name of
-                       Just pn -> "A cycle appears in the definition of the type synonym " ++ runProperName pn
+                       Just pn -> "A cycle appears in the definition of type synonym " ++ runProperName pn
                        Nothing -> "A cycle appears in a set of type synonym definitions."
             , line "Cycles are disallowed because they can lead to loops in the type checker."
             , line "Consider using a 'newtype' instead."
             ]
     renderSimpleErrorMessage (NameIsUndefined ident) =
-      line $ "The value " ++ showIdent ident ++ " is undefined."
+      line $ "Value " ++ showIdent ident ++ " is undefined."
     renderSimpleErrorMessage (UndefinedTypeVariable name) =
-      line $ "The type variable " ++ runProperName name ++ " is undefined."
+      line $ "Type variable " ++ runProperName name ++ " is undefined."
     renderSimpleErrorMessage (PartiallyAppliedSynonym name) =
-      paras [ line $ "The type synonym " ++ showQualified runProperName name ++ " is partially applied."
+      paras [ line $ "Type synonym " ++ showQualified runProperName name ++ " is partially applied."
             , line "Type synonyms must be applied to all of their type arguments."
             ]
     renderSimpleErrorMessage (EscapedSkolem binding) =
@@ -544,7 +546,7 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
             , indent $ line $ prettyPrintKind k2
             ]
     renderSimpleErrorMessage (ConstrainedTypeUnified t1 t2) =
-      paras [ line "Could not match the constrained type"
+      paras [ line "Could not match constrained type"
             , indent $ typeAsBox t1
             , line "with type"
             , indent $ typeAsBox t2
@@ -567,7 +569,7 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
                                            ]
             ]
     renderSimpleErrorMessage (PossiblyInfiniteInstance nm ts) =
-      paras [ line "The type class instance for"
+      paras [ line "Type class instance for"
             , indent $ Box.hsep 1 Box.left [ line (showQualified runProperName nm)
                                            , Box.vcat Box.left (map typeAtomAsBox ts)
                                            ]
@@ -582,12 +584,12 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
     renderSimpleErrorMessage (CannotFindDerivingType nm) =
       line $ "Cannot derive a type class instance, because the type declaration for " ++ runProperName nm ++ " could not be found."
     renderSimpleErrorMessage (DuplicateLabel l expr) =
-      paras $ [ line $ "The label " ++ show l ++ " appears more than once in a row type." ]
+      paras $ [ line $ "Label " ++ show l ++ " appears more than once in a row type." ]
                        <> foldMap (\expr' -> [ line "Relevant expression: "
                                              , indent $ prettyPrintValue expr'
                                              ]) expr
     renderSimpleErrorMessage (DuplicateTypeArgument name) =
-      line $ "The type argument " ++ show name ++ " appears more than once."
+      line $ "Type argument " ++ show name ++ " appears more than once."
     renderSimpleErrorMessage (DuplicateValueDeclaration nm) =
       line $ "Multiple value declarations exist for " ++ showIdent nm ++ "."
     renderSimpleErrorMessage (ArgListLengthsDiffer ident) =
@@ -595,7 +597,7 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
     renderSimpleErrorMessage (OverlappingArgNames ident) =
       line $ "Overlapping names in function/binder" ++ foldMap ((" in declaration" ++) . showIdent) ident
     renderSimpleErrorMessage (MissingClassMember ident) =
-      line $ "The type class member " ++ showIdent ident ++ " has not been implemented."
+      line $ "Type class member " ++ showIdent ident ++ " has not been implemented."
     renderSimpleErrorMessage (ExtraneousClassMember ident className) =
       line $ showIdent ident ++ " is not a member of type class " ++ showQualified runProperName className
     renderSimpleErrorMessage (ExpectedType ty kind) =
@@ -607,17 +609,17 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
             , line "instead."
             ]
     renderSimpleErrorMessage (IncorrectConstructorArity nm) =
-      line $ "The data constructor " ++ showQualified runProperName nm ++ " was given the wrong number of arguments in a case expression."
+      line $ "Data constructor " ++ showQualified runProperName nm ++ " was given the wrong number of arguments in a case expression."
     renderSimpleErrorMessage (ExprDoesNotHaveType expr ty) =
-      paras [ line "The expression"
+      paras [ line "Expression"
             , indent $ prettyPrintValue expr
             , line "does not have type"
             , indent $ typeAsBox ty
             ]
     renderSimpleErrorMessage (PropertyIsMissing prop row) =
-      paras [ line "The row type"
+      paras [ line "Row type"
             , indent $ prettyPrintRowWith '(' ')' row
-            , line $ "lacks the required label " ++ show prop
+            , line $ "lacks required label " ++ show prop
             ]
     renderSimpleErrorMessage (CannotApplyFunction fn arg) =
       paras [ line "A function of type"
@@ -628,7 +630,7 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
     renderSimpleErrorMessage TypeSynonymInstance =
       line "Type class instances for type synonyms are disallowed."
     renderSimpleErrorMessage (OrphanInstance nm cnm ts) =
-      paras [ line $ "The type class instance " ++ showIdent nm ++ " for "
+      paras [ line $ "Type class instance " ++ showIdent nm ++ " for "
             , indent $ Box.hsep 1 Box.left [ line (showQualified runProperName cnm)
                                            , Box.vcat Box.left (map typeAtomAsBox ts)
                                            ]
@@ -637,11 +639,11 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
             , line "Consider moving the instance, if possible, or using a newtype wrapper."
             ]
     renderSimpleErrorMessage (InvalidNewtype name) =
-      paras [ line $ "The newtype " ++ runProperName name ++ " is invalid."
+      paras [ line $ "Newtype " ++ runProperName name ++ " is invalid."
             , line "Newtypes must define a single constructor with a single argument."
             ]
     renderSimpleErrorMessage (InvalidInstanceHead ty) =
-      paras [ line "Type class instance head is invalid due to the use of the type"
+      paras [ line "Type class instance head is invalid due to use of type"
             , indent $ typeAsBox ty
             , line "All types appearing in instance declarations must be of the form T a_1 .. a_n, where each type a_i is of the same form."
             ]
@@ -649,13 +651,13 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
       paras $ line ("An export for " ++ prettyPrintExport x ++ " requires the following to also be exported: ")
               : map (line . prettyPrintExport) ys
     renderSimpleErrorMessage (ShadowedName nm) =
-      line $ "The name '" ++ showIdent nm ++ "' was shadowed."
+      line $ "Name '" ++ showIdent nm ++ "' was shadowed."
     renderSimpleErrorMessage (ShadowedTypeVar tv) =
-      line $ "The type variable '" ++ tv ++ "' was shadowed."
+      line $ "Type variable '" ++ tv ++ "' was shadowed."
     renderSimpleErrorMessage (UnusedTypeVar tv) =
-      line $ "The type variable '" ++ tv ++ "' was declared but not used."
+      line $ "Type variable '" ++ tv ++ "' was declared but not used."
     renderSimpleErrorMessage (ClassOperator className opName) =
-      paras [ line $ "The type class '" ++ runProperName className ++ "' declares operator " ++ showIdent opName ++ "."
+      paras [ line $ "Type class '" ++ runProperName className ++ "' declares operator " ++ showIdent opName ++ "."
             , line "This may be disallowed in the future - consider declaring a named member in the class and making the operator an alias:"
             , indent . line $ showIdent opName ++ " = someMember"
             ]
@@ -666,7 +668,7 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
             , line $ "An attempt was made to hide the import of " ++ runModuleName name
             ]
     renderSimpleErrorMessage (WildcardInferredType ty) =
-      paras [ line "The wildcard type definition has the inferred type "
+      paras [ line "Wildcard type definition has the inferred type "
             , indent $ typeAsBox ty
             ]
     renderSimpleErrorMessage (MissingTypeDeclaration ident) =
@@ -695,9 +697,9 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
     renderHint (NotYetDefined names) =
       line $ "The following are not yet defined here: " ++ intercalate ", " (map showIdent names) ++ ":"
     renderHint (ErrorUnifyingTypes t1 t2) =
-      paras [ lineWithLevel "while trying to match the type "
+      paras [ lineWithLevel "while trying to match type "
             , indent $ typeAsBox t1
-            , line "with the type"
+            , line "with type"
             , indent $ typeAsBox t2
             ]
     renderHint (ErrorInExpression expr) =
@@ -708,9 +710,9 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
       paras [ lineWithLevel $ "in module " ++ runModuleName mn ++ ":"
             ]
     renderHint (ErrorInSubsumption t1 t2) =
-      paras [ lineWithLevel "checking that the type"
+      paras [ lineWithLevel "checking that type"
             , indent $ typeAsBox t1
-            , line "is at least as general as the type"
+            , line "is at least as general as type"
             , indent $ typeAsBox t2
             ]
     renderHint (ErrorInInstance nm ts) =
@@ -720,17 +722,17 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
                                            ]
             ]
     renderHint (ErrorCheckingKind ty) =
-      paras [ lineWithLevel "checking the kind of the type"
+      paras [ lineWithLevel "checking kind of type"
             , indent $ typeAsBox ty
             ]
     renderHint (ErrorInferringType expr) =
-      paras [ lineWithLevel "inferring the type of the expression"
+      paras [ lineWithLevel "inferring type of expression"
             , indent $ prettyPrintValue expr
             ]
     renderHint (ErrorCheckingType expr ty) =
-      paras [ lineWithLevel "checking that the expression"
+      paras [ lineWithLevel "checking that expression"
             , indent $ prettyPrintValue expr
-            , line "has the type"
+            , line "has type"
             , indent $ typeAsBox ty
             ]
     renderHint (ErrorInApplication f t a) =
@@ -738,7 +740,7 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage . positionHintsFir
             , indent $ prettyPrintValue f
             , line "of type"
             , indent $ typeAsBox t
-            , line "to the argument"
+            , line "to argument"
             , indent $ prettyPrintValue a
             ]
     renderHint (ErrorInDataConstructor nm) =

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -38,6 +38,7 @@ import Data.Aeson.TH
 
 import qualified Data.Map as M
 
+import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Environment
 import Language.PureScript.Names
@@ -152,7 +153,7 @@ applyExternsFileToEnvironment ExternsFile{..} = flip (foldl' applyDecl) efDeclar
 
 -- | Generate an externs file for all declarations in a module
 moduleToExternsFile :: Module -> Environment -> ExternsFile
-moduleToExternsFile (Module _ _ _ _ Nothing) _ = error "moduleToExternsFile: module exports were not elaborated"
+moduleToExternsFile (Module _ _ _ _ Nothing) _ = internalError "moduleToExternsFile: module exports were not elaborated"
 moduleToExternsFile (Module _ _ mn ds (Just exps)) env = ExternsFile{..}
   where
   efVersion       = showVersion Paths.version
@@ -181,7 +182,7 @@ moduleToExternsFile (Module _ _ mn ds (Just exps)) env = ExternsFile{..}
   toExternsDeclaration (PositionedDeclarationRef _ _ r) = toExternsDeclaration r
   toExternsDeclaration (TypeRef pn dctors) =
     case Qualified (Just mn) pn `M.lookup` types env of
-      Nothing -> error "toExternsDeclaration: no kind in toExternsDeclaration"
+      Nothing -> internalError "toExternsDeclaration: no kind in toExternsDeclaration"
       Just (kind, TypeSynonym)
         | Just (args, synTy) <- Qualified (Just mn) pn `M.lookup` typeSynonyms env -> [ EDType pn kind TypeSynonym, EDTypeSynonym pn args synTy ]
       Just (kind, ExternData) -> [ EDType pn kind ExternData ]
@@ -190,7 +191,7 @@ moduleToExternsFile (Module _ _ mn ds (Just exps)) env = ExternsFile{..}
                             | dctor <- fromMaybe (map fst tys) dctors
                             , (dty, _, ty, args) <- maybeToList (M.lookup (Qualified (Just mn) dctor) (dataConstructors env))
                             ]
-      _ -> error "toExternsDeclaration: Invalid input"
+      _ -> internalError "toExternsDeclaration: Invalid input"
   toExternsDeclaration (ValueRef ident)
     | Just (ty, _, _) <- (mn, ident) `M.lookup` names env
     = [ EDValue ident ty ]

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -30,6 +30,7 @@ import Control.Applicative
 #endif
 import Control.Monad.Writer.Class
 
+import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Names
 import Language.PureScript.Errors
@@ -50,7 +51,7 @@ lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDecl
   getDeclIdent (ValueDeclaration ident _ _ _) = Just ident
   getDeclIdent (ExternDeclaration ident _) = Just ident
   getDeclIdent (TypeInstanceDeclaration ident _ _ _ _) = Just ident
-  getDeclIdent (BindingGroupDeclaration _) = error "lint: binding groups should not be desugared yet."
+  getDeclIdent (BindingGroupDeclaration _) = internalError "lint: binding groups should not be desugared yet."
   getDeclIdent _ = Nothing
 
   lintDeclaration :: Declaration -> m ()

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -38,6 +38,7 @@ import Control.Applicative
 import Control.Arrow (first, second)
 import Control.Monad.Writer.Class
 
+import Language.PureScript.Crash
 import Language.PureScript.AST.Binders
 import Language.PureScript.AST.Declarations
 import Language.PureScript.Environment
@@ -92,7 +93,7 @@ getConstructors env defmn n = extractConstructors lnte
 
   extractConstructors :: Maybe (Kind, TypeKind) -> [(ProperName, [Type])]
   extractConstructors (Just (_, DataType _ pt)) = pt
-  extractConstructors _ = error "Data name not in the scope of the current environment in extractConstructors"
+  extractConstructors _ = internalError "Data name not in the scope of the current environment in extractConstructors"
 
 -- |
 -- Replicates a wildcard binder
@@ -197,7 +198,7 @@ missingCasesMultiple env mn = go
     where
     (miss1, pr1) = missingCasesSingle env mn x y
     (miss2, pr2) = go xs ys
-  go _ _ = error "Argument lengths did not match in missingCasesMultiple."
+  go _ _ = internalError "Argument lengths did not match in missingCasesMultiple."
 
 -- |
 -- Guard handling

--- a/src/Language/PureScript/ModuleDependencies.hs
+++ b/src/Language/PureScript/ModuleDependencies.hs
@@ -25,6 +25,7 @@ import Data.Graph
 import Data.List (nub)
 import Data.Maybe (fromMaybe, mapMaybe)
 
+import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Names
 import Language.PureScript.Types
@@ -43,7 +44,7 @@ sortModules ms = do
   ms' <- mapM toModule $ stronglyConnComp verts
   let (graph, fromVertex, toVertex) = graphFromEdges verts
       moduleGraph = do (_, mn, _) <- verts
-                       let v       = fromMaybe (error "sortModules: vertex not found") (toVertex mn)
+                       let v       = fromMaybe (internalError "sortModules: vertex not found") (toVertex mn)
                            deps    = reachable graph v
                            toKey i = case fromVertex i of (_, key, _) -> key
                        return (mn, filter (/= mn) (map toKey deps))

--- a/src/Language/PureScript/Pretty/JS.hs
+++ b/src/Language/PureScript/Pretty/JS.hs
@@ -30,6 +30,7 @@ import Control.Monad.State
 import Control.PatternArrows
 import qualified Control.Arrow as A
 
+import Language.PureScript.Crash
 import Language.PureScript.CodeGen.JS.AST
 import Language.PureScript.CodeGen.JS.Common
 import Language.PureScript.Pretty.Common
@@ -251,13 +252,13 @@ prettyStatements sts = do
 -- Generate a pretty-printed string representing a Javascript expression
 --
 prettyPrintJS1 :: JS -> String
-prettyPrintJS1 = fromMaybe (error "Incomplete pattern") . flip evalStateT (PrinterState 0) . prettyPrintJS'
+prettyPrintJS1 = fromMaybe (internalError "Incomplete pattern") . flip evalStateT (PrinterState 0) . prettyPrintJS'
 
 -- |
 -- Generate a pretty-printed string representing a collection of Javascript expressions at the same indentation level
 --
 prettyPrintJS :: [JS] -> String
-prettyPrintJS = fromMaybe (error "Incomplete pattern") . flip evalStateT (PrinterState 0) . prettyStatements
+prettyPrintJS = fromMaybe (internalError "Incomplete pattern") . flip evalStateT (PrinterState 0) . prettyStatements
 
 -- |
 -- Generate an indented, pretty-printed string representing a Javascript expression

--- a/src/Language/PureScript/Pretty/Kinds.hs
+++ b/src/Language/PureScript/Pretty/Kinds.hs
@@ -22,6 +22,7 @@ import Data.Maybe (fromMaybe)
 import Control.Arrow (ArrowPlus(..))
 import Control.PatternArrows
 
+import Language.PureScript.Crash
 import Language.PureScript.Kinds
 import Language.PureScript.Pretty.Common
 
@@ -47,7 +48,7 @@ funKind = mkPattern match
 
 -- | Generate a pretty-printed string representing a Kind
 prettyPrintKind :: Kind -> String
-prettyPrintKind = fromMaybe (error "Incomplete pattern") . pattern matchKind ()
+prettyPrintKind = fromMaybe (internalError "Incomplete pattern") . pattern matchKind ()
   where
   matchKind :: Pattern () Kind String
   matchKind = buildPrettyPrinter operators (typeLiterals <+> fmap parens matchKind)

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -27,6 +27,7 @@ import Data.Maybe (fromMaybe)
 import Control.Arrow ((<+>))
 import Control.PatternArrows
 
+import Language.PureScript.Crash
 import Language.PureScript.Types
 import Language.PureScript.Names
 import Language.PureScript.Kinds
@@ -136,14 +137,14 @@ forall_ = mkPattern match
   match _ = Nothing
 
 typeAtomAsBox :: Type -> Box
-typeAtomAsBox = fromMaybe (error "Incomplete pattern") . pattern matchTypeAtom () . insertPlaceholders
+typeAtomAsBox = fromMaybe (internalError "Incomplete pattern") . pattern matchTypeAtom () . insertPlaceholders
 
 -- | Generate a pretty-printed string representing a Type, as it should appear inside parentheses
 prettyPrintTypeAtom :: Type -> String
 prettyPrintTypeAtom = render . typeAtomAsBox
 
 typeAsBox :: Type -> Box
-typeAsBox = fromMaybe (error "Incomplete pattern") . pattern matchType () . insertPlaceholders
+typeAsBox = fromMaybe (internalError "Incomplete pattern") . pattern matchType () . insertPlaceholders
 
 -- | Generate a pretty-printed string representing a Type
 prettyPrintType :: Type -> String

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -25,6 +25,7 @@ import Data.List (intercalate)
 
 import Control.Arrow (second)
 
+import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Names
 import Language.PureScript.Pretty.Common
@@ -103,7 +104,7 @@ prettyPrintDeclaration (BindingGroupDeclaration ds) =
   where
   toDecl (nm, t, e) = ValueDeclaration nm t [] (Right e)
 prettyPrintDeclaration (PositionedDeclaration _ _ d) = prettyPrintDeclaration d
-prettyPrintDeclaration _ = error "Invalid argument to prettyPrintDeclaration"
+prettyPrintDeclaration _ = internalError "Invalid argument to prettyPrintDeclaration"
 
 prettyPrintCaseAlternative :: CaseAlternative -> Box
 prettyPrintCaseAlternative (CaseAlternative binders result) =

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -35,6 +35,7 @@ import Control.Monad.Error.Class (MonadError(..))
 
 import qualified Data.Set as S
 
+import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Names
 import Language.PureScript.Types
@@ -145,13 +146,13 @@ usedProperNames moduleName =
 getIdent :: Declaration -> Ident
 getIdent (ValueDeclaration ident _ _ _) = ident
 getIdent (PositionedDeclaration _ _ d) = getIdent d
-getIdent _ = error "Expected ValueDeclaration"
+getIdent _ = internalError "Expected ValueDeclaration"
 
 getProperName :: Declaration -> ProperName
 getProperName (DataDeclaration _ pn _ _) = pn
 getProperName (TypeSynonymDeclaration pn _ _) = pn
 getProperName (PositionedDeclaration _ _ d) = getProperName d
-getProperName _ = error "Expected DataDeclaration"
+getProperName _ = internalError "Expected DataDeclaration"
 
 -- |
 -- Convert a group of mutually-recursive dependencies into a BindingGroupDeclaration (or simple ValueDeclaration).
@@ -185,7 +186,7 @@ toBindingGroup moduleName (CyclicSCC ds') =
   cycleError (PositionedDeclaration p _ d) ds = rethrowWithPosition p $ cycleError d ds
   cycleError (ValueDeclaration n _ _ (Right _)) [] = throwError . errorMessage $ CycleInDeclaration n
   cycleError d ds@(_:_) = rethrow (addHint (NotYetDefined (map getIdent ds))) $ cycleError d []
-  cycleError _ _ = error "Expected ValueDeclaration"
+  cycleError _ _ = internalError "Expected ValueDeclaration"
 
 toDataBindingGroup :: (MonadError MultipleErrors m) => SCC Declaration -> m Declaration
 toDataBindingGroup (AcyclicSCC d) = return d
@@ -203,6 +204,6 @@ isTypeSynonym _ = Nothing
 
 fromValueDecl :: Declaration -> (Ident, NameKind, Expr)
 fromValueDecl (ValueDeclaration ident nameKind [] (Right val)) = (ident, nameKind, val)
-fromValueDecl ValueDeclaration{} = error "Binders should have been desugared"
+fromValueDecl ValueDeclaration{} = internalError "Binders should have been desugared"
 fromValueDecl (PositionedDeclaration _ _ d) = fromValueDecl d
-fromValueDecl _ = error "Expected ValueDeclaration"
+fromValueDecl _ = internalError "Expected ValueDeclaration"

--- a/src/Language/PureScript/Sugar/CaseDeclarations.hs
+++ b/src/Language/PureScript/Sugar/CaseDeclarations.hs
@@ -23,6 +23,7 @@ module Language.PureScript.Sugar.CaseDeclarations (
     desugarCasesModule
 ) where
 
+import Language.PureScript.Crash
 import Data.Maybe (catMaybes)
 import Data.List (nub, groupBy)
 
@@ -112,7 +113,7 @@ toDecls [ValueDeclaration ident nameKind bs (Right val)] | all isVarBinder bs = 
   fromVarBinder (VarBinder name) = return name
   fromVarBinder (PositionedBinder _ _ b) = fromVarBinder b
   fromVarBinder (TypedBinder _ b) = fromVarBinder b
-  fromVarBinder _ = error "fromVarBinder: Invalid argument"
+  fromVarBinder _ = internalError "fromVarBinder: Invalid argument"
 toDecls ds@(ValueDeclaration ident _ bs result : _) = do
   let tuples = map toTuple ds
   unless (all ((== length bs) . length . fst) tuples) $
@@ -129,7 +130,7 @@ toDecls ds = return ds
 toTuple :: Declaration -> ([Binder], Either [(Guard, Expr)] Expr)
 toTuple (ValueDeclaration _ _ bs result) = (bs, result)
 toTuple (PositionedDeclaration _ _ d) = toTuple d
-toTuple _ = error "Not a value declaration"
+toTuple _ = internalError "Not a value declaration"
 
 makeCaseDeclaration :: forall m. (Functor m, Applicative m, MonadSupply m, MonadError MultipleErrors m) => Ident -> [([Binder], Either [(Guard, Expr)] Expr)] -> m Declaration
 makeCaseDeclaration ident alternatives = do

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -22,6 +22,7 @@ module Language.PureScript.Sugar.DoNotation (
     desugarDoModule
 ) where
 
+import Language.PureScript.Crash
 import Language.PureScript.Names
 import Language.PureScript.AST
 import Language.PureScript.Errors
@@ -56,7 +57,7 @@ desugarDo d =
   replace other = return other
 
   go :: [DoNotationElement] -> m Expr
-  go [] = error "The impossible happened in desugarDo"
+  go [] = internalError "The impossible happened in desugarDo"
   go [DoNotationValue val] = return val
   go (DoNotationValue val : rest) = do
     rest' <- go rest

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -30,6 +30,7 @@ import Control.Monad.Writer (MonadWriter(..))
 
 import qualified Data.Map as M
 
+import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Names
 import Language.PureScript.Types
@@ -99,7 +100,7 @@ desugarImports externs modules = do
   renameInModule' :: Env -> Module -> m Module
   renameInModule' env m@(Module _ _ mn _ _) =
     rethrow (addHint (ErrorInModule mn)) $ do
-      let (_, imps, exps) = fromMaybe (error "Module is missing in renameInModule'") $ M.lookup mn env
+      let (_, imps, exps) = fromMaybe (internalError "Module is missing in renameInModule'") $ M.lookup mn env
       elaborateImports imps <$> renameInModule env imps (elaborateExports exps m)
 
 -- |

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -29,6 +29,7 @@ module Language.PureScript.Sugar.Operators (
   desugarOperatorSections
 ) where
 
+import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Errors
 import Language.PureScript.Names
@@ -93,7 +94,7 @@ collectFixities (Module _ _ moduleName ds _) = concatMap collect ds
   where
   collect :: Declaration -> [(Qualified Ident, SourceSpan, Fixity)]
   collect (PositionedDeclaration pos _ (FixityDeclaration fixity name)) = [(Qualified (Just moduleName) (Op name), pos, fixity)]
-  collect FixityDeclaration{} = error "Fixity without srcpos info"
+  collect FixityDeclaration{} = internalError "Fixity without srcpos info"
   collect _ = []
 
 ensureNoDuplicates :: (MonadError MultipleErrors m) => [(Qualified Ident, SourceSpan)] -> m ()
@@ -129,7 +130,7 @@ matchOperators ops = parseChains
   extendChain (BinaryNoParens op l r) = Left l : Right op : extendChain r
   extendChain other = [Left other]
   bracketChain :: Chain -> m Expr
-  bracketChain = either (\_ -> error "matchOperators: cannot reorder operators") return . P.parse (P.buildExpressionParser opTable parseValue <* P.eof) "operator expression"
+  bracketChain = either (\_ -> internalError "matchOperators: cannot reorder operators") return . P.parse (P.buildExpressionParser opTable parseValue <* P.eof) "operator expression"
   opTable = [P.Infix (P.try (parseTicks >>= \op -> return (\t1 t2 -> App (App op t1) t2))) P.AssocLeft]
             : map (map (\(name, f, a) -> P.Infix (P.try (matchOp name) >> return f) (toAssoc a))) ops
             ++ [[ P.Infix (P.try (parseOp >>= \ident -> return (\t1 t2 -> App (App (Var ident) t1) t2))) P.AssocLeft ]]

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -129,7 +129,7 @@ matchOperators ops = parseChains
   extendChain (BinaryNoParens op l r) = Left l : Right op : extendChain r
   extendChain other = [Left other]
   bracketChain :: Chain -> m Expr
-  bracketChain = either (const . throwError . errorMessage $ CannotReorderOperators) return . P.parse (P.buildExpressionParser opTable parseValue <* P.eof) "operator expression"
+  bracketChain = either (\_ -> error "matchOperators: cannot reorder operators") return . P.parse (P.buildExpressionParser opTable parseValue <* P.eof) "operator expression"
   opTable = [P.Infix (P.try (parseTicks >>= \op -> return (\t1 t2 -> App (App op t1) t2))) P.AssocLeft]
             : map (map (\(name, f, a) -> P.Infix (P.try (matchOp name) >> return f) (toAssoc a))) ops
             ++ [[ P.Infix (P.try (parseOp >>= \ident -> return (\t1 t2 -> App (App (Var ident) t1) t2))) P.AssocLeft ]]

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -24,6 +24,7 @@ module Language.PureScript.Sugar.TypeClasses
   , superClassDictionaryNames
   ) where
 
+import Language.PureScript.Crash
 import Language.PureScript.AST hiding (isExported)
 import Language.PureScript.Environment
 import Language.PureScript.Errors
@@ -75,7 +76,7 @@ desugarModule (Module ss coms name decls (Just exps)) = do
     | isTypeClassDeclaration d1 && not (isTypeClassDeclaration d2) = LT
     | not (isTypeClassDeclaration d1) && isTypeClassDeclaration d2 = GT
     | otherwise = EQ
-desugarModule _ = error "Exports should have been elaborated in name desugaring"
+desugarModule _ = internalError "Exports should have been elaborated in name desugaring"
 
 {- Desugar type class and type class instance declarations
 --
@@ -177,7 +178,7 @@ desugarDecl mn exps = go
   go d@(TypeClassDeclaration name args implies members) = do
     modify (M.insert (mn, name) (args, implies, members))
     return (Nothing, d : typeClassDictionaryDeclaration name args implies members : map (typeClassMemberToDictionaryAccessor mn name args) members)
-  go (TypeInstanceDeclaration _ _ _ _ DerivedInstance) = error "Derived instanced should have been desugared"
+  go (TypeInstanceDeclaration _ _ _ _ DerivedInstance) = internalError "Derived instanced should have been desugared"
   go d@(TypeInstanceDeclaration name deps className tys (ExplicitInstance members)) = do
     desugared <- desugarCases members
     dictDecl <- typeInstanceDictionaryDeclaration name mn deps className tys desugared
@@ -200,7 +201,7 @@ desugarDecl mn exps = go
 
   isExported :: (ProperName -> [DeclarationRef] -> Bool) -> Qualified ProperName -> Bool
   isExported test (Qualified (Just mn') pn) = mn /= mn' || test pn exps
-  isExported _ _ = error "Names should have been qualified in name desugaring"
+  isExported _ _ = internalError "Names should have been qualified in name desugaring"
 
   matchesTypeRef :: ProperName -> DeclarationRef -> Bool
   matchesTypeRef pn (TypeRef pn' _) = pn == pn'
@@ -216,7 +217,7 @@ desugarDecl mn exps = go
 memberToNameAndType :: Declaration -> (Ident, Type)
 memberToNameAndType (TypeDeclaration ident ty) = (ident, ty)
 memberToNameAndType (PositionedDeclaration _ _ d) = memberToNameAndType d
-memberToNameAndType _ = error "Invalid declaration in type class definition"
+memberToNameAndType _ = internalError "Invalid declaration in type class definition"
 
 typeClassDictionaryDeclaration :: ProperName -> [(String, Maybe Kind)] -> [Constraint] -> [Declaration] -> Declaration
 typeClassDictionaryDeclaration name args implies members =
@@ -236,7 +237,7 @@ typeClassMemberToDictionaryAccessor mn name args (TypeDeclaration ident ty) =
       moveQuantifiersToFront (quantify (ConstrainedType [(className, map (TypeVar . fst) args)] ty))
 typeClassMemberToDictionaryAccessor mn name args (PositionedDeclaration pos com d) =
   PositionedDeclaration pos com $ typeClassMemberToDictionaryAccessor mn name args d
-typeClassMemberToDictionaryAccessor _ _ _ _ = error "Invalid declaration in type class definition"
+typeClassMemberToDictionaryAccessor _ _ _ _ = internalError "Invalid declaration in type class definition"
 
 unit :: Type
 unit = TypeApp tyObject REmpty
@@ -294,13 +295,13 @@ typeInstanceDictionaryDeclaration name mn deps className tys decls =
   memberToValue tys' (PositionedDeclaration pos com d) = rethrowWithPosition pos $ do
     val <- memberToValue tys' d
     return (PositionedValue pos com val)
-  memberToValue _ _ = error "Invalid declaration in type instance definition"
+  memberToValue _ _ = internalError "Invalid declaration in type instance definition"
 
 typeClassMemberName :: Declaration -> String
 typeClassMemberName (TypeDeclaration ident _) = runIdent ident
 typeClassMemberName (ValueDeclaration ident _ _ _) = runIdent ident
 typeClassMemberName (PositionedDeclaration _ _ d) = typeClassMemberName d
-typeClassMemberName _ = error "typeClassMemberName: Invalid declaration in type class definition"
+typeClassMemberName _ = internalError "typeClassMemberName: Invalid declaration in type class definition"
 
 superClassDictionaryNames :: [Constraint] -> [String]
 superClassDictionaryNames supers =

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -289,7 +289,7 @@ typeInstanceDictionaryDeclaration name mn deps className tys decls =
 
   memberToValue :: (Functor m, Applicative m, MonadSupply m, MonadError MultipleErrors m) => [(Ident, Type)] -> Declaration -> Desugar m Expr
   memberToValue tys' (ValueDeclaration ident _ [] (Right val)) = do
-    _ <- maybe (throwError . errorMessage $ ExtraneousClassMember ident) return $ lookup ident tys'
+    _ <- maybe (throwError . errorMessage $ ExtraneousClassMember ident className) return $ lookup ident tys'
     return val
   memberToValue tys' (PositionedDeclaration pos com d) = rethrowWithPosition pos $ do
     val <- memberToValue tys' d

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -36,6 +36,7 @@ import Control.Monad (replicateM)
 import Control.Monad.Supply.Class (MonadSupply, freshName)
 import Control.Monad.Error.Class (MonadError(..))
 
+import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Environment
 import Language.PureScript.Errors
@@ -116,7 +117,7 @@ mkSpineFunction mn (DataDeclaration _ _ _ args) = lamCase "$x" <$> mapM mkCtorCl
           $ decomposeRec rec
   toSpineFun i _ = lamNull $ App (mkGenVar C.toSpine) i
 mkSpineFunction mn (PositionedDeclaration _ _ d) = mkSpineFunction mn d
-mkSpineFunction _ _ = error "mkSpineFunction: expected DataDeclaration"
+mkSpineFunction _ _ = internalError "mkSpineFunction: expected DataDeclaration"
 
 mkSignatureFunction :: ModuleName -> Declaration -> Expr
 mkSignatureFunction _ (DataDeclaration _ _ _ args) = lamNull . mkSigProd $ map mkProdClause args
@@ -145,7 +146,7 @@ mkSignatureFunction _ (DataDeclaration _ _ _ args) = lamNull . mkSigProd $ map m
   mkProductSignature typ = lamNull $ App (mkGenVar C.toSignature)
                            (TypedValue False (mkGenVar "anyProxy") (proxy typ))
 mkSignatureFunction mn (PositionedDeclaration _ _ d) = mkSignatureFunction mn d
-mkSignatureFunction _ _ = error "mkSignatureFunction: expected DataDeclaration"
+mkSignatureFunction _ _ = internalError "mkSignatureFunction: expected DataDeclaration"
 
 mkFromSpineFunction :: forall m. (Functor m, MonadSupply m) => ModuleName -> Declaration -> m Expr
 mkFromSpineFunction mn (DataDeclaration _ _ _ args) = lamCase "$x" <$> (addCatch <$> mapM mkAlternative args)
@@ -194,7 +195,7 @@ mkFromSpineFunction mn (DataDeclaration _ _ _ args) = lamCase "$x" <$> (addCatch
   mkRecFun xs = mkJust $ foldr (\s e -> lam s e) recLiteral (map fst xs)
      where recLiteral = ObjectLiteral $ map (\(s,_) -> (s,mkVar s)) xs
 mkFromSpineFunction mn (PositionedDeclaration _ _ d) = mkFromSpineFunction mn d
-mkFromSpineFunction _ _ = error "mkFromSpineFunction: expected DataDeclaration"
+mkFromSpineFunction _ _ = internalError "mkFromSpineFunction: expected DataDeclaration"
 
 -- Helpers
 

--- a/src/Language/PureScript/Sugar/TypeDeclarations.hs
+++ b/src/Language/PureScript/Sugar/TypeDeclarations.hs
@@ -29,6 +29,7 @@ import Control.Monad (forM, when)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Writer.Class (MonadWriter(tell))
 
+import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Names
 import Language.PureScript.Environment
@@ -63,7 +64,7 @@ desugarTypeDeclarationsModule ms = forM ms $ \(Module ss coms name ds exps) ->
     -- At the top level, match a type signature or emit a warning.
     when reqd $ case val of
                   Right TypedValue{} -> return ()
-                  Left _ -> error "desugarTypeDeclarations: cases were not desugared"
+                  Left _ -> internalError "desugarTypeDeclarations: cases were not desugared"
                   _ -> tell (addHint (ErrorInValueDeclaration name) $ errorMessage $ MissingTypeDeclaration name)
     let (_, f, _) = everywhereOnValuesTopDownM return go return
         f' (Left gs) = Left <$> mapM (pairM return f) gs

--- a/src/Language/PureScript/Sugar/TypeDeclarations.hs
+++ b/src/Language/PureScript/Sugar/TypeDeclarations.hs
@@ -28,7 +28,6 @@ import Control.Applicative
 import Control.Monad (forM)
 import Control.Monad.Error.Class (MonadError(..))
 
-import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Names
 import Language.PureScript.Environment

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -35,6 +35,7 @@ import Control.Monad.State
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Writer.Class (tell)
 
+import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Errors
 import Language.PureScript.Names
@@ -53,11 +54,11 @@ entails moduleName context = solve
   where
     forClassName :: Qualified ProperName -> [Type] -> [TypeClassDictionaryInScope]
     forClassName cn@(Qualified (Just mn) _) tys = concatMap (findDicts cn) (Nothing : Just mn : map Just (mapMaybe ctorModules tys))
-    forClassName _ _ = error "forClassName: expected qualified class name"
+    forClassName _ _ = internalError "forClassName: expected qualified class name"
 
     ctorModules :: Type -> Maybe ModuleName
     ctorModules (TypeConstructor (Qualified (Just mn) _)) = Just mn
-    ctorModules (TypeConstructor (Qualified Nothing _)) = error "ctorModules: unqualified type name"
+    ctorModules (TypeConstructor (Qualified Nothing _)) = internalError "ctorModules: unqualified type name"
     ctorModules (TypeApp ty _) = ctorModules ty
     ctorModules _ = Nothing
 

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -40,6 +40,7 @@ import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State
 import Control.Monad.Unify
 
+import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Errors
 import Language.PureScript.Kinds
@@ -220,4 +221,4 @@ infer' other = (, []) <$> go other
     k <- go ty
     k =?= Star
     return Star
-  go _ = error "Invalid argument to infer"
+  go _ = internalError "Invalid argument to infer"

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -153,7 +153,7 @@ checkVisibility :: (e ~ MultipleErrors, Functor m, MonadState CheckState m, Mona
 checkVisibility currentModule name@(Qualified _ var) = do
   vis <- getVisibility currentModule name
   case vis of
-    Undefined -> throwError . errorMessage $ NameNotInScope var
+    Undefined -> throwError . errorMessage $ CycleInDeclaration var
     _ -> return ()
 
 -- |

--- a/src/Language/PureScript/TypeChecker/Skolems.hs
+++ b/src/Language/PureScript/TypeChecker/Skolems.hs
@@ -33,6 +33,7 @@ import Control.Applicative
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Unify
 
+import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Errors
 import Language.PureScript.TypeChecker.Monad
@@ -115,4 +116,4 @@ skolemEscapeCheck root@TypedValue{} =
     where
     go' val@(TypedValue _ _ (ForAll _ _ (Just sco'))) | sco == sco' = First (Just val)
     go' _ = mempty
-skolemEscapeCheck _ = error "Untyped value passed to skolemEscapeCheck"
+skolemEscapeCheck _ = internalError "Untyped value passed to skolemEscapeCheck"

--- a/src/Language/PureScript/TypeChecker/Subsumption.hs
+++ b/src/Language/PureScript/TypeChecker/Subsumption.hs
@@ -50,7 +50,7 @@ subsumes' val ty1 (ForAll ident ty2 sco) =
       sko <- newSkolemConstant
       let sk = skolemize ident sko sco' ty2
       subsumes val ty1 sk
-    Nothing -> throwError . errorMessage $ UnspecifiedSkolemScope
+    Nothing -> error "subsumes: unspecified skolem scope"
 subsumes' val (TypeApp (TypeApp f1 arg1) ret1) (TypeApp (TypeApp f2 arg2) ret2) | f1 == tyFunction && f2 == tyFunction = do
   _ <- subsumes Nothing arg2 arg1
   _ <- subsumes Nothing ret1 ret2

--- a/src/Language/PureScript/TypeChecker/Subsumption.hs
+++ b/src/Language/PureScript/TypeChecker/Subsumption.hs
@@ -22,6 +22,7 @@ import Data.Ord (comparing)
 
 import Control.Monad.Unify
 
+import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Environment
 import Language.PureScript.Errors
@@ -49,7 +50,7 @@ subsumes' val ty1 (ForAll ident ty2 sco) =
       sko <- newSkolemConstant
       let sk = skolemize ident sko sco' ty2
       subsumes val ty1 sk
-    Nothing -> error "subsumes: unspecified skolem scope"
+    Nothing -> internalError "subsumes: unspecified skolem scope"
 subsumes' val (TypeApp (TypeApp f1 arg1) ret1) (TypeApp (TypeApp f2 arg2) ret2) | f1 == tyFunction && f2 == tyFunction = do
   _ <- subsumes Nothing arg2 arg1
   _ <- subsumes Nothing ret1 ret2

--- a/src/Language/PureScript/TypeChecker/Subsumption.hs
+++ b/src/Language/PureScript/TypeChecker/Subsumption.hs
@@ -20,7 +20,6 @@ module Language.PureScript.TypeChecker.Subsumption (
 import Data.List (sortBy)
 import Data.Ord (comparing)
 
-import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Unify
 
 import Language.PureScript.AST

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -51,6 +51,7 @@ import Control.Monad.State
 import Control.Monad.Unify
 import Control.Monad.Error.Class (MonadError(..))
 
+import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Environment
 import Language.PureScript.Errors
@@ -138,7 +139,7 @@ typeForBindingGroupElement :: (Ident, Expr) -> TypeData -> UntypedData -> UnifyT
 typeForBindingGroupElement (ident, val) dict untypedDict = do
   -- Infer the type with the new names in scope
   TypedValue _ val' ty <- bindNames dict $ infer val
-  ty =?= fromMaybe (error "name not found in dictionary") (lookup ident untypedDict)
+  ty =?= fromMaybe (internalError "name not found in dictionary") (lookup ident untypedDict)
   return (ident, (TypedValue True val' ty, ty))
 
 -- |
@@ -189,7 +190,7 @@ instantiatePolyTypeWithUnknowns val (ForAll ident ty _) = do
   instantiatePolyTypeWithUnknowns val ty'
 instantiatePolyTypeWithUnknowns val (ConstrainedType constraints ty) = do
    dicts <- getTypeClassDictionaries
-   (_, ty') <- instantiatePolyTypeWithUnknowns (error "Types under a constraint cannot themselves be constrained") ty
+   (_, ty') <- instantiatePolyTypeWithUnknowns (internalError "Types under a constraint cannot themselves be constrained") ty
    return (foldl App val (map (flip TypeClassDictionary dicts) constraints), ty')
 instantiatePolyTypeWithUnknowns val ty = return (val, ty)
 
@@ -239,7 +240,7 @@ infer' (Abs (Left arg) ret) = do
   withBindingGroupVisible $ bindLocalVariables moduleName [(arg, ty, Defined)] $ do
     body@(TypedValue _ _ bodyTy) <- infer' ret
     return $ TypedValue True (Abs (Left arg) body) $ function ty bodyTy
-infer' (Abs (Right _) _) = error "Binder was not desugared"
+infer' (Abs (Right _) _) = internalError "Binder was not desugared"
 infer' (App f arg) = do
   f'@(TypedValue _ _ ft) <- infer f
   (ret, app) <- checkFunctionApplication f' ft arg Nothing
@@ -284,7 +285,7 @@ infer' (TypedValue checkType val ty) = do
   val' <- if checkType then withScopedTypeVars moduleName args (check val ty') else return val
   return $ TypedValue True val' ty'
 infer' (PositionedValue pos _ val) = warnAndRethrowWithPosition pos $ infer' val
-infer' _ = error "Invalid argument to infer"
+infer' _ = internalError "Invalid argument to infer"
 
 inferLetBinding :: [Declaration] -> [Declaration] -> Expr -> (Expr -> UnifyT Type Check Expr) -> UnifyT Type Check ([Declaration], Expr)
 inferLetBinding seen [] ret j = (,) seen <$> withBindingGroupVisible (j ret)
@@ -315,7 +316,7 @@ inferLetBinding seen (BindingGroupDeclaration ds : rest) ret j = do
 inferLetBinding seen (PositionedDeclaration pos com d : ds) ret j = warnAndRethrowWithPosition pos $ do
   (d' : ds', val') <- inferLetBinding seen (d : ds) ret j
   return (PositionedDeclaration pos com d' : ds', val')
-inferLetBinding _ _ _ _ = error "Invalid argument to inferLetBinding"
+inferLetBinding _ _ _ _ = internalError "Invalid argument to inferLetBinding"
 
 -- |
 -- Infer the types of variables brought into scope by a binder
@@ -332,7 +333,7 @@ inferBinder val (ConstructorBinder ctor binders) = do
   env <- getEnv
   case M.lookup ctor (dataConstructors env) of
     Just (_, _, ty, _) -> do
-      (_, fn) <- instantiatePolyTypeWithUnknowns (error "Data constructor types cannot contain constraints") ty
+      (_, fn) <- instantiatePolyTypeWithUnknowns (internalError "Data constructor types cannot contain constraints") ty
       fn' <- introduceSkolemScope <=< replaceAllTypeSynonyms $ fn
       go binders fn'
         where
@@ -449,7 +450,7 @@ check' val t@(ConstrainedType constraints ty) = do
   newDictionaries :: [(Qualified ProperName, Integer)] -> Qualified Ident -> (Qualified ProperName, [Type]) -> Check [TypeClassDictionaryInScope]
   newDictionaries path name (className, instanceTy) = do
     tcs <- gets (typeClasses . checkEnv)
-    let (args, _, superclasses) = fromMaybe (error "newDictionaries: type class lookup failed") $ M.lookup className tcs
+    let (args, _, superclasses) = fromMaybe (internalError "newDictionaries: type class lookup failed") $ M.lookup className tcs
     supDicts <- join <$> zipWithM (\(supName, supArgs) index ->
                                       newDictionaries ((supName, index) : path)
                                                       name
@@ -484,7 +485,7 @@ check' (Abs (Left arg) ret) ty@(TypeApp (TypeApp t argTy) retTy) = do
   Just moduleName <- checkCurrentModule <$> get
   ret' <- withBindingGroupVisible $ bindLocalVariables moduleName [(arg, argTy, Defined)] $ check ret retTy
   return $ TypedValue True (Abs (Left arg) ret') ty
-check' (Abs (Right _) _) _ = error "Binder was not desugared"
+check' (Abs (Right _) _) _ = internalError "Binder was not desugared"
 check' (App f arg) ret = do
   f'@(TypedValue _ _ ft) <- infer f
   (_, app) <- checkFunctionApplication f' ft arg (Just ret)
@@ -496,7 +497,7 @@ check' v@(Var var) ty = do
   ty' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty
   v' <- subsumes (Just v) repl ty'
   case v' of
-    Nothing -> error "check: unable to check the subsumes relation."
+    Nothing -> internalError "check: unable to check the subsumes relation."
     Just v'' -> return $ TypedValue True v'' ty'
 check' (SuperClassDictionary className tys) _ = do
   {-
@@ -515,7 +516,7 @@ check' (TypedValue checkType val ty1) ty2 = do
   ty2' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty2
   val' <- subsumes (Just val) ty1' ty2'
   case val' of
-    Nothing -> error "check: unable to check the subsumes relation."
+    Nothing -> internalError "check: unable to check the subsumes relation."
     Just _ -> do
       val''' <- if checkType then withScopedTypeVars moduleName args (check val ty2') else return val
       return $ TypedValue checkType val''' ty2'
@@ -557,7 +558,7 @@ check' v@(Constructor c) ty = do
       repl <- introduceSkolemScope <=< replaceAllTypeSynonyms $ ty1
       mv <- subsumes (Just v) repl ty
       case mv of
-        Nothing -> error "check: unable to check the subsumes relation."
+        Nothing -> internalError "check: unable to check the subsumes relation."
         Just v' -> return $ TypedValue True v' ty
 check' (Let ds val) ty = do
   (ds', val') <- inferLetBinding [] ds val (`check` ty)
@@ -572,7 +573,7 @@ check' val ty = do
   TypedValue _ val' ty' <- infer val
   mt <- subsumes (Just val') ty' ty
   case mt of
-    Nothing -> error "check: unable to check the subsumes relation."
+    Nothing -> internalError "check: unable to check the subsumes relation."
     Just v' -> return $ TypedValue True v' ty
 
 -- |

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -496,7 +496,7 @@ check' v@(Var var) ty = do
   ty' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty
   v' <- subsumes (Just v) repl ty'
   case v' of
-    Nothing -> throwError . errorMessage $ SubsumptionCheckFailed
+    Nothing -> error "check: unable to check the subsumes relation."
     Just v'' -> return $ TypedValue True v'' ty'
 check' (SuperClassDictionary className tys) _ = do
   {-
@@ -515,7 +515,7 @@ check' (TypedValue checkType val ty1) ty2 = do
   ty2' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty2
   val' <- subsumes (Just val) ty1' ty2'
   case val' of
-    Nothing -> throwError . errorMessage $ SubsumptionCheckFailed
+    Nothing -> error "check: unable to check the subsumes relation."
     Just _ -> do
       val''' <- if checkType then withScopedTypeVars moduleName args (check val ty2') else return val
       return $ TypedValue checkType val''' ty2'
@@ -557,7 +557,7 @@ check' v@(Constructor c) ty = do
       repl <- introduceSkolemScope <=< replaceAllTypeSynonyms $ ty1
       mv <- subsumes (Just v) repl ty
       case mv of
-        Nothing -> throwError . errorMessage $ SubsumptionCheckFailed
+        Nothing -> error "check: unable to check the subsumes relation."
         Just v' -> return $ TypedValue True v' ty
 check' (Let ds val) ty = do
   (ds', val') <- inferLetBinding [] ds val (`check` ty)
@@ -572,7 +572,7 @@ check' val ty = do
   TypedValue _ val' ty' <- infer val
   mt <- subsumes (Just val') ty' ty
   case mt of
-    Nothing -> throwError . errorMessage $ SubsumptionCheckFailed
+    Nothing -> error "check: unable to check the subsumes relation."
     Just v' -> return $ TypedValue True v' ty
 
 -- |

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -36,6 +36,7 @@ import Control.Monad.Unify
 import Control.Monad.Writer
 import Control.Monad.Error.Class (MonadError(..))
 
+import Language.PureScript.Crash
 import Language.PureScript.Errors
 import Language.PureScript.TypeChecker.Monad
 import Language.PureScript.TypeChecker.Skolems
@@ -74,12 +75,12 @@ unifyTypes t1 t2 = rethrow (addHint (ErrorUnifyingTypes t1 t2)) $
         let sk1 = skolemize ident1 sko sc1' ty1
         let sk2 = skolemize ident2 sko sc2' ty2
         sk1 `unifyTypes` sk2
-      _ -> error "unifyTypes: unspecified skolem scope"
+      _ -> internalError "unifyTypes: unspecified skolem scope"
   unifyTypes' (ForAll ident ty1 (Just sc)) ty2 = do
     sko <- newSkolemConstant
     let sk = skolemize ident sko sc ty1
     sk `unifyTypes` ty2
-  unifyTypes' ForAll{} _ = error "unifyTypes: unspecified skolem scope"
+  unifyTypes' ForAll{} _ = internalError "unifyTypes: unspecified skolem scope"
   unifyTypes' ty f@ForAll{} = f `unifyTypes` ty
   unifyTypes' (TypeVar v1) (TypeVar v2) | v1 == v2 = return ()
   unifyTypes' ty1@(TypeConstructor c1) ty2@(TypeConstructor c2) =

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -74,12 +74,12 @@ unifyTypes t1 t2 = rethrow (addHint (ErrorUnifyingTypes t1 t2)) $
         let sk1 = skolemize ident1 sko sc1' ty1
         let sk2 = skolemize ident2 sko sc2' ty2
         sk1 `unifyTypes` sk2
-      _ -> error "Skolemized type variable was not given a scope"
+      _ -> error "unifyTypes: unspecified skolem scope"
   unifyTypes' (ForAll ident ty1 (Just sc)) ty2 = do
     sko <- newSkolemConstant
     let sk = skolemize ident sko sc ty1
     sk `unifyTypes` ty2
-  unifyTypes' ForAll{} _ = throwError . errorMessage $ UnspecifiedSkolemScope
+  unifyTypes' ForAll{} _ = error "unifyTypes: unspecified skolem scope"
   unifyTypes' ty f@ForAll{} = f `unifyTypes` ty
   unifyTypes' (TypeVar v1) (TypeVar v2) | v1 == v2 = return ()
   unifyTypes' ty1@(TypeConstructor c1) ty2@(TypeConstructor c2) =

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -78,7 +78,7 @@ modulesDir :: FilePath
 modulesDir = ".test_modules" </> "node_modules"
 
 makeActions :: M.Map P.ModuleName FilePath -> P.MakeActions P.Make
-makeActions foreigns = (P.buildMakeActions modulesDir (error "makeActions: input file map was read.") foreigns False)
+makeActions foreigns = (P.buildMakeActions modulesDir (P.internalError "makeActions: input file map was read.") foreigns False)
                          { P.getInputTimestamp = getInputTimestamp
                          , P.getOutputTimestamp = getOutputTimestamp
                          }
@@ -94,7 +94,7 @@ makeActions foreigns = (P.buildMakeActions modulesDir (error "makeActions: input
   getOutputTimestamp mn = do
     let filePath = modulesDir </> P.runModuleName mn
     exists <- liftIO $ doesDirectoryExist filePath
-    return (if exists then Just (error "getOutputTimestamp: read timestamp") else Nothing)
+    return (if exists then Just (P.internalError "getOutputTimestamp: read timestamp") else Nothing)
 
 readInput :: [FilePath] -> IO [(FilePath, String)]
 readInput inputFiles = forM inputFiles $ \inputFile -> do

--- a/tests/common/TestsSetup.hs
+++ b/tests/common/TestsSetup.hs
@@ -28,6 +28,8 @@ import System.Process
 import System.Directory
 import System.Info
 
+import Language.PureScript.Crash
+
 findNodeProcess :: IO (Maybe String)
 findNodeProcess = runMaybeT . msum $ map (MaybeT . findExecutable) names
   where
@@ -35,7 +37,7 @@ findNodeProcess = runMaybeT . msum $ map (MaybeT . findExecutable) names
 
 fetchSupportCode :: IO ()
 fetchSupportCode = do
-  node <- fromMaybe (error "cannot find node executable") <$> findNodeProcess
+  node <- fromMaybe (internalError "cannot find node executable") <$> findNodeProcess
   setCurrentDirectory "tests/support"
   if System.Info.os == "mingw32"
     then callProcess "setup-win.cmd" []


### PR DESCRIPTION
/cc @garyb 

This changes the wording of quite a few errors, either to make them easier to understand, or to turn them into full sentences rather than fragments.

I'm not sure about some of them, but I think it's an improvement overall.

I also

- Use `error` in place of `throwError` for errors which are really compiler bugs
- Moved the `suggestions` inside the branches of `prettyPrintErrorMessage`
- Got rid of the object accessor/function suggestion, since it rarely worked, and I have an idea for a better solution.

Thoughts?