### PR TITLE
fixes #1602: escape sequences for characters with code point below 0x10

### DIFF
--- a/examples/passing/StringEscapes.purs
+++ b/examples/passing/StringEscapes.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Prelude ((==), bind)
+import Test.Assert (assert)
+
+singleCharacter = "\0\b\t\n\v\f\r\"\\" == "\x0\x8\x9\xA\xB\xC\xD\x22\x5C"
+hex = "\x1d306\x2603\x3C6\xE0\x0" == "𝌆☃φà\0"
+decimal  = "\119558\9731\966\224\0" == "𝌆☃φà\0"
+
+main = do
+  assert singleCharacter
+  assert hex
+  assert decimal

--- a/src/Language/PureScript/Pretty/JS.hs
+++ b/src/Language/PureScript/Pretty/JS.hs
@@ -166,6 +166,7 @@ string s = '"' : concatMap encodeChar s ++ "\""
   encodeChar '\\' = "\\\\"
   encodeChar c | fromEnum c > 0xFFF = "\\u" ++ showHex (fromEnum c) ""
   encodeChar c | fromEnum c > 0xFF = "\\u0" ++ showHex (fromEnum c) ""
+  encodeChar c | fromEnum c < 0x10 = "\\x0" ++ showHex (fromEnum c) ""
   encodeChar c | fromEnum c > 0x7E || fromEnum c < 0x20 = "\\x" ++ showHex (fromEnum c) ""
   encodeChar c = [c]
 


### PR DESCRIPTION
Fixes #1602.