### PR TITLE
Expose error suggestions in JSON

### DIFF
--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -185,10 +185,9 @@ lintImportDecl env mni qualifierName names declType =
     :: (ModuleName -> [DeclarationRef] -> SimpleErrorMessage)
     -> m ()
   checkImplicit warning =
-    let allRefs = findUsedRefs env mni qualifierName names
-    in if null allRefs
-       then unused
-       else tell $ errorMessage $ warning mni allRefs
+    if null allRefs
+    then unused
+    else tell $ errorMessage $ warning mni allRefs
 
   checkExplicit
     :: [DeclarationRef]
@@ -201,7 +200,7 @@ lintImportDecl env mni qualifierName names declType =
     case (length diff, length idents) of
       (0, _) -> return ()
       (n, m) | n == m -> unused
-      _ -> tell $ errorMessage $ UnusedExplicitImport mni diff
+      _ -> tell $ errorMessage $ UnusedExplicitImport mni diff qualifierName allRefs
 
     -- If we've not already warned a type is unused, check its data constructors
     forM_ (mapMaybe getTypeRef declrefs) $ \(tn, c) -> do
@@ -217,6 +216,9 @@ lintImportDecl env mni qualifierName names declType =
 
   unused :: m ()
   unused = tell $ errorMessage $ UnusedImport mni
+
+  allRefs :: [DeclarationRef]
+  allRefs = findUsedRefs env mni qualifierName names
 
   dtys
     :: ModuleName


### PR DESCRIPTION
So this works for me and I think the concept is sound but scope for discussion and refinement of format in particular.

I'm starting from a point where I see the compiler telling me in a warning how I should update my import statement, but I want my editor to do it for me:
![quick-fix-explicit-import-l](https://cloud.githubusercontent.com/assets/2770891/12066635/d6b14964-afe2-11e5-8584-44d291044614.gif)
(https://github.com/nwolverson/atom-ide-purescript/pull/38)

Discussion on IRC showed another way of working, "I want the compiler to output a diff that I could apply". It was then suggested that this might be the result of another frontend tool making use of the compiler output.

So thoughts on this version:
  * For the cases I implemented a source span to be replaced + replacement text was enough. Not sure if there is a better representation, presumably you could construct a diff from this if you wanted
  * I can see wanting a separate source span for the suggestion more specific than for the error itself
  * I could see in some cases you might want a list of edits to make