### PR TITLE
Fix #1700, remove featureRemoved calls in parser (for 0.8)

### DIFF
--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -93,7 +93,7 @@ augmentDeclarations (partitionEithers -> (augments, toplevels)) =
 -- fixity declarations.
 --
 -- TODO: This may no longer be necessary after issue 806 is resolved, hopefully
--- in 0.8.
+-- in 0.9.
 addDefaultFixity :: Declaration -> Declaration
 addDefaultFixity decl@Declaration{..}
   | isOp declTitle && isNothing declFixity =

--- a/src/Language/PureScript/Parser/Common.hs
+++ b/src/Language/PureScript/Parser/Common.hs
@@ -27,11 +27,6 @@ import Language.PureScript.Names
 
 import qualified Text.Parsec as P
 
-featureWasRemoved :: String -> TokenParser a
-featureWasRemoved err = do
-  pos <- P.getPosition
-  error $ "It looks like you are trying to use a feature from a previous version of the compiler:\n" ++ err ++ "\nat " ++ show pos
-
 properName :: TokenParser ProperName
 properName = ProperName <$> uname
 

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -106,9 +106,6 @@ parseExternDeclaration = P.try (reserved "foreign") *> indented *> reserved "imp
    (ExternDataDeclaration <$> (P.try (reserved "data") *> indented *> properName)
                           <*> (indented *> doubleColon *> parseKind)
    <|> (do ident <- parseIdent
-           -- TODO: add a wiki page link with migration info
-           -- TODO: remove this deprecation warning in 0.8
-           _ <- P.optional $ stringLiteral *> featureWasRemoved "Inline foreign string literals are no longer supported."
            ty <- indented *> doubleColon *> noWildcards parsePolyType
            return $ ExternDeclaration ident ty))
 
@@ -524,10 +521,8 @@ parseIdentifierAndBinder =
 -- Parse a binder
 --
 parseBinder :: TokenParser Binder
-parseBinder = withSourceSpan PositionedBinder (P.buildExpressionParser operators (buildPostfixParser postfixTable parseBinderAtom))
+parseBinder = withSourceSpan PositionedBinder (buildPostfixParser postfixTable parseBinderAtom)
   where
-  -- TODO: remove this deprecation warning in 0.8
-  operators = [ [ P.Infix (P.try $ C.indented *> colon *> featureWasRemoved "Cons binders are no longer supported. Consider using purescript-lists or purescript-sequences instead.") P.AssocRight ] ]
   -- TODO: parsePolyType when adding support for polymorphic types
   postfixTable = [ \b -> flip TypedBinder b <$> (P.try (indented *> doubleColon) *> parseType)
                  ]

--- a/src/Language/PureScript/Parser/Types.hs
+++ b/src/Language/PureScript/Parser/Types.hs
@@ -17,17 +17,6 @@ import Language.PureScript.Environment
 import qualified Text.Parsec as P
 import qualified Text.Parsec.Expr as P
 
--- TODO: remove these deprecation warnings in 0.8
-parseArray :: TokenParser Type
-parseArray = do
-  _ <- squares $ return tyArray
-  featureWasRemoved "Array notation is no longer supported. Use Array instead of []."
-
-parseArrayOf :: TokenParser Type
-parseArrayOf = do
-  _ <- squares $ TypeApp tyArray <$> parseType
-  featureWasRemoved "Array notation is no longer supported. Use Array _ instead of [_]."
-
 parseFunction :: TokenParser Type
 parseFunction = parens $ rarrow >> return tyFunction
 
@@ -56,8 +45,6 @@ parseForAll = mkForAll <$> (P.try (reserved "forall") *> P.many1 (indented *> id
 parseTypeAtom :: TokenParser Type
 parseTypeAtom = indented *> P.choice (map P.try
             [ parseConstrainedType
-            , parseArray
-            , parseArrayOf
             , parseFunction
             , parseObject
             , parseTypeWildcard


### PR DESCRIPTION
This removes the deprecation errors for features broken in `0.7.*`.