### PR TITLE
Display hints after main error, resolve #1563

### DIFF
--- a/examples/failing/MutRec.purs
+++ b/examples/failing/MutRec.purs
@@ -1,4 +1,5 @@
 -- @shouldFailWith CycleInDeclaration
+-- @shouldFailWith CycleInDeclaration
 module MutRec where
 
 import Prelude


### PR DESCRIPTION
/cc @garyb 

Here is an example with verbose errors turned on now:

```text
Error 2 of 2:

  in module MultipleErrors
  at MultipleErrors.purs line 12, column 1 - line 13, column 1
  at MultipleErrors.purs line 12, column 9 - line 13, column 1

    Could not match expected type

      String

    with actual type

      Int


  while trying to match type String
    with type Int
  while checking that type String
    is at least as general as type Int
  while checking that expression "Test"
    has type Int
  while checking that expression case _1 of
                                   0 -> "Test"
                                   n -> foo (((-) n) 1)
    has type Int
  while checking that expression \_1 ->
                                   case _1 of
                                     0 -> "Test"
                                     n -> foo (((-) n) 1)
    has type Int -> Int
  in binding group foo, bar

  See https://github.com/purescript/purescript/wiki/Error-Code-TypesDoNotUnify for more information,
  or to contribute content related to this error.
```