### PR TITLE
Drop paren requirement for constraints

### DIFF
--- a/examples/passing/UntupledConstraints.purs
+++ b/examples/passing/UntupledConstraints.purs
@@ -1,0 +1,17 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console
+
+class Show a <= Nonsense a where
+  method :: a -> a
+
+data Box a = Box a
+
+instance showBox :: Show a => Show (Box a) where
+  show (Box a) = "Box " <> show a
+
+strangeThing :: forall m. Semigroup (m Unit) => m Unit -> m Unit -> m Unit
+strangeThing x y = x <> y
+
+main = log "Done"


### PR DESCRIPTION
Resolves #1669.

I've left parens optional again here to explain why I think it might be nice: one of the slightly annoying things about the tuple-style syntax is it makes it awkward to break constraints over multiple lines. If parens are optional it makes it a little more natural to do something like this:

``` purescript
someFunc
  :: forall m a
   . Monad m
   , Semigroup (m a)
  => m a
  -> m a
  -> m Unit
```

Plus, you still can use them if you prefer to do so, this is a backwards compatible change.