### PR TITLE
Add native Partial constraint, relax tuple syntax for constraints

### DIFF
--- a/examples/passing/EmptyTypeClass.purs
+++ b/examples/passing/EmptyTypeClass.purs
@@ -2,11 +2,11 @@ module Main where
 
 import Prelude
 
-class Partial
+class PartialP
 
-head :: forall a. (Partial) => Array a -> a
+head :: forall a. (PartialP) => Array a -> a
 head [x] = x
 
-instance allowPartials :: Partial
+instance allowPartials :: PartialP
 
 main = Control.Monad.Eff.Console.log $ head ["Done"]

--- a/examples/passing/NakedConstraint.purs
+++ b/examples/passing/NakedConstraint.purs
@@ -2,8 +2,6 @@ module Main where
 
 import Control.Monad.Eff.Console
 
-class Partial 
-
 data List a = Nil | Cons a (List a)
 
 head :: (Partial) => List Int -> Int

--- a/examples/passing/UntupledConstraints.purs
+++ b/examples/passing/UntupledConstraints.purs
@@ -1,0 +1,14 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console
+
+data List a = Nil | Cons a (List a)
+
+head :: Partial => List Int -> Int
+head (Cons x _) = x
+
+strangeThing :: forall m. Monad m, Semigroup (m Unit) => m Unit
+strangeThing = pure unit
+
+main = log "Done"

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -66,7 +66,7 @@ data Environment = Environment {
 -- The initial environment with no values and only the default javascript types defined
 --
 initEnvironment :: Environment
-initEnvironment = Environment M.empty primTypes M.empty M.empty M.empty M.empty
+initEnvironment = Environment M.empty primTypes M.empty M.empty M.empty primClasses
 
 -- |
 -- The visibility of a name in scope
@@ -236,17 +236,32 @@ function :: Type -> Type -> Type
 function t1 = TypeApp (TypeApp tyFunction t1)
 
 -- |
--- The primitive types in the external javascript environment with their associated kinds.
+-- The primitive types in the external javascript environment with their
+-- associated kinds. There is also a pseudo `Partial` type that corresponds to
+-- the class with the same name.
 --
 primTypes :: M.Map (Qualified ProperName) (Kind, TypeKind)
-primTypes = M.fromList [ (primName "Function" , (FunKind Star (FunKind Star Star), ExternData))
-                       , (primName "Array"    , (FunKind Star Star, ExternData))
-                       , (primName "Object"   , (FunKind (Row Star) Star, ExternData))
-                       , (primName "String"   , (Star, ExternData))
-                       , (primName "Char"     , (Star, ExternData))
-                       , (primName "Number"   , (Star, ExternData))
-                       , (primName "Int"      , (Star, ExternData))
-                       , (primName "Boolean"  , (Star, ExternData)) ]
+primTypes =
+  M.fromList
+    [ (primName "Function", (FunKind Star (FunKind Star Star), ExternData))
+    , (primName "Array", (FunKind Star Star, ExternData))
+    , (primName "Object", (FunKind (Row Star) Star, ExternData))
+    , (primName "String", (Star, ExternData))
+    , (primName "Char", (Star, ExternData))
+    , (primName "Number", (Star, ExternData))
+    , (primName "Int", (Star, ExternData))
+    , (primName "Boolean", (Star, ExternData))
+    , (primName "Partial", (Star, ExternData))
+    ]
+
+-- |
+-- The primitive class map. This just contains to `Partial` class, used as a
+-- kind of magic constraint for partial functions.
+--
+primClasses :: M.Map (Qualified ProperName) ([(String, Maybe Kind)], [(Ident, Type)], [Constraint])
+primClasses =
+  M.fromList
+    [ (primName "Partial", ([], [], [])) ]
 
 -- |
 -- Finds information about data constructors from the current environment.

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -19,10 +19,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Language.PureScript.Linter.Exhaustive
-  ( checkExhaustive
-  , checkExhaustiveModule
-  ) where
+module Language.PureScript.Linter.Exhaustive (checkExhaustiveModule) where
 
 import Prelude ()
 import Prelude.Compat
@@ -32,7 +29,7 @@ import Data.Maybe (fromMaybe)
 import Data.List (foldl', sortBy, nub)
 import Data.Function (on)
 
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 import Control.Applicative
 import Control.Arrow (first, second)
 import Control.Monad.Writer.Class
@@ -48,7 +45,7 @@ import Language.PureScript.Errors
 
 -- | There are two modes of failure for the redudancy check:
 --
--- 1. Exhaustivity was incomeplete due to too many cases, so we couldn't determine redundancy.
+-- 1. Exhaustivity was incomplete due to too many cases, so we couldn't determine redundancy.
 -- 2. We didn't attempt to determine redundancy for a binder, e.g. an integer binder.
 --
 -- We want to warn the user in the first case.
@@ -239,8 +236,8 @@ missingAlternative env mn ca uncovered
 -- it partitions that set with the new uncovered cases, until it consumes the whole set of clauses.
 -- Then, returns the uncovered set of case alternatives.
 --
-checkExhaustive :: forall m. (MonadWriter MultipleErrors m) => Environment -> ModuleName -> Int -> [CaseAlternative] -> m ()
-checkExhaustive env mn numArgs cas = makeResult . first nub $ foldl' step ([initialize numArgs], (pure True, [])) cas
+checkExhaustive :: forall m. (MonadWriter MultipleErrors m) => Bool -> Environment -> ModuleName -> Int -> [CaseAlternative] -> m ()
+checkExhaustive hasConstraint env mn numArgs cas = makeResult . first nub $ foldl' step ([initialize numArgs], (pure True, [])) cas
   where
   step :: ([[Binder]], (Either RedudancyError Bool, [[Binder]])) -> CaseAlternative -> ([[Binder]], (Either RedudancyError Bool, [[Binder]]))
   step (uncovered, (nec, redundant)) ca =
@@ -258,13 +255,14 @@ checkExhaustive env mn numArgs cas = makeResult . first nub $ foldl' step ([init
 
   makeResult :: ([[Binder]], (Either RedudancyError Bool, [[Binder]])) -> m ()
   makeResult (bss, (rr, bss')) =
-    do unless (null bss) tellExhaustive
+    do unless (hasConstraint || null bss) tellNonExhaustive
        unless (null bss') tellRedundant
        case rr of
-         Left Incomplete -> tellIncomplete
-         _ -> return ()
+         Left Incomplete -> unless hasConstraint tellIncomplete
+         _ -> when (hasConstraint && null bss) tellExhaustive
     where
-    tellExhaustive = tell . errorMessage . uncurry NotExhaustivePattern . second null . splitAt 5 $ bss
+    tellExhaustive = tell . errorMessage $ NotPartial
+    tellNonExhaustive = tell . errorMessage . uncurry NotExhaustivePattern . second null . splitAt 5 $ bss
     tellRedundant = tell . errorMessage . uncurry OverlappingPattern . second null . splitAt 5 $ bss'
     tellIncomplete = tell . errorMessage $ IncompleteExhaustivityCheck
 
@@ -279,29 +277,33 @@ checkExhaustiveDecls env mn = mapM_ onDecl
     where
     convert :: (Ident, NameKind, Expr) -> Declaration
     convert (name, nk, e) = ValueDeclaration name nk [] (Right e)
-  onDecl (ValueDeclaration name _ _ (Right e)) = censor (addHint (ErrorInValueDeclaration name)) (onExpr e)
+  onDecl (ValueDeclaration name _ _ (Right e)) = censor (addHint (ErrorInValueDeclaration name)) (onExpr False e)
   onDecl (PositionedDeclaration pos _ dec) = censor (addHint (PositionedError pos)) (onDecl dec)
   onDecl _ = return ()
 
-  onExpr :: Expr -> m ()
-  onExpr (UnaryMinus e) = onExpr e
-  onExpr (ArrayLiteral es) = mapM_ onExpr es
-  onExpr (ObjectLiteral es) = mapM_ (onExpr . snd) es
-  onExpr (TypeClassDictionaryConstructorApp _ e) = onExpr e
-  onExpr (Accessor _ e) = onExpr e
-  onExpr (ObjectUpdate o es) = onExpr o >> mapM_ (onExpr . snd) es
-  onExpr (Abs _ e) = onExpr e
-  onExpr (App e1 e2) = onExpr e1 >> onExpr e2
-  onExpr (IfThenElse e1 e2 e3) = onExpr e1 >> onExpr e2 >> onExpr e3
-  onExpr (Case es cas) = checkExhaustive env mn (length es) cas >> mapM_ onExpr es >> mapM_ onCaseAlternative cas
-  onExpr (TypedValue _ e _) = onExpr e
-  onExpr (Let ds e) = mapM_ onDecl ds >> onExpr e
-  onExpr (PositionedValue pos _ e) = censor (addHint (PositionedError pos)) (onExpr e)
-  onExpr _ = return ()
+  onExpr :: Bool -> Expr -> m ()
+  onExpr isP (UnaryMinus e) = onExpr isP e
+  onExpr isP (ArrayLiteral es) = mapM_ (onExpr isP) es
+  onExpr isP (ObjectLiteral es) = mapM_ (onExpr isP . snd) es
+  onExpr isP (TypeClassDictionaryConstructorApp _ e) = onExpr isP e
+  onExpr isP (Accessor _ e) = onExpr isP e
+  onExpr isP (ObjectUpdate o es) = onExpr isP o >> mapM_ (onExpr isP . snd) es
+  onExpr isP (Abs _ e) = onExpr isP e
+  onExpr isP (App e1 e2) = onExpr isP e1 >> onExpr isP e2
+  onExpr isP (IfThenElse e1 e2 e3) = onExpr isP e1 >> onExpr isP e2 >> onExpr isP e3
+  onExpr isP (Case es cas) = checkExhaustive isP env mn (length es) cas >> mapM_ (onExpr isP) es >> mapM_ (onCaseAlternative isP) cas
+  onExpr isP (TypedValue _ e ty) = onExpr (isP || hasPartialConstraint ty) e
+  onExpr isP (Let ds e) = mapM_ onDecl ds >> onExpr isP e
+  onExpr isP (PositionedValue pos _ e) = censor (addHint (PositionedError pos)) (onExpr isP e)
+  onExpr _ _ = return ()
 
-  onCaseAlternative :: CaseAlternative -> m ()
-  onCaseAlternative (CaseAlternative _ (Left es)) = mapM_ (\(e, g) -> onExpr e >> onExpr g) es
-  onCaseAlternative (CaseAlternative _ (Right e)) = onExpr e
+  onCaseAlternative :: Bool -> CaseAlternative -> m ()
+  onCaseAlternative isP (CaseAlternative _ (Left es)) = mapM_ (\(e, g) -> onExpr isP e >> onExpr isP g) es
+  onCaseAlternative isP (CaseAlternative _ (Right e)) = onExpr isP e
+
+  hasPartialConstraint :: Type -> Bool
+  hasPartialConstraint (ConstrainedType cs _) = any ((== primName "Partial") . fst) cs
+  hasPartialConstraint _ = False
 
 -- |
 -- Exhaustivity checking over a single module

--- a/src/Language/PureScript/Parser/Types.hs
+++ b/src/Language/PureScript/Parser/Types.hs
@@ -70,7 +70,8 @@ parseForAll = mkForAll <$> (P.try (reserved "forall") *> P.many1 (indented *> id
 --
 parseTypeAtom :: TokenParser Type
 parseTypeAtom = indented *> P.choice (map P.try
-            [ parseArray
+            [ parseConstrainedType
+            , parseArray
             , parseArrayOf
             , parseFunction
             , parseObject
@@ -79,21 +80,23 @@ parseTypeAtom = indented *> P.choice (map P.try
             , parseTypeConstructor
             , parseForAll
             , parens parseRow
-            , parseConstrainedType
             , parens parsePolyType
             ])
 
 parseConstrainedType :: TokenParser Type
 parseConstrainedType = do
-  constraints <- parens . commaSep1 $ do
-    className <- parseQualified properName
-    indented
-    ty <- P.many parseTypeAtom
-    return (className, ty)
+  constraints <- P.try (commaSep1 parseConstraint) <|> parens (commaSep1 parseConstraint)
   _ <- rfatArrow
   indented
   ty <- parseType
   return $ ConstrainedType constraints ty
+  where
+  parseConstraint = do
+    className <- parseQualified properName
+    indented
+    ty <- P.many parseTypeAtom
+    return (className, ty)
+
 
 parseAnyType :: TokenParser Type
 parseAnyType = P.buildExpressionParser operators (buildPostfixParser postfixTable parseTypeAtom) P.<?> "type"

--- a/src/Language/PureScript/Sugar/Names/Env.hs
+++ b/src/Language/PureScript/Sugar/Names/Env.hs
@@ -16,6 +16,7 @@ module Language.PureScript.Sugar.Names.Env
   , getExports
   ) where
 
+import Data.Maybe (fromJust)
 import qualified Data.Map as M
 
 import Control.Monad
@@ -116,9 +117,10 @@ envModuleExports (_, _, exps) = exps
 -- The exported types from the @Prim@ module
 --
 primExports :: Exports
-primExports = Exports (mkTypeEntry `map` M.keys primTypes) [] []
+primExports = Exports (mkTypeEntry `map` M.keys primTypes) (mkClassEntry `map` M.keys primClasses) []
   where
-  mkTypeEntry (Qualified _ name) = ((name, []), ModuleName [ProperName "Prim"])
+  mkTypeEntry (Qualified mn name) = ((name, []), fromJust mn)
+  mkClassEntry (Qualified mn name) = (name, fromJust mn)
 
 -- | Environment which only contains the Prim module.
 primEnv :: Env


### PR DESCRIPTION
Resolves #1694, resolves #1669.

- Hides non-exhaustive pattern warning when applied
- Hides exhaustivity bail-out warning when applied
- Adds a warning for when the `Partial` constraint it used but the function is exhaustive.
- Updated the error to state `Partial` constraints for non-exhaustive patterns will be required from 0.9
- Constraints no longer need bracketing, even when comma-separated… maybe we don’t want that? Since we don’t have `ConstraintKind`s or actual tuple syntax it seemed reasonable to do so.