### PR TITLE
Add native Partial constraint

### DIFF
--- a/examples/passing/EmptyTypeClass.purs
+++ b/examples/passing/EmptyTypeClass.purs
@@ -2,11 +2,11 @@ module Main where
 
 import Prelude
 
-class Partial
+class PartialP
 
-head :: forall a. (Partial) => Array a -> a
+head :: forall a. (PartialP) => Array a -> a
 head [x] = x
 
-instance allowPartials :: Partial
+instance allowPartials :: PartialP
 
 main = Control.Monad.Eff.Console.log $ head ["Done"]

--- a/examples/passing/NakedConstraint.purs
+++ b/examples/passing/NakedConstraint.purs
@@ -2,8 +2,6 @@ module Main where
 
 import Control.Monad.Eff.Console
 
-class Partial 
-
 data List a = Nil | Cons a (List a)
 
 head :: (Partial) => List Int -> Int

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -66,7 +66,7 @@ data Environment = Environment {
 -- The initial environment with no values and only the default javascript types defined
 --
 initEnvironment :: Environment
-initEnvironment = Environment M.empty primTypes M.empty M.empty M.empty M.empty
+initEnvironment = Environment M.empty primTypes M.empty M.empty M.empty primClasses
 
 -- |
 -- The visibility of a name in scope
@@ -236,17 +236,32 @@ function :: Type -> Type -> Type
 function t1 = TypeApp (TypeApp tyFunction t1)
 
 -- |
--- The primitive types in the external javascript environment with their associated kinds.
+-- The primitive types in the external javascript environment with their
+-- associated kinds. There is also a pseudo `Partial` type that corresponds to
+-- the class with the same name.
 --
 primTypes :: M.Map (Qualified ProperName) (Kind, TypeKind)
-primTypes = M.fromList [ (primName "Function" , (FunKind Star (FunKind Star Star), ExternData))
-                       , (primName "Array"    , (FunKind Star Star, ExternData))
-                       , (primName "Object"   , (FunKind (Row Star) Star, ExternData))
-                       , (primName "String"   , (Star, ExternData))
-                       , (primName "Char"     , (Star, ExternData))
-                       , (primName "Number"   , (Star, ExternData))
-                       , (primName "Int"      , (Star, ExternData))
-                       , (primName "Boolean"  , (Star, ExternData)) ]
+primTypes =
+  M.fromList
+    [ (primName "Function", (FunKind Star (FunKind Star Star), ExternData))
+    , (primName "Array", (FunKind Star Star, ExternData))
+    , (primName "Object", (FunKind (Row Star) Star, ExternData))
+    , (primName "String", (Star, ExternData))
+    , (primName "Char", (Star, ExternData))
+    , (primName "Number", (Star, ExternData))
+    , (primName "Int", (Star, ExternData))
+    , (primName "Boolean", (Star, ExternData))
+    , (primName "Partial", (Star, ExternData))
+    ]
+
+-- |
+-- The primitive class map. This just contains to `Partial` class, used as a
+-- kind of magic constraint for partial functions.
+--
+primClasses :: M.Map (Qualified ProperName) ([(String, Maybe Kind)], [(Ident, Type)], [Constraint])
+primClasses =
+  M.fromList
+    [ (primName "Partial", ([], [], [])) ]
 
 -- |
 -- Finds information about data constructors from the current environment.

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -773,9 +773,12 @@ prettyPrintSingleError full level e = do
     renderSimpleErrorMessage (NotExhaustivePattern bs b) =
       paras $ [ line "A case expression could not be determined to cover all inputs."
               , line "The following additional cases are required to cover all inputs:\n"
-              , Box.hsep 1 Box.left (map (paras . map (line . prettyPrintBinderAtom)) (transpose bs))
-              ] ++
-              [ line "..." | not b ]
+              , indent $ paras $
+                  [ Box.hsep 1 Box.left (map (paras . map (line . prettyPrintBinderAtom)) (transpose bs)) ]
+                  ++ [ line "..." | not b ]
+              , line "Or alternatively, add a Partial constraint to the type of the enclosing value."
+              , line "Non-exhaustive patterns for values without a `Partial` constraint will be disallowed in PureScript 0.9."
+              ]
     renderSimpleErrorMessage (OverlappingPattern bs b) =
       paras $ [ line "A case expression contains unreachable cases:\n"
               , Box.hsep 1 Box.left (map (paras . map (line . prettyPrintBinderAtom)) (transpose bs))

--- a/src/Language/PureScript/Sugar/Names/Env.hs
+++ b/src/Language/PureScript/Sugar/Names/Env.hs
@@ -20,6 +20,7 @@ module Language.PureScript.Sugar.Names.Env
 
 import Data.Function (on)
 import Data.List (groupBy, sortBy, nub)
+import Data.Maybe (fromJust)
 import qualified Data.Map as M
 
 import Control.Monad
@@ -121,9 +122,10 @@ envModuleExports (_, _, exps) = exps
 -- The exported types from the @Prim@ module
 --
 primExports :: Exports
-primExports = Exports (mkTypeEntry `map` M.keys primTypes) [] []
+primExports = Exports (mkTypeEntry `map` M.keys primTypes) (mkClassEntry `map` M.keys primClasses) []
   where
-  mkTypeEntry (Qualified _ name) = ((name, []), ModuleName [ProperName "Prim"])
+  mkTypeEntry (Qualified mn name) = ((name, []), fromJust mn)
+  mkClassEntry (Qualified mn name) = (name, fromJust mn)
 
 -- | Environment which only contains the Prim module.
 primEnv :: Env


### PR DESCRIPTION
Resolves #1694.

- Hides non-exhaustive pattern warning when applied
- Hides exhaustivity bail-out warning when applied
- Adds a warning for when the `Partial` constraint it used but the function is exhaustive.
- Updated the error to state `Partial` constraints for non-exhaustive patterns will be required from 0.9