### PR TITLE
Remove warning about implicitly importing data constructors

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -139,7 +139,6 @@ data SimpleErrorMessage
   | IntOutOfRange Integer String Integer Integer
   | RedundantEmptyHidingImport ModuleName
   | ImplicitImport ModuleName [DeclarationRef]
-  | ImplicitDctorImport (ProperName 'TypeName) [ProperName 'ConstructorName]
   | CaseBinderLengthDiffers Int [Binder]
   deriving (Show)
 
@@ -311,7 +310,6 @@ errorCode em = case unwrapErrorMessage em of
   IntOutOfRange{} -> "IntOutOfRange"
   RedundantEmptyHidingImport{} -> "RedundantEmptyHidingImport"
   ImplicitImport{} -> "ImplicitImport"
-  ImplicitDctorImport{} -> "ImplicitDctorImport"
   CaseBinderLengthDiffers{} -> "CaseBinderLengthDiffers"
 
 -- |
@@ -863,11 +861,6 @@ prettyPrintSingleError full level showWiki e = flip evalState defaultUnknownMap 
     renderSimpleErrorMessage (ImplicitImport mn refs) =
       paras [ line $ "Module " ++ runModuleName mn ++ " has unspecified imports, consider using the explicit form: "
             , indent $ line $ "import " ++ runModuleName mn ++ " (" ++ intercalate ", " (map prettyPrintRef refs) ++ ")"
-            ]
-
-    renderSimpleErrorMessage (ImplicitDctorImport ty ctors) =
-      paras [ line $ "Import of type " ++ runProperName ty ++ " has unspecified data constructors, consider using the explicit form: "
-            , indent $ line $ runProperName ty ++ " (" ++ intercalate ", " (map runProperName ctors) ++ ")"
             ]
 
     renderSimpleErrorMessage (CaseBinderLengthDiffers l bs) =

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -86,11 +86,10 @@ findUnusedImports (Module _ _ _ mdecls mexports) env usedImps = do
               when (runProperName tn `elem` usedNames) $ case (c, usedDctors `intersect` allCtors) of
                 (_, []) | c /= Just [] ->
                   tell $ errorMessage $ UnusedDctorImport tn
-                (Nothing, usedDctors') ->
-                  tell $ errorMessage $ ImplicitDctorImport tn usedDctors'
                 (Just ctors, usedDctors') ->
                   let ddiff = ctors \\ usedDctors'
                   in unless (null ddiff) $ tell $ errorMessage $ UnusedDctorExplicitImport tn ddiff
+                _ -> return ()
 
             return ()
 


### PR DESCRIPTION
The warning is obnoxious and does not help with the safety issue the
same way implicit module imports does, as per later discussion in #1741