### PR TITLE
Make `let` optional in psci

### DIFF
--- a/psci/Parser.hs
+++ b/psci/Parser.hs
@@ -98,10 +98,12 @@ psciExpression = Expression <$> P.parseValue
 -- we actually want the normal @let@.
 --
 psciLet :: P.TokenParser Command
-psciLet = Decls <$> (P.reserved "let" *> P.indented *> manyDecls)
+psciLet = Decls <$> (optionalLet *> manyDecls)
   where
   manyDecls :: P.TokenParser [P.Declaration]
   manyDecls = mark (many1 (same *> P.parseLocalDeclaration))
+
+  optionalLet = optional (P.reserved "let" *> P.indented)
 
 -- | Imports must be handled separately from other declarations, so that
 -- :show import works, for example.


### PR DESCRIPTION
Only tested by hand. I tried to get some sort of thing wired up so that we could give a list of commands and an expected output but it turns out that's actually quite difficult. I am beginning to wonder whether the best approach is to actually run psci in a separate process, and to use something like https://github.com/stroan/haskell-libexpect/.
