### PR TITLE
Adds psc-ide to the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ matrix:
       compiler: ": #GHC 7.8.4 - tests"
       # ^ HACK before https://github.com/travis-ci/travis-ci/issues/4393 is resolved
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.8.4,happy-1.19.5,alex-3.1.4], sources: [hvr-ghc]}}
-    - env: GHCVER=7.8.4 CABALVER=1.22 STACKAGE=lts-2.22
-      compiler: ": #GHC 7.8.4 - lts-2.22-1"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.8.4,happy-1.19.5,alex-3.1.4], sources: [hvr-ghc]}}
     - env: GHCVER=7.6.3 CABALVER=1.22
       compiler: ": #GHC 7.6.3"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.6.3,happy-1.19.5,alex-3.1.4], sources: [hvr-ghc]}}

--- a/bundle/README
+++ b/bundle/README
@@ -10,12 +10,15 @@ Installation Instructions
 
 This bundle contains the following executables:
 
-- psc           The PureScript compiler
-- psci          The PureScript interactive REPL (requires NodeJS)
-- psc-docs      A Markdown documentation generator for PureScript code
-- psc-bundle    Bundles together CommonJS modules produced by `psc` into a
-                single JavaScript file; useful for running in the browser.
-- psc-publish   Generates documentation packages for uploading to Pursuit
+- psc            The PureScript compiler
+- psci           The PureScript interactive REPL (requires NodeJS)
+- psc-docs       A Markdown documentation generator for PureScript code
+- psc-bundle     Bundles together CommonJS modules produced by `psc` into a
+                 single JavaScript file; useful for running in the browser.
+- psc-publish    Generates documentation packages for uploading to Pursuit
+- psc-ide-server Provides Editor Support in the form of type information and
+                 autocompletion
+- psc-ide-client Utility to query psc-ide-server
 
 Copy these files anywhere on your PATH.
 

--- a/bundle/build.sh
+++ b/bundle/build.sh
@@ -21,16 +21,20 @@ strip ../dist/build/psci/psci
 strip ../dist/build/psc-docs/psc-docs
 strip ../dist/build/psc-publish/psc-publish
 strip ../dist/build/psc-bundle/psc-bundle
+strip ../dist/build/psc-ide-server/psc-ide-server
+strip ../dist/build/psc-ide-client/psc-ide-client
 
 # Copy files to staging directory
-cp ../dist/build/psc/psc                 build/purescript/
-cp ../dist/build/psci/psci               build/purescript/
-cp ../dist/build/psc-docs/psc-docs       build/purescript/
-cp ../dist/build/psc-publish/psc-publish build/purescript/
-cp ../dist/build/psc-bundle/psc-bundle   build/purescript/
-cp README                                build/purescript/
-cp ../LICENSE                            build/purescript/
-cp ../INSTALL.md                         build/purescript/
+cp ../dist/build/psc/psc                       build/purescript/
+cp ../dist/build/psci/psci                     build/purescript/
+cp ../dist/build/psc-docs/psc-docs             build/purescript/
+cp ../dist/build/psc-publish/psc-publish       build/purescript/
+cp ../dist/build/psc-bundle/psc-bundle         build/purescript/
+cp ../dist/build/psc-ide-server/psc-ide-server build/purescript/
+cp ../dist/build/psc-ide-client/psc-ide-client build/purescript/
+cp README                                      build/purescript/
+cp ../LICENSE                                  build/purescript/
+cp ../INSTALL.md                               build/purescript/
 
 # Make the binary bundle
 pushd build > /dev/null

--- a/bundle/winbuild.sh
+++ b/bundle/winbuild.sh
@@ -17,16 +17,20 @@ strip ../dist/build/psci/psci.exe
 strip ../dist/build/psc-docs/psc-docs.exe
 strip ../dist/build/psc-publish/psc-publish.exe
 strip ../dist/build/psc-bundle/psc-bundle.exe
+strip ../dist/build/psc-ide-server/psc-ide-server
+strip ../dist/build/psc-ide-client/psc-ide-client
 
 # Copy files to staging directory
-cp ../dist/build/psc/psc.exe                 build/purescript/
-cp ../dist/build/psci/psci.exe               build/purescript/
-cp ../dist/build/psc-docs/psc-docs.exe       build/purescript/
-cp ../dist/build/psc-publish/psc-publish.exe build/purescript/
-cp ../dist/build/psc-bundle/psc-bundle.exe   build/purescript/
-cp README                                    build/purescript/
-cp ../LICENSE                                build/purescript/
-cp ../INSTALL.md                             build/purescript/
+cp ../dist/build/psc/psc.exe                       build/purescript/
+cp ../dist/build/psci/psci.exe                     build/purescript/
+cp ../dist/build/psc-docs/psc-docs.exe             build/purescript/
+cp ../dist/build/psc-publish/psc-publish.exe       build/purescript/
+cp ../dist/build/psc-bundle/psc-bundle.exe         build/purescript/
+cp ../dist/build/psc-ide-server/psc-ide-server.exe build/purescript/
+cp ../dist/build/psc-ide-client/psc-ide-client.exe build/purescript/
+cp README                                          build/purescript/
+cp ../LICENSE                                      build/purescript/
+cp ../INSTALL.md                                   build/purescript/
 
 # Make the binary bundle
 pushd build

--- a/psc-ide-client/Main.hs
+++ b/psc-ide-client/Main.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import           Prelude             ()
+import           Prelude.Compat
+
+import           Control.Exception
+import           Data.Maybe          (fromMaybe)
+import           Data.Text           (Text)
+import qualified Data.Text           as T
+import qualified Data.Text.IO        as T
+import           Data.Version        (showVersion)
+import           Network
+import           Options.Applicative
+import           System.Exit
+import           System.IO
+
+import qualified Paths_purescript    as Paths
+
+data Options = Options
+    { optionsPort :: Maybe Int
+    }
+
+main :: IO ()
+main = do
+    Options port <- execParser opts
+    let port' = PortNumber . fromIntegral $ fromMaybe 4242 port
+    client port'
+  where
+    parser =
+        Options <$>
+          optional (option auto (long "port" <> short 'p'))
+    opts = info (version <*> parser) mempty
+    version = abortOption (InfoMsg (showVersion Paths.version)) $ long "version" <> help "Show the version number" <> hidden
+
+client :: PortID -> IO ()
+client port = do
+    h <-
+        connectTo "localhost" port `catch`
+        (\(SomeException e) ->
+              putStrLn
+                  ("Couldn't connect to psc-ide-server on port: " ++
+                   show port ++ " Error: " ++ show e) >>
+              exitFailure)
+    cmd <- T.getLine
+    -- Temporary fix for emacs windows bug
+    let cleanedCmd = removeSurroundingTicks cmd
+    --
+    T.hPutStrLn h cleanedCmd
+    res <- T.hGetLine h
+    putStrLn (T.unpack res)
+    hFlush stdout
+    hClose h
+
+-- TODO: Fix this in the emacs plugin by using a real process over shellcommands
+removeSurroundingTicks :: Text -> Text
+removeSurroundingTicks = T.dropWhile (== '\'') . T.dropWhileEnd (== '\'')

--- a/psc-ide-server/Main.hs
+++ b/psc-ide-server/Main.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PackageImports        #-}
+{-# LANGUAGE TemplateHaskell       #-}
+module Main where
+
+import           Prelude                           ()
+import           Prelude.Compat
+
+import           Control.Concurrent                (forkFinally)
+import           Control.Concurrent.STM
+import           Control.Exception                 (bracketOnError)
+import           Control.Monad
+import           "monad-logger" Control.Monad.Logger
+import           Control.Monad.Reader
+import           Control.Monad.Trans.Except
+import qualified Data.Text                         as T
+import qualified Data.Text.IO                      as T
+import           Data.Version                      (showVersion)
+import           Language.PureScript.Ide
+import           Language.PureScript.Ide.CodecJSON
+import           Language.PureScript.Ide.Error
+import           Language.PureScript.Ide.Types
+import           Language.PureScript.Ide.Watcher
+import           Network                           hiding (socketPort)
+import           Network.BSD                       (getProtocolNumber)
+import           Network.Socket                    hiding (PortNumber, Type,
+                                                    accept, sClose)
+import           Options.Applicative
+import           System.Directory
+import           System.FilePath
+import           System.IO
+
+import qualified Paths_purescript                  as Paths
+
+-- "Borrowed" from the Idris Compiler
+-- Copied from upstream impl of listenOn
+-- bound to localhost interface instead of iNADDR_ANY
+listenOnLocalhost :: PortID -> IO Socket
+listenOnLocalhost (PortNumber port) = do
+  proto <- getProtocolNumber "tcp"
+  localhost <- inet_addr "127.0.0.1"
+  bracketOnError
+    (socket AF_INET Stream proto)
+    sClose
+    (\sock -> do
+      setSocketOption sock ReuseAddr 1
+      bindSocket sock (SockAddrInet port localhost)
+      listen sock maxListenQueue
+      pure sock)
+listenOnLocalhost _ = error "Wrong Porttype"
+
+data Options = Options
+  { optionsDirectory  :: Maybe FilePath
+  , optionsOutputPath :: FilePath
+  , optionsPort       :: PortID
+  , optionsDebug      :: Bool
+  }
+
+main :: IO ()
+main = do
+  Options dir outputPath port debug  <- execParser opts
+  maybe (pure ()) setCurrentDirectory dir
+  serverState <- newTVarIO emptyPscIdeState
+  cwd <- getCurrentDirectory
+  _ <- forkFinally (watcher serverState (cwd </> outputPath)) print
+  let conf =
+        Configuration
+        {
+          confDebug = debug
+        , confOutputPath = outputPath
+        }
+  let env =
+        PscIdeEnvironment
+        {
+          envStateVar = serverState
+        , envConfiguration = conf
+        }
+  startServer port env
+  where
+    parser =
+      Options <$>
+        optional (strOption (long "directory" <> short 'd')) <*>
+        strOption (long "output-directory" <> value "output/") <*>
+        (PortNumber . fromIntegral <$>
+         option auto (long "port" <> short 'p' <> value (4242 :: Integer))) <*>
+        switch (long "debug")
+    opts = info (version <*> parser) mempty
+    version = abortOption
+      (InfoMsg (showVersion Paths.version))
+      (long "version" <> help "Show the version number")
+
+startServer :: PortID -> PscIdeEnvironment -> IO ()
+startServer port env = withSocketsDo $ do
+  sock <- listenOnLocalhost port
+  runLogger (runReaderT (forever (loop sock)) env)
+  where
+    runLogger = runStdoutLoggingT . filterLogger (\_ _ -> confDebug (envConfiguration env))
+
+    loop :: (PscIde m, MonadLogger m) => Socket -> m ()
+    loop sock = do
+      (cmd,h) <- acceptCommand sock
+      case decodeT cmd of
+        Just cmd' -> do
+          result <- runExceptT (handleCommand cmd')
+          $(logDebug) ("Answer was: " <> T.pack (show result))
+          liftIO (hFlush stdout)
+          case result of
+            -- What function can I use to clean this up?
+            Right r  -> liftIO $ T.hPutStrLn h (encodeT r)
+            Left err -> liftIO $ T.hPutStrLn h (encodeT err)
+        Nothing -> do
+          $(logDebug) ("Parsing the command failed. Command: " <> cmd)
+          liftIO $ do
+            T.hPutStrLn h (encodeT (GeneralError "Error parsing Command."))
+            hFlush stdout
+      liftIO (hClose h)
+
+
+acceptCommand :: (Applicative m, MonadIO m, MonadLogger m)
+                 => Socket -> m (T.Text, Handle)
+acceptCommand sock = do
+  h <- acceptConnection
+  $(logDebug) "Accepted a connection"
+  cmd <- liftIO (T.hGetLine h)
+  $(logDebug) cmd
+  pure (cmd, h)
+  where
+   acceptConnection = liftIO $ do
+     (h,_,_) <- accept sock
+     hSetEncoding h utf8
+     hSetBuffering h LineBuffering
+     pure h

--- a/psc-ide-server/PROTOCOL.md
+++ b/psc-ide-server/PROTOCOL.md
@@ -1,0 +1,409 @@
+# Protocol
+
+Encode the following JSON formats into a single line string and pass them to
+`psc-ide-client`s stdin. You can then read the result from `psc-ide-client`s
+stdout as a single line. The result needs to be unwrapped from the "wrapper"
+which separates success from failure. This wrapper is described at the end of
+this document.
+
+## Command:
+### Load
+The `load` command "loads" the requested modules into the server
+for completion and type info.
+
+**Params:**
+ - `modules :: (optional) [ModuleName]`: A list of modules to load.
+  psc-ide-server will try to parse all the declarations in these modules
+ - `dependencies :: (optional) [ModuleName]`: A list of modules to load 
+  including their dependencies. In contrast to the `module` field, all the
+  imports in these Modules will also be loaded.
+
+```json
+{
+  "command": "load",
+  "params": {
+    "modules": (optional)["Module.Name1", "Module.Name2"],
+    "dependencies": (optional)["Module.Name3"]
+  }
+}
+```
+
+**Result:**
+
+The Load Command returns a string.
+
+### Type
+The `type` command looks up the type for a given identifier.
+
+**Params:**
+ - `search :: String`: The identifier to look for. Only matches on equality.
+ - `filters :: [Filter]`: These filters will be applied before looking for the
+  identifier. These filters get combined with *AND*, so a candidate must match *ALL*
+  of them to be eligible.
+```json
+{
+  "command": "type",
+  "params": {
+    "search": "filterM",
+    "filters": [Filter]
+  }
+}
+```
+
+**Result:**
+The possible types are returned in the same format as completions
+
+### Complete
+The `complete` command looks up possible completions/corrections.
+
+**Params**:
+ - `filters :: [Filter]`: The same as for the `type` command. A candidate must match
+  all filters.
+ - `matcher :: (optional) Matcher`: The strategy used for matching candidates after filtering.
+  Results are scored internally and will be returned in the descending order where
+  the nth element is better then the n+1-th.
+
+  If no matcher is given every candidate, that passes the filters, is returned in no 
+  particular order.
+```json
+{
+  "command": "complete",
+  "params": {
+    "filters": [Filter],
+    "matcher": (optional) Matcher
+  }
+}
+```
+
+**Result:**
+
+The following format is returned as the Result:
+
+```json
+[
+  {
+  "module": "Data.Array",
+  "identifier": "filter",
+  "type": "forall a. (a -> Boolean) -> Array a -> Array a"
+  }
+]
+```
+
+
+### CaseSplit 
+
+The CaseSplit command takes a line of source code, an area in that line of code
+and replaces it with all patterns for a given type. The parameter `annotations`
+is used to turn type annotations on or off for the constructor fields.
+
+```json
+{
+ "command": "caseSplit",
+ "params": {
+  "line": "elem a as",
+  "begin": 8,
+  "end": 10,
+  "annotations": true,
+  "type": "List"
+ }
+}
+```
+
+**Result:**
+
+The following format is returned as the Result:
+
+```json
+[
+  "elem a Nil",
+  "elem a (Cons (_ :: a) (_ :: List a))"
+]
+```
+You should then be able to replace the affected line of code in the editor with the new suggestions.
+
+### Add Clause
+
+The AddClause command takes a typedeclaration and generates a function template for the given type.
+The `annotations` option turns type annotations on or off for the function arguments.
+
+```json
+{
+ "command": "addClause",
+ "params": {
+  "line": "elem :: forall a. (Eq a) => a -> List a",
+  "annotations": true
+ }
+}
+```
+
+**Result:**
+
+The following format is returned as the Result:
+
+```json
+[
+  "elem :: forall a. (Eq a) => a -> List a",
+  "elem ( _ :: a) = ?elem"
+]
+```
+You should then be able to replace the affected line of code in the editor with the new suggestions.
+
+### Pursuit
+The `pursuit` command looks up the packages/completions for a given identifier from Pursuit.
+
+**Params:**
+ - `query :: String`: With `type: "package"` this should be a module name. With
+   `type: "completion"` this can be any string to look up.
+ - `type :: String`: Takes the following values:
+   - `package`: Looks for packages that contain the given module name.
+   - `completion` Looks for declarations for the query from Pursuit.
+
+```json
+{
+  "command": "pursuit",
+  "params": {
+    "query": "Data.Array",
+    "type": "package"
+  }
+}
+```
+
+**Result:**
+
+`package` returns:
+
+```json
+[
+  {
+  "module": "Module1.Name",
+  "package": "purescript-packagename"
+  }
+]
+```
+
+`completion` returns:
+
+```json
+[
+  {
+  "module": "Data.Array",
+  "identifier": "filter",
+  "type": "forall a. (a -> Boolean) -> Array a -> Array a",
+  "package": "purescript-arrays"
+  }
+]
+```
+
+### List
+
+#### Loaded Modules
+
+`list` of type `loadedModules` lists all loaded modules (This means they can be searched for completions etc)
+
+```json
+{
+  "command": "list",
+  "params": {
+    "type": "loadedModules"
+  }
+}
+```
+
+#### Response:
+
+The list loadedModules command returns a list of strings.
+
+#### Available Modules
+
+`list` of type `availableModules` lists all available modules. (This basically
+means the contents of the `output/` folder.))
+
+```json
+{
+  "command": "list",
+  "params": {
+    "type": "availableModules"
+  }
+}
+```
+
+#### Response:
+
+The list availableModules command returns a list of strings.
+
+#### Imports
+
+The list commmand can also list the imports for a given file.
+
+```json
+{
+  "command": "list",
+  "params": {
+    "type": "import",
+    "file": "/home/kritzcreek/Documents/psc-ide/examples/Main.purs"
+  }
+}
+```
+
+#### Response:
+
+The list import command returns a list of imports where imports are of the following form:
+
+Implicit Import(`import Data.Array`):
+```json
+[
+  {
+  "module": "Data.Array",
+  "importType": "implicit"
+  }
+]
+```
+
+Implicit qualified Import(`import qualified Data.Array as A`):
+```json
+[
+  {
+  "module": "Data.Array",
+  "importType": "implicit",
+  "qualifier": "A"
+  }
+]
+```
+
+Explicit Import(`import Data.Array (filter, filterM, join)`):
+```json
+[
+  {
+  "module": "Data.Array",
+  "importType": "explicit",
+  "identifiers": ["filter", "filterM", "join"]
+  }
+]
+```
+
+Hiding Import(`import Data.Array hiding (filter, filterM, join)`):
+```json
+[
+  {
+  "module": "Data.Array",
+  "importType": "hiding",
+  "identifiers": ["filter", "filterM", "join"]
+  }
+]
+```
+### Cwd/Quit
+`cwd` returns the working directory of the server(should be your project root).
+
+`quit` quits the server.
+
+```json
+{
+  "command": "cwd|quit"
+}
+```
+
+**Result:**
+These commands return strings.
+
+## Filter:
+
+### Exact filter
+The Exact filter only keeps identifiers that are equal to the search term.
+
+```json
+{
+  "filter": "exact",
+  "params": {
+    "search": "filterM"
+  }
+}
+```
+### Prefix filter
+The Prefix filter keeps identifiers/modules/data declarations that
+are prefixed by the search term.
+
+```json
+{
+   "filter": "prefix",
+   "params": {
+     "search": "filt"
+   }
+}
+```
+
+### Module filter
+The Module filter only keeps identifiers that appear in the listed modules.
+
+```json
+{
+   "filter": "modules",
+   "params": {
+     "modules": ["My.Module"]
+   }
+}
+```
+
+### Dependency filter
+The Dependency filter only keeps identifiers that appear in the listed modules
+and in any of their dependencies/imports.
+
+```json
+{
+  "filter": "dependencies",
+  "params": {
+    "modules": ["My.Module"]
+  }
+}
+```
+
+## Matcher:
+
+### Flex matcher
+Matches any occurence of the search string with intersections
+
+The scoring measures how far the matches span the string, where
+closer is better. The matches then get sorted with highest score first.
+
+Examples:
+- flMa matches **fl**ex**Ma**tcher. Score: 14.28
+- sons matches **so**rtCompletio**ns**. Score: 6.25
+```json
+
+{
+  "matcher": "flex",
+  "params": {
+    "search": "filt"
+  }
+}
+```
+
+### Distance Matcher
+
+The Distance matcher is meant to provide corrections for typos. It calculates
+the edit distance in between the search and the loaded identifiers.
+
+```json
+{
+  "matcher": "distance",
+  "params": {
+    "search": "dilterM",
+    "maximumDistance": 3
+  }
+}
+```
+
+## Responses
+
+All Responses are wrapped in the following format:
+
+```json
+{
+  "resultType": "success|error",
+  "result": Result|Error
+}
+```
+
+### Error
+
+Errors at this point are merely Error strings. Newlines are escaped like `\n`
+and should be taken care of by the editor-plugin.

--- a/psc-ide-server/README.md
+++ b/psc-ide-server/README.md
@@ -1,0 +1,40 @@
+psc-ide
+===
+
+A tool which provides editor support for the PureScript programming language.
+
+## Editor Integration
+* [@epost](https://github.com/epost) wrote a plugin to integrate psc-ide with Emacs at https://github.com/epost/psc-ide-emacs.
+* Atom integration is available with https://github.com/nwolverson/atom-ide-purescript.
+* Visual Studio Code integration is available with https://github.com/nwolverson/vscode-ide-purescript.
+* Vim integration is available here: https://github.com/FrigoEU/psc-ide-vim.
+
+## Running the Server
+Start the server by running the `psc-ide-server` executable.
+It supports the following options:
+
+- `-p / --port` specify a port. Defaults to 4242
+- `-d / --directory` specify the toplevel directory of your project. Defaults to
+  the current directory
+- `--output-directory`: Specify where to look for compiled output inside your
+  project directory. Defaults to `output/`, relative to either the current
+  directory or the directory specified by `-d`.
+- `--debug`: Enables some logging meant for debugging
+- `--version`: Output psc-ide version
+
+## Issuing queries
+
+After you started the server you can start issuing requests using
+`psc-ide-client`. Make sure you start by loading the modules before you try to
+query them.
+
+`psc-ide-server` expects the build externs.purs inside the `output/` folder of
+your project after running `pulp build` or `psc-make` respectively.
+
+(If you changed the port of the server you can change the port for
+`psc-ide-client` by using the -p option accordingly)
+
+## Protocol
+
+For documentation about the protocol have a look at:
+[PROTOCOL.md](PROTOCOL.md)

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -14,7 +14,8 @@ Homepage: http://www.purescript.org/
 author: Phil Freeman <paf31@cantab.net>,
         Gary Burgess <gary.burgess@gmail.com>,
         Hardy Jones <jones3.hardy@gmail.com>,
-        Harry Garrood <harry@garrood.me>
+        Harry Garrood <harry@garrood.me>,
+        Christoph Hegemann <christoph.hegemann1337@gmail.com>
 
 tested-with: GHC==7.8.4, GHC==7.10.3, GHC==8.0.1
 
@@ -80,7 +81,15 @@ library
                    safe >= 0.3.9 && < 0.4,
                    semigroups >= 0.16.2 && < 0.19,
                    parallel >= 3.2 && < 3.3,
-                   sourcemap >= 0.1.6
+                   sourcemap >= 0.1.6,
+                   stm >= 0.2.4.0,
+                   regex-tdfa -any,
+                   edit-distance -any,
+                   fsnotify >= 0.2.1,
+                   monad-logger >= 0.3 && < 0.4,
+                   pipes >= 4.0.0 && < 4.2.0 ,
+                   pipes-http -any,
+                   http-types -any
 
     exposed-modules: Language.PureScript
                      Language.PureScript.AST
@@ -188,6 +197,22 @@ library
                      Language.PureScript.Publish.ErrorsWarnings
                      Language.PureScript.Publish.BoxesHelpers
 
+                     Language.PureScript.Ide
+                     Language.PureScript.Ide.Command
+                     Language.PureScript.Ide.Externs
+                     Language.PureScript.Ide.Error
+                     Language.PureScript.Ide.CodecJSON
+                     Language.PureScript.Ide.Pursuit
+                     Language.PureScript.Ide.Completion
+                     Language.PureScript.Ide.Matcher
+                     Language.PureScript.Ide.Filter
+                     Language.PureScript.Ide.Types
+                     Language.PureScript.Ide.State
+                     Language.PureScript.Ide.CaseSplit
+                     Language.PureScript.Ide.SourceFile
+                     Language.PureScript.Ide.Watcher
+                     Language.PureScript.Ide.Reexports
+
                      Control.Monad.Logger
                      Control.Monad.Supply
                      Control.Monad.Supply.Class
@@ -286,13 +311,46 @@ executable psc-bundle
   ghc-options:         -Wall -O2
   hs-source-dirs:      psc-bundle
 
+executable psc-ide-server
+  main-is:             Main.hs
+  other-modules:
+  other-extensions:
+  build-depends:       base >=4 && <5
+                     , purescript -any
+                     , directory -any
+                     , filepath -any
+                     , monad-logger -any
+                     , mtl -any
+                     , transformers -any
+                     , transformers-compat -any
+                     , network -any
+                     , optparse-applicative >= 0.10.0
+                     , stm -any
+                     , text -any
+                     , base-compat >=0.6.0
+  ghc-options:         -Wall -O2 -threaded
+  hs-source-dirs:      psc-ide-server
+
+executable psc-ide-client
+  main-is:             Main.hs
+  other-modules:
+  other-extensions:
+  build-depends:       base >=4 && <5
+                     , mtl -any
+                     , text -any
+                     , optparse-applicative >= 0.10.0
+                     , network -any
+                     , base-compat >=0.6.0
+  ghc-options:         -Wall -O2
+  hs-source-dirs:      psc-ide-client
+
 test-suite tests
     build-depends: base >=4 && <5, containers -any, directory -any,
                    filepath -any, mtl -any, parsec -any, purescript -any,
                    transformers -any, process -any, transformers-compat -any, time -any,
                    Glob -any, aeson-better-errors -any, bytestring -any, aeson -any,
                    base-compat -any, haskeline >= 0.7.0.0, optparse-applicative -any,
-                   boxes -any, HUnit -any
+                   boxes -any, HUnit -any, hspec -any, hspec-discover -any, stm -any, text -any
     ghc-options: -Wall
     type: exitcode-stdio-1.0
     main-is: Main.hs
@@ -301,5 +359,7 @@ test-suite tests
                    TestDocs
                    TestPscPublish
                    TestPsci
+                   TestPscIde
+                   PscIdeSpec
     buildable: True
     hs-source-dirs: tests psci

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -1,0 +1,199 @@
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PackageImports        #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TupleSections         #-}
+
+module Language.PureScript.Ide where
+
+import           Prelude                            ()
+import           Prelude.Compat
+
+import           Control.Monad.Error.Class
+import           Control.Monad.IO.Class
+import           "monad-logger" Control.Monad.Logger
+import           Control.Monad.Reader.Class
+import           Data.Foldable
+import qualified Data.Map.Lazy                      as M
+import           Data.Maybe                         (catMaybes, mapMaybe)
+import           Data.Monoid
+import           Data.Text                          (Text)
+import qualified Data.Text                          as T
+import qualified Language.PureScript.Ide.CaseSplit  as CS
+import           Language.PureScript.Ide.Command
+import           Language.PureScript.Ide.Completion
+import           Language.PureScript.Ide.Error
+import           Language.PureScript.Ide.Externs
+import           Language.PureScript.Ide.Filter
+import           Language.PureScript.Ide.Matcher
+import           Language.PureScript.Ide.Pursuit
+import           Language.PureScript.Ide.Reexports
+import           Language.PureScript.Ide.SourceFile
+import           Language.PureScript.Ide.State
+import           Language.PureScript.Ide.Types
+import           System.Directory
+import           System.FilePath
+import           System.Exit
+
+
+handleCommand :: (PscIde m, MonadLogger m, MonadError PscIdeError m) =>
+                 Command -> m Success
+handleCommand (Load modules deps) =
+    loadModulesAndDeps modules deps
+handleCommand (Type search filters) =
+    findType search filters
+handleCommand (Complete filters matcher) =
+    findCompletions filters matcher
+handleCommand (Pursuit query Package) =
+    findPursuitPackages query
+handleCommand (Pursuit query Identifier) =
+    findPursuitCompletions query
+handleCommand (List LoadedModules) =
+    printModules
+handleCommand (List AvailableModules) =
+    listAvailableModules
+handleCommand (List (Imports fp)) =
+    importsForFile fp
+handleCommand (CaseSplit l b e wca t) =
+    caseSplit l b e wca t
+handleCommand (AddClause l wca) =
+    pure $ addClause l wca
+handleCommand Cwd =
+    TextResult . T.pack <$> liftIO getCurrentDirectory
+handleCommand Quit = liftIO exitSuccess
+
+findCompletions :: (PscIde m, MonadLogger m) =>
+                   [Filter] -> Matcher -> m Success
+findCompletions filters matcher =
+  CompletionResult . getCompletions filters matcher <$> getAllModulesWithReexports
+
+findType :: (PscIde m, MonadLogger m) =>
+            DeclIdent -> [Filter] -> m Success
+findType search filters =
+  CompletionResult . getExactMatches search filters <$> getAllModulesWithReexports
+
+findPursuitCompletions :: (Applicative m, MonadIO m, MonadLogger m) =>
+                          PursuitQuery -> m Success
+findPursuitCompletions (PursuitQuery q) =
+  PursuitResult <$> liftIO (searchPursuitForDeclarations q)
+
+findPursuitPackages :: (Applicative m, MonadIO m, MonadLogger m) =>
+                       PursuitQuery -> m Success
+findPursuitPackages (PursuitQuery q) =
+  PursuitResult <$> liftIO (findPackagesForModuleIdent q)
+
+loadExtern ::(PscIde m, MonadLogger m, MonadError PscIdeError m) =>
+             FilePath -> m ()
+loadExtern fp = do
+  m <- readExternFile fp
+  insertModule m
+
+printModules :: (PscIde m) => m Success
+printModules = printModules' <$> getPscIdeState
+
+printModules' :: M.Map ModuleIdent [ExternDecl] -> Success
+printModules' = ModuleList . M.keys
+
+listAvailableModules :: PscIde m => m Success
+listAvailableModules = do
+  outputPath <- confOutputPath . envConfiguration <$> ask
+  liftIO $ do
+    cwd <- getCurrentDirectory
+    dirs <- getDirectoryContents (cwd </> outputPath)
+    return (ModuleList (listAvailableModules' dirs))
+
+listAvailableModules' :: [FilePath] -> [Text]
+listAvailableModules' dirs =
+  let cleanedModules = filter (`notElem` [".", ".."]) dirs
+  in map T.pack cleanedModules
+
+caseSplit :: (PscIde m, MonadLogger m, MonadError PscIdeError m) =>
+  Text -> Int -> Int -> CS.WildcardAnnotations -> Text -> m Success
+caseSplit l b e csa t = do
+  patterns <- CS.makePattern l b e csa <$> CS.caseSplit t
+  pure (MultilineTextResult patterns)
+
+addClause :: Text -> CS.WildcardAnnotations -> Success
+addClause t wca = MultilineTextResult (CS.addClause t wca)
+
+importsForFile :: (Applicative m, MonadIO m, MonadLogger m, MonadError PscIdeError m) =>
+                  FilePath -> m Success
+importsForFile fp = do
+  imports <- getImportsForFile fp
+  pure (ImportList imports)
+
+-- | The first argument is a set of modules to load. The second argument
+--   denotes modules for which to load dependencies
+loadModulesAndDeps :: (PscIde m, MonadLogger m, MonadError PscIdeError m) =>
+                     [ModuleIdent] -> [ModuleIdent] -> m Success
+loadModulesAndDeps mods deps = do
+  r1 <- mapM loadModule (mods ++ deps)
+  r2 <- mapM loadModuleDependencies deps
+  let moduleResults = T.concat r1
+  let dependencyResults = T.concat r2
+  pure (TextResult (moduleResults <> ", " <> dependencyResults))
+
+loadModuleDependencies ::(PscIde m, MonadLogger m, MonadError PscIdeError m) =>
+                         ModuleIdent -> m Text
+loadModuleDependencies moduleName = do
+  m <- getModule moduleName
+  case getDependenciesForModule <$> m of
+    Just deps -> do
+      mapM_ loadModule deps
+      -- We need to load the modules, that get reexported from the dependencies
+      depModules <- catMaybes <$> mapM getModule deps
+      -- What to do with errors here? This basically means a reexported dependency
+      -- doesn't exist in the output/ folder
+      traverse_ loadReexports depModules
+      pure ("Dependencies for " <> moduleName <> " loaded.")
+    Nothing -> throwError (ModuleNotFound moduleName)
+
+loadReexports :: (PscIde m, MonadLogger m, MonadError PscIdeError m) =>
+                Module -> m [ModuleIdent]
+loadReexports m = case getReexports m of
+  [] -> pure []
+  exportDeps -> do
+    -- I'm fine with this crashing on a failed pattern match.
+    -- If this ever fails I'll need to look at GADTs
+    let reexports = map (\(Export mn) -> mn) exportDeps
+    $(logDebug) ("Loading reexports for module: " <> fst m <>
+                 " reexports: " <> T.intercalate ", " reexports)
+    traverse_ loadModule reexports
+    exportDepsModules <- catMaybes <$> traverse getModule reexports
+    exportDepDeps <- traverse loadReexports exportDepsModules
+    return $ concat exportDepDeps
+
+getDependenciesForModule :: Module -> [ModuleIdent]
+getDependenciesForModule (_, decls) = mapMaybe getDependencyName decls
+  where getDependencyName (Dependency dependencyName _ _) = Just dependencyName
+        getDependencyName _ = Nothing
+
+loadModule :: (PscIde m, MonadLogger m, MonadError PscIdeError m) =>
+              ModuleIdent -> m Text
+loadModule "Prim" = pure "Prim won't be loaded"
+loadModule mn = do
+  path <- filePathFromModule mn
+  loadExtern path
+  $(logDebug) ("Loaded extern file at: " <> T.pack path)
+  pure ("Loaded extern file at: " <> T.pack path)
+
+filePathFromModule :: (PscIde m, MonadError PscIdeError m) =>
+                      ModuleIdent -> m FilePath
+filePathFromModule moduleName = do
+  outputPath <- confOutputPath . envConfiguration <$> ask
+  cwd <- liftIO getCurrentDirectory
+  let path = cwd </> outputPath </> T.unpack moduleName </> "externs.json"
+  ex <- liftIO $ doesFileExist path
+  if ex
+    then pure path
+    else throwError (ModuleFileNotFound moduleName)
+
+-- | Taken from Data.Either.Utils
+maybeToEither :: MonadError e m =>
+                 e                      -- ^ (Left e) will be returned if the Maybe value is Nothing
+              -> Maybe a                -- ^ (Right a) will be returned if this is (Just a)
+              -> m a
+maybeToEither errorval Nothing = throwError errorval
+maybeToEither _ (Just normalval) = return normalval

--- a/src/Language/PureScript/Ide/CaseSplit.hs
+++ b/src/Language/PureScript/Ide/CaseSplit.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PackageImports        #-}
+{-# LANGUAGE RecordWildCards       #-}
+
+module Language.PureScript.Ide.CaseSplit
+       ( WildcardAnnotations()
+       , explicitAnnotations
+       , noAnnotations
+       , makePattern
+       , addClause
+       , caseSplit
+       ) where
+
+import           Prelude                                 ()
+import           Prelude.Compat                          hiding (lex)
+
+import           Control.Monad.Error.Class
+import           "monad-logger" Control.Monad.Logger
+import           Data.List                               (find)
+import           Data.Monoid
+import           Data.Text                               (Text)
+import qualified Data.Text                               as T
+import           Language.PureScript.AST
+import           Language.PureScript.Environment
+import           Language.PureScript.Externs
+import           Language.PureScript.Ide.Error
+import           Language.PureScript.Ide.Externs         (unwrapPositioned)
+import           Language.PureScript.Ide.State
+import           Language.PureScript.Ide.Types           hiding (Type)
+import           Language.PureScript.Names
+import           Language.PureScript.Parser.Common       (runTokenParser)
+import           Language.PureScript.Parser.Declarations
+import           Language.PureScript.Parser.Lexer        (lex)
+import           Language.PureScript.Parser.Types
+import           Language.PureScript.Pretty
+import           Language.PureScript.Types
+import           Text.Parsec                             as P
+
+type Constructor = (ProperName 'ConstructorName, [Type])
+
+newtype WildcardAnnotations = WildcardAnnotations Bool
+
+explicitAnnotations :: WildcardAnnotations
+explicitAnnotations = WildcardAnnotations True
+
+noAnnotations :: WildcardAnnotations
+noAnnotations = WildcardAnnotations False
+
+caseSplit :: (PscIde m, MonadLogger m, MonadError PscIdeError m) =>
+             Text -> m [Constructor]
+caseSplit q = do
+  (tc, args) <- splitTypeConstructor (parseType' (T.unpack q))
+  (EDType _ _ (DataType typeVars ctors)) <- findTypeDeclaration tc
+  let applyTypeVars = everywhereOnTypes (replaceAllTypeVars (zip (map fst typeVars) args))
+  let appliedCtors = map (\(n, ts) -> (n, map applyTypeVars ts)) ctors
+  pure appliedCtors
+
+{- ["EDType {
+     edTypeName = ProperName {runProperName = \"Either\"}
+   , edTypeKind = FunKind Star (FunKind Star Star)
+   , edTypeDeclarationKind =
+       DataType [(\"a\",Just Star),(\"b\",Just Star)]
+                [(ProperName {runProperName = \"Left\"},[TypeVar \"a\"])
+                ,(ProperName {runProperName = \"Right\"},[TypeVar \"b\"])]}"]
+-}
+
+findTypeDeclaration :: (PscIde m, MonadLogger m, MonadError PscIdeError m) =>
+                         ProperName 'TypeName -> m ExternsDeclaration
+findTypeDeclaration q = do
+  efs <- getExternFiles
+  let m = getFirst $ foldMap (findTypeDeclaration' q) efs
+  case m of
+    Just mn -> pure mn
+    Nothing -> throwError (GeneralError "Not Found")
+
+findTypeDeclaration' ::
+  ProperName 'TypeName
+  -> ExternsFile
+  -> First ExternsDeclaration
+findTypeDeclaration' t ExternsFile{..} =
+  First $ find (\case
+            EDType tn _ _ -> tn == t
+            _ -> False) efDeclarations
+
+splitTypeConstructor :: (Applicative m, MonadError PscIdeError m) =>
+                        Type -> m (ProperName 'TypeName, [Type])
+splitTypeConstructor = go []
+  where
+    go acc (TypeApp ty arg) = go (arg : acc) ty
+    go acc (TypeConstructor tc) = pure (disqualify tc, acc)
+    go _ _ = throwError (GeneralError "Failed to read TypeConstructor")
+
+prettyCtor :: WildcardAnnotations -> Constructor -> Text
+prettyCtor _ (ctorName, []) = T.pack (runProperName ctorName)
+prettyCtor wsa (ctorName, ctorArgs) =
+  "("<> T.pack (runProperName ctorName) <> " "
+  <> T.unwords (map (prettyPrintWildcard wsa) ctorArgs) <>")"
+
+prettyPrintWildcard :: WildcardAnnotations -> Type -> Text
+prettyPrintWildcard (WildcardAnnotations True) = prettyWildcard
+prettyPrintWildcard (WildcardAnnotations False) = const "_"
+
+prettyWildcard :: Type -> Text
+prettyWildcard t = "( _ :: " <> T.strip (T.pack (prettyPrintTypeAtom t)) <> ")"
+
+-- | Constructs Patterns to insert into a sourcefile
+makePattern :: Text -- ^ Current line
+            -> Int -- ^ Begin of the split
+            -> Int -- ^ End of the split
+            -> WildcardAnnotations -- ^ Whether to explicitly type the splits
+            -> [Constructor] -- ^ Constructors to split
+            -> [Text]
+makePattern t x y wsa = makePattern' (T.take x t) (T.drop y t)
+  where
+    makePattern' lhs rhs = map (\ctor -> lhs <> prettyCtor wsa ctor <> rhs)
+
+addClause :: Text -> WildcardAnnotations -> [Text]
+addClause s wca =
+  let (fName, fType) = parseTypeDeclaration' (T.unpack s)
+      (args, _) = splitFunctionType fType
+      template = T.pack (runIdent fName) <> " " <>
+        T.unwords (map (prettyPrintWildcard wca) args) <>
+        " = ?" <> (T.strip . T.pack . runIdent $ fName)
+  in [s, template]
+
+parseType' :: String -> Type
+parseType' s = let (Right t) = do
+                     ts <- lex "" s
+                     runTokenParser "" (parseType <* P.eof) ts
+               in t
+
+parseTypeDeclaration' :: String -> (Ident, Type)
+parseTypeDeclaration' s =
+  let x = do
+        ts <- lex "" s
+        runTokenParser "" (parseDeclaration <* P.eof) ts
+  in
+    case unwrapPositioned <$> x of
+      Right (TypeDeclaration i t) -> (i, t)
+      y -> error (show y)
+
+splitFunctionType :: Type -> ([Type], Type)
+splitFunctionType t = (arguments, returns)
+  where
+    returns = last splitted
+    arguments = init splitted
+    splitted = splitType' t
+    splitType' (ForAll _ t' _) = splitType' t'
+    splitType' (ConstrainedType _ t') = splitType' t'
+    splitType' (TypeApp (TypeApp t' lhs) rhs)
+          | t' == tyFunction = lhs : splitType' rhs
+    splitType' t' = [t']

--- a/src/Language/PureScript/Ide/CodecJSON.hs
+++ b/src/Language/PureScript/Ide/CodecJSON.hs
@@ -1,0 +1,13 @@
+module Language.PureScript.Ide.CodecJSON where
+
+import Data.Aeson
+import Data.Text (Text())
+import Data.Text.Lazy (toStrict, fromStrict)
+import Data.Text.Lazy.Encoding (decodeUtf8, encodeUtf8)
+
+encodeT :: (ToJSON a) => a -> Text
+encodeT = toStrict . decodeUtf8 . encode
+
+decodeT :: (FromJSON a) => Text -> Maybe a
+decodeT = decode . encodeUtf8 . fromStrict
+

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+
+module Language.PureScript.Ide.Command where
+
+import           Prelude                           ()
+import           Prelude.Compat
+
+import           Control.Monad
+import           Data.Aeson
+import           Data.Maybe
+import           Data.Text                         (Text)
+import           Language.PureScript.Ide.CaseSplit
+import           Language.PureScript.Ide.Filter
+import           Language.PureScript.Ide.Matcher
+import           Language.PureScript.Ide.Types
+
+data Command
+    = Load { loadModules      :: [ModuleIdent]
+           , loadDependencies :: [ModuleIdent]}
+    | Type { typeSearch  :: DeclIdent
+           , typeFilters :: [Filter]}
+    | Complete { completeFilters :: [Filter]
+               , completeMatcher :: Matcher}
+    | Pursuit { pursuitQuery      :: PursuitQuery
+              , pursuitSearchType :: PursuitSearchType}
+    | List {listType :: ListType}
+    | CaseSplit {
+      caseSplitLine          :: Text
+      , caseSplitBegin       :: Int
+      , caseSplitEnd         :: Int
+      , caseSplitAnnotations :: WildcardAnnotations
+      , caseSplitType        :: Type}
+    | AddClause {
+      addClauseLine          :: Text
+      , addClauseAnnotations :: WildcardAnnotations}
+    | Cwd
+    | Quit
+
+data ListType = LoadedModules | Imports FilePath | AvailableModules
+
+instance FromJSON ListType where
+  parseJSON = withObject "ListType" $ \o -> do
+    (listType' :: String) <- o .: "type"
+    case listType' of
+      "import" -> do
+        fp <- o .: "file"
+        return (Imports fp)
+      "loadedModules" -> return LoadedModules
+      "availableModules" -> return AvailableModules
+      _ -> mzero
+
+instance FromJSON Command where
+  parseJSON = withObject "command" $ \o -> do
+    (command :: String) <- o .: "command"
+    case command of
+      "list" -> do
+        listType' <- o .:? "params"
+        return $ List (fromMaybe LoadedModules listType')
+      "cwd"  -> return Cwd
+      "quit" -> return Quit
+      "load" -> do
+        params <- o .: "params"
+        mods <- params .:? "modules"
+        deps <- params .:? "dependencies"
+        return $ Load (fromMaybe [] mods) (fromMaybe [] deps)
+      "type" -> do
+        params <- o .: "params"
+        search <- params .: "search"
+        filters <- params .: "filters"
+        return $ Type search filters
+      "complete" -> do
+        params <- o .: "params"
+        filters <- params .:? "filters"
+        matcher <- params .:? "matcher"
+        return $ Complete (fromMaybe [] filters) (fromMaybe mempty matcher)
+      "pursuit" -> do
+        params <- o .: "params"
+        query <- params .: "query"
+        queryType <- params .: "type"
+        return $ Pursuit query queryType
+      "caseSplit" -> do
+        params <- o .: "params"
+        line <- params .: "line"
+        begin <- params .: "begin"
+        end <- params .: "end"
+        annotations <- params .: "annotations"
+        type' <- params .: "type"
+        return $ CaseSplit line begin end (if annotations
+                                           then explicitAnnotations
+                                           else noAnnotations) type'
+      "addClause" -> do
+        params <- o .: "params"
+        line <- params .: "line"
+        annotations <- params .: "annotations"
+        return $ AddClause line (if annotations
+                                 then explicitAnnotations
+                                 else noAnnotations)
+      _ -> mzero
+

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Language.PureScript.Ide.Completion
+       (getCompletions, getExactMatches)
+       where
+
+import           Prelude                         ()
+import           Prelude.Compat
+
+import           Data.Maybe                      (mapMaybe)
+import           Language.PureScript.Ide.Filter
+import           Language.PureScript.Ide.Matcher
+import           Language.PureScript.Ide.Types
+
+-- | Applies the CompletionFilters and the Matcher to the given Modules
+--   and sorts the found Completions according to the Matching Score
+getCompletions :: [Filter] -> Matcher -> [Module] -> [Completion]
+getCompletions filters matcher modules =
+    runMatcher matcher $ completionsFromModules (applyFilters filters modules)
+
+getExactMatches :: DeclIdent -> [Filter] -> [Module] -> [Completion]
+getExactMatches search filters modules =
+    completionsFromModules $
+    applyFilters (equalityFilter search : filters) modules
+
+completionsFromModules :: [Module] -> [Completion]
+completionsFromModules = foldMap completionFromModule
+    where
+        completionFromModule :: Module -> [Completion]
+        completionFromModule (moduleIdent, decls) = mapMaybe (completionFromDecl moduleIdent) decls
+
+completionFromDecl :: ModuleIdent -> ExternDecl -> Maybe Completion
+completionFromDecl mi (FunctionDecl name type') = Just (Completion (mi, name, type'))
+completionFromDecl mi (DataDecl name kind)      = Just (Completion (mi, name, kind))
+completionFromDecl _ (ModuleDecl name _)        = Just (Completion ("module", name, "module"))
+completionFromDecl _ _                          = Nothing

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Language.PureScript.Ide.Error
+       (ErrorMsg, PscIdeError(..), textError, first)
+       where
+
+import           Data.Aeson
+import           Data.Monoid
+import           Data.Text                     (Text, pack)
+import           Language.PureScript.Ide.Types (ModuleIdent)
+import qualified Text.Parsec.Error             as P
+
+type ErrorMsg = String
+
+data PscIdeError
+    = GeneralError ErrorMsg
+    | NotFound Text
+    | ModuleNotFound ModuleIdent
+    | ModuleFileNotFound ModuleIdent
+    | ParseError P.ParseError ErrorMsg
+    deriving (Show, Eq)
+
+instance ToJSON PscIdeError where
+  toJSON err = object
+               [
+                 "resultType" .= ("error" :: Text),
+                 "result" .= textError err
+               ]
+
+textError :: PscIdeError -> Text
+textError (GeneralError msg)           = pack msg
+textError (NotFound ident)             = "Symbol '" <> ident <> "' not found."
+textError (ModuleNotFound ident)       = "Module '" <> ident <> "' not found."
+textError (ModuleFileNotFound ident)   = "Extern file for module " <> ident <>" could not be found"
+textError (ParseError parseError msg)  = pack $ msg <> ": " <> show (escape parseError)
+    where
+    -- escape newlines and other special chars so we can send the error over the socket as a single line
+      escape :: P.ParseError -> String
+      escape = show
+
+-- | Specialized version of `first` from `Data.Bifunctors`
+first :: (a -> b) -> Either a r -> Either b r
+first f (Left x)   = Left (f x)
+first _ (Right r2) = Right r2

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+
+module Language.PureScript.Ide.Externs
+  (
+    ExternDecl(..),
+    ModuleIdent,
+    DeclIdent,
+    Type,
+    Fixity(..),
+    readExternFile,
+    convertExterns,
+    unwrapPositioned,
+    unwrapPositionedRef
+  ) where
+
+import           Prelude                              ()
+import           Prelude.Compat
+
+import           Control.Monad.Error.Class
+import           Control.Monad.IO.Class
+import           Data.Maybe                           (mapMaybe)
+import           Data.Text                            (Text)
+import qualified Data.Text                            as T
+import qualified Data.Text.IO                         as T
+import qualified Language.PureScript.AST.Declarations as D
+import qualified Language.PureScript.Externs          as PE
+import           Language.PureScript.Ide.CodecJSON
+import           Language.PureScript.Ide.Error        (PscIdeError (..))
+import           Language.PureScript.Ide.Types
+import qualified Language.PureScript.Names            as N
+import qualified Language.PureScript.Pretty           as PP
+
+readExternFile :: (Applicative m, MonadIO m, MonadError PscIdeError m) =>
+                  FilePath -> m PE.ExternsFile
+readExternFile fp = do
+   parseResult <- liftIO (decodeT <$> T.readFile fp)
+   case parseResult of
+     Nothing -> throwError . GeneralError $ "Parsing the extern at: " ++ fp ++ " failed"
+     Just externs -> pure externs
+
+moduleNameToText :: N.ModuleName -> Text
+moduleNameToText = T.pack . N.runModuleName
+
+properNameToText :: N.ProperName a -> Text
+properNameToText = T.pack . N.runProperName
+
+identToText :: N.Ident -> Text
+identToText  = T.pack . N.runIdent
+
+convertExterns :: PE.ExternsFile -> Module
+convertExterns ef = (moduleName, exportDecls ++ importDecls ++ otherDecls)
+  where
+    moduleName = moduleNameToText (PE.efModuleName ef)
+    importDecls = convertImport <$> PE.efImports ef
+    exportDecls = mapMaybe (convertExport . unwrapPositionedRef) (PE.efExports ef)
+    -- Ignoring operator fixities for now since we're not using them
+    -- operatorDecls = convertOperator <$> PE.efFixities ef
+    otherDecls = mapMaybe convertDecl (PE.efDeclarations ef)
+
+convertImport :: PE.ExternsImport -> ExternDecl
+convertImport ei = Dependency
+  (moduleNameToText (PE.eiModule ei))
+  []
+  (moduleNameToText <$> PE.eiImportedAs ei)
+
+convertExport :: D.DeclarationRef -> Maybe ExternDecl
+convertExport (D.ModuleRef mn) = Just (Export (moduleNameToText mn))
+convertExport _ = Nothing
+
+convertDecl :: PE.ExternsDeclaration -> Maybe ExternDecl
+convertDecl PE.EDType{..} = Just $
+  DataDecl
+  (properNameToText edTypeName)
+  (packAndStrip (PP.prettyPrintKind edTypeKind))
+convertDecl PE.EDTypeSynonym{..} = Just $
+  DataDecl
+  (properNameToText edTypeSynonymName)
+  (packAndStrip (PP.prettyPrintType edTypeSynonymType))
+convertDecl PE.EDDataConstructor{..} = Just $
+  DataDecl
+  (properNameToText edDataCtorName)
+  (packAndStrip (PP.prettyPrintType edDataCtorType))
+convertDecl PE.EDValue{..} = Just $
+  FunctionDecl
+  (identToText edValueName)
+  (packAndStrip (PP.prettyPrintType edValueType))
+convertDecl _ = Nothing
+
+packAndStrip :: String -> Text
+packAndStrip = T.unwords . fmap T.strip . T.lines . T.pack
+
+unwrapPositioned :: D.Declaration -> D.Declaration
+unwrapPositioned (D.PositionedDeclaration _ _ x) = x
+unwrapPositioned x = x
+
+unwrapPositionedRef :: D.DeclarationRef -> D.DeclarationRef
+unwrapPositionedRef (D.PositionedDeclarationRef _ _ x) = x
+unwrapPositionedRef x = x

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+module Language.PureScript.Ide.Filter
+       (Filter, moduleFilter, prefixFilter, equalityFilter, dependencyFilter,
+        runFilter, applyFilters)
+       where
+
+import           Prelude                       ()
+import           Prelude.Compat
+
+import           Control.Monad
+import           Data.Aeson
+import           Data.Foldable
+import           Data.Maybe                    (listToMaybe, mapMaybe)
+import           Data.Monoid
+import           Data.Text                     (Text, isPrefixOf)
+import           Language.PureScript.Ide.Types
+
+newtype Filter = Filter (Endo [Module]) deriving(Monoid)
+
+mkFilter :: ([Module] -> [Module]) -> Filter
+mkFilter = Filter . Endo
+
+-- | Only keeps the given Modules
+moduleFilter :: [ModuleIdent] -> Filter
+moduleFilter =
+    mkFilter . moduleFilter'
+
+moduleFilter' :: [ModuleIdent] -> [Module] -> [Module]
+moduleFilter' moduleIdents = filter (flip elem moduleIdents . fst)
+
+-- | Only keeps the given Modules and all of their dependencies
+dependencyFilter :: [ModuleIdent] -> Filter
+dependencyFilter = mkFilter . dependencyFilter'
+
+dependencyFilter' :: [ModuleIdent] -> [Module] -> [Module]
+dependencyFilter' moduleIdents mods =
+  moduleFilter' (concatMap (getDepForModule mods) moduleIdents) mods
+  where
+    getDepForModule :: [Module] -> ModuleIdent -> [ModuleIdent]
+    getDepForModule ms moduleIdent =
+      moduleIdent : maybe [] extractDeps (findModule moduleIdent ms)
+
+    findModule :: ModuleIdent -> [Module] -> Maybe Module
+    findModule i ms = listToMaybe $ filter go ms
+      where go (mn, _) = i == mn
+
+    extractDeps :: Module -> [ModuleIdent]
+    extractDeps = mapMaybe extractDep . snd
+      where extractDep (Dependency n _ _) = Just n
+            extractDep _ = Nothing
+
+-- | Only keeps Identifiers that start with the given prefix
+prefixFilter :: Text -> Filter
+prefixFilter "" = mkFilter id
+prefixFilter t = mkFilter $ identFilter prefix t
+  where
+    prefix :: ExternDecl -> Text -> Bool
+    prefix (FunctionDecl name _) search = search `isPrefixOf` name
+    prefix (DataDecl name _) search = search `isPrefixOf` name
+    prefix (ModuleDecl name _) search = search `isPrefixOf` name
+    prefix _ _ = False
+
+
+-- | Only keeps Identifiers that are equal to the search string
+equalityFilter :: Text -> Filter
+equalityFilter = mkFilter . identFilter equality
+  where
+    equality :: ExternDecl -> Text -> Bool
+    equality (FunctionDecl name _) prefix = prefix == name
+    equality (DataDecl name _) prefix = prefix == name
+    equality _ _ = False
+
+
+identFilter :: (ExternDecl -> Text -> Bool ) -> Text -> [Module] -> [Module]
+identFilter predicate search =
+    filter (not . null . snd) . fmap filterModuleDecls
+  where
+    filterModuleDecls :: Module -> Module
+    filterModuleDecls (moduleIdent,decls) =
+        (moduleIdent, filter (`predicate` search) decls)
+
+runFilter :: Filter -> [Module] -> [Module]
+runFilter (Filter f)= appEndo f
+
+applyFilters :: [Filter] -> [Module] -> [Module]
+applyFilters = runFilter . fold
+
+instance FromJSON Filter where
+  parseJSON = withObject "filter" $ \o -> do
+    (filter' :: String) <- o .: "filter"
+    case filter' of
+      "exact" -> do
+        params <- o .: "params"
+        search <- params .: "search"
+        return $ equalityFilter search
+      "prefix" -> do
+        params <- o.: "params"
+        search <- params .: "search"
+        return $ prefixFilter search
+      "modules" -> do
+        params <- o .: "params"
+        modules <- params .: "modules"
+        return $ moduleFilter modules
+      "dependencies" -> do
+        params <- o .: "params"
+        deps <- params .: "modules"
+        return $ dependencyFilter deps
+      _ -> mzero

--- a/src/Language/PureScript/Ide/Matcher.hs
+++ b/src/Language/PureScript/Ide/Matcher.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+module Language.PureScript.Ide.Matcher (Matcher, flexMatcher, runMatcher) where
+
+import           Prelude                       ()
+import           Prelude.Compat
+
+import           Control.Monad
+import           Data.Aeson
+import           Data.Function                 (on)
+import           Data.List                     (sortBy)
+import           Data.Maybe                    (mapMaybe)
+import           Data.Monoid
+import           Data.Text                     (Text)
+import qualified Data.Text                     as T
+import qualified Data.Text.Encoding            as TE
+import           Language.PureScript.Ide.Types
+import           Text.EditDistance
+import           Text.Regex.TDFA               ((=~))
+
+
+type ScoredCompletion = (Completion, Double)
+
+newtype Matcher = Matcher (Endo [Completion]) deriving(Monoid)
+
+instance FromJSON Matcher where
+  parseJSON = withObject "matcher" $ \o -> do
+    (matcher :: Maybe String) <- o .:? "matcher"
+    case matcher of
+      Just "flex" -> do
+        params <- o .: "params"
+        search <- params .: "search"
+        pure $ flexMatcher search
+      Just "distance" -> do
+        params <- o .: "params"
+        search <- params .: "search"
+        maxDist <- params .: "maximumDistance"
+        pure $ distanceMatcher search maxDist
+      Just _ -> mzero
+      Nothing -> return mempty
+
+-- | Matches any occurence of the search string with intersections
+-- |
+-- | The scoring measures how far the matches span the string where
+-- | closer is better.
+-- | Examples:
+-- |   flMa matches flexMatcher. Score: 14.28
+-- |   sons matches sortCompletions. Score: 6.25
+flexMatcher :: Text -> Matcher
+flexMatcher pattern = mkMatcher (flexMatch pattern)
+
+distanceMatcher :: Text -> Int -> Matcher
+distanceMatcher q maxDist = mkMatcher (distanceMatcher' q maxDist)
+
+distanceMatcher' :: Text -> Int -> [Completion] -> [ScoredCompletion]
+distanceMatcher' q maxDist = mapMaybe go
+  where
+    go c@(Completion (_, y, _)) = let d = dist (T.unpack y)
+                                  in if d <= maxDist
+                                     then Just (c, 1 / fromIntegral d)
+                                     else Nothing
+    dist = levenshteinDistance defaultEditCosts (T.unpack q)
+
+mkMatcher :: ([Completion] -> [ScoredCompletion]) -> Matcher
+mkMatcher matcher = Matcher . Endo  $ fmap fst . sortCompletions . matcher
+
+runMatcher :: Matcher -> [Completion] -> [Completion]
+runMatcher (Matcher m)= appEndo m
+
+sortCompletions :: [ScoredCompletion] -> [ScoredCompletion]
+sortCompletions = sortBy (flip compare `on` snd)
+
+flexMatch :: Text -> [Completion] -> [ScoredCompletion]
+flexMatch pattern = mapMaybe (flexRate pattern)
+
+flexRate :: Text -> Completion -> Maybe ScoredCompletion
+flexRate pattern c@(Completion (_,ident,_)) = do
+    score <- flexScore pattern ident
+    return (c, score)
+
+-- FlexMatching ala Sublime.
+-- Borrowed from: http://cdewaka.com/2013/06/fuzzy-pattern-matching-in-haskell/
+--
+-- By string =~ pattern we'll get the start of the match and the length of
+-- the matchas a (start, length) tuple if there's a match.
+-- If match fails then it would be (-1,0)
+flexScore :: Text -> DeclIdent -> Maybe Double
+flexScore "" _ = Nothing
+flexScore pat str =
+    case TE.encodeUtf8 str =~ TE.encodeUtf8 pat' :: (Int, Int) of
+        (-1,0) -> Nothing
+        (start,len) -> Just $ calcScore start (start + len)
+  where
+    Just (first,pattern) = T.uncons pat
+    -- This just interleaves the search string with .*
+    -- abcd -> a.*b.*c.*d
+    pat' = first `T.cons` T.concatMap (T.snoc ".*") pattern
+    calcScore start end =
+        100.0 / fromIntegral ((1 + start) * (end - start + 1))

--- a/src/Language/PureScript/Ide/Pursuit.hs
+++ b/src/Language/PureScript/Ide/Pursuit.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Language.PureScript.Ide.Pursuit where
+
+import           Prelude                       ()
+import           Prelude.Compat
+
+import qualified Control.Exception             as E
+import           Data.Aeson
+import           Data.ByteString               (ByteString)
+import           Data.ByteString.Lazy          (fromStrict)
+import Data.Foldable (toList)
+import           Data.Monoid                   ((<>))
+import           Data.Maybe                   (mapMaybe)
+import           Data.String
+import           Data.Text                     (Text)
+import qualified Data.Text                     as T
+import           Language.PureScript.Ide.Types
+import           Network.HTTP.Types.Header     (hAccept)
+import           Pipes.HTTP
+import qualified Pipes.Prelude                 as P
+
+-- We need to remove trailing dots because Pursuit will return a 400 otherwise
+-- TODO: remove this when the issue is fixed at Pursuit
+queryPursuit :: Text -> IO ByteString
+queryPursuit q = do
+  let qClean = T.dropWhileEnd (== '.') q
+  req' <- parseUrl "http://pursuit.purescript.org/search"
+  let req = req'
+        { queryString=("q=" <> (fromString . T.unpack) qClean)
+        , requestHeaders=[(hAccept, "application/json")]
+        }
+  m <- newManager tlsManagerSettings
+  withHTTP req m $ \resp ->
+    P.fold (\x a -> x <> a) "" id $ responseBody resp
+
+
+handler :: HttpException -> IO [a]
+handler StatusCodeException{} = return []
+handler _ = return []
+
+searchPursuitForDeclarations :: Text -> IO [PursuitResponse]
+searchPursuitForDeclarations query =
+    (do r <- queryPursuit query
+        let results' = decode (fromStrict r) :: Maybe Array
+        case results' of
+          Nothing -> pure []
+          Just results -> pure (mapMaybe isDeclarationResponse (map fromJSON (toList results)))) `E.catch`
+    handler
+  where
+    isDeclarationResponse (Success a@DeclarationResponse{}) = Just a
+    isDeclarationResponse _ = Nothing
+
+findPackagesForModuleIdent :: Text -> IO [PursuitResponse]
+findPackagesForModuleIdent query =
+    (do r <- queryPursuit query
+        let results' = decode (fromStrict r) :: Maybe Array
+        case results' of
+          Nothing -> pure []
+          Just results -> pure (mapMaybe isModuleResponse (map fromJSON (toList results)))) `E.catch`
+    handler
+  where
+    isModuleResponse (Success a@ModuleResponse{}) = Just a
+    isModuleResponse _ = Nothing

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards     #-}
+{-# LANGUAGE TupleSections     #-}
+module Language.PureScript.Ide.Reexports where
+
+
+import           Prelude                       ()
+import           Prelude.Compat
+
+import           Data.List                     (union)
+import           Data.Map                      (Map)
+import qualified Data.Map                      as Map
+import           Data.Maybe
+import           Language.PureScript.Ide.Types
+
+getReexports :: Module -> [ExternDecl]
+getReexports (mn, decls)= concatMap getExport decls
+   where getExport d
+           | (Export mn') <- d
+           , mn /= mn' = replaceExportWithAliases decls mn'
+           | otherwise = []
+
+dependencyToExport :: ExternDecl -> ExternDecl
+dependencyToExport (Dependency m _ _) = Export m
+dependencyToExport decl = decl
+
+replaceExportWithAliases :: [ExternDecl] -> ModuleIdent -> [ExternDecl]
+replaceExportWithAliases decls ident =
+  case filter isMatch decls of
+    [] -> [Export ident]
+    aliases -> map dependencyToExport aliases
+  where isMatch d
+          | Dependency _ _ (Just alias) <- d
+          , alias == ident = True
+          | otherwise = False
+
+replaceReexport :: ExternDecl -> Module -> Module -> Module
+replaceReexport e@(Export _) (m, decls) (_, newDecls) =
+  (m, filter (/= e) decls `union` newDecls)
+replaceReexport _ _ _ = error "Should only get Exports here."
+
+emptyModule :: Module
+emptyModule = ("Empty", [])
+
+isExport :: ExternDecl -> Bool
+isExport (Export _) = True
+isExport _ = False
+
+removeExportDecls :: Module -> Module
+removeExportDecls = fmap (filter (not . isExport))
+
+replaceReexports :: Module -> Map ModuleIdent [ExternDecl] -> Module
+replaceReexports m db = result
+  where reexports = getReexports m
+        result = foldl go (removeExportDecls m) reexports
+
+        go :: Module -> ExternDecl -> Module
+        go m' re@(Export name) = replaceReexport re m' (getModule name)
+        go _ _ = error "partiality! woohoo"
+
+        getModule :: ModuleIdent -> Module
+        getModule name = clean res
+          where res = fromMaybe emptyModule $ (name , ) <$> Map.lookup name db
+                -- we have to do this because keeping self exports in will result in
+                -- infinite loops
+                clean (mn, decls) = (mn,) (filter (/= Export mn) decls)
+
+resolveReexports :: Map ModuleIdent [ExternDecl] -> Module ->  Module
+resolveReexports modules m = do
+  let replaced = replaceReexports m modules
+  if null . getReexports $ replaced
+    then replaced
+    else resolveReexports modules replaced

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+module Language.PureScript.Ide.SourceFile where
+
+import           Prelude                              ()
+import           Prelude.Compat
+
+import           Control.Monad.Error.Class
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Except
+import           Data.Maybe                           (mapMaybe)
+import           Data.Monoid
+import qualified Data.Text                            as T
+import qualified Language.PureScript.AST.Declarations as D
+import qualified Language.PureScript.AST.SourcePos    as SP
+import           Language.PureScript.Ide.Error
+import           Language.PureScript.Ide.Externs      (unwrapPositioned,
+                                                       unwrapPositionedRef)
+import           Language.PureScript.Ide.Types
+import qualified Language.PureScript.Names            as N
+import qualified Language.PureScript.Parser           as P
+import           System.Directory
+
+parseModuleFromFile :: (Applicative m, MonadIO m, MonadError PscIdeError m) =>
+                       FilePath -> m D.Module
+parseModuleFromFile fp = do
+  exists <- liftIO (doesFileExist fp)
+  if exists
+    then do
+      content <- liftIO (readFile fp)
+      let m = do tokens <- P.lex fp content
+                 P.runTokenParser "" P.parseModule tokens
+      either (throwError . (`ParseError` "File could not be parsed.")) pure m
+    else throwError (NotFound "File does not exist.")
+
+-- data Module = Module SourceSpan [Comment] ModuleName [Declaration] (Maybe [DeclarationRef])
+
+getDeclarations :: D.Module -> [D.Declaration]
+getDeclarations (D.Module _ _ _ declarations _) = declarations
+
+getImports :: D.Module -> [D.Declaration]
+getImports (D.Module _ _ _ declarations _) =
+  mapMaybe isImport declarations
+  where
+    isImport (D.PositionedDeclaration _ _ (i@D.ImportDeclaration{})) = Just i
+    isImport _ = Nothing
+
+getImportsForFile :: (Applicative m, MonadIO m, MonadError PscIdeError m) =>
+                     FilePath -> m [ModuleImport]
+getImportsForFile fp = do
+  module' <- parseModuleFromFile fp
+  let imports = getImports module'
+  pure (mkModuleImport . unwrapPositionedImport <$> imports)
+  where mkModuleImport (D.ImportDeclaration mn importType' qualifier _) =
+          ModuleImport
+            (T.pack (N.runModuleName mn))
+            importType'
+            (T.pack . N.runModuleName <$> qualifier)
+        mkModuleImport _ = error "Shouldn't have gotten anything but Imports here"
+        unwrapPositionedImport (D.ImportDeclaration mn importType' qualifier b) =
+          D.ImportDeclaration mn (unwrapImportType importType') qualifier b
+        unwrapPositionedImport x = x
+        unwrapImportType (D.Explicit decls) = D.Explicit (map unwrapPositionedRef decls)
+        unwrapImportType (D.Hiding decls)   = D.Hiding (map unwrapPositionedRef decls)
+        unwrapImportType D.Implicit         = D.Implicit
+
+getPositionedImports :: D.Module -> [D.Declaration]
+getPositionedImports (D.Module _ _ _ declarations _) =
+  mapMaybe isImport declarations
+  where
+    isImport i@(D.PositionedDeclaration _ _ (D.ImportDeclaration{})) = Just i
+    isImport _ = Nothing
+
+getDeclPosition :: D.Module -> String -> Maybe SP.SourceSpan
+getDeclPosition m ident =
+  let decls = getDeclarations m
+  in getFirst (foldMap (match ident) decls)
+     where match q (D.PositionedDeclaration ss _ decl) = First (if go q decl
+                                                                then Just ss
+                                                                else Nothing)
+           match _ _ = First Nothing
+
+           go q (D.DataDeclaration _ name _ constructors)  =
+             properEqual name q || any (\(x,_) -> properEqual x q) constructors
+           go q (D.DataBindingGroupDeclaration decls)      = any (go q) decls
+           go q (D.TypeSynonymDeclaration name _ _)        = properEqual name q
+           go q (D.TypeDeclaration ident' _)               = identEqual ident' q
+           go q (D.ValueDeclaration ident' _ _ _)          = identEqual ident' q
+           go q (D.ExternDeclaration ident' _)             = identEqual ident' q
+           go q (D.ExternDataDeclaration name _)           = properEqual name q
+           go q (D.TypeClassDeclaration name _ _ members)  =
+             properEqual name q || any (go q . unwrapPositioned) members
+           go q (D.TypeInstanceDeclaration ident' _ _ _ _) =
+             identEqual ident' q
+           go _ _ = False
+
+           properEqual x q = N.runProperName x == q
+           identEqual x q = N.runIdent x == q
+
+goToDefinition :: String -> FilePath -> IO (Maybe SP.SourceSpan)
+goToDefinition q fp = do
+  m <- runExceptT (parseModuleFromFile fp)
+  case m of
+    Right module' -> return $ getDeclPosition module' q
+    Left _ -> return Nothing

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PackageImports        #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TupleSections         #-}
+
+module Language.PureScript.Ide.State where
+
+import           Prelude                           ()
+import           Prelude.Compat
+
+import           Control.Concurrent.STM
+import           Control.Monad.IO.Class
+import           "monad-logger" Control.Monad.Logger
+import           Control.Monad.Reader.Class
+import qualified Data.Map.Lazy                     as M
+import           Data.Maybe                        (catMaybes)
+import           Data.Monoid
+import qualified Data.Text                         as T
+import           Language.PureScript.Externs
+import           Language.PureScript.Ide.Externs
+import           Language.PureScript.Ide.Reexports
+import           Language.PureScript.Ide.Types
+import           Language.PureScript.Names
+
+getPscIdeState :: (PscIde m, Functor m) =>
+                  m (M.Map ModuleIdent [ExternDecl])
+getPscIdeState = do
+  stateVar <- envStateVar <$> ask
+  liftIO $ pscStateModules <$> readTVarIO stateVar
+
+getExternFiles :: (PscIde m, Functor m) =>
+                  m (M.Map ModuleName ExternsFile)
+getExternFiles = do
+  stateVar <- envStateVar <$> ask
+  liftIO (externsFiles <$> readTVarIO stateVar)
+
+getAllDecls :: (PscIde m, Functor m) => m [ExternDecl]
+getAllDecls = concat <$> getPscIdeState
+
+getAllModules :: (PscIde m, Functor m) => m [Module]
+getAllModules = M.toList <$> getPscIdeState
+
+getAllModulesWithReexports :: (PscIde m, MonadLogger m, Applicative m) =>
+                              m [Module]
+getAllModulesWithReexports = do
+  mis <- M.keys <$> getPscIdeState
+  ms  <- traverse getModuleWithReexports mis
+  pure (catMaybes ms)
+
+getModule :: (PscIde m, MonadLogger m, Applicative m) =>
+             ModuleIdent -> m (Maybe Module)
+getModule m = do
+  modules <- getPscIdeState
+  pure ((m,) <$> M.lookup m modules)
+
+getModuleWithReexports :: (PscIde m, MonadLogger m, Applicative m) =>
+                          ModuleIdent -> m (Maybe Module)
+getModuleWithReexports mi = do
+  m <- getModule mi
+  modules <- getPscIdeState
+  pure $ resolveReexports modules <$> m
+
+insertModule ::(PscIde m, MonadLogger m) =>
+               ExternsFile -> m ()
+insertModule externsFile = do
+  env <- ask
+  let moduleName = efModuleName externsFile
+  $(logDebug) $ "Inserting Module: " <> (T.pack (runModuleName moduleName))
+  liftIO . atomically $ insertModule' (envStateVar env) externsFile
+
+insertModule' :: TVar PscIdeState -> ExternsFile -> STM ()
+insertModule' st ef = do
+    modifyTVar (st) $ \x ->
+      x { externsFiles = M.insert (efModuleName ef) ef (externsFiles x)
+          , pscStateModules = let (mn, decls ) = convertExterns ef
+                              in M.insert mn decls (pscStateModules x)
+        }

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -1,0 +1,240 @@
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+module Language.PureScript.Ide.Types where
+
+import           Prelude                              ()
+import           Prelude.Compat
+
+import           Control.Concurrent.STM
+import           Control.Monad
+import           Control.Monad.Reader.Class
+import           Control.Monad.Trans
+import           Data.Aeson
+import           Data.Map.Lazy                        as M
+import           Data.Maybe                           (maybeToList)
+import           Data.Text                            (Text (), pack, unpack)
+import qualified Language.PureScript.AST.Declarations as D
+import           Language.PureScript.Externs
+import           Language.PureScript.Names
+import qualified Language.PureScript.Names            as N
+
+import           Text.Parsec
+import           Text.Parsec.Text
+
+type ModuleIdent = Text
+type DeclIdent   = Text
+type Type        = Text
+
+data Fixity = Infix | Infixl | Infixr deriving(Show, Eq, Ord)
+
+data ExternDecl
+    = FunctionDecl { functionName :: DeclIdent
+                   , functionType :: Type
+                   }
+    | FixityDeclaration Fixity
+                        Int
+                        DeclIdent
+    | Dependency { dependencyModule :: ModuleIdent
+                 , dependencyNames  :: [Text]
+                 , dependencyAlias  :: Maybe Text
+                 }
+    | ModuleDecl ModuleIdent
+                 [DeclIdent]
+    | DataDecl DeclIdent
+               Text
+    | Export ModuleIdent
+    deriving (Show,Eq,Ord)
+
+instance ToJSON ExternDecl where
+  toJSON (FunctionDecl n t)        = object ["name" .= n, "type" .= t]
+  toJSON (ModuleDecl   n t)        = object ["name" .= n, "type" .= t]
+  toJSON (DataDecl     n t)        = object ["name" .= n, "type" .= t]
+  toJSON (Dependency   n names _)  = object ["module" .= n, "names" .= names]
+  toJSON (FixityDeclaration f p n) = object ["name" .= n
+                                            , "fixity" .= show f
+                                            , "precedence" .= p]
+  toJSON (Export _) = object []
+
+type Module = (ModuleIdent, [ExternDecl])
+
+data Configuration =
+  Configuration {
+    confOutputPath :: FilePath
+  , confDebug      :: Bool
+  }
+
+data PscIdeEnvironment =
+  PscIdeEnvironment {
+    envStateVar      :: TVar PscIdeState
+  , envConfiguration :: Configuration
+  }
+
+type PscIde m = (Applicative m, MonadIO m, MonadReader PscIdeEnvironment m)
+
+data PscIdeState =
+  PscIdeState {
+    pscStateModules :: M.Map Text [ExternDecl]
+  , externsFiles    :: M.Map ModuleName ExternsFile
+  } deriving Show
+
+emptyPscIdeState :: PscIdeState
+emptyPscIdeState = PscIdeState M.empty M.empty
+
+newtype Completion =
+    Completion (ModuleIdent, DeclIdent, Type)
+    deriving (Show,Eq)
+
+data ModuleImport =
+  ModuleImport {
+    importModuleName :: ModuleIdent
+  , importType       :: D.ImportDeclarationType
+  , importQualifier  :: Maybe Text
+  } deriving(Show)
+
+instance Eq ModuleImport where
+  mi1 == mi2 = importModuleName mi1 == importModuleName mi2
+               && importQualifier mi1 == importQualifier mi2
+
+instance ToJSON ModuleImport where
+  toJSON (ModuleImport mn D.Implicit qualifier) =
+    object $  ["module" .= mn
+              , "importType" .= ("implicit" :: Text)
+              ] ++ fmap (\x -> "qualifier" .= x) (maybeToList qualifier)
+  toJSON (ModuleImport mn (D.Explicit refs) _) =
+    object ["module" .= mn
+           , "importType" .= ("explicit" :: Text)
+           , "identifiers" .= (identifierFromDeclarationRef <$> refs)]
+  toJSON (ModuleImport mn (D.Hiding refs) _) =
+    object ["module" .= mn
+           , "importType" .= ("hiding" :: Text)
+           , "identifiers" .= (identifierFromDeclarationRef <$> refs)]
+
+identifierFromDeclarationRef :: D.DeclarationRef -> String
+identifierFromDeclarationRef (D.TypeRef name _) = N.runProperName name
+identifierFromDeclarationRef (D.ValueRef ident) = N.runIdent ident
+identifierFromDeclarationRef (D.TypeClassRef name) = N.runProperName name
+identifierFromDeclarationRef _ = ""
+
+instance FromJSON Completion where
+    parseJSON (Object o) = do
+        m <- o .: "module"
+        d <- o .: "identifier"
+        t <- o .: "type"
+        return $ Completion (m, d, t)
+    parseJSON _ = mzero
+
+instance ToJSON Completion where
+    toJSON (Completion (m,d,t)) =
+        object ["module" .= m, "identifier" .= d, "type" .= t]
+
+data Success =
+  CompletionResult [Completion]
+  | TextResult Text
+  | MultilineTextResult [Text]
+  | PursuitResult [PursuitResponse]
+  | ImportList [ModuleImport]
+  | ModuleList [ModuleIdent]
+  deriving(Show, Eq)
+
+encodeSuccess :: (ToJSON a) => a -> Value
+encodeSuccess res =
+    object ["resultType" .= ("success" :: Text), "result" .= res]
+
+instance ToJSON Success where
+  toJSON (CompletionResult cs) = encodeSuccess cs
+  toJSON (TextResult t) = encodeSuccess t
+  toJSON (MultilineTextResult ts) = encodeSuccess ts
+  toJSON (PursuitResult resp) = encodeSuccess resp
+  toJSON (ImportList decls) = encodeSuccess decls
+  toJSON (ModuleList modules) = encodeSuccess modules
+
+newtype PursuitQuery = PursuitQuery Text
+                     deriving (Show, Eq)
+
+data PursuitSearchType = Package | Identifier
+                       deriving (Show, Eq)
+
+instance FromJSON PursuitSearchType where
+  parseJSON (String t) = case t of
+    "package"    -> return Package
+    "completion" -> return Identifier
+    _            -> mzero
+  parseJSON _ = mzero
+
+instance FromJSON PursuitQuery where
+  parseJSON o = fmap PursuitQuery (parseJSON o)
+
+data PursuitResponse
+    = ModuleResponse { moduleResponseName    :: Text
+                     , moduleResponsePackage :: Text}
+    | DeclarationResponse { declarationResponseType    :: Text
+                          , declarationResponseModule  :: Text
+                          , declarationResponseIdent   :: Text
+                          , declarationResponsePackage :: Text
+                          }
+    deriving (Show,Eq)
+
+instance FromJSON PursuitResponse where
+  parseJSON (Object o) = do
+    package <- o .: "package"
+    info <- o .: "info"
+    (type' :: String) <- info .: "type"
+    case type' of
+      "module" -> do
+          name <- info .: "module"
+          return
+              ModuleResponse
+              { moduleResponseName = name
+              , moduleResponsePackage = package
+              }
+      "declaration" -> do
+          moduleName <- info .: "module"
+          Right (ident, declType) <- typeParse <$> o .: "text"
+          return
+              DeclarationResponse
+              { declarationResponseType = declType
+              , declarationResponseModule = moduleName
+              , declarationResponseIdent = ident
+              , declarationResponsePackage = package
+              }
+      _ -> mzero
+  parseJSON _ = mzero
+
+
+typeParse :: Text -> Either Text (Text, Text)
+typeParse t = case parse parseType "" t of
+  Right (x,y) -> Right (pack x, pack y)
+  Left err -> Left (pack (show err))
+  where
+    parseType :: Parser (String, String)
+    parseType = do
+      name <- identifier
+      _ <- string "::"
+      spaces
+      type' <- many1 anyChar
+      return (unpack name, type')
+
+identifier :: Parser Text
+identifier = do
+  spaces
+  ident <-
+    -- necessary for being able to parse the following ((++), concat)
+    between (char '(') (char ')') (many1 (noneOf ", )")) <|>
+    many1 (noneOf ", )")
+  spaces
+  return (pack ident)
+
+instance ToJSON PursuitResponse where
+  toJSON ModuleResponse{..} =
+    object ["module" .= moduleResponseName, "package" .= moduleResponsePackage]
+  toJSON DeclarationResponse{..} =
+    object
+      [ "module"  .= declarationResponseModule
+      , "ident"   .= declarationResponseIdent
+      , "type"    .= declarationResponseType
+      , "package" .= declarationResponsePackage]

--- a/src/Language/PureScript/Ide/Watcher.hs
+++ b/src/Language/PureScript/Ide/Watcher.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE RecordWildCards #-}
+module Language.PureScript.Ide.Watcher where
+
+import           Prelude                         ()
+import           Prelude.Compat
+
+import           Control.Concurrent              (threadDelay)
+import           Control.Concurrent.STM
+import           Control.Monad
+import           Control.Monad.Trans.Except
+import qualified Data.Map                        as M
+import           Data.Maybe                      (isJust)
+import           Language.PureScript.Externs
+import           Language.PureScript.Ide.Externs
+import           Language.PureScript.Ide.State
+import           Language.PureScript.Ide.Types
+import           System.FilePath
+import           System.FSNotify
+
+
+reloadFile :: TVar PscIdeState -> FilePath -> IO ()
+reloadFile stateVar fp = do
+  (Right ef@ExternsFile{..}) <- runExceptT $ readExternFile fp
+  reloaded <- atomically $ do
+    st <- readTVar stateVar
+    if isLoaded efModuleName st
+      then
+        insertModule' stateVar ef *> pure True
+      else
+        pure False
+  when reloaded $ putStrLn $ "Reloaded File at: " ++ fp
+  where
+    isLoaded name st = isJust (M.lookup name (externsFiles st))
+
+watcher :: TVar PscIdeState -> FilePath -> IO ()
+watcher stateVar fp = withManager $ \mgr -> do
+  _ <- watchTree mgr fp
+    (\ev -> takeFileName (eventPath ev) == "externs.json")
+    (reloadFile stateVar . eventPath)
+  forever (threadDelay 10000)

--- a/stack-lts-2.yaml
+++ b/stack-lts-2.yaml
@@ -7,4 +7,5 @@ extra-deps:
 - boxes-0.1.4
 - pattern-arrows-0.0.2
 - sourcemap-0.1.6
+- fsnotify-0.2.1
 resolver: lts-2.22

--- a/tests/Language/PureScript/Ide/FilterSpec.hs
+++ b/tests/Language/PureScript/Ide/FilterSpec.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Language.PureScript.Ide.FilterSpec where
+
+import           Data.Text                      (Text)
+import           Language.PureScript.Ide.Filter
+import           Language.PureScript.Ide.Types
+import           Test.Hspec
+
+modules :: [Module]
+modules =
+  [
+    ("Module.A", [FunctionDecl "function1" ""]),
+    ("Module.B", [DataDecl "data1" ""]),
+    ("Module.C", [ModuleDecl "Module.C" []]),
+    ("Module.D", [Dependency "Module.C" [] Nothing, FunctionDecl "asd" ""])
+  ]
+
+runEq :: Text -> [Module]
+runEq s = runFilter (equalityFilter s) modules
+runPrefix :: Text -> [Module]
+runPrefix s = runFilter (prefixFilter s) modules
+runModule :: [ModuleIdent] -> [Module]
+runModule ms = runFilter (moduleFilter ms) modules
+runDependency :: [ModuleIdent] -> [Module]
+runDependency ms = runFilter (dependencyFilter ms) modules
+
+spec :: Spec
+spec = do
+  describe "equality Filter" $ do
+    it "removes empty modules" $
+      runEq "test" `shouldBe` []
+    it "keeps function declarations that are equal" $
+      runEq "function1" `shouldBe` [head modules]
+    -- TODO: It would be more sensible to match Constructors
+    it "keeps data declarations that are equal" $
+      runEq "data1" `shouldBe` [modules !! 1]
+  describe "prefixFilter" $ do
+    it "keeps everything on empty string" $
+      runPrefix "" `shouldBe` modules
+    it "keeps functionname prefix matches" $
+      runPrefix "fun" `shouldBe` [head modules]
+    it "keeps data decls prefix matches" $
+      runPrefix "dat" `shouldBe` [modules !! 1]
+    it "keeps module decl prefix matches" $
+      runPrefix "Mod" `shouldBe` [modules !! 2]
+  describe "moduleFilter" $ do
+    it "removes everything on empty input" $
+      runModule [] `shouldBe` []
+    it "only keeps the specified modules" $
+      runModule ["Module.A", "Module.C"] `shouldBe` [head modules, modules !! 2]
+    it "ignores modules that are not in scope" $
+      runModule ["Module.A", "Module.C", "Unknown"] `shouldBe` [head modules, modules !! 2]
+  describe "dependencyFilter" $ do
+    it "removes everything on empty input" $
+      runDependency [] `shouldBe` []
+    it "only keeps the specified modules if they have no imports" $
+      runDependency ["Module.A", "Module.B"] `shouldBe` [head modules, modules !! 1]
+    it "keeps the specified modules and their imports" $
+      runDependency ["Module.A", "Module.D"] `shouldBe` [head modules, modules !! 2, modules !! 3]

--- a/tests/Language/PureScript/Ide/MatcherSpec.hs
+++ b/tests/Language/PureScript/Ide/MatcherSpec.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.PureScript.Ide.MatcherSpec where
+
+import           Data.Text                       (Text)
+import           Language.PureScript.Ide.Matcher
+import           Language.PureScript.Ide.Types
+import           Test.Hspec
+
+completions :: [Completion]
+completions = [
+  Completion ("", "firstResult", ""),
+  Completion ("", "secondResult", ""),
+  Completion ("", "fiult", "")
+  ]
+
+mkResult :: [Int] -> [Completion]
+mkResult = map (completions !!)
+
+runFlex :: Text -> [Completion]
+runFlex s = runMatcher (flexMatcher s) completions
+
+spec :: Spec
+spec = do
+  describe "Flex Matcher" $ do
+    it "doesn't match on an empty string" $
+       runFlex "" `shouldBe` []
+    it "matches on equality" $
+      runFlex "firstResult" `shouldBe` mkResult [0]
+    it "scores short matches higher and sorts accordingly" $
+      runFlex "filt" `shouldBe` mkResult [2, 0]

--- a/tests/Language/PureScript/Ide/ReexportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ReexportsSpec.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Language.PureScript.Ide.ReexportsSpec where
+
+import           Control.Exception                 (evaluate)
+import           Data.List                         (sort)
+import qualified Data.Map                          as Map
+import           Language.PureScript.Ide.Reexports
+import           Language.PureScript.Ide.Types
+import           Test.Hspec
+
+decl1 :: ExternDecl
+decl1 = FunctionDecl "filter" "asdasd"
+decl2 :: ExternDecl
+decl2 = DataDecl "Tree" "* -> *"
+decl3 :: ExternDecl
+decl3 = DataDecl "TreeAsd" "* -> *"
+dep1 :: ExternDecl
+dep1 = Dependency "Test.Foo" [] (Just "T")
+dep2 :: ExternDecl
+dep2 = Dependency "Test.Bar" [] (Just "T")
+
+circularModule :: Module
+circularModule = ("Circular", [Export "Circular"])
+
+module1 :: Module
+module1 = ("Module1", [Export "Module2", Export "Module3", decl1])
+
+module2 :: Module
+module2 = ("Module2", [decl2])
+
+module3 :: Module
+module3 = ("Module3", [decl3])
+
+module4 :: Module
+module4 = ("Module4", [Export "T", decl1, dep1, dep2])
+
+result :: Module
+result = ("Module1", [decl1, decl2, Export "Module3"])
+
+db :: Map.Map ModuleIdent [ExternDecl]
+db = Map.fromList [module1, module2, module3]
+
+shouldBeEqualSorted :: Module -> Module -> Expectation
+shouldBeEqualSorted (n1, d1) (n2, d2) = (n1, sort d1) `shouldBe` (n2, sort d2)
+
+spec :: Spec
+spec = do
+  describe "Reexports" $ do
+    it "finds all reexports" $
+      getReexports module1 `shouldBe` [Export "Module2", Export "Module3"]
+
+    it "replaces a reexport with another module" $
+      replaceReexport (Export "Module2") module1 module2 `shouldBeEqualSorted` result
+
+    it "adds another module even if there is no export statement" $
+      replaceReexport (Export "Module2") ("Module1", [decl1, Export "Module3"]) module2
+      `shouldBeEqualSorted` result
+
+    it "only adds a declaration once" $
+      let replaced = replaceReexport (Export "Module2") module1 module2
+      in replaceReexport (Export "Module2") replaced module2  `shouldBeEqualSorted` result
+
+    it "should error when given a non-Export to replace" $
+      evaluate (replaceReexport decl1 module1 module2)
+      `shouldThrow` errorCall "Should only get Exports here."
+    it "replaces all Exports with their corresponding declarations" $
+      replaceReexports module1 db `shouldBe` ("Module1", [decl1, decl2, decl3])
+
+    it "does not list itself as a reexport" $
+      getReexports circularModule `shouldBe` []
+
+    it "does not include circular references when replacing reexports" $
+      replaceReexports circularModule (uncurry Map.singleton circularModule )
+      `shouldBe` ("Circular", [])
+
+    it "replaces exported aliases with imported module" $
+      getReexports module4 `shouldBe` [Export "Test.Foo", Export "Test.Bar"]

--- a/tests/Language/PureScript/IdeSpec.hs
+++ b/tests/Language/PureScript/IdeSpec.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports    #-}
+module Language.PureScript.IdeSpec where
+
+import           Control.Concurrent.STM
+import           Control.Monad.Reader
+import           Data.List
+import qualified Data.Map               as Map
+import           Language.PureScript.Ide
+import           Language.PureScript.Ide.Types
+import           Test.Hspec
+
+testState :: PscIdeState
+testState = PscIdeState (Map.fromList [("Data.Array", []), ("Control.Monad.Eff", [])]) (Map.empty)
+
+defaultConfig :: Configuration
+defaultConfig =
+  Configuration
+  {
+    confOutputPath = "output/"
+  , confDebug = False
+  }
+
+spec :: SpecWith ()
+spec = do
+  describe "list" $ do
+    describe "loadedModules" $ do
+      it "returns an empty list when no modules are loaded" $ do
+       st <- newTVarIO emptyPscIdeState
+       result <- runReaderT printModules (PscIdeEnvironment st defaultConfig)
+       result `shouldBe` ModuleList []
+      it "returns the list of loaded modules" $ do
+        st <- newTVarIO testState
+        ModuleList result <- runReaderT printModules (PscIdeEnvironment st defaultConfig)
+        sort result `shouldBe` sort ["Data.Array", "Control.Monad.Eff"]

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -25,6 +25,7 @@ import qualified TestCompiler
 import qualified TestPscPublish
 import qualified TestDocs
 import qualified TestPsci
+import qualified TestPscIde
 
 main :: IO ()
 main = do
@@ -36,6 +37,8 @@ main = do
   TestPscPublish.main
   heading "psci test suite"
   TestPsci.main
+  heading "psc-ide test suite"
+  TestPscIde.main
 
   where
   heading msg = do

--- a/tests/PscIdeSpec.hs
+++ b/tests/PscIdeSpec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=PscIdeSpec #-}

--- a/tests/TestPscIde.hs
+++ b/tests/TestPscIde.hs
@@ -1,0 +1,7 @@
+module TestPscIde where
+
+import qualified PscIdeSpec
+import Test.Hspec
+
+main :: IO ()
+main = hspec PscIdeSpec.spec


### PR DESCRIPTION
## Todos:
- [x] Move tests into the testsuite
- [x] Tidy up dependencies and figure out version ranges
- [x] Figure out where to put the protocol documentation/readme
- [x] GHC < 7.10 compatibility

## Why did I move the library code over aswell?
When I moved just the executables cabal/stack would complain about the circular dependency between psc-ide <=> purescript.

## Pursuit Client
These dependencies result out of the Pursuit querying module, I could drop it for now as it really doesn't offer a lot of features and revise it later using a more lowlevel interface like conduit-http or pipes-http. The Pursuit client is also responsible for the orphan instance warning. I'm not quite sure how to get around that warning without making a way too big "Types" module.
```
wreq,
lens,
lens-aeson,
http-client
```

Edit:
I switched to using `pipes-http` in this PR

## Renaming psc-ide to psc-ide-client
I think this is a more consistent name.