### PR TITLE
Fix #1596, don't show type checker warnings in the event of an error

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -944,7 +944,7 @@ renderBox = unlines . map trimEnd . lines . Box.render
 rethrow :: (MonadError e m) => (e -> e) -> m a -> m a
 rethrow f = flip catchError $ \e -> throwError (f e)
 
-reifyErrors :: (MonadError e m) => m a -> m (Either e a)
+reifyErrors :: (Functor m, MonadError e m) => m a -> m (Either e a)
 reifyErrors ma = catchError (fmap Right ma) (return . Left)
 
 reflectErrors :: (MonadError e m) => m (Either e a) -> m a

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -32,7 +32,7 @@ import Control.Monad
 import Control.Monad.Writer
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Trans.State.Lazy
-import Control.Arrow(first)
+import Control.Arrow (first)
 
 import Language.PureScript.Crash
 import Language.PureScript.AST
@@ -939,18 +939,16 @@ renderBox = unlines . map trimEnd . lines . Box.render
   trimEnd = reverse . dropWhile (== ' ') . reverse
 
 -- |
--- Interpret multiple errors and warnings in a monad supporting errors and warnings
---
-interpretMultipleErrorsAndWarnings :: (MonadError MultipleErrors m, MonadWriter MultipleErrors m) => (Either MultipleErrors a, MultipleErrors) -> m a
-interpretMultipleErrorsAndWarnings (err, ws) = do
-  tell ws
-  either throwError return err
-
--- |
 -- Rethrow an error with a more detailed error message in the case of failure
 --
 rethrow :: (MonadError e m) => (e -> e) -> m a -> m a
 rethrow f = flip catchError $ \e -> throwError (f e)
+
+reifyErrors :: (MonadError e m) => m a -> m (Either e a)
+reifyErrors ma = catchError (fmap Right ma) (return . Left)
+
+reflectErrors :: (MonadError e m) => m (Either e a) -> m a
+reflectErrors ma = ma >>= either throwError return
 
 warnAndRethrow :: (MonadError e m, MonadWriter e m) => (e -> e) -> m a -> m a
 warnAndRethrow f = rethrow f . censor f

--- a/src/Language/PureScript/Sugar/Names/Imports.hs
+++ b/src/Language/PureScript/Sugar/Names/Imports.hs
@@ -158,7 +158,7 @@ resolveImport currentModule importModule exps imps impQual =
   -- Import something explicitly
   importExplicit :: Imports -> DeclarationRef -> m Imports
   importExplicit imp (PositionedDeclarationRef pos _ r) =
-    rethrowWithPosition pos . warnWithPosition pos $ importExplicit imp r
+    warnAndRethrowWithPosition pos $ importExplicit imp r
   importExplicit imp (ValueRef name) = do
     values' <- updateImports (importedValues imp) showIdent (exportedValues exps) name
     return $ imp { importedValues = values' }

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -211,14 +211,14 @@ freshDictionaryName = do
 
 -- | Run a computation in the substitution monad, generating a return value and the final substitution.
 liftUnify ::
-  (MonadState CheckState m, MonadWriter MultipleErrors m, MonadError MultipleErrors m) =>
+  (Functor m, MonadState CheckState m, MonadWriter MultipleErrors m, MonadError MultipleErrors m) =>
   m a ->
   m (a, Substitution)
 liftUnify = liftUnifyWarnings (const id)
 
 -- | Run a computation in the substitution monad, generating a return value, the final substitution and updating warnings values.
 liftUnifyWarnings ::
-  (MonadState CheckState m, MonadWriter MultipleErrors m, MonadError MultipleErrors m) =>
+  (Functor m, MonadState CheckState m, MonadWriter MultipleErrors m, MonadError MultipleErrors m) =>
   (Substitution -> ErrorMessage -> ErrorMessage) ->
   m a ->
   m (a, Substitution)

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -211,21 +211,21 @@ freshDictionaryName = do
 
 -- | Run a computation in the substitution monad, generating a return value and the final substitution.
 liftUnify ::
-  (MonadState CheckState m, MonadWriter MultipleErrors m) =>
+  (MonadState CheckState m, MonadWriter MultipleErrors m, MonadError MultipleErrors m) =>
   m a ->
   m (a, Substitution)
 liftUnify = liftUnifyWarnings (const id)
 
 -- | Run a computation in the substitution monad, generating a return value, the final substitution and updating warnings values.
 liftUnifyWarnings ::
-  (MonadState CheckState m, MonadWriter MultipleErrors m) =>
+  (MonadState CheckState m, MonadWriter MultipleErrors m, MonadError MultipleErrors m) =>
   (Substitution -> ErrorMessage -> ErrorMessage) ->
   m a ->
   m (a, Substitution)
 liftUnifyWarnings replace ma = do
   orig <- get
   modify $ \st -> st { checkSubstitution = emptySubstitution }
-  (a, w) <- censor (const mempty) . listen $ ma
+  (a, w) <- reflectErrors . censor (const mempty) . reifyErrors . listen $ ma
   subst <- gets checkSubstitution
   tell . onErrorMessages (replace subst) $ w
   modify $ \st -> st { checkSubstitution = checkSubstitution orig }


### PR DESCRIPTION
I'm not particularly happy with this fix, but it's as good as it's going to get, without making our own `mtl`-like classes. The reason for the lack of position information is related to the interaction between `MonadWriter`, `censor` and `ExceptT`.

This change just omits warnings from the typechecker whenever an error occurs. Those warnings are never useful anyway, since they always contain unknown types due to the lack of a substitution.

/cc @garyb 