### PR TITLE
Fix #1645, implement new indentation rules for types

### DIFF
--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -160,6 +160,7 @@ prettyPrintBinderAtom (ArrayBinder bs) =
   ++ " ]"
 prettyPrintBinderAtom (NamedBinder ident binder) = showIdent ident ++ "@" ++ prettyPrintBinder binder
 prettyPrintBinderAtom (PositionedBinder _ _ binder) = prettyPrintBinderAtom binder
+prettyPrintBinderAtom (TypedBinder _ binder) = prettyPrintBinderAtom binder
 prettyPrintBinderAtom b = parens (prettyPrintBinder b)
 
 -- |


### PR DESCRIPTION
/cc @garyb 

How does this look?

New example of an error message:

```text
  Could not match type

    Unit

  with type

    String


while trying to match type Unit
  with type String
while checking that expression case _0 of
                                 s -> log "Done"
  has type Eff
             ( console :: CONSOLE
             | _3
             )
             _2
while checking that expression \_0 ->
                                 case _0 of
                                   s -> log "Done"
  has type Unit
           -> Eff
                ( console :: CONSOLE
                | _3
                )
                _2
while applying a function (bind (#dict Bind _1)) (log "Foo")
  of type (_0
           -> _1
                _2)
          -> _1
               _2
  to argument \_0 ->
                case _0 of
                  s -> log "Done"
```

It gets a little too verbose on small examples like unknowns and skolem types, I think.