### PR TITLE
Rename `foreign` argument to fix compiling issue

### DIFF
--- a/psci/Types.hs
+++ b/psci/Types.hs
@@ -51,11 +51,11 @@ mkPSCiState :: [ImportedModule]
             -> [P.Declaration]
             -> [String]
             -> PSCiState
-mkPSCiState imported loaded foreign lets nodeFlags =
+mkPSCiState imported loaded foreigns lets nodeFlags =
   (initialPSCiState
     |> each imported updateImportedModules
     |> updateModules loaded)
-    { psciForeignFiles = foreign
+    { psciForeignFiles = foreigns
     , psciLetBindings = lets
     , psciNodeFlags = nodeFlags
     }


### PR DESCRIPTION
This fixes a compilation issue with ghc 7.10.2 when running `stack ghci`:

```
/Users/antti/code/purescript/purescript/psci/Types.hs:54:29:
    parse error on input ‘foreign’
```

Not exactly sure why it doesn't compile in ghci but does with `stack build`. 