### PR TITLE
Psc publish error reporting

### DIFF
--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -122,7 +122,7 @@ preparePackage' opts = do
   requireCleanWorkingTree
 
   pkgMeta <- liftIO (Bower.decodeFile "bower.json")
-                    >>= flip catchLeft (userError . CouldntParseBowerJSON)
+                    >>= flip catchLeft (userError . CouldntDecodeBowerJSON)
   (pkgVersionTag, pkgVersion) <- publishGetVersion opts
   pkgGithub                   <- getBowerInfo pkgMeta
   (pkgBookmarks, pkgModules)  <- getModulesAndBookmarks

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -56,7 +56,6 @@ data UserError
   = BowerJSONNotFound
   | BowerExecutableNotFound [String] -- list of executable names tried
   | CouldntParseBowerJSON (ParseError BowerError)
-  | BowerJSONNameMissing
   | TagMustBeCheckedOut
   | AmbiguousVersions [Version] -- Invariant: should contain at least two elements
   | BadRepositoryField RepositoryFieldError
@@ -137,14 +136,6 @@ displayUserError e = case e of
         , "aeson reported: " ++ show err
         ]
       , para "Please ensure that your bower.json file is valid JSON."
-      ]
-  BowerJSONNameMissing ->
-    vcat
-      [ successivelyIndented
-        [ "In bower.json:"
-        , "the \"name\" key was not found."
-        ]
-      , para "Please give your package a name first."
       ]
   TagMustBeCheckedOut ->
       vcat


### PR DESCRIPTION
Fix all of the problems noted in #1560.

Example error message now:

```
There is a problem with your package, which meant that it could not be
published.
Details:
  There was a problem with your bower.json file:
    At the path: ["name"]
    Invalid package name: The following characters are not permitted in package
    names: $

  Please ensure that your bower.json file is valid.
```

as opposed to:

```
There is a problem with your package, which meant that it could not be           
published.                                                                       
Details:                                                                         
  The bower.json file could not be parsed as JSON:                               
    aeson reported: BadSchema [ObjectKey "name"] (CustomError (InvalidPackageName
    (InvalidChars "$")))                                                         
                                                                                 
  Please ensure that your bower.json file is valid JSON. 
```