### PR TITLE
Use stackage over HTTPS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   - mkdir -p .cabal-sandbox
   - cabal sandbox init --sandbox .cabal-sandbox
   # Download stackage cabal.config, not sure whether filtering is necessary
-  - if [ -n "$STACKAGE" ]; then curl http://www.stackage.org/$STACKAGE/cabal.config | grep -v purescript > cabal.config; fi
+  - if [ -n "$STACKAGE" ]; then curl https://www.stackage.org/$STACKAGE/cabal.config | grep -v purescript > cabal.config; fi
   - cabal install --only-dependencies --enable-tests
   - cabal install hpc-coveralls
   # Snapshot state of the sandbox now, so we don't need to make new one for test install


### PR DESCRIPTION
Stackage has started redirecting permanently to HTTPS, which is breaking
the CI build, so this should fix it.