### PR TITLE
Remove ParseDesugarError data type

### DIFF
--- a/psc-docs/Main.hs
+++ b/psc-docs/Main.hs
@@ -70,13 +70,7 @@ docgen (PSCDocsOptions fmt inputGlob output) = do
     Markdown -> do
       e <- D.parseAndDesugar input [] (\_ ms -> return ms)
       case e of
-        Left (D.ParseError err) -> do
-          hPutStrLn stderr $ show err
-          exitFailure
-        Left (D.SortModulesError err) -> do
-          hPutStrLn stderr $ P.prettyPrintMultipleErrors False err
-          exitFailure
-        Left (D.DesugarError err) -> do
+        Left err -> do
           hPutStrLn stderr $ P.prettyPrintMultipleErrors False err
           exitFailure
         Right ms' ->

--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -147,7 +147,7 @@ getModulesAndBookmarks :: PrepareM ([D.Bookmark], [D.Module])
 getModulesAndBookmarks = do
   (inputFiles, depsFiles) <- liftIO getInputAndDepsFiles
   liftIO (D.parseAndDesugar inputFiles depsFiles renderModules)
-    >>= either (userError . ParseAndDesugarError) return
+    >>= either (userError . CompileError) return
   where
   renderModules bookmarks modules =
     return (bookmarks, map D.convertModule modules)

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -33,7 +33,6 @@ import Web.Bower.PackageMeta (BowerError, PackageName, runPackageName, showBower
 import qualified Web.Bower.PackageMeta as Bower
 
 import qualified Language.PureScript as P
-import qualified Language.PureScript.Docs as D
 
 import Language.PureScript.Publish.BoxesHelpers
 
@@ -61,7 +60,7 @@ data UserError
   | AmbiguousVersions [Version] -- Invariant: should contain at least two elements
   | BadRepositoryField RepositoryFieldError
   | MissingDependencies (NonEmpty PackageName)
-  | ParseAndDesugarError D.ParseDesugarError
+  | CompileError P.MultipleErrors
   | DirtyWorkingTree
   deriving (Show)
 
@@ -188,19 +187,9 @@ displayUserError e = case e of
         [ "Please install ", them, " first, by running `bower install`."
         ])
       ]
-  ParseAndDesugarError (D.ParseError err) ->
+  CompileError err ->
     vcat
-      [ para "Parse error:"
-      , indented (P.prettyPrintMultipleErrorsBox False err)
-      ]
-  ParseAndDesugarError (D.SortModulesError err) ->
-    vcat
-      [ para "Error in sortModules:"
-      , indented (P.prettyPrintMultipleErrorsBox False err)
-      ]
-  ParseAndDesugarError (D.DesugarError err) ->
-    vcat
-      [ para "Error while desugaring:"
+      [ para "Compile error:"
       , indented (P.prettyPrintMultipleErrorsBox False err)
       ]
   DirtyWorkingTree ->


### PR DESCRIPTION
There's no reason to distinguish the individual cases, I think, so this
data type just adds noise for no benefit.

I came across this because I am currently looking into #1677, and getting this in first would simplify that, too, particularly in `psc-docs`.