### PR TITLE
Infer types in psc-{docs,publish}

### DIFF
--- a/examples/docs/src/ExplicitTypeSignatures.purs
+++ b/examples/docs/src/ExplicitTypeSignatures.purs
@@ -1,0 +1,16 @@
+
+module ExplicitTypeSignatures where
+
+-- This should use the explicit type signature so that the type variable name
+-- is preserved.
+explicit :: forall something. something -> something
+explicit x
+  | true = x
+  | false = x
+
+-- This should use the inferred type.
+anInt :: _
+anInt = 0
+
+-- This should infer a type.
+aNumber = 1.0

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -170,7 +170,7 @@ library
                      Language.PureScript.Docs.RenderedCode.Types
                      Language.PureScript.Docs.RenderedCode.Render
                      Language.PureScript.Docs.AsMarkdown
-                     Language.PureScript.Docs.ParseAndDesugar
+                     Language.PureScript.Docs.ParseAndBookmark
                      Language.PureScript.Docs.Utils.MonoidExtras
 
                      Language.PureScript.Publish

--- a/src/Language/PureScript/Docs.hs
+++ b/src/Language/PureScript/Docs.hs
@@ -11,4 +11,4 @@ import Language.PureScript.Docs.RenderedCode.Types as Docs
 import Language.PureScript.Docs.RenderedCode.Render as Docs
 import Language.PureScript.Docs.Convert as Docs
 import Language.PureScript.Docs.Render as Docs
-import Language.PureScript.Docs.ParseAndDesugar as Docs
+import Language.PureScript.Docs.ParseAndBookmark as Docs

--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -31,31 +31,29 @@ import qualified Language.PureScript.Docs.Render as Render
 renderModulesAsMarkdown ::
   (Functor m, Applicative m,
   MonadError P.MultipleErrors m) =>
-  P.Env ->
   [P.Module] ->
   m String
-renderModulesAsMarkdown env =
-  fmap (runDocs . modulesAsMarkdown) . Convert.convertModules env
+renderModulesAsMarkdown =
+  fmap (runDocs . modulesAsMarkdown) . Convert.convertModules
 
 modulesAsMarkdown :: [Module] -> Docs
 modulesAsMarkdown = mapM_ moduleAsMarkdown
 
 moduleAsMarkdown :: Module -> Docs
 moduleAsMarkdown Module{..} = do
-  headerLevel 2 $ "Module " ++ modName
+  headerLevel 2 $ "Module " ++ P.runModuleName modName
   spacer
   for_ modComments tell'
   mapM_ (declAsMarkdown modName) modDeclarations
   spacer
   for_ modReExports $ \(mn, decls) -> do
-    let modName' = P.runModuleName mn
-    headerLevel 3 $ "Re-exported from " ++ modName' ++ ":"
+    headerLevel 3 $ "Re-exported from " ++ P.runModuleName mn ++ ":"
     spacer
-    mapM_ (declAsMarkdown modName') decls
+    mapM_ (declAsMarkdown mn) decls
 
-declAsMarkdown :: String -> Declaration -> Docs
+declAsMarkdown :: P.ModuleName -> Declaration -> Docs
 declAsMarkdown mn decl@Declaration{..} = do
-  let options = defaultRenderTypeOptions { currentModule = Just (P.moduleNameFromString mn) }
+  let options = defaultRenderTypeOptions { currentModule = Just mn }
   headerLevel 4 (ticks declTitle)
   spacer
 

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -73,7 +73,7 @@ packageName :: Package a -> PackageName
 packageName = bowerName . pkgMeta
 
 data Module = Module
-  { modName         :: String
+  { modName         :: P.ModuleName
   , modComments     :: Maybe String
   , modDeclarations :: [Declaration]
   -- Re-exported values from other modules
@@ -346,7 +346,7 @@ parseVersion' str =
 
 asModule :: Parse PackageError Module
 asModule =
-  Module <$> key "name" asString
+  Module <$> key "name" (P.moduleNameFromString <$> asString)
          <*> key "comments" (perhaps asString)
          <*> key "declarations" (eachInArray asDeclaration)
          <*> key "reExports" (eachInArray asReExport)
@@ -512,7 +512,7 @@ instance A.ToJSON NotYetKnown where
 
 instance A.ToJSON Module where
   toJSON Module{..} =
-    A.object [ "name"         .= modName
+    A.object [ "name"         .= P.runModuleName modName
              , "comments"     .= modComments
              , "declarations" .= modDeclarations
              , "reExports"    .= map toObj modReExports

--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -146,15 +146,15 @@ preparePackage' opts = do
 getModulesAndBookmarks :: PrepareM ([D.Bookmark], [D.Module])
 getModulesAndBookmarks = do
   (inputFiles, depsFiles) <- liftIO getInputAndDepsFiles
-  (modules', bookmarks, env) <- parseAndDesugar inputFiles depsFiles
+  (modules', bookmarks) <- parseAndBookmark inputFiles depsFiles
 
-  case runExcept (D.convertModulesInPackage env modules') of
+  case runExcept (D.convertModulesInPackage modules') of
     Right modules -> return (bookmarks, modules)
     Left err -> userError (CompileError err)
 
   where
-  parseAndDesugar inputFiles depsFiles = do
-    r <- liftIO . runExceptT $ D.parseAndDesugar inputFiles depsFiles
+  parseAndBookmark inputFiles depsFiles = do
+    r <- liftIO . runExceptT $ D.parseAndBookmark inputFiles depsFiles
     case r of
       Right r' ->
         return r'

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -17,6 +17,7 @@ import Prelude.Compat
 import Data.List (find, nub)
 import Data.Maybe (fromMaybe, mapMaybe)
 
+import Control.Arrow (first)
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Writer (MonadWriter(..), censor)
@@ -54,7 +55,7 @@ desugarImportsWithEnv
 desugarImportsWithEnv externs modules = do
   env <- silence $ foldM externsEnv primEnv externs
   modules' <- traverse updateExportRefs modules
-  (modules'', env') <- foldM updateEnv ([], env) modules'
+  (modules'', env') <- first reverse <$> foldM updateEnv ([], env) modules'
   (env',) <$> traverse (renameInModule' env') modules''
   where
   silence :: m a -> m a


### PR DESCRIPTION
Fixes #1834

Instead of taking types from the partially-desugared AST, we now use
placeholder types for all value declarations in the first pass,
then we typecheck all the modules, and insert the real types for all
value declarations later on, using the Environment obtained during
typechecking.

This involved:

* Changing the module name field in the Docs.Types.Module type to a real
  P.ModuleName; to be frank, it really ought to have been that type to
  begin with.

* Refactoring ParseAndDesugar so that it no longer does any desugaring.
  With this new pipeline, it is easier to pass modules that are not
  desugared at all into Docs.Convert. Also renamed ParseAndDesugar
  appropriately.

* Re-reversing the modules in Sugar.Names; desugarImports was previously
  (unintentionally) reversing the list of modules. This new code depends
  on those modules remaining in a topologically sorted order, which is
  why this change was necessary.