### PR TITLE
Fix true not being treated as an infallible guard

### DIFF
--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -201,9 +201,11 @@ isExhaustiveGuard :: Either [(Guard, Expr)] Expr -> Bool
 isExhaustiveGuard (Left gs) = not . null $ filter (\(g, _) -> isOtherwise g) gs
   where
   isOtherwise :: Expr -> Bool
-  isOtherwise (TypedValue _ (BooleanLiteral True) _) = True
-  isOtherwise (TypedValue _ (Var (Qualified (Just (ModuleName [ProperName "Prelude"])) (Ident "otherwise"))) _) = True
-  isOtherwise (TypedValue _ (Var (Qualified (Just (ModuleName [ProperName "Data", ProperName "Boolean"])) (Ident "otherwise"))) _) = True
+  isOtherwise (BooleanLiteral True) = True
+  isOtherwise (Var (Qualified (Just (ModuleName [ProperName "Prelude"])) (Ident "otherwise"))) = True
+  isOtherwise (Var (Qualified (Just (ModuleName [ProperName "Data", ProperName "Boolean"])) (Ident "otherwise"))) = True
+  isOtherwise (TypedValue _ e _) = isOtherwise e
+  isOtherwise (PositionedValue _ _ e) = isOtherwise e
   isOtherwise _ = False
 isExhaustiveGuard (Right _) = True
 


### PR DESCRIPTION
Resolves #1906

I have some worries that maybe there are other things not behaving properly now, if we don't have a step-through case for ever `PositionedValue`, but not sure how we can catch them all at this point. Nothing else is obviously broken anyway, I think...