### PR TITLE
Renamer updates

### DIFF
--- a/examples/passing/1697.purs
+++ b/examples/passing/1697.purs
@@ -1,0 +1,24 @@
+module Main where
+
+import Prelude
+
+_2 :: forall a. a -> a
+_2 a = a
+
+x :: forall m. (Monad m) => m Unit
+x = do
+  _ <- pure unit
+  pure unit
+
+y :: forall m. (Monad m) => m Unit
+y = do
+  _ <- pure unit
+  pure unit
+
+wtf :: forall m. (Monad m) => m Unit
+wtf = do
+  _ <- pure unit
+  let tmp = _2 1
+  pure unit
+
+main = Control.Monad.Eff.Console.log "Done"

--- a/src/Control/Monad/Supply/Class.hs
+++ b/src/Control/Monad/Supply/Class.hs
@@ -1,20 +1,8 @@
------------------------------------------------------------------------------
---
--- Module      :  Control.Monad.Supply.Class
--- Copyright   :  (c) PureScript 2015
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
+{-# LANGUAGE MultiParamTypeClasses #-}
+
 -- |
 -- A class for monads supporting a supply of fresh names
 --
------------------------------------------------------------------------------
-
-{-# LANGUAGE MultiParamTypeClasses #-}
-
 module Control.Monad.Supply.Class where
 
 import Control.Monad.Supply
@@ -22,15 +10,15 @@ import Control.Monad.State
 
 class (Monad m) => MonadSupply m where
   fresh :: m Integer
-  
+
 instance (Monad m) => MonadSupply (SupplyT m) where
   fresh = SupplyT $ do
     n <- get
     put (n + 1)
     return n
-  
+
 instance (MonadSupply m) => MonadSupply (StateT s m) where
   fresh = lift fresh
 
 freshName :: (MonadSupply m) => m String
-freshName = liftM (('_' :) . show) fresh
+freshName = liftM (('$' :) . show) fresh

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -1,23 +1,11 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.CodeGen.JS
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
--- |
--- This module generates code in the simplified Javascript intermediate representation from Purescript code
---
------------------------------------------------------------------------------
-
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+-- |
+-- This module generates code in the simplified Javascript intermediate representation from Purescript code
+--
 module Language.PureScript.CodeGen.JS
   ( module AST
   , module Common
@@ -180,6 +168,7 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
   accessor :: Ident -> JS -> JS
   accessor (Ident prop) = accessorString prop
   accessor (Op op) = JSIndexer (JSStringLiteral op)
+  accessor (GenIdent _ _) = internalError "GenIdent in accessor"
 
   accessorString :: String -> JS -> JS
   accessorString prop | identNeedsEscaping prop = JSIndexer (JSStringLiteral prop)

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -1,23 +1,12 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.CodeGen.Common
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Common code generation utility functions
 --
------------------------------------------------------------------------------
-
 module Language.PureScript.CodeGen.JS.Common where
 
 import Data.Char
 import Data.List (intercalate)
 
+import Language.PureScript.Crash
 import Language.PureScript.Names
 
 -- |
@@ -33,6 +22,7 @@ identToJs :: Ident -> String
 identToJs (Ident name) | nameIsJsReserved name = "$$" ++ name
 identToJs (Ident name) = concatMap identCharToString name
 identToJs (Op op) = concatMap identCharToString op
+identToJs (GenIdent _ _) = internalError "GenIdent in identToJs"
 
 -- |
 -- Test if a string is a valid JS identifier without escaping.

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -1,17 +1,3 @@
------------------------------------------------------------------------------
---
--- Module      :  Make
--- Copyright   :  (c) 2013-15 Phil Freeman, (c) 2014-15 Gary Burgess
--- License     :  MIT (http://opensource.org/licenses/MIT)
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
--- |
---
------------------------------------------------------------------------------
-
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -225,8 +211,9 @@ make MakeActions{..} ms = do
                 progress $ CompilingModule moduleName
                 let env = foldl' (flip applyExternsFileToEnvironment) initEnvironment externs
                 lint m
-                ([desugared], nextVar) <- runSupplyT 0 $ desugar externs [m]
-                (checked@(Module ss coms _ elaborated exps), env') <- runCheck' env $ typeCheckModule desugared
+                ((checked@(Module ss coms _ elaborated exps), env'), nextVar) <- runSupplyT 0 $ do
+                  [desugared] <- desugar externs [m]
+                  runCheck' env $ typeCheckModule desugared
                 checkExhaustiveModule env' checked
                 regrouped <- createBindingGroups moduleName . collapseBindingGroups $ elaborated
                 let mod' = Module ss coms moduleName regrouped exps

--- a/src/Language/PureScript/Names.hs
+++ b/src/Language/PureScript/Names.hs
@@ -1,24 +1,15 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Names
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
--- |
--- Data types for names
---
------------------------------------------------------------------------------
-
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE GADTs #-}
 
+-- |
+-- Data types for names
+--
 module Language.PureScript.Names where
+
+import Control.Monad (liftM)
+import Control.Monad.Supply.Class
 
 import Data.List
 import Data.Data
@@ -38,15 +29,27 @@ data Ident
   -- |
   -- A symbolic name for an infix operator
   --
-  | Op String deriving (Show, Read, Eq, Ord, Data, Typeable)
+  | Op String
+  -- |
+  -- A generated name for an identifier
+  --
+  | GenIdent (Maybe String) Integer deriving (Show, Read, Eq, Ord, Data, Typeable)
 
 runIdent :: Ident -> String
 runIdent (Ident i) = i
 runIdent (Op op) = op
+runIdent (GenIdent Nothing n) = "$" ++ show n
+runIdent (GenIdent (Just name) n) = "$" ++ name ++ show n
 
 showIdent :: Ident -> String
-showIdent (Ident i) = i
 showIdent (Op op) = '(' : op ++ ")"
+showIdent i = runIdent i
+
+freshIdent :: (MonadSupply m) => String -> m Ident
+freshIdent name = liftM (GenIdent (Just name)) fresh
+
+freshIdent' :: (MonadSupply m) => m Ident
+freshIdent' = liftM (GenIdent Nothing) fresh
 
 -- |
 -- Proper names, i.e. capitalized names for e.g. module names, type//data constructors.

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -1,22 +1,10 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Sugar.DoNotation
--- Copyright   :  (c) 2013-15 Phil Freeman, (c) 2014-15 Gary Burgess
--- License     :  MIT (http://opensource.org/licenses/MIT)
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 -- |
 -- This module implements the desugaring pass which replaces do-notation statements with
 -- appropriate calls to bind from the Prelude.Monad type class.
 --
------------------------------------------------------------------------------
-
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Language.PureScript.Sugar.DoNotation (
     desugarDoModule
 ) where
@@ -68,7 +56,7 @@ desugarDo d =
     return $ App (App bind val) (Abs (Left ident) rest')
   go (DoNotationBind binder val : rest) = do
     rest' <- go rest
-    ident <- Ident <$> freshName
+    ident <- freshIdent'
     return $ App (App bind val) (Abs (Left ident) (Case [Var (Qualified Nothing ident)] [CaseAlternative [binder] (Right rest')]))
   go [DoNotationLet _] = throwError . errorMessage $ InvalidDoLet
   go (DoNotationLet ds : rest) = do

--- a/src/Language/PureScript/Sugar/ObjectWildcards.hs
+++ b/src/Language/PureScript/Sugar/ObjectWildcards.hs
@@ -1,17 +1,3 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Sugar.ObjectWildcards
--- Copyright   :  (c) 2013-15 Phil Freeman, (c) 2014-15 Gary Burgess
--- License     :  MIT (http://opensource.org/licenses/MIT)
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>, Gary Burgess <gary.burgess@gmail.com>
--- Stability   :  experimental
--- Portability :
---
--- |
---
------------------------------------------------------------------------------
-
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -44,10 +30,10 @@ desugarObjectConstructors (Module ss coms mn ds exts) = Module ss coms mn <$> ma
   desugarExpr (ObjectConstructor ps) = wrapLambda ObjectLiteral ps
   desugarExpr (ObjectUpdater (Just obj) ps) = wrapLambda (ObjectUpdate obj) ps
   desugarExpr (ObjectUpdater Nothing ps) = do
-    obj <- Ident <$> freshName
+    obj <- freshIdent'
     Abs (Left obj) <$> wrapLambda (ObjectUpdate (Var (Qualified Nothing obj))) ps
   desugarExpr (ObjectGetter prop) = do
-    arg <- Ident <$> freshName
+    arg <- freshIdent'
     return $ Abs (Left arg) (Accessor prop (Var (Qualified Nothing arg)))
   desugarExpr e = return e
 
@@ -63,5 +49,5 @@ desugarObjectConstructors (Module ss coms mn ds exts) = Module ss coms mn <$> ma
   mkProp :: (String, Maybe Expr) -> m (Maybe Ident, (String, Expr))
   mkProp (name, Just e) = return (Nothing, (name, e))
   mkProp (name, Nothing) = do
-    arg <- Ident <$> freshName
+    arg <- freshIdent'
     return (Just arg, (name, Var (Qualified Nothing arg)))

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -178,6 +178,6 @@ desugarOperatorSections (Module ss coms mn ds exts) = Module ss coms mn <$> trav
   goExpr :: Expr -> m Expr
   goExpr (OperatorSection op (Left val)) = return $ App op val
   goExpr (OperatorSection op (Right val)) = do
-    arg <- Ident <$> freshName
+    arg <- freshIdent'
     return $ Abs (Left arg) $ App (App op (Var (Qualified Nothing arg))) val
   goExpr other = return other

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -1,18 +1,3 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Sugar.TypeClasses.Deriving
--- Copyright   :  (c) Gershom Bazerman 2015
--- License     :  MIT (http://opensource.org/licenses/MIT)
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
--- |
--- This module implements the generic deriving elaboration that takes place during desugaring.
---
------------------------------------------------------------------------------
-
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -20,6 +5,9 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+-- |
+-- This module implements the generic deriving elaboration that takes place during desugaring.
+--
 module Language.PureScript.Sugar.TypeClasses.Deriving (
     deriveInstances
 ) where
@@ -32,7 +20,7 @@ import Data.Maybe (fromMaybe)
 import Data.Ord (comparing)
 
 import Control.Monad (replicateM)
-import Control.Monad.Supply.Class (MonadSupply, freshName)
+import Control.Monad.Supply.Class (MonadSupply)
 import Control.Monad.Error.Class (MonadError(..))
 
 import Language.PureScript.Crash
@@ -106,7 +94,7 @@ mkSpineFunction mn (DataDeclaration _ _ _ args) = lamCase "$x" <$> mapM mkCtorCl
 
   mkCtorClause :: (ProperName, [Type]) -> m CaseAlternative
   mkCtorClause (ctorName, tys) = do
-    idents <- replicateM (length tys) (fmap Ident freshName)
+    idents <- replicateM (length tys) freshIdent'
     return $ CaseAlternative [ConstructorBinder (Qualified (Just mn) ctorName) (map VarBinder idents)] (Right (caseResult idents))
     where
     caseResult idents =
@@ -172,7 +160,7 @@ mkFromSpineFunction mn (DataDeclaration _ _ _ args) = lamCase "$x" <$> (addCatch
 
   mkAlternative :: (ProperName, [Type]) -> m CaseAlternative
   mkAlternative (ctorName, tys) = do
-    idents <- replicateM (length tys) (fmap Ident freshName)
+    idents <- replicateM (length tys) freshIdent'
     return $ CaseAlternative [ prodBinder [ StringBinder (showQualified runProperName (Qualified (Just mn) ctorName)), ArrayBinder (map VarBinder idents)]]
                . Right
                $ liftApplicative (mkJust $ Constructor (Qualified (Just mn) ctorName))

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -25,6 +25,7 @@ import Data.Foldable (for_, traverse_)
 import qualified Data.Map as M
 
 import Control.Monad (when, unless, void, forM, forM_)
+import Control.Monad.Supply.Class (MonadSupply)
 import Control.Monad.State.Class (MonadState(..), modify)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Writer.Class (MonadWriter(..))
@@ -179,7 +180,7 @@ checkTypeSynonyms = void . replaceAllTypeSynonyms
 --  * Process module imports
 --
 typeCheckAll :: forall m.
-  (Functor m, Applicative m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) =>
+  (Functor m, Applicative m, MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) =>
   ModuleName ->
   [DeclarationRef] ->
   [Declaration] ->
@@ -335,7 +336,7 @@ typeCheckAll moduleName _ ds = traverse go ds <* traverse_ checkFixities ds
 -- required by exported members are also exported.
 --
 typeCheckModule :: forall m.
-  (Functor m, Applicative m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) =>
+  (Functor m, Applicative m, MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) =>
   Module ->
   m Module
 typeCheckModule (Module _ _ _ _ Nothing) = internalError "exports should have been elaborated"

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -57,14 +57,13 @@ data CheckState = CheckState
   , checkNextKind :: Int                    -- ^ The next kind unification variable
   , checkNextSkolem :: Int                  -- ^ The next skolem variable
   , checkNextSkolemScope :: Int             -- ^ The next skolem scope constant
-  , checkNextDictName :: Int                -- ^ The next type class dictionary name
   , checkCurrentModule :: Maybe ModuleName  -- ^ The current module
   , checkSubstitution :: Substitution       -- ^ The current substitution
   }
 
 -- | Create an empty @CheckState@
 emptyCheckState :: Environment -> CheckState
-emptyCheckState env = CheckState env 0 0 0 0 0 Nothing emptySubstitution
+emptyCheckState env = CheckState env 0 0 0 0 Nothing emptySubstitution
 
 -- | Unification variables
 type Unknown = Int
@@ -201,13 +200,6 @@ runCheck' env check = fmap (second checkEnv) $ runStateT check (emptyCheckState 
 guardWith :: (MonadError e m) => e -> Bool -> m ()
 guardWith _ True = return ()
 guardWith e False = throwError e
-
--- | Generate new type class dictionary name
-freshDictionaryName :: (Functor m, MonadState CheckState m) => m Int
-freshDictionaryName = do
-  n <- checkNextDictName <$> get
-  modify $ \s -> s { checkNextDictName = succ (checkNextDictName s) }
-  return n
 
 -- | Run a computation in the substitution monad, generating a return value and the final substitution.
 liftUnify ::


### PR DESCRIPTION
Resolves #1697

I also took the opportunity to tweak two other aspects of codegen:

- instead of generating `x$prime` for `x'` it will now generate a name like `x1` (or `x2` if `x1` is in scope, or `x3` if `x1` and `x2` are in scope, etc.)
- the generated class dictionary names are improved, so instead of `__dict_Functor_0` it will generate `dictFunctor` now, and then start numbering if there are multiple in scope

I understand if you object to the `x'` change, as it's slightly rewriting the input, but I think it's not a very difficult rule to understand, and generates much nicer names IMO.