### PR TITLE
Solves #1853

### DIFF
--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -31,13 +31,13 @@ import Language.PureScript.Kinds
 import Language.PureScript.Types as P
 import Language.PureScript.Errors
 
--- | There are two modes of failure for the redudancy check:
+-- | There are two modes of failure for the redundancy check:
 --
 -- 1. Exhaustivity was incomplete due to too many cases, so we couldn't determine redundancy.
 -- 2. We didn't attempt to determine redundancy for a binder, e.g. an integer binder.
 --
 -- We want to warn the user in the first case.
-data RedudancyError = Incomplete | Unknown
+data RedundancyError = Incomplete | Unknown
 
 -- |
 -- Qualifies a propername from a given qualified propername and a default module name
@@ -106,7 +106,7 @@ genericMerge f bsl@((s, b):bs) bsr@((s', b'):bs')
 -- Find the uncovered set between two binders:
 -- the first binder is the case we are trying to cover, the second one is the matching binder
 --
-missingCasesSingle :: Environment -> ModuleName -> Binder -> Binder -> ([Binder], Either RedudancyError Bool)
+missingCasesSingle :: Environment -> ModuleName -> Binder -> Binder -> ([Binder], Either RedundancyError Bool)
 missingCasesSingle _ _ _ NullBinder = ([], return True)
 missingCasesSingle _ _ _ (VarBinder _) = ([], return True)
 missingCasesSingle env mn (VarBinder _) b = missingCasesSingle env mn NullBinder b
@@ -175,7 +175,7 @@ missingCasesSingle _ _ b _ = ([b], Left Unknown)
 --       redundant or not, but uncovered at least. If we use `y` instead, we'll need to have a redundancy checker
 --       (which ought to be available soon), or increase the complexity of the algorithm.
 --
-missingCasesMultiple :: Environment -> ModuleName -> [Binder] -> [Binder] -> ([[Binder]], Either RedudancyError Bool)
+missingCasesMultiple :: Environment -> ModuleName -> [Binder] -> [Binder] -> ([[Binder]], Either RedundancyError Bool)
 missingCasesMultiple env mn = go
   where
   go [] [] = ([], pure True)
@@ -210,10 +210,10 @@ isExhaustiveGuard (Right _) = True
 -- |
 -- Returns the uncovered set of case alternatives
 --
-missingCases :: Environment -> ModuleName -> [Binder] -> CaseAlternative -> ([[Binder]], Either RedudancyError Bool)
+missingCases :: Environment -> ModuleName -> [Binder] -> CaseAlternative -> ([[Binder]], Either RedundancyError Bool)
 missingCases env mn uncovered ca = missingCasesMultiple env mn uncovered (caseAlternativeBinders ca)
 
-missingAlternative :: Environment -> ModuleName -> CaseAlternative -> [Binder] -> ([[Binder]], Either RedudancyError Bool)
+missingAlternative :: Environment -> ModuleName -> CaseAlternative -> [Binder] -> ([[Binder]], Either RedundancyError Bool)
 missingAlternative env mn ca uncovered
   | isExhaustiveGuard (caseAlternativeResult ca) = mcases
   | otherwise = ([uncovered], snd mcases)
@@ -229,13 +229,13 @@ missingAlternative env mn ca uncovered
 checkExhaustive :: forall m. (MonadWriter MultipleErrors m) => Bool -> Environment -> ModuleName -> Int -> [CaseAlternative] -> m ()
 checkExhaustive hasConstraint env mn numArgs cas = makeResult . first nub $ foldl' step ([initialize numArgs], (pure True, [])) cas
   where
-  step :: ([[Binder]], (Either RedudancyError Bool, [[Binder]])) -> CaseAlternative -> ([[Binder]], (Either RedudancyError Bool, [[Binder]]))
+  step :: ([[Binder]], (Either RedundancyError Bool, [[Binder]])) -> CaseAlternative -> ([[Binder]], (Either RedundancyError Bool, [[Binder]]))
   step (uncovered, (nec, redundant)) ca =
     let (missed, pr) = unzip (map (missingAlternative env mn ca) uncovered)
         (missed', approx) = splitAt 10000 (nub (concat missed))
-        cond = liftA2 (&&) (or <$> sequenceA pr) nec
+        cond = or <$> sequenceA pr
     in (missed', ( if null approx
-                     then cond
+                     then liftA2 (&&) cond nec
                      else Left Incomplete
                  , if either (const True) id cond
                      then redundant
@@ -243,7 +243,7 @@ checkExhaustive hasConstraint env mn numArgs cas = makeResult . first nub $ fold
                  )
        )
 
-  makeResult :: ([[Binder]], (Either RedudancyError Bool, [[Binder]])) -> m ()
+  makeResult :: ([[Binder]], (Either RedundancyError Bool, [[Binder]])) -> m ()
   makeResult (bss, (rr, bss')) =
     do unless (hasConstraint || null bss) tellNonExhaustive
        unless (null bss') tellRedundant


### PR DESCRIPTION
The problem was the condition `cond` we were using: I compared it with an older version of the redundancy checker that worked well and changed that piece of code.

Now it's working fine:

```purescript
module Main where

data Options = Foo | Bar | Baz

brokenPatternMatch :: Options -> Boolean
brokenPatternMatch Foo = true
brokenPatternMatch Foo = true
brokenPatternMatch Bar = false
brokenPatternMatch Baz = false
```

Throws:

```
  in module Main
  at /home/delpi/Desktop/Development/purescript/psctests/test.purs line 5, column 1 - line 6, column 1

    A case expression contains unreachable cases:

    Foo

  in value declaration brokenPatternMatch
```