### PR TITLE
Fix #1557

### DIFF
--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -232,7 +232,7 @@ infer' (ObjectUpdate o ps) = do
   let oldTy = TypeApp tyObject $ rowFromList (oldTys, row)
   o' <- TypedValue True <$> check o oldTy <*> pure oldTy
   return $ TypedValue True (ObjectUpdate o' newVals) $ TypeApp tyObject $ rowFromList (newTys, row)
-infer' (Accessor prop val) = do
+infer' (Accessor prop val) = rethrow (addHint (ErrorCheckingAccessor val prop)) $ do
   field <- fresh
   rest <- fresh
   typed <- check val (TypeApp tyObject (RCons prop field rest))
@@ -551,7 +551,7 @@ check' (ObjectUpdate obj ps) t@(TypeApp o row) | o == tyObject = do
   obj' <- check obj (TypeApp tyObject (rowFromList (us ++ remainingProps, rest)))
   ps' <- checkProperties ps row True
   return $ TypedValue True (ObjectUpdate obj' ps') t
-check' (Accessor prop val) ty = do
+check' (Accessor prop val) ty = rethrow (addHint (ErrorCheckingAccessor val prop)) $ do
   rest <- fresh
   val' <- check val (TypeApp tyObject (RCons prop ty rest))
   return $ TypedValue True (Accessor prop val') ty


### PR DESCRIPTION
/cc @garyb 

Example message:

```text
Error found:
Error in module M1:
--------------------------------------------------------------------------------
Error in value declaration compose:
--------------------------------------------------------------------------------
Error at test.purs line 4, column 15 - line 4, column 19:
--------------------------------------------------------------------------------
Error checking type of property accessor

  g."f"

--------------------------------------------------------------------------------
Error checking that expression

  g

has type

  { f :: _0 -> _1
  | _2
  }

--------------------------------------------------------------------------------
Error while trying to match type

  Object

with type

  Function _3

--------------------------------------------------------------------------------
Could not match expected type

  Object

with actual type

  Function _3

--------------------------------------------------------------------------------
```

This commit also removes some stuff to do with the order in which hints get rendered, because it was almost always wrong.

Also, how do you like the line breaks? This commit doesn't include them, but I'm trying to find a nice way to vertically separate different bits in an error message. Another option might be to indent pieces and punctuate them with something like "Caused by:" 