### PR TITLE
refactor PSCi code

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,6 +65,7 @@ This file lists the contributors to the PureScript compiler project, and the ter
 - [@codedmart](https://github.com/codedmart) (Brandon Martin) My existing contributions and all future contributions until further notice are Copyright Brandon Martin, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 - [@passy](https://github.com/passy) (Pascal Hartig) My existing contributions and all future contributions until further notice are Copyright Pascal Hartig, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 - [@DavidLindbom](https://github.com/DavidLindbom) (David Lindbom) My existing contributions and all future contributions until further notice are Copyright David Lindbom, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
+- [@izgzhen](https://github.com/izgzhen) (Zhen Zhang) My existing contributions and all future contributions until further notice are Copyright Zhen Zhang, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 
 ### Companies
 

--- a/psci/PSCi.hs
+++ b/psci/PSCi.hs
@@ -7,16 +7,14 @@
 -- |
 -- PureScript Compiler Interactive.
 --
-module PSCi where
+module PSCi (runPSCi) where
 
 import Prelude ()
 import Prelude.Compat
 
 import Data.Foldable (traverse_)
-import Data.Maybe (mapMaybe)
-import Data.List (intersperse, intercalate, nub, sort, find)
+import Data.List (intercalate, nub, sort, find)
 import Data.Tuple (swap)
-import Data.Version (showVersion)
 import qualified Data.Map as M
 
 import Control.Arrow (first)
@@ -24,166 +22,29 @@ import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Except (ExceptT(), runExceptT)
-import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 import Control.Monad.Trans.State.Strict
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Writer.Strict (Writer(), runWriter)
 
-import Options.Applicative as Opts
-
 import System.Console.Haskeline
-import System.Directory (doesFileExist, findExecutable, getHomeDirectory, getCurrentDirectory)
+import System.Directory (doesFileExist, getHomeDirectory, getCurrentDirectory)
 import System.Exit
-import System.FilePath (pathSeparator, (</>), isPathSeparator)
+import System.FilePath ((</>))
 import System.FilePath.Glob (glob)
 import System.Process (readProcessWithExitCode)
 import System.IO.Error (tryIOError)
-import qualified Text.PrettyPrint.Boxes as Box
 
 import qualified Language.PureScript as P
 import qualified Language.PureScript.Names as N
-import qualified Paths_purescript as Paths
 
-import qualified PSCi.Directive as D
 import PSCi.Completion (completion)
-import PSCi.IO (mkdirp)
 import PSCi.Parser (parseCommand)
+import PSCi.Option
 import PSCi.Types
-
--- | The name of the PSCI support module
-supportModuleName :: P.ModuleName
-supportModuleName = P.ModuleName [P.ProperName "$PSCI", P.ProperName "Support"]
-
--- | Support module, contains code to evaluate terms
-supportModule :: P.Module
-supportModule =
-  case P.parseModulesFromFiles id [("", code)] of
-    Right [(_, P.Module ss cs _ ds exps)] -> P.Module ss cs supportModuleName ds exps
-    _ -> P.internalError "Support module could not be parsed"
-  where
-  code :: String
-  code = unlines
-    [ "module S where"
-    , ""
-    , "import Prelude"
-    , "import Control.Monad.Eff"
-    , "import Control.Monad.Eff.Console"
-    , "import Control.Monad.Eff.Unsafe"
-    , ""
-    , "class Eval a where"
-    , "  eval :: a -> Eff (console :: CONSOLE) Unit"
-    , ""
-    , "instance evalShow :: (Show a) => Eval a where"
-    , "  eval = print"
-    , ""
-    , "instance evalEff :: (Eval a) => Eval (Eff eff a) where"
-    , "  eval x = unsafeInterleaveEff x >>= eval"
-    ]
-
--- File helpers
-
-onFirstFileMatching :: Monad m => (b -> m (Maybe a)) -> [b] -> m (Maybe a)
-onFirstFileMatching f pathVariants = runMaybeT . msum $ map (MaybeT . f) pathVariants
-
--- |
--- Locates the node executable.
--- Checks for either @nodejs@ or @node@.
---
-findNodeProcess :: IO (Maybe String)
-findNodeProcess = onFirstFileMatching findExecutable names
-  where names = ["nodejs", "node"]
-
--- |
--- Grabs the filename where the history is stored.
---
-getHistoryFilename :: IO FilePath
-getHistoryFilename = do
-  home <- getHomeDirectory
-  let filename = home </> ".purescript" </> "psci_history"
-  mkdirp filename
-  return filename
-
--- |
--- Loads a file for use with imports.
---
-loadModule :: FilePath -> IO (Either String [P.Module])
-loadModule filename = do
-  content <- readFile filename
-  return $ either (Left . P.prettyPrintMultipleErrors False) (Right . map snd) $ P.parseModulesFromFiles id [(filename, content)]
-
--- |
--- Load all modules.
---
-loadAllModules :: [FilePath] -> IO (Either P.MultipleErrors [(FilePath, P.Module)])
-loadAllModules files = do
-  filesAndContent <- forM files $ \filename -> do
-    content <- readFile filename
-    return (filename, content)
-  return $ P.parseModulesFromFiles id filesAndContent
-
--- |
--- Load all modules, updating the application state
---
-loadAllImportedModules :: PSCI ()
-loadAllImportedModules = do
-  files <- PSCI . lift $ fmap psciImportedFilenames get
-  modulesOrFirstError <- psciIO $ loadAllModules files
-  case modulesOrFirstError of
-    Left errs -> printErrors errs
-    Right modules -> PSCI . lift . modify $ updateModules modules
-
--- |
--- Expands tilde in path.
---
-expandTilde :: FilePath -> IO FilePath
-expandTilde ('~':p:rest) | isPathSeparator p = (</> rest) <$> getHomeDirectory
-expandTilde p = return p
-
--- Messages
-
--- |
--- The help message.
---
-helpMessage :: String
-helpMessage = "The following commands are available:\n\n    " ++
-  intercalate "\n    " (map line D.help) ++
-  "\n\n" ++ extraHelp
-  where
-  line :: (Directive, String, String) -> String
-  line (dir, arg, desc) =
-    let cmd = ':' : D.stringFor dir
-    in unwords [ cmd
-               , replicate (11 - length cmd) ' '
-               , arg
-               , replicate (11 - length arg) ' '
-               , desc
-               ]
-
-  extraHelp =
-    "Further information is available on the PureScript wiki:\n" ++
-    " --> https://github.com/purescript/purescript/wiki/psci"
-
-
--- |
--- The welcome prologue.
---
-prologueMessage :: String
-prologueMessage = intercalate "\n"
-  [ " ____                 ____            _       _   "
-  , "|  _ \\ _   _ _ __ ___/ ___|  ___ _ __(_)_ __ | |_ "
-  , "| |_) | | | | '__/ _ \\___ \\ / __| '__| | '_ \\| __|"
-  , "|  __/| |_| | | |  __/___) | (__| |  | | |_) | |_ "
-  , "|_|    \\__,_|_|  \\___|____/ \\___|_|  |_| .__/ \\__|"
-  , "                                       |_|        "
-  , ""
-  , ":? shows help"
-  ]
-
--- |
--- The quit message.
---
-quitMessage :: String
-quitMessage = "See ya!"
+import PSCi.Message
+import PSCi.IO
+import PSCi.Printer
+import PSCi.Module
 
 -- |
 -- PSCI monad
@@ -194,50 +55,65 @@ psciIO :: IO a -> PSCI a
 psciIO io = PSCI . lift $ lift io
 
 -- |
--- Makes a volatile module to execute the current expression.
+-- The runner
 --
-createTemporaryModule :: Bool -> PSCiState -> P.Expr -> P.Module
-createTemporaryModule exec PSCiState{psciImportedModules = imports, psciLetBindings = lets} val =
-  let
-    moduleName = P.ModuleName [P.ProperName "$PSCI"]
-    trace = P.Var (P.Qualified (Just supportModuleName) (P.Ident "eval"))
-    mainValue = P.App trace (P.Var (P.Qualified Nothing (P.Ident "it")))
-    itDecl = P.ValueDeclaration (P.Ident "it") P.Public [] $ Right val
-    mainDecl = P.ValueDeclaration (P.Ident "$main") P.Public [] $ Right mainValue
-    decls = if exec then [itDecl, mainDecl] else [itDecl]
-  in
-    P.Module (P.internalModuleSourceSpan "<internal>") [] moduleName ((importDecl `map` imports) ++ lets ++ decls) Nothing
-
+runPSCi :: IO ()
+runPSCi = getOpt >>= loop
 
 -- |
--- Makes a volatile module to hold a non-qualified type synonym for a fully-qualified data type declaration.
+-- The PSCI main loop.
 --
-createTemporaryModuleForKind :: PSCiState -> P.Type -> P.Module
-createTemporaryModuleForKind PSCiState{psciImportedModules = imports, psciLetBindings = lets} typ =
-  let
-    moduleName = P.ModuleName [P.ProperName "$PSCI"]
-    itDecl = P.TypeSynonymDeclaration (P.ProperName "IT") [] typ
-  in
-    P.Module (P.internalModuleSourceSpan "<internal>") [] moduleName ((importDecl `map` imports) ++ lets ++ [itDecl]) Nothing
+loop :: PSCiOptions -> IO ()
+loop PSCiOptions{..} = do
+  config <- loadUserConfig
+  inputFiles <- concat <$> traverse glob psciInputFile
+  foreignFiles <- concat <$> traverse glob psciForeignInputFiles
+  modulesOrFirstError <- loadAllModules inputFiles
+  case modulesOrFirstError of
+    Left errs -> putStrLn (P.prettyPrintMultipleErrors False errs) >> exitFailure
+    Right modules -> do
+      historyFilename <- getHistoryFilename
+      let settings = defaultSettings { historyFile = Just historyFilename }
+      foreignsOrError <- runMake $ do
+        foreignFilesContent <- forM foreignFiles (\inFile -> (inFile,) <$> makeIO (const (P.ErrorMessage [] $ P.CannotReadFile inFile)) (readFile inFile))
+        P.parseForeignModulesFromFiles foreignFilesContent
+      case foreignsOrError of
+        Left errs -> putStrLn (P.prettyPrintMultipleErrors False errs) >> exitFailure
+        Right foreigns ->
+          flip evalStateT (mkPSCiState [] modules foreigns [] psciInputNodeFlags) . runInputT (setComplete completion settings) $ do
+            outputStrLn prologueMessage
+            traverse_ (traverse_ (runPSCI . handleCommand)) config
+            modules' <- lift $ gets psciLoadedModules
+            unless (consoleIsDefined (map snd modules')) . outputStrLn $ unlines
+              [ "PSCi requires the purescript-console module to be installed."
+              , "For help getting started, visit http://wiki.purescript.org/PSCi"
+              ]
+            go
+      where
+        go :: InputT (StateT PSCiState IO) ()
+        go = do
+          c <- getCommand (not psciMultiLineMode)
+          case c of
+            Left err -> outputStrLn err >> go
+            Right Nothing -> go
+            Right (Just QuitPSCi) -> outputStrLn quitMessage
+            Right (Just c') -> do
+              handleInterrupt (outputStrLn "Interrupted.")
+                              (withInterrupt (runPSCI (loadAllImportedModules >> handleCommand c')))
+              go
+
+-- Compile the module
 
 -- |
--- Makes a volatile module to execute the current imports.
+-- Load all modules, updating the application state
 --
-createTemporaryModuleForImports :: PSCiState -> P.Module
-createTemporaryModuleForImports PSCiState{psciImportedModules = imports} =
-  let
-    moduleName = P.ModuleName [P.ProperName "$PSCI"]
-  in
-    P.Module (P.internalModuleSourceSpan "<internal>") [] moduleName (importDecl `map` imports) Nothing
-
-importDecl :: ImportedModule -> P.Declaration
-importDecl (mn, declType, asQ) = P.ImportDeclaration mn declType asQ False
-
-indexFile :: FilePath
-indexFile = ".psci_modules" ++ pathSeparator : "index.js"
-
-modulesDir :: FilePath
-modulesDir = ".psci_modules" ++ pathSeparator : "node_modules"
+loadAllImportedModules :: PSCI ()
+loadAllImportedModules = do
+  files <- PSCI . lift $ fmap psciImportedFilenames get
+  modulesOrFirstError <- psciIO $ loadAllModules files
+  case modulesOrFirstError of
+    Left errs -> PSCI $ printErrors errs
+    Right modules -> PSCI . lift . modify $ updateModules modules
 
 -- | This is different than the runMake in 'Language.PureScript.Make' in that it specifies the
 -- options and ignores the warning messages.
@@ -258,6 +134,58 @@ make st@PSCiState{..} ms = P.make actions' (map snd loadedModules ++ ms)
   loadedModules = psciLoadedModules st
   allModules = map (first Right) loadedModules ++ map (Left P.RebuildAlways,) ms
 
+
+-- Commands
+
+-- |
+-- Parses the input and returns either a Metacommand, or an error as a string.
+--
+getCommand :: Bool -> InputT (StateT PSCiState IO) (Either String (Maybe Command))
+getCommand singleLineMode = handleInterrupt (return (Right Nothing)) $ do
+  firstLine <- withInterrupt $ getInputLine "> "
+  case firstLine of
+    Nothing -> return (Right (Just QuitPSCi)) -- Ctrl-D when input is empty
+    Just "" -> return (Right Nothing)
+    Just s | singleLineMode || head s == ':' -> return .fmap Just $ parseCommand s
+    Just s -> fmap Just . parseCommand <$> go [s]
+  where
+    go :: [String] -> InputT (StateT PSCiState IO) String
+    go ls = maybe (return . unlines $ reverse ls) (go . (:ls)) =<< getInputLine "  "
+
+-- |
+-- Performs an action for each meta-command given, and also for expressions.
+--
+handleCommand :: Command -> PSCI ()
+handleCommand (Expression val) = handleExpression val
+handleCommand ShowHelp = PSCI $ outputStrLn helpMessage
+handleCommand (Import im) = handleImport im
+handleCommand (Decls l) = handleDecls l
+handleCommand (LoadFile filePath) = PSCI $ whenFileExists filePath $ \absPath -> do
+  m <- lift . lift $ loadModule absPath
+  case m of
+    Left err -> outputStrLn err
+    Right mods -> lift $ modify (updateModules (map (absPath,) mods))
+handleCommand (LoadForeign filePath) = PSCI $ whenFileExists filePath $ \absPath -> do
+  foreignsOrError <- lift . lift . runMake $ do
+    foreignFile <- makeIO (const (P.ErrorMessage [] $ P.CannotReadFile absPath)) (readFile absPath)
+    P.parseForeignModulesFromFiles [(absPath, foreignFile)]
+  case foreignsOrError of
+    Left err -> outputStrLn $ P.prettyPrintMultipleErrors False err
+    Right foreigns -> lift $ modify (updateForeignFiles foreigns)
+handleCommand ResetState = do
+  PSCI . lift . modify $ \st ->
+    st { psciImportedModules = []
+       , psciLetBindings     = []
+       }
+  loadAllImportedModules
+handleCommand (TypeOf val) = handleTypeOf val
+handleCommand (KindOf typ) = handleKindOf typ
+handleCommand (BrowseModule moduleName) = handleBrowse moduleName
+handleCommand (ShowInfo QueryLoaded) = handleShowLoadedModules
+handleCommand (ShowInfo QueryImport) = handleShowImportedModules
+handleCommand QuitPSCi = P.internalError "`handleCommand QuitPSCi` was called. This is a bug."
+
+
 -- |
 -- Takes a value expression and evaluates it with the current state.
 --
@@ -268,7 +196,7 @@ handleExpression val = do
   let nodeArgs = psciNodeFlags st ++ [indexFile]
   e <- psciIO . runMake $ make st [supportModule, m]
   case e of
-    Left errs -> printErrors errs
+    Left errs -> PSCI $ printErrors errs
     Right _ -> do
       psciIO $ writeFile indexFile "require('$PSCI')['$main']();"
       process <- psciIO findNodeProcess
@@ -289,7 +217,7 @@ handleDecls ds = do
   let m = createTemporaryModule False st' (P.ObjectLiteral [])
   e <- psciIO . runMake $ make st' [m]
   case e of
-    Left err -> printErrors err
+    Left err -> PSCI $ printErrors err
     Right _ -> PSCI $ lift (put st')
 
 -- |
@@ -344,7 +272,7 @@ handleImport im = do
    let m = createTemporaryModuleForImports st
    e <- psciIO . runMake $ make st [m]
    case e of
-     Left errs -> printErrors errs
+     Left errs -> PSCI $ printErrors errs
      Right _  -> do
        PSCI $ lift $ put st
        return ()
@@ -358,123 +286,11 @@ handleTypeOf val = do
   let m = createTemporaryModule False st val
   e <- psciIO . runMake $ make st [m]
   case e of
-    Left errs -> printErrors errs
+    Left errs -> PSCI $ printErrors errs
     Right env' ->
       case M.lookup (P.ModuleName [P.ProperName "$PSCI"], P.Ident "it") (P.names env') of
         Just (ty, _, _) -> PSCI . outputStrLn . P.prettyPrintType $ ty
         Nothing -> PSCI $ outputStrLn "Could not find type"
-
--- |
--- Pretty print a module's signatures
---
-printModuleSignatures :: P.ModuleName -> P.Environment -> PSCI ()
-printModuleSignatures moduleName (P.Environment {..}) =
-  PSCI $
-    -- get relevant components of a module from environment
-    let moduleNamesIdent = (filter ((== moduleName) . fst) . M.keys) names
-        moduleTypeClasses = (filter (\(P.Qualified maybeName _) -> maybeName == Just moduleName) . M.keys) typeClasses
-        moduleTypes = (filter (\(P.Qualified maybeName _) -> maybeName == Just moduleName) . M.keys) types
-
-  in
-    -- print each component
-    (outputStr . unlines . map trimEnd . lines . Box.render . Box.vsep 1 Box.left)
-      [ printModule's (mapMaybe (showTypeClass . findTypeClass typeClasses)) moduleTypeClasses -- typeClasses
-      , printModule's (mapMaybe (showType typeClasses dataConstructors typeSynonyms . findType types)) moduleTypes -- types
-      , printModule's (map (showNameType . findNameType names)) moduleNamesIdent -- functions
-      ]
-
-  where printModule's showF = Box.vsep 1 Box.left . showF
-
-        findNameType :: M.Map (P.ModuleName, P.Ident) (P.Type, P.NameKind, P.NameVisibility) -> (P.ModuleName, P.Ident) -> (P.Ident, Maybe (P.Type, P.NameKind, P.NameVisibility))
-        findNameType envNames m@(_, mIdent) = (mIdent, M.lookup m envNames)
-
-        showNameType :: (P.Ident, Maybe (P.Type, P.NameKind, P.NameVisibility)) -> Box.Box
-        showNameType (mIdent, Just (mType, _, _)) = Box.text (P.showIdent mIdent ++ " :: ") Box.<> P.typeAsBox mType
-        showNameType _ = P.internalError "The impossible happened in printModuleSignatures."
-
-        findTypeClass
-          :: M.Map (P.Qualified (P.ProperName 'P.ClassName)) ([(String, Maybe P.Kind)], [(P.Ident, P.Type)], [P.Constraint])
-          -> P.Qualified (P.ProperName 'P.ClassName)
-          -> (P.Qualified (P.ProperName 'P.ClassName), Maybe ([(String, Maybe P.Kind)], [(P.Ident, P.Type)], [P.Constraint]))
-        findTypeClass envTypeClasses name = (name, M.lookup name envTypeClasses)
-
-        showTypeClass
-          :: (P.Qualified (P.ProperName 'P.ClassName), Maybe ([(String, Maybe P.Kind)], [(P.Ident, P.Type)], [P.Constraint]))
-          -> Maybe Box.Box
-        showTypeClass (_, Nothing) = Nothing
-        showTypeClass (P.Qualified _ name, Just (vars, body, constrs)) =
-            let constraints =
-                    if null constrs
-                    then Box.text ""
-                    else Box.text "("
-                         Box.<> Box.hcat Box.left (intersperse (Box.text ", ") $ map (\(P.Qualified _ pn, lt) -> Box.text (P.runProperName pn) Box.<+> Box.hcat Box.left (map P.typeAtomAsBox lt)) constrs)
-                         Box.<> Box.text ") <= "
-                className =
-                    Box.text (P.runProperName name)
-                    Box.<> Box.text (concatMap ((' ':) . fst) vars)
-                classBody =
-                    Box.vcat Box.top (map (\(i, t) -> Box.text (P.showIdent i ++ " ::") Box.<+> P.typeAsBox t) body)
-
-            in
-              Just $
-                (Box.text "class "
-                Box.<> constraints
-                Box.<> className
-                Box.<+> if null body then Box.text "" else Box.text "where")
-                Box.// Box.moveRight 2 classBody
-
-
-        findType
-          :: M.Map (P.Qualified (P.ProperName 'P.TypeName)) (P.Kind, P.TypeKind)
-          -> P.Qualified (P.ProperName 'P.TypeName)
-          -> (P.Qualified (P.ProperName 'P.TypeName), Maybe (P.Kind, P.TypeKind))
-        findType envTypes name = (name, M.lookup name envTypes)
-
-        showType
-          :: M.Map (P.Qualified (P.ProperName 'P.ClassName)) ([(String, Maybe P.Kind)], [(P.Ident, P.Type)], [P.Constraint])
-          -> M.Map (P.Qualified (P.ProperName 'P.ConstructorName)) (P.DataDeclType, P.ProperName 'P.TypeName, P.Type, [P.Ident])
-          -> M.Map (P.Qualified (P.ProperName 'P.TypeName)) ([(String, Maybe P.Kind)], P.Type)
-          -> (P.Qualified (P.ProperName 'P.TypeName), Maybe (P.Kind, P.TypeKind))
-          -> Maybe Box.Box
-        showType typeClassesEnv dataConstructorsEnv typeSynonymsEnv (n@(P.Qualified modul name), typ) =
-          case (typ, M.lookup n typeSynonymsEnv) of
-            (Just (_, P.TypeSynonym), Just (typevars, dtType)) ->
-                if M.member (fmap P.coerceProperName n) typeClassesEnv
-                then
-                  Nothing
-                else
-                  Just $
-                    Box.text ("type " ++ P.runProperName name ++ concatMap ((' ':) . fst) typevars)
-                    Box.// Box.moveRight 2 (Box.text "=" Box.<+> P.typeAsBox dtType)
-
-            (Just (_, P.DataType typevars pt), _) ->
-              let prefix =
-                    case pt of
-                      [(dtProperName,_)] ->
-                        case M.lookup (P.Qualified modul dtProperName) dataConstructorsEnv of
-                          Just (dataDeclType, _, _, _) -> P.showDataDeclType dataDeclType
-                          _ -> "data"
-                      _ -> "data"
-
-              in
-                Just $ Box.text (prefix ++ " " ++ P.runProperName name ++ concatMap ((' ':) . fst) typevars) Box.// printCons pt
-
-            _ ->
-              Nothing
-
-          where printCons pt =
-                    Box.moveRight 2 $
-                    Box.vcat Box.left $
-                    mapFirstRest (Box.text "=" Box.<+>) (Box.text "|" Box.<+>) $
-                    map (\(cons,idents) -> (Box.text (P.runProperName cons) Box.<> Box.hcat Box.left (map prettyPrintType idents))) pt
-
-                prettyPrintType t = Box.text " " Box.<> P.typeAtomAsBox t
-
-                mapFirstRest _ _ [] = []
-                mapFirstRest f g (x:xs) = f x : map g xs
-
-        trimEnd = reverse . dropWhile (== ' ') . reverse
-
 
 -- |
 -- Browse a module and displays its signature (if module exists).
@@ -484,14 +300,14 @@ handleBrowse moduleName = do
   st <- PSCI $ lift get
   env <- psciIO . runMake $ make st []
   case env of
-    Left errs -> printErrors errs
+    Left errs -> PSCI $ printErrors errs
     Right env' ->
       if isModInEnv moduleName st
-        then printModuleSignatures moduleName env'
+        then PSCI $ printModuleSignatures moduleName env'
         else case lookupUnQualifiedModName moduleName st of
           Just unQualifiedName ->
             if isModInEnv unQualifiedName st
-              then printModuleSignatures unQualifiedName env'
+              then PSCI $ printModuleSignatures unQualifiedName env'
               else failNotInEnv moduleName
           Nothing ->
             failNotInEnv moduleName
@@ -503,10 +319,6 @@ handleBrowse moduleName = do
     lookupUnQualifiedModName quaModName st =
         (\(modName,_,_) -> modName) <$> find ( \(_, _, mayQuaName) -> mayQuaName == Just quaModName) (psciImportedModules st)
 
--- | Pretty-print errors
-printErrors :: P.MultipleErrors -> PSCI ()
-printErrors = PSCI . outputStrLn . P.prettyPrintMultipleErrors False
-
 -- |
 -- Takes a value and prints its kind
 --
@@ -517,7 +329,7 @@ handleKindOf typ = do
       mName = P.ModuleName [P.ProperName "$PSCI"]
   e <- psciIO . runMake $ make st [m]
   case e of
-    Left errs -> printErrors errs
+    Left errs -> PSCI $ printErrors errs
     Right env' ->
       case M.lookup (P.Qualified (Just mName) $ P.ProperName "IT") (P.typeSynonyms env') of
         Just (_, typ') -> do
@@ -531,63 +343,7 @@ handleKindOf typ = do
             Right (kind, _) -> PSCI . outputStrLn . P.prettyPrintKind $ kind
         Nothing -> PSCI $ outputStrLn "Could not find kind"
 
--- Commands
-
--- |
--- Parses the input and returns either a Metacommand, or an error as a string.
---
-getCommand :: Bool -> InputT (StateT PSCiState IO) (Either String (Maybe Command))
-getCommand singleLineMode = handleInterrupt (return (Right Nothing)) $ do
-  firstLine <- withInterrupt $ getInputLine "> "
-  case firstLine of
-    Nothing -> return (Right (Just QuitPSCi)) -- Ctrl-D when input is empty
-    Just "" -> return (Right Nothing)
-    Just s | singleLineMode || head s == ':' -> return .fmap Just $ parseCommand s
-    Just s -> fmap Just . parseCommand <$> go [s]
-  where
-    go :: [String] -> InputT (StateT PSCiState IO) String
-    go ls = maybe (return . unlines $ reverse ls) (go . (:ls)) =<< getInputLine "  "
-
--- |
--- Performs an action for each meta-command given, and also for expressions.
---
-handleCommand :: Command -> PSCI ()
-handleCommand (Expression val) = handleExpression val
-handleCommand ShowHelp = PSCI $ outputStrLn helpMessage
-handleCommand (Import im) = handleImport im
-handleCommand (Decls l) = handleDecls l
-handleCommand (LoadFile filePath) = whenFileExists filePath $ \absPath -> do
-  m <- psciIO $ loadModule absPath
-  case m of
-    Left err -> PSCI $ outputStrLn err
-    Right mods -> PSCI . lift $ modify (updateModules (map (absPath,) mods))
-handleCommand (LoadForeign filePath) = whenFileExists filePath $ \absPath -> do
-  foreignsOrError <- psciIO . runMake $ do
-    foreignFile <- makeIO (const (P.ErrorMessage [] $ P.CannotReadFile absPath)) (readFile absPath)
-    P.parseForeignModulesFromFiles [(absPath, foreignFile)]
-  case foreignsOrError of
-    Left err -> PSCI $ outputStrLn $ P.prettyPrintMultipleErrors False err
-    Right foreigns -> PSCI . lift $ modify (updateForeignFiles foreigns)
-handleCommand ResetState = do
-  PSCI . lift . modify $ \st ->
-    st { psciImportedModules = []
-       , psciLetBindings     = []
-       }
-  loadAllImportedModules
-handleCommand (TypeOf val) = handleTypeOf val
-handleCommand (KindOf typ) = handleKindOf typ
-handleCommand (BrowseModule moduleName) = handleBrowse moduleName
-handleCommand (ShowInfo QueryLoaded) = handleShowLoadedModules
-handleCommand (ShowInfo QueryImport) = handleShowImportedModules
-handleCommand QuitPSCi = P.internalError "`handleCommand QuitPSCi` was called. This is a bug."
-
-whenFileExists :: FilePath -> (FilePath -> PSCI ()) -> PSCI ()
-whenFileExists filePath f = do
-  absPath <- psciIO $ expandTilde filePath
-  exists <- psciIO $ doesFileExist absPath
-  if exists
-    then f absPath
-    else PSCI . outputStrLn $ "Couldn't locate: " ++ filePath
+-- Misc
 
 -- |
 -- Attempts to read initial commands from '.psci' in the present working
@@ -610,92 +366,6 @@ loadUserConfig = onFirstFileMatching readCommands pathGetters
     else
       return Nothing
 
-
 -- | Checks if the Console module is defined
 consoleIsDefined :: [P.Module] -> Bool
 consoleIsDefined = any ((== P.ModuleName (map P.ProperName [ "Control", "Monad", "Eff", "Console" ])) . P.getModuleName)
-
--- |
--- The PSCI main loop.
---
-loop :: PSCiOptions -> IO ()
-loop PSCiOptions{..} = do
-  config <- loadUserConfig
-  inputFiles <- concat <$> traverse glob psciInputFile
-  foreignFiles <- concat <$> traverse glob psciForeignInputFiles
-  modulesOrFirstError <- loadAllModules inputFiles
-  case modulesOrFirstError of
-    Left errs -> putStrLn (P.prettyPrintMultipleErrors False errs) >> exitFailure
-    Right modules -> do
-      historyFilename <- getHistoryFilename
-      let settings = defaultSettings { historyFile = Just historyFilename }
-      foreignsOrError <- runMake $ do
-        foreignFilesContent <- forM foreignFiles (\inFile -> (inFile,) <$> makeIO (const (P.ErrorMessage [] $ P.CannotReadFile inFile)) (readFile inFile))
-        P.parseForeignModulesFromFiles foreignFilesContent
-      case foreignsOrError of
-        Left errs -> putStrLn (P.prettyPrintMultipleErrors False errs) >> exitFailure
-        Right foreigns ->
-          flip evalStateT (mkPSCiState [] modules foreigns [] psciInputNodeFlags) . runInputT (setComplete completion settings) $ do
-            outputStrLn prologueMessage
-            traverse_ (traverse_ (runPSCI . handleCommand)) config
-            modules' <- lift $ gets psciLoadedModules
-            unless (consoleIsDefined (map snd modules')) . outputStrLn $ unlines
-              [ "PSCi requires the purescript-console module to be installed."
-              , "For help getting started, visit http://wiki.purescript.org/PSCi"
-              ]
-            go
-      where
-        go :: InputT (StateT PSCiState IO) ()
-        go = do
-          c <- getCommand (not psciMultiLineMode)
-          case c of
-            Left err -> outputStrLn err >> go
-            Right Nothing -> go
-            Right (Just QuitPSCi) -> outputStrLn quitMessage
-            Right (Just c') -> do
-              handleInterrupt (outputStrLn "Interrupted.")
-                              (withInterrupt (runPSCI (loadAllImportedModules >> handleCommand c')))
-              go
-
-multiLineMode :: Parser Bool
-multiLineMode = switch $
-     long "multi-line-mode"
-  <> short 'm'
-  <> Opts.help "Run in multi-line mode (use ^D to terminate commands)"
-
-inputFile :: Parser FilePath
-inputFile = strArgument $
-     metavar "FILE"
-  <> Opts.help "Optional .purs files to load on start"
-
-inputForeignFile :: Parser FilePath
-inputForeignFile = strOption $
-     short 'f'
-  <> long "ffi"
-  <> help "The input .js file(s) providing foreign import implementations"
-
-nodeFlagsFlag :: Parser [String]
-nodeFlagsFlag = option parser $
-     long "node-opts"
-  <> metavar "NODE_OPTS"
-  <> value []
-  <> Opts.help "Flags to pass to node, separated by spaces"
-  where
-    parser = words <$> str
-
-psciOptions :: Parser PSCiOptions
-psciOptions = PSCiOptions <$> multiLineMode
-                          <*> many inputFile
-                          <*> many inputForeignFile
-                          <*> nodeFlagsFlag
-
-runPSCi :: IO ()
-runPSCi = execParser opts >>= loop
-  where
-  opts        = info (version <*> helper <*> psciOptions) infoModList
-  infoModList = fullDesc <> headerInfo <> footerInfo
-  headerInfo  = header   "psci - Interactive mode for PureScript"
-  footerInfo  = footer $ "psci " ++ showVersion Paths.version
-
-  version :: Parser (a -> a)
-  version = abortOption (InfoMsg (showVersion Paths.version)) $ long "version" <> Opts.help "Show the version number" <> hidden

--- a/psci/PSCi/Directive.hs
+++ b/psci/PSCi/Directive.hs
@@ -15,6 +15,10 @@
 
 module PSCi.Directive where
 
+import Prelude ()
+import Prelude.Compat
+
+
 import Data.Maybe (fromJust, listToMaybe)
 import Data.List (isPrefixOf)
 import Data.Tuple (swap)

--- a/psci/PSCi/IO.hs
+++ b/psci/PSCi/IO.hs
@@ -14,8 +14,55 @@
 
 module PSCi.IO where
 
-import System.Directory (createDirectoryIfMissing)
-import System.FilePath (takeDirectory)
+import Prelude ()
+import Prelude.Compat
+
+import System.Directory (createDirectoryIfMissing, getHomeDirectory, findExecutable, doesFileExist)
+import System.FilePath (takeDirectory, (</>), isPathSeparator)
+import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
+import Control.Monad (msum)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import System.Console.Haskeline (outputStrLn, InputT)
 
 mkdirp :: FilePath -> IO ()
 mkdirp = createDirectoryIfMissing True . takeDirectory
+
+-- File helpers
+
+onFirstFileMatching :: Monad m => (b -> m (Maybe a)) -> [b] -> m (Maybe a)
+onFirstFileMatching f pathVariants = runMaybeT . msum $ map (MaybeT . f) pathVariants
+
+-- |
+-- Locates the node executable.
+-- Checks for either @nodejs@ or @node@.
+--
+findNodeProcess :: IO (Maybe String)
+findNodeProcess = onFirstFileMatching findExecutable names
+  where names = ["nodejs", "node"]
+
+-- |
+-- Grabs the filename where the history is stored.
+--
+getHistoryFilename :: IO FilePath
+getHistoryFilename = do
+  home <- getHomeDirectory
+  let filename = home </> ".purescript" </> "psci_history"
+  mkdirp filename
+  return filename
+
+
+-- |
+-- Expands tilde in path.
+--
+expandTilde :: FilePath -> IO FilePath
+expandTilde ('~':p:rest) | isPathSeparator p = (</> rest) <$> getHomeDirectory
+expandTilde p = return p
+
+
+whenFileExists :: MonadIO m => FilePath -> (FilePath -> InputT m ()) -> InputT m ()
+whenFileExists filePath f = do
+  absPath <- liftIO $ expandTilde filePath
+  exists <- liftIO $ doesFileExist absPath
+  if exists
+    then f absPath
+    else outputStrLn $ "Couldn't locate: " ++ filePath

--- a/psci/PSCi/Message.hs
+++ b/psci/PSCi/Message.hs
@@ -1,0 +1,53 @@
+module PSCi.Message where
+
+
+import Data.List (intercalate)
+import qualified PSCi.Directive as D
+import PSCi.Types
+
+-- Messages
+
+-- |
+-- The help message.
+--
+helpMessage :: String
+helpMessage = "The following commands are available:\n\n    " ++
+  intercalate "\n    " (map line D.help) ++
+  "\n\n" ++ extraHelp
+  where
+  line :: (Directive, String, String) -> String
+  line (dir, arg, desc) =
+    let cmd = ':' : D.stringFor dir
+    in unwords [ cmd
+               , replicate (11 - length cmd) ' '
+               , arg
+               , replicate (11 - length arg) ' '
+               , desc
+               ]
+
+  extraHelp =
+    "Further information is available on the PureScript wiki:\n" ++
+    " --> https://github.com/purescript/purescript/wiki/psci"
+
+
+-- |
+-- The welcome prologue.
+--
+prologueMessage :: String
+prologueMessage = intercalate "\n"
+  [ " ____                 ____            _       _   "
+  , "|  _ \\ _   _ _ __ ___/ ___|  ___ _ __(_)_ __ | |_ "
+  , "| |_) | | | | '__/ _ \\___ \\ / __| '__| | '_ \\| __|"
+  , "|  __/| |_| | | |  __/___) | (__| |  | | |_) | |_ "
+  , "|_|    \\__,_|_|  \\___|____/ \\___|_|  |_| .__/ \\__|"
+  , "                                       |_|        "
+  , ""
+  , ":? shows help"
+  ]
+
+-- |
+-- The quit message.
+--
+quitMessage :: String
+quitMessage = "See ya!"
+

--- a/psci/PSCi/Module.hs
+++ b/psci/PSCi/Module.hs
@@ -1,0 +1,106 @@
+module PSCi.Module where
+
+import Prelude ()
+import Prelude.Compat
+
+import qualified Language.PureScript as P
+import PSCi.Types
+import System.FilePath (pathSeparator)
+import Control.Monad
+
+-- | The name of the PSCI support module
+supportModuleName :: P.ModuleName
+supportModuleName = P.ModuleName [P.ProperName "$PSCI", P.ProperName "Support"]
+
+-- | Support module, contains code to evaluate terms
+supportModule :: P.Module
+supportModule =
+  case P.parseModulesFromFiles id [("", code)] of
+    Right [(_, P.Module ss cs _ ds exps)] -> P.Module ss cs supportModuleName ds exps
+    _ -> P.internalError "Support module could not be parsed"
+  where
+  code :: String
+  code = unlines
+    [ "module S where"
+    , ""
+    , "import Prelude"
+    , "import Control.Monad.Eff"
+    , "import Control.Monad.Eff.Console"
+    , "import Control.Monad.Eff.Unsafe"
+    , ""
+    , "class Eval a where"
+    , "  eval :: a -> Eff (console :: CONSOLE) Unit"
+    , ""
+    , "instance evalShow :: (Show a) => Eval a where"
+    , "  eval = print"
+    , ""
+    , "instance evalEff :: (Eval a) => Eval (Eff eff a) where"
+    , "  eval x = unsafeInterleaveEff x >>= eval"
+    ]
+
+-- Module Management
+
+-- |
+-- Loads a file for use with imports.
+--
+loadModule :: FilePath -> IO (Either String [P.Module])
+loadModule filename = do
+  content <- readFile filename
+  return $ either (Left . P.prettyPrintMultipleErrors False) (Right . map snd) $ P.parseModulesFromFiles id [(filename, content)]
+
+-- |
+-- Load all modules.
+--
+loadAllModules :: [FilePath] -> IO (Either P.MultipleErrors [(FilePath, P.Module)])
+loadAllModules files = do
+  filesAndContent <- forM files $ \filename -> do
+    content <- readFile filename
+    return (filename, content)
+  return $ P.parseModulesFromFiles id filesAndContent
+
+
+-- |
+-- Makes a volatile module to execute the current expression.
+--
+createTemporaryModule :: Bool -> PSCiState -> P.Expr -> P.Module
+createTemporaryModule exec PSCiState{psciImportedModules = imports, psciLetBindings = lets} val =
+  let
+    moduleName = P.ModuleName [P.ProperName "$PSCI"]
+    trace = P.Var (P.Qualified (Just supportModuleName) (P.Ident "eval"))
+    mainValue = P.App trace (P.Var (P.Qualified Nothing (P.Ident "it")))
+    itDecl = P.ValueDeclaration (P.Ident "it") P.Public [] $ Right val
+    mainDecl = P.ValueDeclaration (P.Ident "$main") P.Public [] $ Right mainValue
+    decls = if exec then [itDecl, mainDecl] else [itDecl]
+  in
+    P.Module (P.internalModuleSourceSpan "<internal>") [] moduleName ((importDecl `map` imports) ++ lets ++ decls) Nothing
+
+
+-- |
+-- Makes a volatile module to hold a non-qualified type synonym for a fully-qualified data type declaration.
+--
+createTemporaryModuleForKind :: PSCiState -> P.Type -> P.Module
+createTemporaryModuleForKind PSCiState{psciImportedModules = imports, psciLetBindings = lets} typ =
+  let
+    moduleName = P.ModuleName [P.ProperName "$PSCI"]
+    itDecl = P.TypeSynonymDeclaration (P.ProperName "IT") [] typ
+  in
+    P.Module (P.internalModuleSourceSpan "<internal>") [] moduleName ((importDecl `map` imports) ++ lets ++ [itDecl]) Nothing
+
+-- |
+-- Makes a volatile module to execute the current imports.
+--
+createTemporaryModuleForImports :: PSCiState -> P.Module
+createTemporaryModuleForImports PSCiState{psciImportedModules = imports} =
+  let
+    moduleName = P.ModuleName [P.ProperName "$PSCI"]
+  in
+    P.Module (P.internalModuleSourceSpan "<internal>") [] moduleName (importDecl `map` imports) Nothing
+
+importDecl :: ImportedModule -> P.Declaration
+importDecl (mn, declType, asQ) = P.ImportDeclaration mn declType asQ False
+
+indexFile :: FilePath
+indexFile = ".psci_modules" ++ pathSeparator : "index.js"
+
+modulesDir :: FilePath
+modulesDir = ".psci_modules" ++ pathSeparator : "node_modules"

--- a/psci/PSCi/Option.hs
+++ b/psci/PSCi/Option.hs
@@ -1,0 +1,57 @@
+module PSCi.Option (
+  getOpt
+) where
+
+import Prelude ()
+import Prelude.Compat
+
+import Options.Applicative as Opts
+import Data.Version (showVersion)
+
+import PSCi.Types
+import qualified Paths_purescript as Paths
+
+-- Parse Command line option
+
+multiLineMode :: Parser Bool
+multiLineMode = switch $
+     long "multi-line-mode"
+  <> short 'm'
+  <> Opts.help "Run in multi-line mode (use ^D to terminate commands)"
+
+inputFile :: Parser FilePath
+inputFile = strArgument $
+     metavar "FILE"
+  <> Opts.help "Optional .purs files to load on start"
+
+inputForeignFile :: Parser FilePath
+inputForeignFile = strOption $
+     short 'f'
+  <> long "ffi"
+  <> help "The input .js file(s) providing foreign import implementations"
+
+nodeFlagsFlag :: Parser [String]
+nodeFlagsFlag = option parser $
+     long "node-opts"
+  <> metavar "NODE_OPTS"
+  <> value []
+  <> Opts.help "Flags to pass to node, separated by spaces"
+  where
+    parser = words <$> str
+
+psciOptions :: Parser PSCiOptions
+psciOptions = PSCiOptions <$> multiLineMode
+                          <*> many inputFile
+                          <*> many inputForeignFile
+                          <*> nodeFlagsFlag
+
+version :: Parser (a -> a)
+version = abortOption (InfoMsg (showVersion Paths.version)) $ long "version" <> Opts.help "Show the version number" <> hidden
+
+getOpt :: IO PSCiOptions
+getOpt = execParser opts
+    where
+      opts        = info (version <*> helper <*> psciOptions) infoModList
+      infoModList = fullDesc <> headerInfo <> footerInfo
+      headerInfo  = header   "psci - Interactive mode for PureScript"
+      footerInfo  = footer $ "psci " ++ showVersion Paths.version

--- a/psci/PSCi/Printer.hs
+++ b/psci/PSCi/Printer.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DataKinds #-}
+
+module PSCi.Printer where
+
+import Prelude ()
+import Prelude.Compat
+
+import qualified Language.PureScript as P
+import qualified Text.PrettyPrint.Boxes as Box
+import qualified Data.Map as M
+import System.Console.Haskeline
+import Data.Maybe (mapMaybe)
+import Data.List (intersperse)
+import Control.Monad.IO.Class (MonadIO)
+
+-- Printers
+
+-- |
+-- Pretty print a module's signatures
+--
+printModuleSignatures :: MonadIO m => P.ModuleName -> P.Environment -> InputT m ()
+printModuleSignatures moduleName (P.Environment {..}) =
+    -- get relevant components of a module from environment
+    let moduleNamesIdent = (filter ((== moduleName) . fst) . M.keys) names
+        moduleTypeClasses = (filter (\(P.Qualified maybeName _) -> maybeName == Just moduleName) . M.keys) typeClasses
+        moduleTypes = (filter (\(P.Qualified maybeName _) -> maybeName == Just moduleName) . M.keys) types
+
+  in
+    -- print each component
+    (outputStr . unlines . map trimEnd . lines . Box.render . Box.vsep 1 Box.left)
+      [ printModule's (mapMaybe (showTypeClass . findTypeClass typeClasses)) moduleTypeClasses -- typeClasses
+      , printModule's (mapMaybe (showType typeClasses dataConstructors typeSynonyms . findType types)) moduleTypes -- types
+      , printModule's (map (showNameType . findNameType names)) moduleNamesIdent -- functions
+      ]
+
+  where printModule's showF = Box.vsep 1 Box.left . showF
+
+        findNameType :: M.Map (P.ModuleName, P.Ident) (P.Type, P.NameKind, P.NameVisibility) -> (P.ModuleName, P.Ident) -> (P.Ident, Maybe (P.Type, P.NameKind, P.NameVisibility))
+        findNameType envNames m@(_, mIdent) = (mIdent, M.lookup m envNames)
+
+        showNameType :: (P.Ident, Maybe (P.Type, P.NameKind, P.NameVisibility)) -> Box.Box
+        showNameType (mIdent, Just (mType, _, _)) = Box.text (P.showIdent mIdent ++ " :: ") Box.<> P.typeAsBox mType
+        showNameType _ = P.internalError "The impossible happened in printModuleSignatures."
+
+        findTypeClass
+          :: M.Map (P.Qualified (P.ProperName 'P.ClassName)) ([(String, Maybe P.Kind)], [(P.Ident, P.Type)], [P.Constraint])
+          -> P.Qualified (P.ProperName 'P.ClassName)
+          -> (P.Qualified (P.ProperName 'P.ClassName), Maybe ([(String, Maybe P.Kind)], [(P.Ident, P.Type)], [P.Constraint]))
+        findTypeClass envTypeClasses name = (name, M.lookup name envTypeClasses)
+
+        showTypeClass
+          :: (P.Qualified (P.ProperName 'P.ClassName), Maybe ([(String, Maybe P.Kind)], [(P.Ident, P.Type)], [P.Constraint]))
+          -> Maybe Box.Box
+        showTypeClass (_, Nothing) = Nothing
+        showTypeClass (P.Qualified _ name, Just (vars, body, constrs)) =
+            let constraints =
+                    if null constrs
+                    then Box.text ""
+                    else Box.text "("
+                         Box.<> Box.hcat Box.left (intersperse (Box.text ", ") $ map (\(P.Qualified _ pn, lt) -> Box.text (P.runProperName pn) Box.<+> Box.hcat Box.left (map P.typeAtomAsBox lt)) constrs)
+                         Box.<> Box.text ") <= "
+                className =
+                    Box.text (P.runProperName name)
+                    Box.<> Box.text (concatMap ((' ':) . fst) vars)
+                classBody =
+                    Box.vcat Box.top (map (\(i, t) -> Box.text (P.showIdent i ++ " ::") Box.<+> P.typeAsBox t) body)
+
+            in
+              Just $
+                (Box.text "class "
+                Box.<> constraints
+                Box.<> className
+                Box.<+> if null body then Box.text "" else Box.text "where")
+                Box.// Box.moveRight 2 classBody
+
+
+        findType
+          :: M.Map (P.Qualified (P.ProperName 'P.TypeName)) (P.Kind, P.TypeKind)
+          -> P.Qualified (P.ProperName 'P.TypeName)
+          -> (P.Qualified (P.ProperName 'P.TypeName), Maybe (P.Kind, P.TypeKind))
+        findType envTypes name = (name, M.lookup name envTypes)
+
+        showType
+          :: M.Map (P.Qualified (P.ProperName 'P.ClassName)) ([(String, Maybe P.Kind)], [(P.Ident, P.Type)], [P.Constraint])
+          -> M.Map (P.Qualified (P.ProperName 'P.ConstructorName)) (P.DataDeclType, P.ProperName 'P.TypeName, P.Type, [P.Ident])
+          -> M.Map (P.Qualified (P.ProperName 'P.TypeName)) ([(String, Maybe P.Kind)], P.Type)
+          -> (P.Qualified (P.ProperName 'P.TypeName), Maybe (P.Kind, P.TypeKind))
+          -> Maybe Box.Box
+        showType typeClassesEnv dataConstructorsEnv typeSynonymsEnv (n@(P.Qualified modul name), typ) =
+          case (typ, M.lookup n typeSynonymsEnv) of
+            (Just (_, P.TypeSynonym), Just (typevars, dtType)) ->
+                if M.member (fmap P.coerceProperName n) typeClassesEnv
+                then
+                  Nothing
+                else
+                  Just $
+                    Box.text ("type " ++ P.runProperName name ++ concatMap ((' ':) . fst) typevars)
+                    Box.// Box.moveRight 2 (Box.text "=" Box.<+> P.typeAsBox dtType)
+
+            (Just (_, P.DataType typevars pt), _) ->
+              let prefix =
+                    case pt of
+                      [(dtProperName,_)] ->
+                        case M.lookup (P.Qualified modul dtProperName) dataConstructorsEnv of
+                          Just (dataDeclType, _, _, _) -> P.showDataDeclType dataDeclType
+                          _ -> "data"
+                      _ -> "data"
+
+              in
+                Just $ Box.text (prefix ++ " " ++ P.runProperName name ++ concatMap ((' ':) . fst) typevars) Box.// printCons pt
+
+            _ ->
+              Nothing
+
+          where printCons pt =
+                    Box.moveRight 2 $
+                    Box.vcat Box.left $
+                    mapFirstRest (Box.text "=" Box.<+>) (Box.text "|" Box.<+>) $
+                    map (\(cons,idents) -> (Box.text (P.runProperName cons) Box.<> Box.hcat Box.left (map prettyPrintType idents))) pt
+
+                prettyPrintType t = Box.text " " Box.<> P.typeAtomAsBox t
+
+                mapFirstRest _ _ [] = []
+                mapFirstRest f g (x:xs) = f x : map g xs
+
+        trimEnd = reverse . dropWhile (== ' ') . reverse
+
+-- | Pretty-print errors
+printErrors :: MonadIO m => P.MultipleErrors -> InputT m ()
+printErrors = outputStrLn . P.prettyPrintMultipleErrors False

--- a/psci/PSCi/Types.hs
+++ b/psci/PSCi/Types.hs
@@ -15,6 +15,9 @@
 
 module PSCi.Types where
 
+import Prelude ()
+import Prelude.Compat
+
 import Control.Arrow (second)
 import Data.Map (Map)
 import qualified Data.Map as Map

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -206,7 +206,7 @@ executable psc
     main-is: Main.hs
     buildable: True
     hs-source-dirs: psc
-    other-modules: JSON
+    other-modules: JSON, Paths_purescript
     ghc-options: -Wall -O2 -fno-warn-unused-do-bind -threaded -rtsopts "-with-rtsopts=-N"
 
 executable psci
@@ -225,6 +225,11 @@ executable psci
                    PSCi.Directive
                    PSCi.Completion
                    PSCi.IO
+                   PSCi.Message
+                   PSCi.Option
+                   PSCi.Module
+                   PSCi.Printer
+                   Paths_purescript
     ghc-options: -Wall -O2
 
 executable psc-docs
@@ -234,6 +239,7 @@ executable psc-docs
                    filepath -any, Glob -any, transformers -any,
                    transformers-compat -any
     main-is: Main.hs
+    other-modules: Paths_purescript
     buildable: True
     hs-source-dirs: psc-docs
     other-modules: Ctags
@@ -244,6 +250,7 @@ executable psc-docs
 executable psc-publish
     build-depends: base >=4 && <5, purescript -any, bytestring -any, aeson -any, optparse-applicative -any
     main-is: Main.hs
+    other-modules: Paths_purescript
     buildable: True
     hs-source-dirs: psc-publish
     ghc-options: -Wall -O2
@@ -253,6 +260,7 @@ executable psc-hierarchy
                    process -any, mtl -any, parsec -any, filepath -any, directory -any,
                    Glob -any
     main-is: Main.hs
+    other-modules: Paths_purescript
     buildable: True
     hs-source-dirs: hierarchy
     other-modules:
@@ -260,7 +268,7 @@ executable psc-hierarchy
 
 executable psc-bundle
   main-is:             Main.hs
-  other-modules:
+  other-modules:       Paths_purescript
   other-extensions:
   build-depends:       base >=4 && <5,
                        purescript -any,

--- a/tests/TestPsci.hs
+++ b/tests/TestPsci.hs
@@ -23,7 +23,7 @@ import Test.HUnit
 
 import qualified Language.PureScript as P
 
-import PSCi
+import PSCi.Module (loadAllModules)
 import PSCi.Completion
 import PSCi.Types
 


### PR DESCRIPTION
I simply factored the old `PSCi.hs` into several modules (including `PSCi.IO`, `PSCi.Message`, `PSCi.Option`, `PSCi.Module`, `PSCi.Printer`). No real modification is made.

The reason is that, the old module is relatively hard to read and maintain (over 600 lines of code). And by splitting out different sub-functionalities, the code might be reused somewhere else in the future.

Besides, I added `Paths_purescript` to `other-modules` fields in .cabal file, so some warnings can be eliminated.