### PR TITLE
Fix generic deriving bug with >1 type argument

### DIFF
--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -17,6 +17,7 @@ import Data.List (foldl', find, sortBy)
 import Data.Maybe (fromMaybe)
 import Data.Ord (comparing)
 
+import Control.Arrow (second)
 import Control.Monad (replicateM)
 import Control.Monad.Supply.Class (MonadSupply)
 import Control.Monad.Error.Class (MonadError(..))
@@ -55,11 +56,13 @@ deriveInstance mn ds (PositionedDeclaration pos com d) = PositionedDeclaration p
 deriveInstance _  _  e = return e
 
 unwrapTypeConstructor :: Type -> Maybe (Qualified (ProperName 'TypeName), [Type])
-unwrapTypeConstructor (TypeConstructor tyCon) = Just (tyCon, [])
-unwrapTypeConstructor (TypeApp ty arg) = do
-  (tyCon, args) <- unwrapTypeConstructor ty
-  return (tyCon, arg : args)
-unwrapTypeConstructor _ = Nothing
+unwrapTypeConstructor = fmap (second reverse) . go
+  where
+  go (TypeConstructor tyCon) = Just (tyCon, [])
+  go (TypeApp ty arg) = do
+    (tyCon, args) <- go ty
+    return (tyCon, arg : args)
+  go _ = Nothing
 
 dataGeneric :: ModuleName
 dataGeneric = ModuleName [ ProperName "Data", ProperName "Generic" ]


### PR DESCRIPTION
When trying to derive an instance for a data type which has more than one type argument, the arguments get mixed up. This appears to be because `unwrapTypeConstructor` reverses the order of the type arguments due to the way it's implemented, so I addressed it by re-reversing the type arguments at the end.

The tests in https://github.com/paf31/purescript-foreign-generic/pull/10 pass with this modification.

For example, the following code will trigger this bug:
```purescript
data MyTuple a b = MyTuple a b
derive instance genericMyTuple :: (Generic a, Generic b) => Generic (MyTuple a b)
```

It manifests in the `toSignature` implementation; the resulting `GenericSignature` has the type arguments the wrong way around. For example, `toSignature (Proxy :: Proxy (MyTuple Int String))` would have `[ \_ -> SigString, \_ -> SigInt ]` for the `sigValues`.

If we wanted to test this, we would need to compile code like the above, make assertions about the resulting `GenericSignature` in a PureScript source file, and then run that under `node`. Is that worth the effort? Maybe we can just use the tests in `purescript-foreign-generic` (once that PR is merged)? Also, I noticed `core-tests/tests/generic-deriving/Main.purs` but it doesn't seem to be referenced in any test files.