### PR TITLE
Unused imports 2

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -139,6 +139,8 @@ data SimpleErrorMessage
   | ImportHidingModule ModuleName
   | UnusedImport ModuleName
   | UnusedExplicitImport ModuleName [String]
+  | UnusedDctorImport ProperName
+  | UnusedDctorExplicitImport ProperName [ProperName]
   deriving (Show)
 
 -- | Error message hints, providing more detailed information about failure.
@@ -271,6 +273,9 @@ errorCode em = case unwrapErrorMessage em of
   ImportHidingModule{} -> "ImportHidingModule"
   UnusedImport{} -> "UnusedImport"
   UnusedExplicitImport{} -> "UnusedExplicitImport"
+  UnusedDctorImport{} -> "UnusedDctorImport"
+  UnusedDctorExplicitImport{} -> "UnusedDctorExplicitImport"
+
 
 -- |
 -- A stack trace for an error
@@ -679,6 +684,13 @@ prettyPrintSingleError full level e = prettyPrintErrorMessage <$> onTypesInError
     renderSimpleErrorMessage (UnusedExplicitImport name names) =
       paras [ line $ "The import of module " ++ runModuleName name ++ " contains the following unused references:"
             , indent $ paras $ map line names ]
+
+    renderSimpleErrorMessage (UnusedDctorImport name) =
+      line $ "The import of type " ++ runProperName name ++ " includes data constructors but only the type is used"
+
+    renderSimpleErrorMessage (UnusedDctorExplicitImport name names) =
+      paras [ line $ "The import of type " ++ runProperName name ++ " includes the following unused data constructors:"
+            , indent $ paras $ map (line .runProperName) names ]
 
     renderHint :: ErrorMessageHint -> Box.Box -> Box.Box
     renderHint (ErrorUnifyingTypes t1 t2) detail =

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -46,7 +46,10 @@ findUnusedImports (Module _ _ _ mdecls mexports) env usedImps = do
           Explicit declrefs -> do
             let idents = mapMaybe runDeclRef declrefs
             let diff = idents \\ usedNames
-            unless (null diff) $ tell $ errorMessage $ UnusedExplicitImport mni diff
+            case (length diff, length idents) of
+              (0, _) -> return ()
+              (n, m) | n == m -> tell $ errorMessage $ UnusedImport mni
+              _ -> tell $ errorMessage $ UnusedExplicitImport mni diff
           _ -> return ()
   where
   sugarNames :: ModuleName -> [ Name ]

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -57,9 +57,11 @@ findUnusedImports (Module _ _ _ mdecls mexports) env usedImps = do
             forM_ (mapMaybe getTypeRef declrefs) $ \(tn, c) -> do
               let allCtors = dctorsForType mni tn
               when (runProperName tn `elem` usedNames) $ case (c, null $ usedDctors `intersect` allCtors) of
-                (_, True) -> tell $ errorMessage $ UnusedDctorImport tn
-                (Just ctors, False) -> let ddiff = ctors \\ usedDctors
-                                       in unless (null ddiff) $ tell $ errorMessage $ UnusedDctorExplicitImport tn ddiff
+                (Nothing, True) -> tell $ errorMessage $ UnusedDctorImport tn
+                (Just (_:_), True) -> tell $ errorMessage $ UnusedDctorImport tn
+                (Just ctors, _) ->
+                  let ddiff = ctors \\ usedDctors
+                  in unless (null ddiff) $ tell $ errorMessage $ UnusedDctorExplicitImport tn ddiff
                 _ -> return ()
             return ()
 


### PR DESCRIPTION
Improvements #1597. Fix warning for unqualified implicit imports, suppress for re-exported modules.

Doesn't yet work for modules re-exported by qualified import alias.
