### PR TITLE
Reexport docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ tmp/
 .stack-work/
 tests/support/flattened/
 output
+examples/docs/docs/
+core-tests/full-core-docs.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ install:
   # Snapshot state of the sandbox now, so we don't need to make new one for test install
   - rm -rf ~/cabal-sandboxes/$GHCVER-${STACKAGE:-none}
   - cp -r .cabal-sandbox ~/cabal-sandboxes/$GHCVER-${STACKAGE:-none}
+  # Install bower globally (for psc-docs/psc-publish tests)
+  - npm install -g bower
 script:
   - ./travis/configure.sh
   - cabal build --ghc-options="-Werror"

--- a/core-tests/test-everything.sh
+++ b/core-tests/test-everything.sh
@@ -18,9 +18,7 @@ if [ "$force_reinstall" = "true" ] && [ -d "bower_components" ]; then
   rm -r bower_components
 fi
 
-npm install bower
-
-node_modules/.bin/bower i \
+bower i \
         purescript-prelude \
         purescript-eff \
         purescript-st \
@@ -75,3 +73,7 @@ fi
 ../dist/build/psc/psc tests/*/*.purs \
                       'bower_components/purescript-*/src/**/*.purs' \
                 --ffi 'bower_components/purescript-*/src/**/*.js'
+
+../dist/build/psc-docs/psc-docs tests/*/*.purs \
+                      'bower_components/purescript-*/src/**/*.purs' \
+                      > full-core-docs.md

--- a/examples/docs/bower.json
+++ b/examples/docs/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "docs-test-package",
+  "version": "1.0.0",
+  "moduleType": [
+    "node"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/not-real/not-a-real-repo.git"
+  },
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "output"
+  ],
+  "dependencies": {
+  }
+}

--- a/examples/docs/bower_components/purescript-prelude/src/Prelude.purs
+++ b/examples/docs/bower_components/purescript-prelude/src/Prelude.purs
@@ -1,0 +1,8 @@
+module Prelude where
+
+newtype Unit = Unit {}
+
+unit :: Unit
+unit = Unit {}
+
+data Boolean2 = True | False

--- a/examples/docs/src/Clash.purs
+++ b/examples/docs/src/Clash.purs
@@ -1,0 +1,32 @@
+module Clash (module Clash1) where
+
+import Clash1 as Clash1
+import Clash2 as Clash2
+
+module Clash1 (module Clash1a) where
+
+import Clash1a
+
+module Clash1a where
+
+value :: Int
+value = 0
+
+type Type = Int
+
+class TypeClass a where
+  typeClassMember :: a
+
+module Clash2 (module Clash2a) where
+
+import Clash2a
+
+module Clash2a where
+
+value :: String
+value = "hello"
+
+type Type = String
+
+class TypeClass a b where
+  typeClassMember :: a -> b

--- a/examples/docs/src/DuplicateNames.purs
+++ b/examples/docs/src/DuplicateNames.purs
@@ -1,0 +1,9 @@
+module DuplicateNames
+  ( module DuplicateNames
+  , module Prelude
+  ) where
+
+import Prelude (Unit)
+
+unit :: Int
+unit = 0

--- a/examples/docs/src/Example.purs
+++ b/examples/docs/src/Example.purs
@@ -1,0 +1,7 @@
+module Example
+  ( module Prelude
+  , module Example2
+  ) where
+
+import Prelude (Unit())
+import Example2 (one)

--- a/examples/docs/src/Example2.purs
+++ b/examples/docs/src/Example2.purs
@@ -1,0 +1,7 @@
+module Example2 where
+
+one :: Int
+one = 1
+
+two :: Int
+two = 2

--- a/examples/docs/src/MultiVirtual.purs
+++ b/examples/docs/src/MultiVirtual.purs
@@ -1,0 +1,27 @@
+module MultiVirtual
+  ( module X )
+  where
+
+import MultiVirtual1 as X
+import MultiVirtual2 as X
+
+
+module MultiVirtual1 where
+
+foo :: Int
+foo = 1
+
+module MultiVirtual2 
+  ( module MultiVirtual2
+  , module MultiVirtual3
+  ) where
+
+import MultiVirtual3
+
+bar :: Int
+bar = 2
+
+module MultiVirtual3 where
+
+baz :: Int
+baz = 3

--- a/examples/docs/src/NewOperators.purs
+++ b/examples/docs/src/NewOperators.purs
@@ -1,0 +1,12 @@
+module NewOperators
+  ( module NewOperators2 )
+  where
+
+import NewOperators2
+
+module NewOperators2 where
+
+infixl 8 _compose as >>>
+
+_compose :: forall a b c. (b -> c) -> (a -> b) -> (a -> c)
+_compose f g x = f (g x)

--- a/examples/docs/src/NotAllCtors.purs
+++ b/examples/docs/src/NotAllCtors.purs
@@ -1,0 +1,5 @@
+module NotAllCtors
+  ( module Prelude )
+  where
+
+import Prelude (Boolean2(True))

--- a/examples/docs/src/OldOperators.purs
+++ b/examples/docs/src/OldOperators.purs
@@ -1,0 +1,10 @@
+
+-- Remove this after 0.9.
+module OldOperators (module OldOperators2) where
+
+import OldOperators2
+
+module OldOperators2 where
+
+(>>) :: forall a. a -> a -> a
+(>>) a b = b

--- a/examples/docs/src/ReExportedTypeClass.purs
+++ b/examples/docs/src/ReExportedTypeClass.purs
@@ -1,0 +1,5 @@
+module ReExportedTypeClass
+  ( module SomeTypeClass )
+  where
+
+import SomeTypeClass

--- a/examples/docs/src/SolitaryTypeClassMember.purs
+++ b/examples/docs/src/SolitaryTypeClassMember.purs
@@ -1,0 +1,6 @@
+module SolitaryTypeClassMember
+  ( module SomeTypeClass )
+  where
+
+import SomeTypeClass (member)
+

--- a/examples/docs/src/SomeTypeClass.purs
+++ b/examples/docs/src/SomeTypeClass.purs
@@ -1,0 +1,5 @@
+
+module SomeTypeClass where
+
+class SomeClass a where
+  member :: a

--- a/examples/docs/src/Transitive1.purs
+++ b/examples/docs/src/Transitive1.purs
@@ -1,0 +1,5 @@
+module Transitive1
+  ( module Transitive2 )
+  where
+
+import Transitive2

--- a/examples/docs/src/Transitive2.purs
+++ b/examples/docs/src/Transitive2.purs
@@ -1,0 +1,5 @@
+module Transitive2
+  ( module Transitive3 )
+  where
+
+import Transitive3

--- a/examples/docs/src/Transitive3.purs
+++ b/examples/docs/src/Transitive3.purs
@@ -1,0 +1,4 @@
+module Transitive3 where
+
+transitive3 :: Int
+transitive3 = 0

--- a/examples/docs/src/TypeClassWithoutMembers.purs
+++ b/examples/docs/src/TypeClassWithoutMembers.purs
@@ -1,0 +1,11 @@
+module TypeClassWithoutMembers
+  ( module Intermediate )
+  where
+
+import Intermediate
+
+module Intermediate
+  ( module SomeTypeClass )
+  where
+
+import SomeTypeClass (SomeClass)

--- a/examples/docs/src/UTF8.purs
+++ b/examples/docs/src/UTF8.purs
@@ -1,0 +1,7 @@
+module UTF8 where
+
+import Prelude (Unit, unit)
+
+-- | üÜäÄ 😰
+thing :: Unit
+thing = unit

--- a/examples/docs/src/Virtual.purs
+++ b/examples/docs/src/Virtual.purs
@@ -1,0 +1,5 @@
+module Virtual
+  ( module VirtualPrelude )
+  where
+
+import Prelude as VirtualPrelude

--- a/psc-docs/Main.hs
+++ b/psc-docs/Main.hs
@@ -74,7 +74,7 @@ docgen (PSCDocsOptions fmt inputGlob output) = do
         Left err -> do
           hPutStrLn stderr $ P.prettyPrintMultipleErrors False err
           exitFailure
-        Right (ms', _) ->
+        Right (ms', _, _) ->
           case output of
             EverythingToStdOut ->
               putStrLn (D.renderModulesAsMarkdown ms')

--- a/psc-docs/Main.hs
+++ b/psc-docs/Main.hs
@@ -16,6 +16,7 @@
 module Main where
 
 import Control.Applicative
+import Control.Monad.Trans.Except (runExceptT)
 import Control.Arrow (first, second)
 import Control.Category ((>>>))
 import Control.Monad.Writer
@@ -68,12 +69,12 @@ docgen (PSCDocsOptions fmt inputGlob output) = do
     Etags -> dumpTags input dumpEtags
     Ctags -> dumpTags input dumpCtags
     Markdown -> do
-      e <- D.parseAndDesugar input [] (\_ ms -> return ms)
+      e <- liftIO . runExceptT $ D.parseAndDesugar input []
       case e of
         Left err -> do
           hPutStrLn stderr $ P.prettyPrintMultipleErrors False err
           exitFailure
-        Right ms' ->
+        Right (ms', _) ->
           case output of
             EverythingToStdOut ->
               putStrLn (D.renderModulesAsMarkdown ms')

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -220,7 +220,8 @@ executable psc-docs
     build-depends: base >=4 && <5, purescript -any,
                    optparse-applicative >= 0.10.0, process -any, mtl -any,
                    split -any, ansi-wl-pprint -any, directory -any,
-                   filepath -any, Glob -any
+                   filepath -any, Glob -any, transformers -any,
+                   transformers-compat -any
     main-is: Main.hs
     buildable: True
     hs-source-dirs: psc-docs

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -162,6 +162,8 @@ library
 
                      Language.PureScript.Docs
                      Language.PureScript.Docs.Convert
+                     Language.PureScript.Docs.Convert.Single
+                     Language.PureScript.Docs.Convert.ReExports
                      Language.PureScript.Docs.Render
                      Language.PureScript.Docs.Types
                      Language.PureScript.Docs.RenderedCode

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -20,6 +20,9 @@ tested-with: GHC==7.8
 
 extra-source-files: examples/passing/*.purs
                   , examples/failing/*.purs
+                  , examples/docs/bower_components/purescript-prelude/src/*.purs
+                  , examples/docs/bower.json
+                  , examples/docs/src/*.purs
                   , tests/support/setup.js
                   , tests/support/package.json
                   , tests/support/bower.json
@@ -273,6 +276,7 @@ test-suite tests
     main-is: Main.hs
     other-modules: TestsSetup
                    TestPscPublish
+                   TestDocs
     buildable: True
     hs-source-dirs: tests tests/common
 

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -2,230 +2,86 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 -- | Functions for converting PureScript ASTs into values of the data types
 -- from Language.PureScript.Docs.
 
 module Language.PureScript.Docs.Convert
-  ( convertModule
+  ( convertModules
+  , convertModulesInPackage
   , collectBookmarks
   ) where
 
 import Prelude ()
 import Prelude.Compat
 
-import Control.Monad
+import Control.Monad.Error.Class (MonadError)
+import Control.Arrow ((&&&))
 import Control.Category ((>>>))
-import Data.Either
-import Data.Maybe (mapMaybe, isNothing)
-import Data.List (nub, isPrefixOf, isSuffixOf)
+import qualified Data.Map as Map
 
 import qualified Language.PureScript as P
 
 import Language.PureScript.Docs.Types
+import Language.PureScript.Docs.Convert.Single (convertSingleModule, collectBookmarks)
+import Language.PureScript.Docs.Convert.ReExports (updateReExports)
 
 -- |
--- Convert a single Module.
+-- Like convertModules, except that it takes a list of modules, together with
+-- their dependency status, and discards dependency modules in the resulting
+-- documentation.
 --
-convertModule :: P.Module -> Module
-convertModule m@(P.Module _ coms moduleName  _ _) =
-  Module (P.runModuleName moduleName) comments (declarations m)
+convertModulesInPackage ::
+  (Functor m, MonadError P.MultipleErrors m) =>
+  P.Env ->
+  [InPackage P.Module] ->
+  m [Module]
+convertModulesInPackage env modules =
+  go modules
   where
-  comments = convertComments coms
-  declarations =
-    P.exportedDeclarations
-    >>> mapMaybe (\d -> getDeclarationTitle d >>= convertDeclaration d)
-    >>> augmentDeclarations
-    >>> map addDefaultFixity
+  localNames =
+    map (P.runModuleName . P.getModuleName) (takeLocals modules)
+  go =
+    map ignorePackage
+     >>> convertModules env
+     >>> fmap (filter ((`elem` localNames) . modName))
 
--- | The data type for an intermediate stage which we go through during
--- converting.
+-- |
+-- Convert a group of modules to the intermediate format, designed for
+-- producing documentation from. It is also necessary to pass an Env containing
+-- imports/exports information about the list of modules, which is needed for
+-- documenting re-exports.
 --
--- In the first pass, we take all top level declarations in the module, and
--- collect other information which will later be used to augment the top level
--- declarations. These two situation correspond to the Right and Left
--- constructors, respectively.
+-- Preconditions:
 --
--- In the second pass, we go over all of the Left values and augment the
--- relevant declarations, leaving only the augmented Right values.
+--     * If any module in the list re-exports documentation from other
+--     modules, those modules must also be included in the list.
+--     * The modules passed must have had names desugared and re-exports
+--     elaborated first.
 --
--- Note that in the Left case, we provide a [String] as well as augment
--- information. The [String] value should be a list of titles of declarations
--- that the augmentation should apply to. For example, for a type instance
--- declaration, that would be any types or type classes mentioned in the
--- instance. For a fixity declaration, it would be just the relevant operator's
--- name.
-type IntermediateDeclaration
-  = Either ([String], DeclarationAugment) Declaration
-
--- | Some data which will be used to augment a Declaration in the
--- output.
+-- If either of these are not satisfied, an internal error will be thrown. To
+-- avoid this, it is recommended to use
+-- Language.PureScript.Docs.ParseAndDesugar to construct the inputs to this
+-- function.
 --
--- The AugmentChild constructor allows us to move all children under their
--- respective parents. It is only necessary for type instance declarations,
--- since they appear at the top level in the AST, and since they might need to
--- appear as children in two places (for example, if a data type defined in a
--- module is an instance of a type class also defined in that module).
+convertModules ::
+  (Functor m, MonadError P.MultipleErrors m) =>
+  P.Env ->
+  [P.Module] ->
+  m [Module]
+convertModules env =
+  P.sortModules >>> fmap (convertSorted env . fst)
+
+-- |
+-- Convert a sorted list of modules.
 --
--- The AugmentFixity constructor allows us to augment operator definitions
--- with their associativity and precedence.
-data DeclarationAugment
-  = AugmentChild ChildDeclaration
-  | AugmentFixity P.Fixity
-
--- | Augment top-level declarations; the second pass. See the comments under
--- the type synonym IntermediateDeclaration for more information.
-augmentDeclarations :: [IntermediateDeclaration] -> [Declaration]
-augmentDeclarations (partitionEithers -> (augments, toplevels)) =
-  foldl go toplevels augments
-  where
-  go ds (parentTitles, a) =
-    map (\d ->
-      if declTitle d `elem` parentTitles
-        then augmentWith a d
-        else d) ds
-
-  augmentWith a d =
-    case a of
-      AugmentChild child ->
-        d { declChildren = declChildren d ++ [child] }
-      AugmentFixity fixity ->
-        d { declFixity = Just fixity }
-
--- | Add the default operator fixity for operators which do not have associated
--- fixity declarations.
---
--- TODO: This may no longer be necessary after issue 806 is resolved, hopefully
--- in 0.9.
-addDefaultFixity :: Declaration -> Declaration
-addDefaultFixity decl@Declaration{..}
-  | isOp declTitle && isNothing declFixity =
-        decl { declFixity = Just defaultFixity }
-  | otherwise =
-        decl
-  where
-  isOp :: String -> Bool
-  isOp str = "(" `isPrefixOf` str && ")" `isSuffixOf` str
-  defaultFixity = P.Fixity P.Infixl (-1)
-
-getDeclarationTitle :: P.Declaration -> Maybe String
-getDeclarationTitle (P.TypeDeclaration name _)               = Just (P.showIdent name)
-getDeclarationTitle (P.ExternDeclaration name _)             = Just (P.showIdent name)
-getDeclarationTitle (P.DataDeclaration _ name _ _)           = Just (P.runProperName name)
-getDeclarationTitle (P.ExternDataDeclaration name _)         = Just (P.runProperName name)
-getDeclarationTitle (P.TypeSynonymDeclaration name _ _)      = Just (P.runProperName name)
-getDeclarationTitle (P.TypeClassDeclaration name _ _ _)      = Just (P.runProperName name)
-getDeclarationTitle (P.TypeInstanceDeclaration name _ _ _ _) = Just (P.showIdent name)
-getDeclarationTitle (P.FixityDeclaration _ name _)           = Just ("(" ++ name ++ ")")
-getDeclarationTitle (P.PositionedDeclaration _ _ d)          = getDeclarationTitle d
-getDeclarationTitle _                                        = Nothing
-
--- | Create a basic Declaration value.
-mkDeclaration :: String -> DeclarationInfo -> Declaration
-mkDeclaration title info =
-  Declaration { declTitle      = title
-              , declComments   = Nothing
-              , declSourceSpan = Nothing
-              , declChildren   = []
-              , declFixity     = Nothing
-              , declInfo       = info
-              }
-
-basicDeclaration :: String -> DeclarationInfo -> Maybe IntermediateDeclaration
-basicDeclaration title info = Just $ Right $ mkDeclaration title info
-
-convertDeclaration :: P.Declaration -> String -> Maybe IntermediateDeclaration
-convertDeclaration (P.TypeDeclaration _ ty) title =
-  basicDeclaration title (ValueDeclaration ty)
-convertDeclaration (P.ExternDeclaration _ ty) title =
-  basicDeclaration title (ValueDeclaration ty)
-convertDeclaration (P.DataDeclaration dtype _ args ctors) title =
-  Just (Right (mkDeclaration title info) { declChildren = children })
-  where
-  info = DataDeclaration dtype args
-  children = map convertCtor ctors
-  convertCtor (ctor', tys) =
-    ChildDeclaration (P.runProperName ctor') Nothing Nothing (ChildDataConstructor tys)
-convertDeclaration (P.ExternDataDeclaration _ kind') title =
-  basicDeclaration title (ExternDataDeclaration kind')
-convertDeclaration (P.TypeSynonymDeclaration _ args ty) title =
-  basicDeclaration title (TypeSynonymDeclaration args ty)
-convertDeclaration (P.TypeClassDeclaration _ args implies ds) title =
-  Just (Right (mkDeclaration title info) { declChildren = children })
-  where
-  info = TypeClassDeclaration args implies
-  children = map convertClassMember ds
-  convertClassMember (P.PositionedDeclaration _ _ d) =
-    convertClassMember d
-  convertClassMember (P.TypeDeclaration ident' ty) =
-    ChildDeclaration (P.showIdent ident') Nothing Nothing (ChildTypeClassMember ty)
-  convertClassMember _ =
-    P.internalError "convertDeclaration: Invalid argument to convertClassMember."
-convertDeclaration (P.TypeInstanceDeclaration _ constraints className tys _) title =
-  Just (Left (classNameString : typeNameStrings, AugmentChild childDecl))
-  where
-  classNameString = unQual className
-  typeNameStrings = nub (concatMap (P.everythingOnTypes (++) extractProperNames) tys)
-  unQual x = let (P.Qualified _ y) = x in P.runProperName y
-
-  extractProperNames (P.TypeConstructor n) = [unQual n]
-  extractProperNames _ = []
-
-  childDecl = ChildDeclaration title Nothing Nothing (ChildInstance constraints classApp)
-  classApp = foldl P.TypeApp (P.TypeConstructor (fmap P.coerceProperName className)) tys
-convertDeclaration (P.FixityDeclaration fixity _ Nothing) title =
-  Just (Left ([title], AugmentFixity fixity))
-convertDeclaration (P.FixityDeclaration fixity _ (Just alias)) title =
-  Just $ Right $ (mkDeclaration title (AliasDeclaration alias fixity)) { declFixity = Just fixity }
-convertDeclaration (P.PositionedDeclaration srcSpan com d') title =
-  fmap (addComments . addSourceSpan) (convertDeclaration d' title)
-  where
-  addComments (Right d) =
-    Right (d { declComments = convertComments com })
-  addComments (Left augment) =
-    Left (withAugmentChild (\d -> d { cdeclComments = convertComments com })
-                           augment)
-
-  addSourceSpan (Right d) =
-    Right (d { declSourceSpan = Just srcSpan })
-  addSourceSpan (Left augment) =
-    Left (withAugmentChild (\d -> d { cdeclSourceSpan = Just srcSpan })
-                           augment)
-
-  withAugmentChild f (t, a) =
-    case a of
-      AugmentChild d -> (t, AugmentChild (f d))
-      _              -> (t, a)
-convertDeclaration _ _ = Nothing
-
-convertComments :: [P.Comment] -> Maybe String
-convertComments cs = do
-  let raw = concatMap toLines cs
-  guard (all hasPipe raw && not (null raw))
-  return (go raw)
-  where
-  go = unlines . map stripPipes
-
-  toLines (P.LineComment s) = [s]
-  toLines (P.BlockComment s) = lines s
-
-  hasPipe s = case dropWhile (== ' ') s of { ('|':_) -> True; _ -> False }
-
-  stripPipes = dropPipe . dropWhile (== ' ')
-
-  dropPipe ('|':' ':s) = s
-  dropPipe ('|':s) = s
-  dropPipe s = s
-
--- | Go through a PureScript module and extract a list of Bookmarks; references
--- to data types or values, to be used as a kind of index. These are used for
--- generating links in the HTML documentation, for example.
-collectBookmarks :: InPackage P.Module -> [Bookmark]
-collectBookmarks (Local m) = map Local (collectBookmarks' m)
-collectBookmarks (FromDep pkg m) = map (FromDep pkg) (collectBookmarks' m)
-
-collectBookmarks' :: P.Module -> [(P.ModuleName, String)]
-collectBookmarks' m =
-  map (P.getModuleName m, )
-      (mapMaybe getDeclarationTitle
-                (P.exportedDeclarations m))
+convertSorted :: P.Env -> [P.Module] -> [Module]
+convertSorted env modules =
+  let
+    traversalOrder =
+      map P.getModuleName modules
+    moduleMap =
+      Map.fromList $ map (P.getModuleName &&& convertSingleModule) modules
+  in
+    Map.elems (updateReExports env traversalOrder moduleMap)

--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -1,0 +1,444 @@
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Language.PureScript.Docs.Convert.ReExports
+  ( updateReExports
+  ) where
+
+import Prelude ()
+import Prelude.Compat
+
+import Control.Monad
+import Control.Monad.Trans.State.Strict (execState)
+import Control.Monad.State.Class (MonadState, gets, modify)
+import Control.Arrow ((&&&), first, second)
+import Data.Either
+import Data.Maybe (mapMaybe)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Monoid ((<>))
+
+import qualified Language.PureScript as P
+
+import Language.PureScript.Docs.Types
+
+-- |
+-- Given:
+--
+--      * The Imports/Exports Env
+--      * An order to traverse the modules (which must be topological)
+--      * A map of modules, indexed by their names, which are assumed to not
+--      have their re-exports listed yet
+--
+-- This function adds all the missing re-exports.
+--
+updateReExports ::
+  P.Env ->
+  [P.ModuleName] ->
+  Map P.ModuleName Module ->
+  Map P.ModuleName Module
+updateReExports env order modules =
+  execState action modules
+  where
+  action =
+    void (traverse go order)
+
+  go mn = do
+    mdl <- lookup' mn
+    reExports <- getReExports env mn
+    let mdl' = mdl { modReExports = reExports }
+    modify (Map.insert mn mdl')
+
+  lookup' mn = do
+    v <- gets (Map.lookup mn)
+    case v of
+      Just v' ->
+        pure v'
+      Nothing ->
+        internalError ("Module missing: " ++ P.runModuleName mn)
+
+-- |
+-- Collect all of the re-exported declarations for a single module.
+--
+-- We require that modules have already been sorted (P.sortModules) in order to
+-- ensure that by the time we convert a particular module, all its dependencies
+-- have already been converted.
+--
+getReExports ::
+  (Functor m, Applicative m,
+  MonadState (Map P.ModuleName Module) m) =>
+  P.Env ->
+  P.ModuleName ->
+  m [(P.ModuleName, [Declaration])]
+getReExports env mn =
+  case Map.lookup mn env of
+    Nothing ->
+      internalError ("Module missing: " ++ P.runModuleName mn)
+    Just (_, imports, exports) ->
+      let notLocal = (/= mn) . fst
+      in filter notLocal <$> collectDeclarations imports exports
+
+-- |
+-- Assemble a list of declarations re-exported from a particular module, based
+-- on the Imports and Exports value for that module, and by extracting the
+-- declarations from the current state.
+--
+-- This function works by searching through the lists of exported declarations
+-- in the Exports, and looking them up in the associated Imports value to find
+-- the module they were imported from.
+--
+-- Additionally:
+--
+--      * Attempts to move re-exported type class members under their parent
+--      type classes, if possible, or otherwise, "promote" them from
+--      ChildDeclarations to proper Declarations.
+--      * Filters data declarations to ensure that only re-exported data
+--      constructors are listed.
+--      * Filters type class declarations to ensure that only re-exported type
+--      class members are listed.
+--
+collectDeclarations ::
+  (Functor m, Applicative m, MonadState (Map P.ModuleName Module) m) =>
+  P.Imports ->
+  P.Exports ->
+  m [(P.ModuleName, [Declaration])]
+collectDeclarations imports exports = do
+  valsAndMembers <- collect lookupValueDeclaration     impVals  expVals
+  typeClasses    <- collect lookupTypeClassDeclaration impTCs   expTCs
+  types          <- collect lookupTypeDeclaration      impTypes expTypes
+
+  let (vals, classes) = handleTypeClassMembers valsAndMembers typeClasses
+
+  let filteredTypes = filterDataConstructors expCtors types
+  let filteredClasses = filterTypeClassMembers (map fst expVals) classes
+
+  pure (Map.toList (Map.unionsWith (<>) [filteredTypes, filteredClasses, vals]))
+
+  where
+  collect lookup' imps exps =
+    Map.fromListWith (<>) <$> traverse (uncurry lookup')
+                                       (map (findImport imps) exps)
+
+  expVals = P.exportedValues exports
+  impVals = concat (Map.elems (P.importedValues imports))
+
+  expTypes = map (first fst) (P.exportedTypes exports)
+  impTypes = concat (Map.elems (P.importedTypes imports))
+
+  expCtors = concatMap (snd . fst) (P.exportedTypes exports)
+
+  expTCs = P.exportedTypeClasses exports
+  impTCs = concat (Map.elems (P.importedTypeClasses imports))
+
+-- |
+-- Given a list of imported declarations (of a particular kind, ie. type, data,
+-- class, value, etc), and the name of an exported declaration of the same
+-- kind, together with the module it was originally defined in, return a tuple
+-- of:
+--
+--      * the module that exported declaration was imported from (note that
+--      this can be different from the module it was originally defined in, if
+--      it is a re-export),
+--      * that same declaration's name.
+--
+-- This function uses a type variable for names because we want to be able to
+-- instantiate @name@ as both 'P.Ident' and 'P.ProperName'.
+--
+findImport ::
+  (Show name, Eq name) =>
+  [(P.Qualified name, P.ModuleName)] ->
+  (name, P.ModuleName) ->
+  (P.ModuleName, name)
+findImport imps (name, orig) =
+  case filter (\(qual, mn) -> P.disqualify qual == name && mn == orig) imps of
+    [(P.Qualified (Just importedFrom) _, _)] ->
+      (importedFrom, name)
+    other ->
+      internalError ("findImport: unexpected result: " ++ show other)
+
+lookupValueDeclaration ::
+  (MonadState (Map P.ModuleName Module) m, Applicative m) =>
+  P.ModuleName ->
+  P.Ident ->
+  m (P.ModuleName, [Either (String, P.Constraint, ChildDeclaration) Declaration])
+lookupValueDeclaration importedFrom ident = do
+  decls <- lookupModuleDeclarations "lookupValueDeclaration" importedFrom
+  let
+    rs =
+      filter (\d -> declTitle d == P.showIdent ident
+                    && (isValue d || isAlias d)) decls
+    errOther other =
+      internalError
+        ("lookupValueDeclaration: unexpected result:\n" ++
+          "other: " ++ show other ++ "\n" ++
+          "ident: " ++ show ident ++ "\n" ++
+          "decls: " ++ show decls)
+
+  case rs of
+    [r] ->
+      pure (importedFrom, [Right r])
+    [] ->
+      -- It's a type class member.
+      -- Note that we need to filter based on the child declaration info using
+      -- `isTypeClassMember` anyway, because child declarations of type classes
+      -- are not necessarily members; they could also be instances.
+      let
+        allTypeClassChildDecls =
+          decls
+           |> mapMaybe (\d -> (d,) <$> typeClassConstraintFor d)
+           |> concatMap (\(d, constr) ->
+                map (declTitle d, constr,)
+                    (declChildren d))
+
+        matchesIdent cdecl =
+          cdeclTitle cdecl == P.showIdent ident
+
+        matchesAndIsTypeClassMember =
+          uncurry (&&) . (matchesIdent &&& isTypeClassMember)
+
+      in
+        case filter (matchesAndIsTypeClassMember . thd) allTypeClassChildDecls of
+          [r'] ->
+            pure (importedFrom, [Left r'])
+          other ->
+            errOther other
+    other -> do
+      errOther other
+
+  where
+  thd :: (a, b, c) -> c
+  thd (_, _, x) = x
+
+-- |
+-- Extract a particular type declaration. For data declarations, constructors
+-- are only included in the output if they are listed in the arguments.
+--
+lookupTypeDeclaration ::
+  (MonadState (Map P.ModuleName Module) m, Applicative m) =>
+  P.ModuleName ->
+  P.ProperName 'P.TypeName ->
+  m (P.ModuleName, [Declaration])
+lookupTypeDeclaration importedFrom ty = do
+  decls <- lookupModuleDeclarations "lookupTypeDeclaration" importedFrom
+  let
+    ds = filter (\d -> declTitle d == P.runProperName ty && isType d) decls
+  case ds of
+    [d] ->
+      pure (importedFrom, [d])
+    other ->
+      internalError
+        ("lookupTypeDeclaration: unexpected result: " ++ show other)
+
+lookupTypeClassDeclaration ::
+  (MonadState (Map P.ModuleName Module) m, Applicative m) =>
+  P.ModuleName ->
+  P.ProperName 'P.ClassName ->
+  m (P.ModuleName, [Declaration])
+lookupTypeClassDeclaration importedFrom tyClass = do
+  decls <- lookupModuleDeclarations "lookupTypeClassDeclaration" importedFrom
+  let
+    ds = filter (\d -> declTitle d == P.runProperName tyClass
+                       && isTypeClass d)
+                decls
+  case ds of
+    [d] ->
+      pure (importedFrom, [d])
+    other ->
+      internalError ("lookupTypeClassDeclaration: unexpected result: "
+                    ++ (unlines . map show) other)
+
+-- |
+-- Get the full list of declarations for a particular module out of the
+-- state, or raise an internal error if it is not there.
+--
+lookupModuleDeclarations ::
+  (Applicative m, MonadState (Map P.ModuleName Module) m) =>
+  String ->
+  P.ModuleName ->
+  m [Declaration]
+lookupModuleDeclarations definedIn moduleName = do
+  mmdl <- gets (Map.lookup moduleName)
+  case mmdl of
+    Nothing ->
+      internalError (definedIn ++ ": module missing: "
+                    ++ P.runModuleName moduleName)
+    Just mdl ->
+      pure (allDeclarations mdl)
+
+handleTypeClassMembers ::
+  Map P.ModuleName [Either (String, P.Constraint, ChildDeclaration) Declaration] ->
+  Map P.ModuleName [Declaration] ->
+  (Map P.ModuleName [Declaration], Map P.ModuleName [Declaration])
+handleTypeClassMembers valsAndMembers typeClasses =
+  let
+    moduleEnvs =
+      Map.unionWith (<>)
+        (fmap valsAndMembersToEnv valsAndMembers)
+        (fmap typeClassesToEnv typeClasses)
+  in
+    moduleEnvs
+      |> fmap handleEnv
+      |> splitMap
+
+valsAndMembersToEnv ::
+  [Either (String, P.Constraint, ChildDeclaration) Declaration] -> TypeClassEnv
+valsAndMembersToEnv xs =
+  let (envUnhandledMembers, envValues) = partitionEithers xs
+      envTypeClasses = []
+  in TypeClassEnv{..}
+
+typeClassesToEnv :: [Declaration] -> TypeClassEnv
+typeClassesToEnv classes =
+  TypeClassEnv
+    { envUnhandledMembers = []
+    , envValues = []
+    , envTypeClasses = classes
+    }
+
+-- |
+-- An intermediate data type, used for either moving type class members under
+-- their parent type classes, or promoting them to normal Declaration values
+-- if their parent type class has not been re-exported.
+--
+data TypeClassEnv = TypeClassEnv
+  { -- |
+    -- Type class members which have not yet been dealt with. The String is the
+    -- name of the type class they belong to, and the constraint is used to
+    -- make sure that they have the correct type if they get promoted.
+    --
+    envUnhandledMembers :: [(String, P.Constraint, ChildDeclaration)]
+    -- |
+    -- A list of normal value declarations. Type class members will be added to
+    -- this list if their parent type class is not available.
+    --
+  , envValues :: [Declaration]
+    -- |
+    -- A list of type class declarations. Type class members will be added to
+    -- their parents in this list, if they exist.
+    --
+  , envTypeClasses :: [Declaration]
+  }
+  deriving (Show)
+
+instance Monoid TypeClassEnv where
+  mempty =
+    TypeClassEnv mempty mempty mempty
+  mappend (TypeClassEnv a1 b1 c1)
+          (TypeClassEnv a2 b2 c2) =
+    TypeClassEnv (a1 <> a2) (b1 <> b2) (c1 <> c2)
+
+-- |
+-- Take a TypeClassEnv and handle all of the type class members in it, either
+-- adding them to their parent classes, or promoting them to normal Declaration
+-- values.
+--
+-- Returns a tuple of (values, type classes).
+--
+handleEnv :: TypeClassEnv -> ([Declaration], [Declaration])
+handleEnv TypeClassEnv{..} =
+  envUnhandledMembers
+    |> foldl go (envValues, mkMap envTypeClasses)
+    |> second Map.elems
+
+  where
+  mkMap =
+    Map.fromList . map (declTitle &&& id)
+
+  go (values, tcs) (title, constraint, childDecl) =
+    case Map.lookup title tcs of
+      Just _ ->
+        -- Leave the state unchanged; if the type class is there, the child
+        -- will be too.
+        (values, tcs)
+      Nothing ->
+        (promoteChild constraint childDecl : values, tcs)
+
+  promoteChild constraint ChildDeclaration{..} =
+    case cdeclInfo of
+      ChildTypeClassMember typ ->
+        Declaration
+          { declTitle      = cdeclTitle
+          , declComments   = cdeclComments
+          , declSourceSpan = cdeclSourceSpan
+          , declChildren   = []
+          , declFixity     = Nothing
+          , declInfo       = ValueDeclaration (addConstraint constraint typ)
+          }
+      _ ->
+        internalError
+          ("handleEnv: Bad child declaration passed to promoteChild: "
+          ++ cdeclTitle)
+
+  addConstraint constraint =
+    P.quantify . P.moveQuantifiersToFront . P.ConstrainedType [constraint]
+
+splitMap :: (Ord k) => Map k (v1, v2) -> (Map k v1, Map k v2)
+splitMap = foldl go (Map.empty, Map.empty) . Map.toList
+  where
+  go (m1, m2) (k, (v1, v2)) =
+    (Map.insert k v1 m1, Map.insert k v2 m2)
+
+-- |
+-- Given a list of exported constructor names, remove any data constructor
+-- names in the provided Map of declarations which are not in the list.
+--
+filterDataConstructors ::
+  [P.ProperName 'P.ConstructorName] ->
+  Map P.ModuleName [Declaration] ->
+  Map P.ModuleName [Declaration]
+filterDataConstructors =
+  filterExportedChildren isDataConstructor P.runProperName
+
+-- |
+-- Given a list of exported type class member names, remove any data
+-- type class member names in the provided Map of declarations which are not in
+-- the list.
+--
+filterTypeClassMembers ::
+  [P.Ident] ->
+  Map P.ModuleName [Declaration] ->
+  Map P.ModuleName [Declaration]
+filterTypeClassMembers =
+  filterExportedChildren isTypeClassMember P.showIdent
+
+filterExportedChildren ::
+  (Functor f) =>
+  (ChildDeclaration -> Bool) ->
+  (name -> String) ->
+  [name] ->
+  f [Declaration] ->
+  f [Declaration]
+filterExportedChildren isTargetedKind runName expNames =
+  fmap filterDecls
+  where
+  filterDecls =
+    map (filterChildren (\c -> not (isTargetedKind c) ||
+                               cdeclTitle c `elem` expNames'))
+
+  expNames' = map runName expNames
+
+allDeclarations :: Module -> [Declaration]
+allDeclarations Module{..} =
+  modDeclarations ++ concatMap snd modReExports
+
+(|>) :: a -> (a -> b) -> b
+x |> f = f x
+
+internalError :: String -> a
+internalError = P.internalError . ("Docs.Convert.ReExports: " ++)
+
+-- |
+-- If the provided Declaration is a TypeClassDeclaration, construct an
+-- appropriate Constraint for use with the types of its members.
+--
+typeClassConstraintFor :: Declaration -> Maybe P.Constraint
+typeClassConstraintFor Declaration{..} =
+  case declInfo of
+    TypeClassDeclaration tyArgs _ ->
+      Just (P.Qualified Nothing (P.ProperName declTitle), mkConstraint tyArgs)
+    _ ->
+      Nothing
+  where
+  mkConstraint = map (P.TypeVar . fst)

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -1,0 +1,230 @@
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Language.PureScript.Docs.Convert.Single
+  ( convertSingleModule
+  , collectBookmarks
+  ) where
+
+import Prelude ()
+import Prelude.Compat
+
+import Control.Monad
+import Control.Category ((>>>))
+import Data.Maybe (mapMaybe, isNothing)
+import Data.Either
+import Data.List (nub, isPrefixOf, isSuffixOf)
+
+import qualified Language.PureScript as P
+
+import Language.PureScript.Docs.Types
+
+-- |
+-- Convert a single Module, but ignore re-exports; any re-exported types or
+-- values will not appear in the result.
+--
+convertSingleModule :: P.Module -> Module
+convertSingleModule m@(P.Module _ coms moduleName  _ _) =
+  Module (P.runModuleName moduleName) comments (declarations m) []
+  where
+  comments = convertComments coms
+  declarations =
+    P.exportedDeclarations
+    >>> mapMaybe (\d -> getDeclarationTitle d >>= convertDeclaration d)
+    >>> augmentDeclarations
+    >>> map addDefaultFixity
+
+-- | The data type for an intermediate stage which we go through during
+-- converting.
+--
+-- In the first pass, we take all top level declarations in the module, and
+-- collect other information which will later be used to augment the top level
+-- declarations. These two situation correspond to the Right and Left
+-- constructors, respectively.
+--
+-- In the second pass, we go over all of the Left values and augment the
+-- relevant declarations, leaving only the augmented Right values.
+--
+-- Note that in the Left case, we provide a [String] as well as augment
+-- information. The [String] value should be a list of titles of declarations
+-- that the augmentation should apply to. For example, for a type instance
+-- declaration, that would be any types or type classes mentioned in the
+-- instance. For a fixity declaration, it would be just the relevant operator's
+-- name.
+type IntermediateDeclaration
+  = Either ([String], DeclarationAugment) Declaration
+
+-- | Some data which will be used to augment a Declaration in the
+-- output.
+--
+-- The AugmentChild constructor allows us to move all children under their
+-- respective parents. It is only necessary for type instance declarations,
+-- since they appear at the top level in the AST, and since they might need to
+-- appear as children in two places (for example, if a data type defined in a
+-- module is an instance of a type class also defined in that module).
+--
+-- The AugmentFixity constructor allows us to augment operator definitions
+-- with their associativity and precedence.
+data DeclarationAugment
+  = AugmentChild ChildDeclaration
+  | AugmentFixity P.Fixity
+
+-- | Augment top-level declarations; the second pass. See the comments under
+-- the type synonym IntermediateDeclaration for more information.
+augmentDeclarations :: [IntermediateDeclaration] -> [Declaration]
+augmentDeclarations (partitionEithers -> (augments, toplevels)) =
+  foldl go toplevels augments
+  where
+  go ds (parentTitles, a) =
+    map (\d ->
+      if declTitle d `elem` parentTitles
+        then augmentWith a d
+        else d) ds
+
+  augmentWith a d =
+    case a of
+      AugmentChild child ->
+        d { declChildren = declChildren d ++ [child] }
+      AugmentFixity fixity ->
+        d { declFixity = Just fixity }
+
+-- | Add the default operator fixity for operators which do not have associated
+-- fixity declarations.
+--
+-- TODO: This may no longer be necessary after issue 806 is resolved, hopefully
+-- in 0.9.
+addDefaultFixity :: Declaration -> Declaration
+addDefaultFixity decl@Declaration{..}
+  | isOp declTitle && isNothing declFixity =
+        decl { declFixity = Just defaultFixity }
+  | otherwise =
+        decl
+  where
+  isOp :: String -> Bool
+  isOp str = "(" `isPrefixOf` str && ")" `isSuffixOf` str
+  defaultFixity = P.Fixity P.Infixl (-1)
+
+getDeclarationTitle :: P.Declaration -> Maybe String
+getDeclarationTitle (P.TypeDeclaration name _)               = Just (P.showIdent name)
+getDeclarationTitle (P.ExternDeclaration name _)             = Just (P.showIdent name)
+getDeclarationTitle (P.DataDeclaration _ name _ _)           = Just (P.runProperName name)
+getDeclarationTitle (P.ExternDataDeclaration name _)         = Just (P.runProperName name)
+getDeclarationTitle (P.TypeSynonymDeclaration name _ _)      = Just (P.runProperName name)
+getDeclarationTitle (P.TypeClassDeclaration name _ _ _)      = Just (P.runProperName name)
+getDeclarationTitle (P.TypeInstanceDeclaration name _ _ _ _) = Just (P.showIdent name)
+getDeclarationTitle (P.FixityDeclaration _ name _)           = Just ("(" ++ name ++ ")")
+getDeclarationTitle (P.PositionedDeclaration _ _ d)          = getDeclarationTitle d
+getDeclarationTitle _                                        = Nothing
+
+-- | Create a basic Declaration value.
+mkDeclaration :: String -> DeclarationInfo -> Declaration
+mkDeclaration title info =
+  Declaration { declTitle      = title
+              , declComments   = Nothing
+              , declSourceSpan = Nothing
+              , declChildren   = []
+              , declFixity     = Nothing
+              , declInfo       = info
+              }
+
+basicDeclaration :: String -> DeclarationInfo -> Maybe IntermediateDeclaration
+basicDeclaration title info = Just $ Right $ mkDeclaration title info
+
+convertDeclaration :: P.Declaration -> String -> Maybe IntermediateDeclaration
+convertDeclaration (P.TypeDeclaration _ ty) title =
+  basicDeclaration title (ValueDeclaration ty)
+convertDeclaration (P.ExternDeclaration _ ty) title =
+  basicDeclaration title (ValueDeclaration ty)
+convertDeclaration (P.DataDeclaration dtype _ args ctors) title =
+  Just (Right (mkDeclaration title info) { declChildren = children })
+  where
+  info = DataDeclaration dtype args
+  children = map convertCtor ctors
+  convertCtor (ctor', tys) =
+    ChildDeclaration (P.runProperName ctor') Nothing Nothing (ChildDataConstructor tys)
+convertDeclaration (P.ExternDataDeclaration _ kind') title =
+  basicDeclaration title (ExternDataDeclaration kind')
+convertDeclaration (P.TypeSynonymDeclaration _ args ty) title =
+  basicDeclaration title (TypeSynonymDeclaration args ty)
+convertDeclaration (P.TypeClassDeclaration _ args implies ds) title =
+  Just (Right (mkDeclaration title info) { declChildren = children })
+  where
+  info = TypeClassDeclaration args implies
+  children = map convertClassMember ds
+  convertClassMember (P.PositionedDeclaration _ _ d) =
+    convertClassMember d
+  convertClassMember (P.TypeDeclaration ident' ty) =
+    ChildDeclaration (P.showIdent ident') Nothing Nothing (ChildTypeClassMember ty)
+  convertClassMember _ =
+    P.internalError "convertDeclaration: Invalid argument to convertClassMember."
+convertDeclaration (P.TypeInstanceDeclaration _ constraints className tys _) title =
+  Just (Left (classNameString : typeNameStrings, AugmentChild childDecl))
+  where
+  classNameString = unQual className
+  typeNameStrings = nub (concatMap (P.everythingOnTypes (++) extractProperNames) tys)
+  unQual x = let (P.Qualified _ y) = x in P.runProperName y
+
+  extractProperNames (P.TypeConstructor n) = [unQual n]
+  extractProperNames _ = []
+
+  childDecl = ChildDeclaration title Nothing Nothing (ChildInstance constraints classApp)
+  classApp = foldl P.TypeApp (P.TypeConstructor (fmap P.coerceProperName className)) tys
+convertDeclaration (P.FixityDeclaration fixity _ Nothing) title =
+  Just (Left ([title], AugmentFixity fixity))
+convertDeclaration (P.FixityDeclaration fixity _ (Just alias)) title =
+  Just $ Right $ (mkDeclaration title (AliasDeclaration alias fixity)) { declFixity = Just fixity }
+convertDeclaration (P.PositionedDeclaration srcSpan com d') title =
+  fmap (addComments . addSourceSpan) (convertDeclaration d' title)
+  where
+  addComments (Right d) =
+    Right (d { declComments = convertComments com })
+  addComments (Left augment) =
+    Left (withAugmentChild (\d -> d { cdeclComments = convertComments com })
+                           augment)
+
+  addSourceSpan (Right d) =
+    Right (d { declSourceSpan = Just srcSpan })
+  addSourceSpan (Left augment) =
+    Left (withAugmentChild (\d -> d { cdeclSourceSpan = Just srcSpan })
+                           augment)
+
+  withAugmentChild f (t, a) =
+    case a of
+      AugmentChild d -> (t, AugmentChild (f d))
+      _              -> (t, a)
+convertDeclaration _ _ = Nothing
+
+convertComments :: [P.Comment] -> Maybe String
+convertComments cs = do
+  let raw = concatMap toLines cs
+  guard (all hasPipe raw && not (null raw))
+  return (go raw)
+  where
+  go = unlines . map stripPipes
+
+  toLines (P.LineComment s) = [s]
+  toLines (P.BlockComment s) = lines s
+
+  hasPipe s = case dropWhile (== ' ') s of { ('|':_) -> True; _ -> False }
+
+  stripPipes = dropPipe . dropWhile (== ' ')
+
+  dropPipe ('|':' ':s) = s
+  dropPipe ('|':s) = s
+  dropPipe s = s
+
+-- | Go through a PureScript module and extract a list of Bookmarks; references
+-- to data types or values, to be used as a kind of index. These are used for
+-- generating links in the HTML documentation, for example.
+collectBookmarks :: InPackage P.Module -> [Bookmark]
+collectBookmarks (Local m) = map Local (collectBookmarks' m)
+collectBookmarks (FromDep pkg m) = map (FromDep pkg) (collectBookmarks' m)
+
+collectBookmarks' :: P.Module -> [(P.ModuleName, String)]
+collectBookmarks' m =
+  map (P.getModuleName m, )
+      (mapMaybe getDeclarationTitle
+                (P.exportedDeclarations m))

--- a/src/Language/PureScript/Docs/ParseAndDesugar.hs
+++ b/src/Language/PureScript/Docs/ParseAndDesugar.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module Language.PureScript.Docs.ParseAndDesugar
   ( parseAndDesugar
@@ -11,7 +12,6 @@ import qualified Data.Map as M
 import Control.Arrow (first)
 import Control.Monad
 
-import Control.Monad.Trans.Except
 import Control.Monad.Writer.Strict (runWriterT)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.IO.Class (MonadIO(..))
@@ -29,40 +29,40 @@ import Language.PureScript.Docs.Convert (collectBookmarks)
 --    * A list of local source files
 --    * A list of source files from external dependencies, together with their
 --      package names
---    * A callback, taking a list of bookmarks, and a list of desugared modules
 --
 -- This function does the following:
 --
 --    * Parse all of the input and dependency source files
---    * Partially desugar all of the resulting modules
+--    * Partially desugar all of the resulting modules (just enough for
+--      producing documentation from them)
 --    * Collect a list of bookmarks from the whole set of source files
 --    * Collect a list of desugared modules from just the input source files (not
 --      dependencies)
---    * Call the callback with the bookmarks and desugared module list.
+--    * Return the desugared modules and the bookmarks.
 parseAndDesugar ::
+  (Functor m, Applicative m, MonadError P.MultipleErrors m, MonadIO m) =>
   [FilePath]
   -> [(PackageName, FilePath)]
-  -> ([Bookmark] -> [P.Module] -> IO a)
-  -> IO (Either P.MultipleErrors a)
-parseAndDesugar inputFiles depsFiles callback = do
+  -> m ([P.Module], [Bookmark])
+parseAndDesugar inputFiles depsFiles = do
   inputFiles' <- traverse (parseAs Local) inputFiles
   depsFiles'  <- traverse (\(pkgName, f) -> parseAs (FromDep pkgName) f) depsFiles
 
-  runExceptT $ do
-    ms         <- parseFiles (inputFiles' ++ depsFiles')
-    ms'        <- sortModules (map snd ms)
-    (bs, ms'') <- desugarWithBookmarks ms ms'
-    liftIO $ callback bs ms''
+  ms  <- parseFiles (inputFiles' ++ depsFiles')
+  ms' <- sortModules (map snd ms)
+  desugarWithBookmarks ms ms'
 
 parseFiles ::
+  (MonadError P.MultipleErrors m, MonadIO m) =>
   [(FileInfo, FilePath)]
-  -> ExceptT P.MultipleErrors IO [(FileInfo, P.Module)]
+  -> m [(FileInfo, P.Module)]
 parseFiles =
   throwLeft . P.parseModulesFromFiles fileInfoToString
 
 sortModules ::
+  (Functor m, MonadError P.MultipleErrors m, MonadIO m) =>
   [P.Module]
-  -> ExceptT P.MultipleErrors IO [P.Module]
+  -> m [P.Module]
 sortModules =
   fmap fst . throwLeft . sortModules' . map importPrim
   where
@@ -70,9 +70,10 @@ sortModules =
   sortModules' = P.sortModules
 
 desugarWithBookmarks ::
+  (MonadError P.MultipleErrors m, MonadIO m) =>
   [(FileInfo, P.Module)]
   -> [P.Module]
-  -> ExceptT P.MultipleErrors IO ([Bookmark], [P.Module])
+  -> m ([P.Module], [Bookmark])
 desugarWithBookmarks msInfo msSorted =  do
   msDesugared <- throwLeft (desugar msSorted)
 
@@ -80,7 +81,7 @@ desugarWithBookmarks msInfo msSorted =  do
       msPackages = map (addPackage msDeps) msDesugared
       bookmarks = concatMap collectBookmarks msPackages
 
-  return (bookmarks, takeLocals msPackages)
+  return (takeLocals msPackages, bookmarks)
 
 throwLeft :: (MonadError l m) => Either l r -> m r
 throwLeft = either throwError return
@@ -101,18 +102,24 @@ fileInfoToString (FromDep _ fn) = fn
 importPrim :: P.Module -> P.Module
 importPrim = P.addDefaultImport (P.ModuleName [P.ProperName C.prim])
 
-desugar :: [P.Module] -> Either P.MultipleErrors [P.Module]
+desugar ::
+  (Functor m, Applicative m, MonadError P.MultipleErrors m) =>
+  [P.Module]
+  -> m [P.Module]
 desugar = P.evalSupplyT 0 . desugar'
   where
-  desugar' :: [P.Module] -> P.SupplyT (Either P.MultipleErrors) [P.Module]
-  desugar' = traverse P.desugarDoModule >=> P.desugarCasesModule >=> ignoreWarnings . P.desugarImports []
+  desugar' =
+    traverse P.desugarDoModule
+      >=> P.desugarCasesModule
+      >=> ignoreWarnings . P.desugarImports []
+
   ignoreWarnings m = liftM fst (runWriterT m)
 
 parseFile :: FilePath -> IO (FilePath, String)
 parseFile input' = (,) input' <$> readFile input'
 
-parseAs :: (FilePath -> a) -> FilePath -> IO (a, String)
-parseAs g = fmap (first g) . parseFile
+parseAs :: (Functor m, MonadIO m) => (FilePath -> a) -> FilePath -> m (a, String)
+parseAs g = fmap (first g) . liftIO . parseFile
 
 getDepsModuleNames :: [InPackage (FilePath, P.Module)] -> M.Map P.ModuleName PackageName
 getDepsModuleNames = foldl go M.empty

--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -49,7 +49,7 @@ renderDeclarationWithOptions opts Declaration{..} =
       [ keywordClass ]
       ++ maybeToList superclasses
       ++ [renderType' (typeApp declTitle args)]
-      ++ [keywordWhere | any (isTypeClassMember . cdeclInfo) declChildren]
+      ++ [keywordWhere | any isTypeClassMember declChildren]
 
       where
       superclasses
@@ -58,9 +58,6 @@ renderDeclarationWithOptions opts Declaration{..} =
             syntax "("
             <> mintersperse (syntax "," <> sp) (map renderConstraint implies)
             <> syntax ")" <> sp <> syntax "<="
-
-      isTypeClassMember (ChildTypeClassMember _) = True
-      isTypeClassMember _ = False
     AliasDeclaration for (P.Fixity associativity precedence) ->
       [ keywordFixity associativity
       , syntax $ show precedence

--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -146,7 +146,7 @@ preparePackage' opts = do
 getModulesAndBookmarks :: PrepareM ([D.Bookmark], [D.Module])
 getModulesAndBookmarks = do
   (inputFiles, depsFiles) <- liftIO getInputAndDepsFiles
-  (modules', bookmarks) <- parseAndDesugar inputFiles depsFiles
+  (modules', bookmarks, _) <- parseAndDesugar inputFiles depsFiles
 
   return (bookmarks, map D.convertModule modules')
 

--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -146,9 +146,11 @@ preparePackage' opts = do
 getModulesAndBookmarks :: PrepareM ([D.Bookmark], [D.Module])
 getModulesAndBookmarks = do
   (inputFiles, depsFiles) <- liftIO getInputAndDepsFiles
-  (modules', bookmarks, _) <- parseAndDesugar inputFiles depsFiles
+  (modules', bookmarks, env) <- parseAndDesugar inputFiles depsFiles
 
-  return (bookmarks, map D.convertModule modules')
+  case runExcept (D.convertModulesInPackage env modules') of
+    Right modules -> return (bookmarks, modules)
+    Left err -> userError (CompileError err)
 
   where
   parseAndDesugar inputFiles depsFiles = do

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -177,10 +177,10 @@ main :: IO ()
 main = do
   heading "Main compiler test suite"
   testCompiler
-  heading "psc-publish test suite"
-  testPscPublish
   heading "Documentation test suite"
   TestDocs.main
+  -- heading "psc-publish test suite"
+  -- testPscPublish
 
   where
   heading msg = do

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -172,8 +172,18 @@ assertDoesNotCompile inputFiles foreigns = do
 
 main :: IO ()
 main = do
+  heading "Main compiler test suite"
   testCompiler
+  heading "psc-publish test suite"
   testPscPublish
+
+  where
+  heading msg = do
+    putStrLn ""
+    putStrLn $ replicate 79 '#'
+    putStrLn $ "# " ++ msg
+    putStrLn $ replicate 79 '#'
+    putStrLn ""
 
 testCompiler :: IO ()
 testCompiler = do

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -30,6 +30,7 @@
 --   -- @shouldFailWith TypesDoNotUnify
 --   -- @shouldFailWith TypesDoNotUnify
 --   -- @shouldFailWith TransitiveExportError
+--
 
 module Main (main) where
 
@@ -39,6 +40,7 @@ import Prelude.Compat
 import qualified Language.PureScript as P
 import qualified Language.PureScript.CodeGen.JS as J
 import qualified Language.PureScript.CoreFn as CF
+import qualified Language.PureScript.Docs as Docs
 
 import Data.Char (isSpace)
 import Data.Maybe (mapMaybe, fromMaybe)
@@ -69,6 +71,7 @@ import Text.Parsec (ParseError)
 
 import TestsSetup
 import TestPscPublish
+import qualified TestDocs
 
 modulesDir :: FilePath
 modulesDir = ".test_modules" </> "node_modules"
@@ -176,6 +179,8 @@ main = do
   testCompiler
   heading "psc-publish test suite"
   testPscPublish
+  heading "Documentation test suite"
+  TestDocs.main
 
   where
   heading msg = do
@@ -211,7 +216,7 @@ testCompiler = do
       assertDoesNotCompile (supportPurs ++ [failing </> inputFile]) foreigns
 
   if null failures
-    then exitSuccess
+    then pure ()
     else do
       putStrLn "Failures:"
       forM_ failures $ \(fp, err) ->
@@ -222,6 +227,7 @@ testCompiler = do
 testPscPublish :: IO ()
 testPscPublish = do
   testPackage "tests/support/prelude"
+
 
 supportModules :: [String]
 supportModules =

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -1,0 +1,232 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE DataKinds #-}
+
+module TestDocs where
+
+import Prelude ()
+import Prelude.Compat
+
+import Data.Version (Version(..))
+
+import Control.Monad hiding (forM_)
+import Control.Applicative
+import Control.Arrow
+import Data.Maybe (fromMaybe)
+import Data.List ((\\))
+import Data.Foldable
+import Data.Traversable
+import System.Exit
+import qualified Text.Parsec as Parsec
+
+import qualified Language.PureScript as P
+import qualified Language.PureScript.Docs as Docs
+import qualified Language.PureScript.Publish as Publish
+
+import qualified TestPscPublish
+
+publishOpts :: Publish.PublishOptions
+publishOpts = Publish.defaultPublishOptions
+  { Publish.publishGetVersion = return testVersion
+  , Publish.publishWorkingTreeDirty = return ()
+  }
+  where testVersion = ("v999.0.0", Version [999,0,0] [])
+
+main :: IO ()
+main = do
+  TestPscPublish.pushd "examples/docs" $ do
+    Docs.Package{..} <- Publish.preparePackage publishOpts
+    forM_ testCases $ \(mn, pragmas) ->
+      let mdl = takeJust ("module not found in docs: " ++ mn)
+                         (find ((==) mn . Docs.modName) pkgModules)
+      in forM_ pragmas (flip runAssertionIO mdl)
+
+takeJust :: String -> Maybe a -> a
+takeJust msg = maybe (error msg) id
+
+data Assertion
+  -- | Assert that a particular declaration is documented with the given
+  -- children
+  = ShouldBeDocumented P.ModuleName String [String]
+  -- | Assert that a particular declaration is not documented
+  | ShouldNotBeDocumented P.ModuleName String
+  -- | Assert that a particular declaration exists, but without a particular
+  -- child.
+  | ChildShouldNotBeDocumented P.ModuleName String String
+  -- | Assert that a particular declaration has a particular type class
+  -- constraint.
+  | ShouldBeConstrained P.ModuleName String String
+  deriving (Show)
+
+data AssertionFailure
+  -- | A declaration was not documented, but should have been
+  = NotDocumented P.ModuleName String
+  -- | A child declaration was not documented, but should have been
+  | ChildrenNotDocumented P.ModuleName String [String]
+  -- | A declaration was documented, but should not have been
+  | Documented P.ModuleName String
+  -- | A child declaration was documented, but should not have been
+  | ChildDocumented P.ModuleName String String
+  -- | A constraint was missing.
+  | ConstraintMissing P.ModuleName String String
+  -- | A declaration had the wrong "type" (ie, value, type, type class)
+  -- Fields: declaration title, expected "type", actual "type".
+  | WrongDeclarationType P.ModuleName String String String
+  deriving (Show)
+
+data AssertionResult
+  = Pass
+  | Fail AssertionFailure
+  deriving (Show)
+
+runAssertion :: Assertion -> Docs.Module -> AssertionResult
+runAssertion assertion Docs.Module{..} =
+  case assertion of
+    ShouldBeDocumented mn decl children ->
+      case findChildren decl (declarationsFor mn) of
+        Nothing ->
+          Fail (NotDocumented mn decl)
+        Just actualChildren ->
+          case children \\ actualChildren of
+            [] -> Pass
+            cs -> Fail (ChildrenNotDocumented mn decl cs)
+
+    ShouldNotBeDocumented mn decl ->
+      case findChildren decl (declarationsFor mn) of
+        Just _ ->
+          Fail (Documented mn decl)
+        Nothing ->
+          Pass
+
+    ChildShouldNotBeDocumented mn decl child ->
+      case findChildren decl (declarationsFor mn) of
+        Just children ->
+          if child `elem` children
+            then Fail (ChildDocumented mn decl child)
+            else Pass
+        Nothing ->
+          Fail (NotDocumented mn decl)
+
+    ShouldBeConstrained mn decl tyClass ->
+      case find ((==) decl . Docs.declTitle) (declarationsFor mn) of
+        Nothing ->
+          Fail (NotDocumented mn decl)
+        Just Docs.Declaration{..} ->
+          case declInfo of
+            Docs.ValueDeclaration ty ->
+              if checkConstrained ty tyClass
+                then Pass
+                else Fail (ConstraintMissing mn decl tyClass)
+            _ ->
+              Fail (WrongDeclarationType mn decl "value"
+                     (Docs.declInfoToString declInfo))
+
+  where
+  declarationsFor mn =
+    if P.runModuleName mn == modName
+      then modDeclarations
+      else fromMaybe [] (lookup mn modReExports)
+
+  findChildren title =
+    fmap childrenTitles . find ((==) title . Docs.declTitle)
+
+  childrenTitles = map Docs.cdeclTitle . Docs.declChildren
+
+checkConstrained ty tyClass =
+  -- Note that we don't recurse on ConstrainedType if none of the constraints
+  -- match; this is by design, as constraints should be moved to the front
+  -- anyway.
+  case ty of
+    P.ConstrainedType cs _ | any (matches tyClass) cs ->
+      True
+    P.ForAll _ ty' _ ->
+      checkConstrained ty' tyClass
+    _ ->
+      False
+  where
+  matches className =
+    (==) className . P.runProperName . P.disqualify . fst
+
+runAssertionIO :: Assertion -> Docs.Module -> IO ()
+runAssertionIO assertion mdl = do
+  putStrLn ("In " ++ Docs.modName mdl ++ ": " ++ show assertion)
+  case runAssertion assertion mdl of
+    Pass -> pure ()
+    fail -> do
+      putStrLn (show fail)
+      exitFailure
+
+testCases :: [(String, [Assertion])]
+testCases =
+  [ ("Example",
+      [ -- From dependencies
+        ShouldBeDocumented    (n "Prelude") "Unit" []
+      , ShouldNotBeDocumented (n "Prelude") "unit"
+
+        -- From local files
+      , ShouldBeDocumented    (n "Example2") "one" []
+      , ShouldNotBeDocumented (n "Example2") "two"
+      ])
+  , ("Example2",
+      [ ShouldBeDocumented (n "Example2") "one" []
+      , ShouldBeDocumented (n "Example2") "two" []
+      ])
+
+  , ("UTF8",
+      [ ShouldBeDocumented (n "UTF8") "thing" []
+      ])
+
+  , ("Transitive1",
+      [ ShouldBeDocumented (n "Transitive2") "transitive3" []
+      ])
+
+  , ("NotAllCtors",
+      [ ShouldBeDocumented         (n "Prelude") "Boolean2" ["True"]
+      , ChildShouldNotBeDocumented (n "Prelude") "Boolean2" "False"
+      ])
+
+  , ("DuplicateNames",
+      [ ShouldBeDocumented    (n "Prelude")        "Unit" []
+      , ShouldBeDocumented    (n "DuplicateNames") "unit" []
+      , ShouldNotBeDocumented (n "Prelude")        "unit"
+      ])
+
+  , ("MultiVirtual",
+      [ ShouldBeDocumented (n "MultiVirtual1") "foo" []
+      , ShouldBeDocumented (n "MultiVirtual2") "bar" []
+      , ShouldBeDocumented (n "MultiVirtual2") "baz" []
+      ])
+
+  , ("Clash",
+      [ ShouldBeDocumented (n "Clash1") "value" []
+      , ShouldBeDocumented (n "Clash1") "Type" []
+      , ShouldBeDocumented (n "Clash1") "TypeClass" ["typeClassMember"]
+      ])
+
+  , ("SolitaryTypeClassMember",
+      [ ShouldBeDocumented    (n "SomeTypeClass") "member" []
+      , ShouldNotBeDocumented (n "SomeTypeClass") "SomeClass"
+      , ShouldBeConstrained   (n "SomeTypeClass") "member" "SomeClass"
+      ])
+
+  , ("ReExportedTypeClass",
+      [ ShouldBeDocumented (n "SomeTypeClass") "SomeClass" ["member"]
+      ])
+
+  , ("TypeClassWithoutMembers",
+      [ ShouldBeDocumented         (n "Intermediate") "SomeClass" []
+      , ChildShouldNotBeDocumented (n "Intermediate") "SomeClass" "member"
+      ])
+
+  -- Remove this after 0.9.
+  , ("OldOperators",
+      [ ShouldBeDocumented  (n "OldOperators2") "(>>)" []
+      ])
+
+  , ("NewOperators",
+      [ ShouldBeDocumented (n "NewOperators2") "(>>>)" []
+      ])
+  ]
+
+  where
+  n = P.moduleNameFromString

--- a/tests/TestPscPublish.hs
+++ b/tests/TestPscPublish.hs
@@ -60,6 +60,6 @@ testPackage dir = do
     case r of
       Pass _ -> pure ()
       other -> do
-        hPutStrLn stderr ("psc-publish tests failed on " ++ dir ++ ":")
-        hPutStrLn stderr (show other)
+        putStrLn ("psc-publish tests failed on " ++ dir ++ ":")
+        putStrLn (show other)
         exitFailure


### PR DESCRIPTION
Addresses #1677.

Changes:
* `Env` is now exported by `Language.PureScript`
* Added a variant of `desugarImports` which also returns the `Env`.
* Generalise `parseAndDesugar` to any `MonadIO m, MonadError P.MultipleErrors m`
* Make `parseAndDesugar` also return the `Env`.
* Remove the useless callback parameter to `parseAndDesugar` (what was I thinking??)
* Add a re-exports field to the `Module` type in `Language.PureScript.Docs`
* Print re-exported values in `psc-docs`.

For now, I just want to see if this passes CI (for some reason, tests aren't working on my machine). Before merging, this still needs:
* [x] History cleanup
* [x] Tests