### PR TITLE
Ensure tests don't exit early

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -201,7 +201,7 @@ testCompiler = do
       assertDoesNotCompile (supportPurs ++ [failing </> inputFile]) foreigns
 
   if null failures
-    then exitSuccess
+    then pure unit
     else do
       putStrLn "Failures:"
       forM_ failures $ \(fp, err) ->

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -201,7 +201,7 @@ testCompiler = do
       assertDoesNotCompile (supportPurs ++ [failing </> inputFile]) foreigns
 
   if null failures
-    then pure unit
+    then pure ()
     else do
       putStrLn "Failures:"
       forM_ failures $ \(fp, err) ->


### PR DESCRIPTION
The test suite was calling exitSuccess after the compiler tests were
complete, which meant that the psc-publish tests were never running.
Oops.