### PR TITLE
Resolve #1787. Better error when let is at end of file, and missing `in`

### DIFF
--- a/examples/failing/1787.purs
+++ b/examples/failing/1787.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith ErrorParsingModule
+module Main where
+
+main = do
+  f $ \x ->
+    let y = z
+        z = 0
+
+g :: Int
+g = 3

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -366,7 +366,7 @@ parseLet = do
   reserved "let"
   C.indented
   ds <- C.mark $ P.many1 (C.same *> parseLocalDeclaration)
-  C.indented
+  C.indented P.<?> "properly indented in keyword"
   reserved "in"
   result <- parseValue
   return $ Let ds result


### PR DESCRIPTION
New error looks like:

```
at /home/michael/dev/contrib/purescript/examples/failing/1787.purs line 9, column 1 - line 9, column 1

  Unable to parse module:
  expecting no indentation or properly indented in keyword

```