### PR TITLE
Fix #1632, instantiate type variables in anyProxy calls in generic instances

### DIFF
--- a/core-tests/tests/generic-deriving/Main.purs
+++ b/core-tests/tests/generic-deriving/Main.purs
@@ -17,7 +17,11 @@ data A a
   | D { a :: a }
   | E Void
 
-derive instance genericA :: (Generic a) => Generic (A a)
+derive instance genericA :: (Generic b) => Generic (A b)
+
+newtype X b = X b
+
+derive instance genericX :: Generic (X String)
 
 main :: forall eff. Eff (console :: CONSOLE | eff) Unit
 main = Control.Monad.Eff.Console.log (gShow (D { a: C [ A 1.0 "test", B 42, D { a: true } ] }))


### PR DESCRIPTION
@garyb @sclv Could you please review this? This also allows generic instances of the form

```purescript
deriving instance genericX :: Generic (X String)
```

i.e. flexible instances.