### PR TITLE
Introduce operator aliases

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/support/prelude"]
+	path = tests/support/prelude
+	url = https://github.com/purescript/purescript-prelude

--- a/examples/failing/OperatorAliasNoExport.purs
+++ b/examples/failing/OperatorAliasNoExport.purs
@@ -1,0 +1,7 @@
+-- @shouldFailWith TransitiveExportError
+module Test ((?!)) where
+
+infixl 4 what as ?!
+
+what :: forall a b. a -> b -> a
+what a _ = a

--- a/examples/passing/OperatorAlias.purs
+++ b/examples/passing/OperatorAlias.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console
+
+infixl 4 what as ?!
+
+what :: forall a b. a -> b -> a
+what a _ = a
+
+main = log $ "Done" ?! true

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -1,5 +1,5 @@
 name: purescript
-version: 0.7.6.1
+version: 0.8.0.0
 cabal-version: >=1.8
 build-type: Simple
 license: MIT

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -261,10 +261,12 @@ test-suite tests
     build-depends: base >=4 && <5, containers -any, directory -any,
                    filepath -any, mtl -any, parsec -any, purescript -any,
                    transformers -any, process -any, transformers-compat -any, time -any,
-                   Glob -any, base-compat >=0.6.0
+                   Glob -any, aeson-better-errors -any, bytestring -any, aeson -any,
+                   base-compat -any
     type: exitcode-stdio-1.0
     main-is: Main.hs
     other-modules: TestsSetup
+                   TestPscPublish
     buildable: True
     hs-source-dirs: tests tests/common
 

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -186,9 +186,9 @@ data Declaration
   --
   | ExternDataDeclaration ProperName Kind
   -- |
-  -- A fixity declaration (fixity data, operator name)
+  -- A fixity declaration (fixity data, operator name, value the operator is an alias for)
   --
-  | FixityDeclaration Fixity String
+  | FixityDeclaration Fixity String (Maybe Ident)
   -- |
   -- A module import (module name, qualified/unqualified/hiding, optional "qualified as" name)
   -- TODO: also a boolean specifying whether the old `qualified` syntax was used, so a warning can be raised in desugaring (remove for 0.9)

--- a/src/Language/PureScript/AST/Exported.hs
+++ b/src/Language/PureScript/AST/Exported.hs
@@ -112,7 +112,7 @@ isExported (Just exps) decl = any (matches decl) exps
   matches (TypeDeclaration ident _)          (ValueRef ident')     = ident == ident'
   matches (ValueDeclaration ident _ _ _)     (ValueRef ident')     = ident == ident'
   matches (ExternDeclaration ident _)        (ValueRef ident')     = ident == ident'
-  matches (FixityDeclaration _ name)         (ValueRef ident')     = name == runIdent ident'
+  matches (FixityDeclaration _ name _)       (ValueRef ident')     = name == runIdent ident'
   matches (DataDeclaration _ ident _ _)      (TypeRef ident' _)    = ident == ident'
   matches (ExternDataDeclaration ident _)    (TypeRef ident' _)    = ident == ident'
   matches (TypeSynonymDeclaration ident _ _) (TypeRef ident' _)    = ident == ident'

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -1,17 +1,3 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.CoreFn.Desugar
--- Copyright   :  (c) 2013-15 Phil Freeman, (c) 2014-15 Gary Burgess
--- License     :  MIT (http://opensource.org/licenses/MIT)
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>, Gary Burgess <gary.burgess@gmail.com>
--- Stability   :  experimental
--- Portability :
---
--- | The AST -> CoreFn desugaring step
---
------------------------------------------------------------------------------
-
 module Language.PureScript.CoreFn.Desugar (moduleToCoreFn) where
 
 import Data.Function (on)
@@ -68,6 +54,9 @@ moduleToCoreFn env (A.Module _ coms mn decls (Just exps)) =
   declToCoreFn ss _   (A.DataBindingGroupDeclaration ds) = concatMap (declToCoreFn ss []) ds
   declToCoreFn ss com (A.ValueDeclaration name _ _ (Right e)) =
     [NonRec name (exprToCoreFn ss com Nothing e)]
+  declToCoreFn ss com (A.FixityDeclaration _ name (Just alias)) =
+    let qname = Qualified (Just mn) alias
+    in [NonRec (Op name) (Var (ss, com, Nothing, getValueMeta qname) (Qualified Nothing alias))]
   declToCoreFn ss _   (A.BindingGroupDeclaration ds) =
     [Rec $ map (\(name, _, e) -> (name, exprToCoreFn ss [] Nothing e)) ds]
   declToCoreFn ss com (A.TypeClassDeclaration name _ supers members) =

--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -45,7 +45,7 @@ declAsMarkdown decl@Declaration{..} = do
     zipWithM_ (\f c -> tell' (childToString f c)) (First : repeat NotFirst) children
   spacer
 
-  for_ declFixity (\fixity -> fixityAsMarkdown fixity >> spacer)
+  for_ declFixity (\(fixity, alias) -> fixityAsMarkdown fixity alias >> spacer)
 
   for_ declComments tell'
 
@@ -68,9 +68,11 @@ codeToString = outputWith elemAsMarkdown
   elemAsMarkdown (Keyword x) = x
   elemAsMarkdown Space       = " "
 
-fixityAsMarkdown :: P.Fixity -> Docs
-fixityAsMarkdown (P.Fixity associativity precedence) =
+fixityAsMarkdown :: P.Fixity -> Maybe String -> Docs
+fixityAsMarkdown (P.Fixity associativity precedence) alias =
+  -- TODO: link alias name to member
   tell' $ concat [ "_"
+                 , maybe "" (\i -> "alias for " ++ i ++ " - ") alias
                  , associativityStr
                  , " / precedence "
                  , show precedence

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -84,7 +84,7 @@ data Declaration = Declaration
   , declComments   :: Maybe String
   , declSourceSpan :: Maybe P.SourceSpan
   , declChildren   :: [ChildDeclaration]
-  , declFixity     :: Maybe P.Fixity
+  , declFixity     :: Maybe (P.Fixity, Maybe String)
   , declInfo       :: DeclarationInfo
   }
   deriving (Show, Eq, Ord)
@@ -307,9 +307,12 @@ asDeclaration =
               <*> key "fixity" (perhaps asFixity)
               <*> key "info" asDeclarationInfo
 
-asFixity :: Parse PackageError P.Fixity
-asFixity = P.Fixity <$> key "associativity" asAssociativity
-                    <*> key "precedence" asIntegral
+asFixity :: Parse PackageError (P.Fixity, Maybe String)
+asFixity = do
+  fixity <- P.Fixity <$> key "associativity" asAssociativity
+                     <*> key "precedence" asIntegral
+  alias <- keyMay "alias" asString
+  return (fixity, alias)
 
 parseAssociativity :: String -> Maybe P.Associativity
 parseAssociativity str = case str of

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -1,22 +1,10 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Externs
--- Copyright   :  (c) 2013-15 Phil Freeman, (c) 2014-15 Gary Burgess
--- License     :  MIT (http://opensource.org/licenses/MIT)
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
--- |
--- This module generates code for \"externs\" files, i.e. files containing only foreign import declarations.
---
------------------------------------------------------------------------------
-
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
+-- |
+-- This module generates code for \"externs\" files, i.e. files containing only foreign import declarations.
+--
 module Language.PureScript.Externs
   ( ExternsFile(..)
   , ExternsImport(..)
@@ -84,6 +72,8 @@ data ExternsFixity = ExternsFixity
   , efPrecedence :: Precedence
   -- | The operator symbol
   , efOperator :: String
+  -- | The value the operator is an alias for
+  , efAlias :: Maybe Ident
   } deriving (Show, Read)
 
 -- | A type or value declaration appearing in an externs file
@@ -163,7 +153,7 @@ moduleToExternsFile (Module _ _ mn ds (Just exps)) env = ExternsFile{..}
   efDeclarations  = concatMap toExternsDeclaration efExports
 
   fixityDecl :: Declaration -> Maybe ExternsFixity
-  fixityDecl (FixityDeclaration (Fixity assoc prec) op) = fmap (const (ExternsFixity assoc prec op)) (find exportsOp exps)
+  fixityDecl (FixityDeclaration (Fixity assoc prec) op alias) = fmap (const (ExternsFixity assoc prec op alias)) (find exportsOp exps)
     where
     exportsOp :: DeclarationRef -> Bool
     exportsOp (PositionedDeclarationRef _ _ r) = exportsOp r

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -1,21 +1,10 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Linter
--- Copyright   :  (c) 2013-15 Phil Freeman, (c) 2014-15 Gary Burgess
--- License     :  MIT (http://opensource.org/licenses/MIT)
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
--- | This module implements a simple linting pass on the PureScript AST.
---
------------------------------------------------------------------------------
-
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE PatternGuards #-}
 
+-- |
+-- This module implements a simple linting pass on the PureScript AST.
+--
 module Language.PureScript.Linter (lint, module L) where
 
 import Prelude ()
@@ -66,11 +55,12 @@ lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDecl
     f dec = warningsInDecl moduleNames dec <> checkTypeVarsInDecl dec
 
     stepD :: S.Set Ident -> Declaration -> MultipleErrors
-    stepD _ (TypeClassDeclaration name _ _ decls) = foldMap go decls
+    stepD _ (ValueDeclaration (Op name) _ _ _) = errorMessage (DeprecatedOperatorDecl name)
+    stepD _ (TypeClassDeclaration _ _ _ decls) = foldMap go decls
       where
       go :: Declaration -> MultipleErrors
       go (PositionedDeclaration _ _ d') = go d'
-      go (TypeDeclaration op@(Op _) _)  = errorMessage (ClassOperator name op)
+      go (TypeDeclaration (Op name) _)  = errorMessage (DeprecatedOperatorDecl name)
       go _ = mempty
     stepD _ _ = mempty
 

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -124,8 +124,9 @@ parseFixityDeclaration :: TokenParser Declaration
 parseFixityDeclaration = do
   fixity <- parseFixity
   indented
+  alias <- P.optionMaybe $ (Ident <$> identifier) <* reserved "as"
   name <- symbol
-  return $ FixityDeclaration fixity name
+  return $ FixityDeclaration fixity name alias
 
 parseImportDeclaration :: TokenParser Declaration
 parseImportDeclaration = do

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -47,6 +47,7 @@ findExportable (Module _ _ mn ds _) =
   updateExports exps (TypeSynonymDeclaration tn _ _) = exportType exps tn [] mn
   updateExports exps (ExternDataDeclaration tn _) = exportType exps tn [] mn
   updateExports exps (ValueDeclaration name _ _ _) = exportValue exps name mn
+  updateExports exps (FixityDeclaration _ name (Just _)) = exportValue exps (Op name) mn
   updateExports exps (ExternDeclaration name _) = exportValue exps name mn
   updateExports exps (PositionedDeclaration pos _ d) = rethrowWithPosition pos $ updateExports exps d
   updateExports exps _ = return exps

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -68,6 +68,7 @@ import qualified System.FilePath.Glob as Glob
 import Text.Parsec (ParseError)
 
 import TestsSetup
+import TestPscPublish
 
 modulesDir :: FilePath
 modulesDir = ".test_modules" </> "node_modules"
@@ -171,6 +172,11 @@ assertDoesNotCompile inputFiles foreigns = do
 
 main :: IO ()
 main = do
+  testCompiler
+  testPscPublish
+
+testCompiler :: IO ()
+testCompiler = do
   fetchSupportCode
   cwd <- getCurrentDirectory
 
@@ -202,6 +208,10 @@ main = do
         let fp' = fromMaybe fp $ stripPrefix (failing ++ [pathSeparator]) fp
         in putStrLn $ fp' ++ ": " ++ err
       exitFailure
+
+testPscPublish :: IO ()
+testPscPublish = do
+  testPackage "tests/support/prelude"
 
 supportModules :: [String]
 supportModules =

--- a/tests/TestPscPublish.hs
+++ b/tests/TestPscPublish.hs
@@ -2,32 +2,23 @@
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
--- | To run these tests:
---
--- * `cabal repl psc-publish`
--- * `:l psc-publish/tests/Test.hs`
--- * `test`
-
-module Test where
+module TestPscPublish where
 
 import Control.Monad
 import Control.Applicative
 import Control.Exception
 import System.Process
 import System.Directory
+import System.IO
+import System.Exit
 import qualified Data.ByteString.Lazy as BL
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.Aeson as A
 import Data.Aeson.BetterErrors
 import Data.Version
 
-import Main
 import Language.PureScript.Docs
 import Language.PureScript.Publish
-
-pkgName = "purescript-prelude"
-packageUrl = "https://github.com/purescript/" ++ pkgName
-packageDir = "tmp/" ++ pkgName
 
 pushd :: forall a. FilePath -> IO a -> IO a
 pushd dir act = do
@@ -37,43 +28,11 @@ pushd dir act = do
   setCurrentDirectory original
   either throwIO return result
 
-clonePackage :: IO ()
-clonePackage = do
-  createDirectoryIfMissing True packageDir
-  pushd packageDir $ do
-    exists <- doesDirectoryExist ".git"
-    unless exists $ do
-      putStrLn ("Cloning " ++ pkgName ++ " into " ++ packageDir ++ "...")
-      readProcess "git" ["clone", packageUrl, "."] "" >>= putStr
-      readProcess "git" ["tag", "v999.0.0"] "" >>= putStr
-
-bowerInstall :: IO ()
-bowerInstall =
-  pushd packageDir $
-    readProcess "bower" ["install"] "" >>= putStr
-
-testRunOptions :: PublishOptions
-testRunOptions = defaultPublishOptions
-  { publishGetVersion = return testVersion
-  }
-  where testVersion = ("v999.0.0", Version [999,0,0] [])
-
-getPackage :: IO UploadedPackage
-getPackage = do
-  clonePackage
-  bowerInstall
-  pushd packageDir $ preparePackage testRunOptions
-
 data TestResult
   = ParseFailed String
   | Mismatch ByteString ByteString -- ^ encoding before, encoding after
   | Pass ByteString
   deriving (Show, Read)
-
--- | Test JSON encoding/decoding; parse the package, roundtrip to/from JSON,
--- and check we get the same string.
-test :: IO TestResult
-test = roundTrip <$> getPackage
 
 roundTrip :: UploadedPackage -> TestResult
 roundTrip pkg =
@@ -85,3 +44,22 @@ roundTrip pkg =
          if before == after
            then Pass before
            else Mismatch before after
+
+testRunOptions :: PublishOptions
+testRunOptions = defaultPublishOptions
+  { publishGetVersion = return testVersion
+  }
+  where testVersion = ("v999.0.0", Version [999,0,0] [])
+
+-- | Given a directory which contains a package, produce JSON from it, and then
+-- | attempt to parse it again, and ensure that it doesn't change.
+testPackage :: String -> IO ()
+testPackage dir = do
+  pushd dir $ do
+    r <- roundTrip <$> preparePackage testRunOptions
+    case r of
+      Pass _ -> pure ()
+      other -> do
+        hPutStrLn stderr ("psc-publish tests failed on " ++ dir ++ ":")
+        hPutStrLn stderr (show other)
+        exitFailure


### PR DESCRIPTION
Resolves #806

This probably isn't the best way of handling it in the long term, it would be nice to desugar during codegen rather than upfront as we'll probably get better error messages that way, but while we're supporting both old and new syntax this seemed a reasonable approach for now.