### PR TITLE
Allow https://github.com URLs for psc-publish

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -61,6 +61,7 @@ This file lists the contributors to the PureScript compiler project, and the ter
 - [@soupi](https://github.com/soupi) (Gil Mizrahi) My existing contributions and all future contributions until further notice are Copyright Gil Mizrahi, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 - [@tfausak](https://github.com/tfausak) (Taylor Fausak) My existing contributions and all future contributions until further notice are Copyright Taylor Fausak, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 - [@codedmart](https://github.com/codedmart) (Brandon Martin) My existing contributions and all future contributions until further notice are Copyright Brandon Martin, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
+- [@passy](https://github.com/passy) (Pascal Hartig) My existing contributions and all future contributions until further notice are Copyright Pascal Hartig, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 
 ### Companies
 


### PR DESCRIPTION
Follow-up to #1549, #1752.

The HTTPS git access is preferable in a lot of network scenarios (e.g.
public WiFi) where other ports are restricted and should work just fine
as only read access is needed.

`https` wasn't mentioned in the original bug report, so it's possible that
I'm just missing something and that was deliberate. Please let me know. :)

/cc @codedmart @hdgarrood

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/purescript/purescript/1782)
<!-- Reviewable:end -->
