### PR TITLE
Infer psc docs types

### DIFF
--- a/examples/docs/src/ForeignImports.js
+++ b/examples/docs/src/ForeignImports.js
@@ -1,0 +1,3 @@
+// module ForeignImports
+
+exports.unsafeCoerce = function(x) { return x; };

--- a/examples/docs/src/ForeignImports.purs
+++ b/examples/docs/src/ForeignImports.purs
@@ -1,0 +1,3 @@
+module ForeignImports where
+
+foreign import unsafeCoerce :: forall a b. a -> b

--- a/examples/docs/src/InferredTypes.purs
+++ b/examples/docs/src/InferredTypes.purs
@@ -1,0 +1,4 @@
+module InferredTypes where
+
+foo = 0
+bar = 0.0

--- a/examples/docs/src/ToplevelCase.purs
+++ b/examples/docs/src/ToplevelCase.purs
@@ -1,0 +1,5 @@
+module ToplevelCase where
+
+foo 0 = 1
+foo x | false = x
+foo _ = 0

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -139,6 +139,8 @@ convertDeclaration (P.ValueDeclaration _ _ _ (Right (P.TypedValue _ _ ty))) titl
   basicDeclaration title (ValueDeclaration ty)
 convertDeclaration (P.ValueDeclaration _ _ _ _) title =
   P.internalError ("Should have been desugared: " ++ title)
+convertDeclaration (P.ExternDeclaration _ ty) title =
+  basicDeclaration title (ValueDeclaration ty)
 convertDeclaration (P.DataDeclaration dtype _ args ctors) title =
   Just (Right (mkDeclaration title info) { declChildren = children })
   where

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -109,7 +109,7 @@ addDefaultFixity decl@Declaration{..}
   defaultFixity = P.Fixity P.Infixl (-1)
 
 getDeclarationTitle :: P.Declaration -> Maybe String
-getDeclarationTitle (P.TypeDeclaration name _)               = Just (P.showIdent name)
+getDeclarationTitle (P.ValueDeclaration name _ _ _)          = Just (P.showIdent name)
 getDeclarationTitle (P.ExternDeclaration name _)             = Just (P.showIdent name)
 getDeclarationTitle (P.DataDeclaration _ name _ _)           = Just (P.runProperName name)
 getDeclarationTitle (P.ExternDataDeclaration name _)         = Just (P.runProperName name)
@@ -135,10 +135,10 @@ basicDeclaration :: String -> DeclarationInfo -> Maybe IntermediateDeclaration
 basicDeclaration title info = Just $ Right $ mkDeclaration title info
 
 convertDeclaration :: P.Declaration -> String -> Maybe IntermediateDeclaration
-convertDeclaration (P.TypeDeclaration _ ty) title =
+convertDeclaration (P.ValueDeclaration _ _ _ (Right (P.TypedValue _ _ ty))) title =
   basicDeclaration title (ValueDeclaration ty)
-convertDeclaration (P.ExternDeclaration _ ty) title =
-  basicDeclaration title (ValueDeclaration ty)
+convertDeclaration (P.ValueDeclaration _ _ _ _) title =
+  P.internalError ("Should have been desugared: " ++ title)
 convertDeclaration (P.DataDeclaration dtype _ args ctors) title =
   Just (Right (mkDeclaration title info) { declChildren = children })
   where

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -17,6 +17,7 @@ import Prelude.Compat
 import Data.List (find, nub)
 import Data.Maybe (fromMaybe, mapMaybe)
 
+import Control.Arrow (first)
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Writer (MonadWriter(..), censor)
@@ -54,7 +55,7 @@ desugarImportsWithEnv
 desugarImportsWithEnv externs modules = do
   env <- silence $ foldM externsEnv primEnv externs
   modules' <- traverse updateExportRefs modules
-  (modules'', env') <- foldM updateEnv ([], env) modules'
+  (modules'', env') <- first reverse <$> foldM updateEnv ([], env) modules'
   (env',) <$> traverse (renameInModule' env') modules''
   where
   silence :: m a -> m a

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -235,6 +235,10 @@ testCases =
   , ("ToplevelCase",
       [ ShouldBeDocumented (n "ToplevelCase") "foo" []
       ])
+
+  , ("ForeignImports",
+      [ ShouldBeDocumented (n "ForeignImports") "unsafeCoerce" []
+      ])
   ]
 
   where

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -226,6 +226,15 @@ testCases =
   , ("NewOperators",
       [ ShouldBeDocumented (n "NewOperators2") "(>>>)" []
       ])
+
+  , ("InferredTypes",
+      [ ShouldBeDocumented (n "InferredTypes") "foo" []
+      , ShouldBeDocumented (n "InferredTypes") "bar" []
+      ])
+
+  , ("ToplevelCase",
+      [ ShouldBeDocumented (n "ToplevelCase") "foo" []
+      ])
   ]
 
   where


### PR DESCRIPTION
WIP fix for #1834 

I'm not quite sure why this doesn't work. The error I'm getting is "Unknown type constructor Prelude.Unit", from `examples/docs/src/UTF8.purs`.

`examples/docs` is set up like a normal PureScript package, and notably, `Prelude` is in `bower_components`. So I was wondering if that might have something to do with it. However, it's failing during type checking, before we remove dependencies modules from the output, so maybe that's just a red herring. I was also wondering if I haven't set up the `CheckEnv`, or specifically, the `Environment`, correctly.