### PR TITLE
Fix #1577, fix #1130

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -156,6 +156,7 @@ data ErrorMessageHint
   | ErrorCheckingAccessor Expr String
   | ErrorCheckingType Expr Type
   | ErrorCheckingKind Type
+  | ErrorCheckingGuard
   | ErrorInferringType Expr
   | ErrorInApplication Expr Type Expr
   | ErrorInDataConstructor ProperName
@@ -530,15 +531,15 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage <$> onTypesInError
                                           , indent $ prettyPrintValue expr
                                           ]) binding
     renderSimpleErrorMessage (TypesDoNotUnify t1 t2)
-      = paras [ line "Could not match expected type"
+      = paras [ line "Could not match type"
               , indent $ typeAsBox t1
-              , line "with actual type"
+              , line "with type"
               , indent $ typeAsBox t2
               ]
     renderSimpleErrorMessage (KindsDoNotUnify k1 k2) =
-      paras [ line "Could not match expected kind"
+      paras [ line "Could not match kind"
             , indent $ line $ prettyPrintKind k1
-            , line "with actual kind"
+            , line "with kind"
             , indent $ line $ prettyPrintKind k2
             ]
     renderSimpleErrorMessage (ConstrainedTypeUnified t1 t2) =
@@ -729,6 +730,10 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage <$> onTypesInError
             , Box.hsep 1 Box.top [ line "while checking the kind of"
                                  , typeAsBox ty
                                  ]
+            ]
+    renderHint ErrorCheckingGuard detail =
+      paras [ detail
+            , line "while checking the type of a guard clause"
             ]
     renderHint (ErrorInferringType expr) detail =
       paras [ detail

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -418,7 +418,7 @@ checkBinders nvals ret (CaseAlternative binders result : bs) = do
       case result of
         Left gs -> do
           gs' <- forM gs $ \(grd, val) -> do
-            grd' <- check grd tyBoolean
+            grd' <- rethrow (addHint ErrorCheckingGuard) $ check grd tyBoolean
             val' <- TypedValue True <$> check val ret <*> pure ret
             return (grd', val')
           return $ Left gs'


### PR DESCRIPTION
@garyb @natefaubion Could you please review? I'd rather just removed "expected" and "actual" since it's tricky to track which types actually correspond to real values in the program, and we should strive to give the best information in the checking judgment anyway, if possible.