### PR TITLE
Match multiple expressions in case statements

### DIFF
--- a/examples/failing/CaseBinderLengthsDiffer.purs
+++ b/examples/failing/CaseBinderLengthsDiffer.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith CaseBinderLengthDiffers
+module Main where
+
+test = case 1, 2 of
+  1, 2, 3 -> 42
+  _, _    -> 43

--- a/examples/passing/CaseMultipleExpressions.purs
+++ b/examples/passing/CaseMultipleExpressions.purs
@@ -1,0 +1,19 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console
+import Control.Monad.Eff
+
+doIt :: forall eff. Eff eff Boolean
+doIt = return true
+
+set = do
+  log "Testing..."
+  case 42, 10 of
+    42, 10 -> doIt
+    _ , _  -> return false
+
+main = do
+  b <- set
+  case b of
+    true -> log "Done"

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -139,6 +139,7 @@ data SimpleErrorMessage
   | IntOutOfRange Integer String Integer Integer
   | RedundantEmptyHidingImport ModuleName
   | ImplicitImport ModuleName [DeclarationRef]
+  | CaseBinderLengthDiffers Int [Binder]
   deriving (Show)
 
 -- | Error message hints, providing more detailed information about failure.
@@ -309,6 +310,7 @@ errorCode em = case unwrapErrorMessage em of
   IntOutOfRange{} -> "IntOutOfRange"
   RedundantEmptyHidingImport{} -> "RedundantEmptyHidingImport"
   ImplicitImport{} -> "ImplicitImport"
+  CaseBinderLengthDiffers{} -> "CaseBinderLengthDiffers"
 
 -- |
 -- A stack trace for an error
@@ -859,6 +861,11 @@ prettyPrintSingleError full level e = do
       paras [ line $ "Module " ++ runModuleName mn ++ " has unspecified imports, consider using the explicit form: "
             , indent $ line $ "import " ++ runModuleName mn ++ " (" ++ intercalate ", " (map prettyPrintRef refs) ++ ")"
             ]
+
+    renderSimpleErrorMessage (CaseBinderLengthDiffers l bs) =
+      paras $ [ line $ "Binder list length differs in case alternative:"
+              , indent $ line $ intercalate ", " $ fmap prettyPrintBinderAtom bs
+              , line $ "Expecting " ++ show l ++ " binder" ++ (if l == 1 then "" else "s") ++ "." ]
 
     renderHint :: ErrorMessageHint -> Box.Box -> Box.Box
     renderHint (ErrorUnifyingTypes t1 t2) detail =

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -349,11 +349,11 @@ parseConstructor :: TokenParser Expr
 parseConstructor = Constructor <$> C.parseQualified C.properName
 
 parseCase :: TokenParser Expr
-parseCase = Case <$> P.between (P.try (reserved "case")) (C.indented *> reserved "of") (return <$> parseValue)
+parseCase = Case <$> P.between (P.try (reserved "case")) (C.indented *> reserved "of") (commaSep1 parseValue)
                  <*> (C.indented *> C.mark (P.many1 (C.same *> C.mark parseCaseAlternative)))
 
 parseCaseAlternative :: TokenParser CaseAlternative
-parseCaseAlternative = CaseAlternative <$> (return <$> parseBinder)
+parseCaseAlternative = CaseAlternative <$> (commaSep1 parseBinder)
                                        <*> (Left <$> (C.indented *>
                                                         P.many1 ((,) <$> parseGuard
                                                                      <*> (indented *> rarrow *> parseValue)


### PR DESCRIPTION
This addresses some of the use cases of #1690 and #1687 by allowing you to match multiple expressions at once in a case statement. This is kind of a no-brainer since its already supported by the AST. Thoughts on adding this?

It's currently missing a check for binder/expression length in the branches like we do for arguments in declarations. Where should that be added? 