### PR TITLE
Extended parser to accept unicode forall and arrows

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -64,6 +64,7 @@ This file lists the contributors to the PureScript compiler project, and the ter
 - [@tfausak](https://github.com/tfausak) (Taylor Fausak) My existing contributions and all future contributions until further notice are Copyright Taylor Fausak, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 - [@codedmart](https://github.com/codedmart) (Brandon Martin) My existing contributions and all future contributions until further notice are Copyright Brandon Martin, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 - [@passy](https://github.com/passy) (Pascal Hartig) My existing contributions and all future contributions until further notice are Copyright Pascal Hartig, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
+- [@DavidLindbom](https://github.com/DavidLindbom) (David Lindbom) My existing contributions and all future contributions until further notice are Copyright David Lindbom, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 
 ### Companies
 

--- a/examples/passing/UnicodeType.purs
+++ b/examples/passing/UnicodeType.purs
@@ -1,0 +1,23 @@
+module Main where
+
+import Prelude
+
+class (Monad m) ⇐ Monad1 m where
+  f1 :: Int
+
+class (Monad m) <= Monad2 m where
+  f2 :: Int
+
+f ∷ ∀ m. Monad m ⇒ Int → m Int
+f n = do
+  n' ← return n
+  return n'
+
+f' :: forall m. Monad m => Int -> m Int
+f' n = do
+  n' <- return n
+  return n'
+
+(←→) a b = a ←→ b
+
+main = Control.Monad.Eff.Console.log "Done"

--- a/src/Language/PureScript/Parser/Lexer.hs
+++ b/src/Language/PureScript/Parser/Lexer.hs
@@ -185,10 +185,15 @@ parsePositionedToken = P.try $ do
 parseToken :: P.Parsec String u Token
 parseToken = P.choice
   [ P.try $ P.string "<-" *> P.notFollowedBy symbolChar *> pure LArrow
+  , P.try $ P.string "←"  *> P.notFollowedBy symbolChar *> pure LArrow
   , P.try $ P.string "<=" *> P.notFollowedBy symbolChar *> pure LFatArrow
+  , P.try $ P.string "⇐"  *> P.notFollowedBy symbolChar *> pure LFatArrow
   , P.try $ P.string "->" *> P.notFollowedBy symbolChar *> pure RArrow
+  , P.try $ P.string "→"  *> P.notFollowedBy symbolChar *> pure RArrow
   , P.try $ P.string "=>" *> P.notFollowedBy symbolChar *> pure RFatArrow
+  , P.try $ P.string "⇒"  *> P.notFollowedBy symbolChar *> pure RFatArrow
   , P.try $ P.string "::" *> P.notFollowedBy symbolChar *> pure DoubleColon
+  , P.try $ P.string "∷"  *> P.notFollowedBy symbolChar *> pure DoubleColon
   , P.try $ P.char '('    *> pure LParen
   , P.try $ P.char ')'    *> pure RParen
   , P.try $ P.char '{'    *> pure LBrace
@@ -411,6 +416,7 @@ reserved :: String -> TokenParser ()
 reserved s = token go P.<?> show s
   where
   go (LName s') | s == s' = Just ()
+  go (Symbol s') | s == s' = Just ()
   go _ = Nothing
 
 uname :: TokenParser String

--- a/src/Language/PureScript/Parser/Types.hs
+++ b/src/Language/PureScript/Parser/Types.hs
@@ -36,7 +36,7 @@ parseTypeConstructor :: TokenParser Type
 parseTypeConstructor = TypeConstructor <$> parseQualified properName
 
 parseForAll :: TokenParser Type
-parseForAll = mkForAll <$> (reserved "forall" *> P.many1 (indented *> identifier) <* indented <* dot)
+parseForAll = mkForAll <$> ((reserved "forall" <|> reserved "∀") *> P.many1 (indented *> identifier) <* indented <* dot)
                        <*> parseType
 
 -- |


### PR DESCRIPTION
Saw it was mentioned in #766. This commit should now accept `f ∷ ∀a m. Monad m ⇒ a → m a` but also `⇐` and `←` in class definition resp. do notation.

