### PR TITLE
Use friendly module name in psc-docs error

### DIFF
--- a/psc-docs/Main.hs
+++ b/psc-docs/Main.hs
@@ -92,12 +92,12 @@ docgen (PSCDocsOptions fmt inputGlob output) = do
   where
   guardMissing [] = return ()
   guardMissing [mn] = do
-    hPutStrLn stderr ("psc-docs: error: unknown module \"" ++ show mn ++ "\"")
+    hPutStrLn stderr ("psc-docs: error: unknown module \"" ++ P.runModuleName mn ++ "\"")
     exitFailure
   guardMissing mns = do
     hPutStrLn stderr "psc-docs: error: unknown modules:"
     forM_ mns $ \mn ->
-      hPutStrLn stderr ("  * " ++ show mn)
+      hPutStrLn stderr ("  * " ++ P.runModuleName mn)
     exitFailure
 
 -- |


### PR DESCRIPTION
I thought my `psc-docs` was entirely screwed up when I saw this but just had an unfriendly module name in error text:
```
psc-docs: error: unknown module "ModuleName [ProperName {runProperName = "BadModuleName"}]"
```