### PR TITLE
Updates & fixes for JS inliner

### DIFF
--- a/src/Language/PureScript/CodeGen/JS/Optimizer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer.hs
@@ -1,13 +1,5 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.CodeGen.JS.Optimizer
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
+{-# LANGUAGE FlexibleContexts #-}
+
 -- |
 -- This module optimizes code in the simplified-Javascript intermediate representation.
 --
@@ -29,13 +21,7 @@
 --
 --  * Inlining primitive Javascript operators
 --
------------------------------------------------------------------------------
-
-{-# LANGUAGE FlexibleContexts #-}
-
-module Language.PureScript.CodeGen.JS.Optimizer (
-    optimize
-) where
+module Language.PureScript.CodeGen.JS.Optimizer (optimize) where
 
 import Prelude ()
 import Prelude.Compat
@@ -79,7 +65,9 @@ optimize' js = do
     , inlineVariables
     , inlineValues
     , inlineOperator (C.prelude, (C.$)) $ \f x -> JSApp f [x]
+    , inlineOperator (C.dataFunction, C.apply) $ \f x -> JSApp f [x]
     , inlineOperator (C.prelude, (C.#)) $ \x f -> JSApp f [x]
+    , inlineOperator (C.dataFunction, C.applyFlipped) $ \x f -> JSApp f [x]
     , inlineOperator (C.dataArrayUnsafe, C.unsafeIndex) $ flip JSIndexer
     , inlineCommonOperators ]) js
 

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/Common.hs
@@ -1,18 +1,6 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.CodeGen.JS.Optimizer.Common
--- Copyright   :  (c) Phil Freeman 2013-14
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Common functions used by the various optimizer phases
 --
------------------------------------------------------------------------------
-
 module Language.PureScript.CodeGen.JS.Optimizer.Common where
 
 import Data.Maybe (fromMaybe)
@@ -76,3 +64,18 @@ isUpdated var1 = everythingOnJS (||) check
 removeFromBlock :: ([JS] -> [JS]) -> JS -> JS
 removeFromBlock go (JSBlock sts) = JSBlock (go sts)
 removeFromBlock _  js = js
+
+isFn :: (String, String) -> JS -> Bool
+isFn (moduleName, fnName) (JSAccessor x (JSVar y)) = x == fnName && y == moduleName
+isFn (moduleName, fnName) (JSIndexer (JSStringLiteral x) (JSVar y)) = x == fnName && y == moduleName
+isFn _ _ = False
+
+isFn' :: [(String, String)] -> JS -> Bool
+isFn' xs js = any (`isFn` js) xs
+
+isDict :: (String, String) -> JS -> Bool
+isDict (moduleName, dictName) (JSAccessor x (JSVar y)) = x == dictName && y == moduleName
+isDict _ _ = False
+
+isDict' :: [(String, String)] -> JS -> Bool
+isDict' xs js = any (`isDict` js) xs

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -1,18 +1,6 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Constants
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Various constants which refer to things in the Prelude
 --
------------------------------------------------------------------------------
-
 module Language.PureScript.Constants where
 
 -- Operators
@@ -20,8 +8,14 @@ module Language.PureScript.Constants where
 ($) :: String
 ($) = "$"
 
+apply :: String
+apply = "apply"
+
 (#) :: String
 (#) = "#"
+
+applyFlipped :: String
+applyFlipped = "applyFlipped"
 
 (<>) :: String
 (<>) = "<>"
@@ -29,50 +23,92 @@ module Language.PureScript.Constants where
 (++) :: String
 (++) = "++"
 
+append :: String
+append = "append"
+
 (>>=) :: String
 (>>=) = ">>="
+
+bind :: String
+bind = "bind"
 
 (+) :: String
 (+) = "+"
 
+add :: String
+add = "add"
+
 (-) :: String
 (-) = "-"
+
+sub :: String
+sub = "sub"
 
 (*) :: String
 (*) = "*"
 
+mul :: String
+mul = "mul"
+
 (/) :: String
 (/) = "/"
+
+div :: String
+div = "div"
 
 (%) :: String
 (%) = "%"
 
+mod :: String
+mod = "mod"
+
 (<) :: String
 (<) = "<"
+
+lessThan :: String
+lessThan = "lessThan"
 
 (>) :: String
 (>) = ">"
 
+greaterThan :: String
+greaterThan = "greaterThan"
+
 (<=) :: String
 (<=) = "<="
+
+lessThanOrEq :: String
+lessThanOrEq = "lessThanOrEq"
 
 (>=) :: String
 (>=) = ">="
 
+greaterThanOrEq :: String
+greaterThanOrEq = "greaterThanOrEq"
+
 (==) :: String
 (==) = "=="
+
+eq :: String
+eq = "eq"
 
 (/=) :: String
 (/=) = "/="
 
+notEq :: String
+notEq = "notEq"
+
 (&&) :: String
 (&&) = "&&"
+
+conj :: String
+conj = "conj"
 
 (||) :: String
 (||) = "||"
 
-bind :: String
-bind = "bind"
+disj :: String
+disj = "disj"
 
 unsafeIndex :: String
 unsafeIndex = "unsafeIndex"
@@ -92,6 +128,12 @@ unsafeIndex = "unsafeIndex"
 compose :: String
 compose = "compose"
 
+(>>>) :: String
+(>>>) = ">>>"
+
+composeFlipped :: String
+composeFlipped = "composeFlipped"
+
 -- Functions
 
 negate :: String
@@ -99,15 +141,6 @@ negate = "negate"
 
 not :: String
 not = "not"
-
-conj :: String
-conj = "conj"
-
-disj :: String
-disj = "disj"
-
-mod :: String
-mod = "mod"
 
 shl :: String
 shl = "shl"
@@ -211,11 +244,20 @@ moduloSemiringNumber = "moduloSemiringNumber"
 moduloSemiringInt :: String
 moduloSemiringInt = "moduloSemiringInt"
 
+ordBoolean :: String
+ordBoolean = "ordBoolean"
+
 ordNumber :: String
 ordNumber = "ordNumber"
 
 ordInt :: String
 ordInt = "ordInt"
+
+ordString :: String
+ordString = "ordString"
+
+ordChar :: String
+ordChar = "ordChar"
 
 eqNumber :: String
 eqNumber = "eqNumber"
@@ -225,6 +267,9 @@ eqInt = "eqInt"
 
 eqString :: String
 eqString = "eqString"
+
+eqChar :: String
+eqChar = "eqChar"
 
 eqBoolean :: String
 eqBoolean = "eqBoolean"
@@ -284,6 +329,39 @@ eff = "Control_Monad_Eff"
 
 st :: String
 st = "Control_Monad_ST"
+
+controlApplicative :: String
+controlApplicative = "Control_Applicative"
+
+controlSemigroupoid :: String
+controlSemigroupoid = "Control_Semigroupoid"
+
+controlBind :: String
+controlBind = "Control_Bind"
+
+dataBounded :: String
+dataBounded = "Data_Bounded"
+
+dataSemigroup :: String
+dataSemigroup = "Data_Semigroup"
+
+dataModuloSemiring :: String
+dataModuloSemiring = "Data_ModuloSemiring"
+
+dataBooleanAlgebra :: String
+dataBooleanAlgebra = "Data_BooleanAlgebra"
+
+dataEq :: String
+dataEq = "Data_Eq"
+
+dataOrd :: String
+dataOrd = "Data_Ord"
+
+dataSemiring :: String
+dataSemiring = "Data_Semiring"
+
+dataRing :: String
+dataRing = "Data_Ring"
 
 dataFunction :: String
 dataFunction = "Data_Function"


### PR DESCRIPTION
Resolves #1805

Manually tested by checking the output of this with both old and new (moduleified) prelude:

``` purescript
module Main where

import Prelude (Unit, void, pure, (>>>), (#), negate, ($), (<<<), bind, mod, div, (/), mul, (*), sub, (-), add, (+), not, disj, conj, (&&), append, (<>), (>=), (<=), (>), (<), (/=), eq, (==))
import Control.Monad.Eff (Eff)
import Control.Monad.Eff.Console (CONSOLE)

main :: forall e. Eff (console :: CONSOLE | e) Unit
main = do

  void <<< pure $ (true == false)
  void <<< pure $ (1    == 2)
  void <<< pure $ (1.0  == 2.0)
  void <<< pure $ ('a'  == 'b')
  void <<< pure $ ("a"  == "b")

  void <<< pure $ (true `eq` false)
  void <<< pure $ (1    `eq` 2)
  void <<< pure $ (1.0  `eq` 2.0)
  void <<< pure $ ('a'  `eq` 'b')
  void <<< pure $ ("a"  `eq` "b")

  void <<< pure $ (true /= false)
  void <<< pure $ (1    /= 2)
  void <<< pure $ (1.0  /= 2.0)
  void <<< pure $ ('a'  /= 'b')
  void <<< pure $ ("a"  /= "b")

  void <<< pure $ (true < false)
  void <<< pure $ (1    < 2)
  void <<< pure $ (1.0  < 2.0)
  void <<< pure $ ('a'  < 'b')
  void <<< pure $ ("a"  < "b")

  void <<< pure $ (true > false)
  void <<< pure $ (1    > 2)
  void <<< pure $ (1.0  > 2.0)
  void <<< pure $ ('a'  > 'b')
  void <<< pure $ ("a"  > "b")

  void <<< pure $ (true <= false)
  void <<< pure $ (1    <= 2)
  void <<< pure $ (1.0  <= 2.0)
  void <<< pure $ ('a'  <= 'b')
  void <<< pure $ ("a"  <= "b")

  void <<< pure $ (true >= false)
  void <<< pure $ (1    >= 2)
  void <<< pure $ (1.0  >= 2.0)
  void <<< pure $ ('a'  >= 'b')
  void <<< pure $ ("a"  >= "b")

  void <<< pure $ ("a"  <> "b")
  void <<< pure $ ("a"  `append` "b")

  void <<< pure $ (true && false)
  void <<< pure $ (true `conj` false)
  void <<< pure $ (true `disj` false)
  void <<< pure $ (not true)
  void <<< pure $ (not false)

  void <<< pure $ (1    + 2)
  void <<< pure $ (1.0  + 2.0)

  void <<< pure $ (1    `add` 2)
  void <<< pure $ (1.0  `add` 2.0)

  void <<< pure $ (1    - 2)
  void <<< pure $ (1.0  - 2.0)

  void <<< pure $ (1    `sub` 2)
  void <<< pure $ (1.0  `sub` 2.0)

  void <<< pure $ (1    * 2)
  void <<< pure $ (1.0  * 2.0)

  void <<< pure $ (1    `mul` 2)
  void <<< pure $ (1.0  `mul` 2.0)

  void <<< pure $ (1    / 2)
  void <<< pure $ (1.0  / 2.0)

  void <<< pure $ (1    `div` 2)
  void <<< pure $ (1.0  `div` 2.0)

  void <<< pure $ (1    `mod` 2)

  void <<< pure $ (-2.0)

  "hi" # pure >>> void

```