### PR TITLE
Warn on duplicate refs in import or export lists

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -146,6 +146,8 @@ data SimpleErrorMessage
   | RedundantUnqualifiedImport ModuleName ImportDeclarationType
   | DuplicateSelectiveImport ModuleName
   | DuplicateImport ModuleName ImportDeclarationType (Maybe ModuleName)
+  | DuplicateImportRef String
+  | DuplicateExportRef String
   | IntOutOfRange Integer String Integer Integer
   deriving (Show)
 
@@ -285,6 +287,8 @@ errorCode em = case unwrapErrorMessage em of
   RedundantUnqualifiedImport{} -> "RedundantUnqualifiedImport"
   DuplicateSelectiveImport{} -> "DuplicateSelectiveImport"
   DuplicateImport{} -> "DuplicateImport"
+  DuplicateImportRef{} -> "DuplicateImportRef"
+  DuplicateExportRef{} -> "DuplicateExportRef"
   IntOutOfRange{} -> "IntOutOfRange"
 
 
@@ -789,6 +793,12 @@ prettyPrintSingleError full level e = do
 
     renderSimpleErrorMessage (DuplicateImport name imp qual) =
       line $ "Duplicate import of " ++ prettyPrintImport name imp qual
+
+    renderSimpleErrorMessage (DuplicateImportRef ref) =
+      line $ "Import list contains multiple references to " ++ ref
+
+    renderSimpleErrorMessage (DuplicateExportRef ref) =
+      line $ "Export list contains multiple references to " ++ ref
 
     renderSimpleErrorMessage (IntOutOfRange value backend lo hi) =
       paras [ line $ "Integer value " ++ show value ++ " is out of range for the " ++ backend ++ " backend."

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -8,7 +8,7 @@ import Prelude.Compat
 
 import qualified Data.Map as M
 import Data.Maybe (mapMaybe)
-import Data.List ((\\), find, intersect)
+import Data.List ((\\), find, intersect, nub)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Writer.Class
 import Control.Monad(unless,when)
@@ -50,7 +50,7 @@ findUnusedImports (Module _ _ _ mdecls mexports) env usedImps = do
         in case declType of
           Implicit -> when (null usedNames) $ tell $ errorMessage $ UnusedImport mni
           Explicit declrefs -> do
-            let idents = mapMaybe runDeclRef declrefs
+            let idents = nub (mapMaybe runDeclRef declrefs)
             let diff = idents \\ usedNames
             case (length diff, length idents) of
               (0, _) -> return ()


### PR DESCRIPTION
Resolves #1661 

Also prevents some redundant warnings (like warning about duplicate imports and then warning about multiple selective imports for the same thing)