### PR TITLE
Ensure no duplicates appear in the PSCiState

### DIFF
--- a/psci/PSCi.hs
+++ b/psci/PSCi.hs
@@ -258,10 +258,10 @@ make st@PSCiState{..} ms = P.make actions' (map snd loadedModules ++ ms)
   allModules = map (first Right) loadedModules ++ map (Left P.RebuildAlways,) ms
 
 -- |
--- Takes a value declaration and evaluates it with the current state.
+-- Takes a value expression and evaluates it with the current state.
 --
-handleDeclaration :: P.Expr -> PSCI ()
-handleDeclaration val = do
+handleExpression :: P.Expr -> PSCI ()
+handleExpression val = do
   st <- PSCI $ lift get
   let m = createTemporaryModule True st val
   let nodeArgs = psciNodeFlags st ++ [indexFile]
@@ -530,7 +530,7 @@ getCommand singleLineMode = handleInterrupt (return (Right Nothing)) $ do
 -- Performs an action for each meta-command given, and also for expressions.
 --
 handleCommand :: Command -> PSCI ()
-handleCommand (Expression val) = handleDeclaration val
+handleCommand (Expression val) = handleExpression val
 handleCommand ShowHelp = PSCI $ outputStrLn helpMessage
 handleCommand (Import im) = handleImport im
 handleCommand (Decls l) = handleDecls l

--- a/psci/PSCi.hs
+++ b/psci/PSCi.hs
@@ -547,7 +547,6 @@ handleCommand (LoadForeign filePath) = whenFileExists filePath $ \absPath -> do
     Left err -> PSCI $ outputStrLn $ P.prettyPrintMultipleErrors False err
     Right foreigns -> PSCI . lift $ modify (updateForeignFiles foreigns)
 handleCommand ResetState = do
-  files <- psciImportedFilenames <$> PSCI (lift get)
   PSCI . lift . modify $ \st ->
     st { psciImportedModules = []
        , psciLetBindings     = []

--- a/psci/Types.hs
+++ b/psci/Types.hs
@@ -15,7 +15,10 @@
 
 module Types where
 
-import qualified Data.Map as M
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Map (Map)
+import qualified Data.Map as Map
 import qualified Language.PureScript as P
 
 data PSCiOptions = PSCiOptions
@@ -32,13 +35,47 @@ data PSCiOptions = PSCiOptions
 -- because it makes more sense to apply the binding to the final evaluated expression.
 --
 data PSCiState = PSCiState
-  { psciImportedFilenames   :: [FilePath]
+  { _psciImportedFilenames  :: Set FilePath
   , psciImportedModules     :: [ImportedModule]
-  , psciLoadedModules       :: [(Either P.RebuildPolicy FilePath, P.Module)]
-  , psciForeignFiles        :: M.Map P.ModuleName FilePath
+  , _psciLoadedModules      :: Map P.ModuleName (Either P.RebuildPolicy FilePath, P.Module)
+  , psciForeignFiles        :: Map P.ModuleName FilePath
   , psciLetBindings         :: [P.Declaration]
   , psciNodeFlags           :: [String]
   }
+
+--  Public psci state accessors
+
+-- | Get the imported filenames as a list.
+psciImportedFilenames :: PSCiState -> [FilePath]
+psciImportedFilenames = Set.toList . _psciImportedFilenames
+
+-- | Get the loaded modules as a list.
+psciLoadedModules :: PSCiState -> [(Either P.RebuildPolicy FilePath, P.Module)]
+psciLoadedModules = Map.elems . _psciLoadedModules
+
+mkPSCiState :: [FilePath]
+               -> [ImportedModule]
+               -> [(Either P.RebuildPolicy FilePath, P.Module)]
+               -> Map P.ModuleName FilePath
+               -> [P.Declaration]
+               -> [String]
+               -> PSCiState
+mkPSCiState files imported loaded foreign lets nodeFlags =
+  (initialPSCiState
+    |> each files updateImportedFiles
+    |> each imported updateImportedModules
+    |> updateModules loaded)
+    { psciForeignFiles = foreign
+    , psciLetBindings = lets
+    , psciNodeFlags = nodeFlags
+    }
+  where
+  x |> f = f x
+  each xs f st = foldl (flip f) st xs
+
+initialPSCiState :: PSCiState
+initialPSCiState =
+  PSCiState Set.empty [] Map.empty Map.empty [] []
 
 -- | All of the data that is contained by an ImportDeclaration in the AST.
 -- That is:
@@ -65,10 +102,10 @@ allImportsOf m (PSCiState{psciImportedModules = is}) =
 -- State helpers
 
 -- |
--- Updates the state to have more imported modules.
+-- Updates the state to have more imported files.
 --
 updateImportedFiles :: FilePath -> PSCiState -> PSCiState
-updateImportedFiles filename st = st { psciImportedFilenames = filename : psciImportedFilenames st }
+updateImportedFiles filename st = st { _psciImportedFilenames = Set.insert filename (_psciImportedFilenames st) }
 
 -- |
 -- Updates the state to have more imported modules.
@@ -80,7 +117,10 @@ updateImportedModules im st = st { psciImportedModules = im : psciImportedModule
 -- Updates the state to have more loaded files.
 --
 updateModules :: [(Either P.RebuildPolicy FilePath, P.Module)] -> PSCiState -> PSCiState
-updateModules modules st = st { psciLoadedModules = psciLoadedModules st ++ modules }
+updateModules modules st =
+  st { _psciLoadedModules = foldl (\m mdl -> Map.insert (keyFor mdl) mdl m) (_psciLoadedModules st) modules }
+  where
+  keyFor = P.getModuleName . snd
 
 -- |
 -- Updates the state to have more let bindings.
@@ -91,8 +131,8 @@ updateLets ds st = st { psciLetBindings = psciLetBindings st ++ ds }
 -- |
 -- Updates the state to have more let bindings.
 --
-updateForeignFiles :: M.Map P.ModuleName FilePath -> PSCiState -> PSCiState
-updateForeignFiles fs st = st { psciForeignFiles = psciForeignFiles st `M.union` fs }
+updateForeignFiles :: Map P.ModuleName FilePath -> PSCiState -> PSCiState
+updateForeignFiles fs st = st { psciForeignFiles = psciForeignFiles st `Map.union` fs }
 
 -- |
 -- Valid Meta-commands for PSCI

--- a/psci/tests/Main.hs
+++ b/psci/tests/Main.hs
@@ -142,7 +142,7 @@ getPSCiState = do
       print err >> exitFailure
     Right modules ->
       let imports = [controlMonadSTasST, (P.ModuleName [P.ProperName "Prelude"], P.Implicit True, Nothing)]
-      in  return (PSCiState [] imports modules foreigns [] [])
+      in  return (mkPSCiState imports modules foreigns [] [])
 
 controlMonadSTasST :: ImportedModule
 controlMonadSTasST = (s "Control.Monad.ST", P.Implicit True, Just (s "ST"))


### PR DESCRIPTION
This is a potential fix for an issue that can be reproduced as follows:

```
$ pulp init
$ pulp psci # note: this adds `:load src/Main.purs` to .psci
> :load src/Main.purs 
> 0
Error found:

  Module Main has been defined multiple times.
```

The way it works is:

- Use a Set for imported filenames, to ensure there are no duplicates
- Use a Map for loaded modules, keyed by module name, to ensure that
  there are no duplicates
- Provide new accessors which preserve the old types

Maybe if a duplicate module is loaded, silently forgetting the old module isn't the right approach, though. Especially if the filenames were different. Perhaps, instead, we should just ignore the second `:load` command if the filenames were the same, and show the error if the modules were different?