### PR TITLE
Update generic deriving for latest purescript-generics changes

### DIFF
--- a/core-tests/tests/generic-deriving/Main.purs
+++ b/core-tests/tests/generic-deriving/Main.purs
@@ -14,7 +14,7 @@ data A a
   = A Number String
   | B Int
   | C (Array (A a)) 
-  | D { a :: a }
+  | D { "asgård" :: a }
   | E Void
 
 derive instance genericA :: (Generic b) => Generic (A b)
@@ -24,4 +24,4 @@ newtype X b = X b
 derive instance genericX :: Generic (X String)
 
 main :: forall eff. Eff (console :: CONSOLE | eff) Unit
-main = Control.Monad.Eff.Console.log (gShow (D { a: C [ A 1.0 "test", B 42, D { a: true } ] }))
+main = Control.Monad.Eff.Console.log (gShow (D { "asgård": C [ A 1.0 "test", B 42, D { "asgård": true } ] }))

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -170,7 +170,7 @@ mkFromSpineFunction mn (DataDeclaration _ _ _ args) = lamCase "$x" <$> (addCatch
   mkAlternative :: (ProperName, [Type]) -> m CaseAlternative
   mkAlternative (ctorName, tys) = do
     idents <- replicateM (length tys) (fmap Ident freshName)
-    return $ CaseAlternative [ prodBinder [ StringBinder (runProperName ctorName), ArrayBinder (map VarBinder idents)]]
+    return $ CaseAlternative [ prodBinder [ StringBinder (showQualified runProperName (Qualified (Just mn) ctorName)), ArrayBinder (map VarBinder idents)]]
                . Right
                $ liftApplicative (mkJust $ Constructor (Qualified (Just mn) ctorName))
                                  (zipWith fromSpineFun (map (Var . Qualified Nothing) idents) tys)


### PR DESCRIPTION
@garyb @gbaz Could you please review this?

- Update to support type constructors in signatures, per https://github.com/purescript/purescript-generics/issues/8
- Make products consistent with the instances in `Data.Generic` by providing fully-qualified data constructor names.