### PR TITLE
Use Types.Proxy.Proxy instead of Data.Generic.Proxy

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,6 +57,7 @@ This file lists the contributors to the PureScript compiler project, and the ter
 - [@senju](https://github.com/senju) - My existing contributions and all future contributions until further notice are Copyright senju, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 <http://opensource.org/licenses/MIT>.
 - [@soupi](https://github.com/soupi) (Gil Mizrahi) My existing contributions and all future contributions until further notice are Copyright Gil Mizrahi, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
+- [@tfausak](https://github.com/tfausak) (Taylor Fausak) My existing contributions and all future contributions until further notice are Copyright Taylor Fausak, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 
 ### Companies
 

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -73,6 +73,9 @@ dataGeneric = ModuleName [ ProperName "Data", ProperName "Generic" ]
 dataMaybe :: ModuleName
 dataMaybe = ModuleName [ ProperName "Data", ProperName "Maybe" ]
 
+typesProxy :: ModuleName
+typesProxy = ModuleName [ ProperName "Types", ProperName "Proxy" ]
+
 deriveGeneric :: (Functor m, MonadError MultipleErrors m, MonadSupply m) => ModuleName -> [Declaration] -> ProperName -> [Type] -> m [Declaration]
 deriveGeneric mn ds tyConNm args = do
   tyCon <- findTypeDecl tyConNm ds
@@ -132,7 +135,7 @@ mkSignatureFunction mn (DataDeclaration _ name tyArgs args) classArgs = lamNull 
   mkSigRec = App (Constructor (Qualified (Just dataGeneric) (ProperName "SigRecord"))) . ArrayLiteral
 
   proxy :: Type -> Type
-  proxy = TypeApp (TypeConstructor (Qualified (Just dataGeneric) (ProperName "Proxy")))
+  proxy = TypeApp (TypeConstructor (Qualified (Just typesProxy) (ProperName "Proxy")))
 
   mkProdClause :: (ProperName, [Type]) -> Expr
   mkProdClause (ctorName, tys) = ObjectLiteral [ ("sigConstructor", StringLiteral (showQualified runProperName (Qualified (Just mn) ctorName)))


### PR DESCRIPTION
This fixes #1573. It changes the deriving mechanism to use `Types.Proxy.Proxy` from purescript-proxy instead of `Data.Generic.Proxy` from purescript-generics. This requires the changes in purescript/purescript-generics#19.