### PR TITLE
Reduce noise in instance declarations

### DIFF
--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -71,11 +71,7 @@ renderChildDeclarationWithOptions :: RenderTypeOptions -> ChildDeclaration -> Re
 renderChildDeclarationWithOptions opts ChildDeclaration{..} =
   mintersperse sp $ case cdeclInfo of
     ChildInstance constraints ty ->
-      [ keywordInstance
-      , ident cdeclTitle
-      , syntax "::"
-      ] ++ maybeToList (renderConstraints constraints)
-        ++ [ renderType' ty ]
+      maybeToList (renderConstraints constraints) ++ [ renderType' ty ]
     ChildDataConstructor args ->
       [ renderType' typeApp' ]
       where


### PR DESCRIPTION
`instance showFoo :: Show Foo` is now rendered as `Show Foo`, since the
extra information is mostly just noise.

I did this mainly with pursuit in mind (to fix purescript/pursuit#124), although it has the same effect on `psc-docs`.

The only situation I can think of where the instance name would be important is if you were calling into PureScript code from JS, but if you were doing that, it's surely easier to write a little PS wrapper exporting monomorphic versions of the functions you want, in most cases at least. In any case I think instance names are not important enough for 99% of use cases to be featured in the docs like this.