### PR TITLE
Warn about unused class imports

### DIFF
--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -226,13 +226,13 @@ renameInModule env imports (Module ss coms mn decls exps) =
   updateConstraints pos = traverse (\(name, ts) -> (,) <$> updateClassName name pos <*> traverse (updateTypesEverywhere pos) ts)
 
   updateTypeName :: Qualified ProperName -> Maybe SourceSpan -> m (Qualified ProperName)
-  updateTypeName = update UnknownType (importedTypes imports) (resolveType . exportedTypes) IsProperName
+  updateTypeName = update UnknownType (importedTypes imports) (resolveType . exportedTypes) TypeName
 
   updateDataConstructorName :: Qualified ProperName -> Maybe SourceSpan -> m (Qualified ProperName)
   updateDataConstructorName = update (flip UnknownDataConstructor Nothing) (importedDataConstructors imports) (resolveDctor . exportedTypes) DctorName
 
   updateClassName  :: Qualified ProperName -> Maybe SourceSpan -> m (Qualified ProperName)
-  updateClassName = update UnknownTypeClass (importedTypeClasses imports) (resolve . exportedTypeClasses) IsProperName
+  updateClassName = update UnknownTypeClass (importedTypeClasses imports) (resolve . exportedTypeClasses) ClassName
 
   updateValueName  :: Qualified Ident -> Maybe SourceSpan -> m (Qualified Ident)
   updateValueName = update UnknownValue (importedValues imports) (resolve . exportedValues) IdentName


### PR DESCRIPTION
Resolves #1392, resolves #1597 (@nwolverson deserves the credit for these, this is just the last bit I think)

Also fixes a bug in the current warnings: when `import X` only imports classes from `X`, it thinks `X` is a redundant import.