### PR TITLE
fix stack.yaml syntax error

### DIFF
--- a/stack-lts-3.yaml
+++ b/stack-lts-3.yaml
@@ -1,5 +1,5 @@
 flags: {}
 packages:
 - '.'
-extra-deps:
+extra-deps: []
 resolver: lts-3.6


### PR DESCRIPTION
Without this change stack fails with:
```
Could not parse '/home/creek/Documents/purescript/stack.yaml':
AesonException "Error in $.extra-deps: failed to parse field 'extra-deps': failed to parse field extra-deps: expected [a], encountered Null"
See http://docs.haskellstack.org/en/stable/yaml_configuration.html.
```