### PR TITLE
Fix missing spaces in psc-publish error message

### DIFF
--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -160,9 +160,9 @@ displayUserError e = case e of
         , indented (para "* {MAJOR}.{MINOR}.{PATCH} (example: \"1.6.2\")")
         , spacer
         , para (concat
-           [ "If the version you are publishing is not yet tagged, you might want to use"
-           , "the --dry-run flag instead, which removes this requirement. Run"
-           , "psc-publish --help for more details."
+           [ "If the version you are publishing is not yet tagged, you might "
+           , "want to use the --dry-run flag instead, which removes this "
+           , "requirement. Run psc-publish --help for more details."
            ])
         ]
   AmbiguousVersions vs ->


### PR DESCRIPTION
This is what the `psc-publish` error message in question looks like in 0.7.5.3:

```
  If the version you are publishing is not yet tagged, you might want to usethe
  --dry-run flag instead, which removes this requirement. Runpsc-publish --help
  for more details.
```

(Note missing spaces between "use" and "the", and "Run" and "psc-publish"). This commit adds these spaces in.