### PR TITLE
Upgrade optparse-applicative to >= 0.12.1 for all executables.

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -228,7 +228,7 @@ library
 executable psc
     build-depends: base >=4 && <5, base-compat >=0.6.0,
                    containers -any, directory -any, filepath -any,
-                   mtl -any, optparse-applicative >= 0.10.0, parsec -any, purescript -any,
+                   mtl -any, optparse-applicative >= 0.12.1, parsec -any, purescript -any,
                    time -any, transformers -any, transformers-compat -any, Glob >= 0.7 && < 0.8,
                    aeson >= 0.8 && < 0.12, bytestring -any, utf8-string >= 1 && < 2
     main-is: Main.hs
@@ -239,7 +239,7 @@ executable psc
 
 executable psci
     build-depends: base >=4 && <5, containers -any, directory -any, filepath -any,
-                   mtl -any, optparse-applicative >= 0.10.0, parsec -any,
+                   mtl -any, optparse-applicative >= 0.12.1, parsec -any,
                    haskeline >= 0.7.0.0, purescript -any, transformers -any,
                    transformers-compat -any, process -any, time -any, Glob -any, base-compat >=0.6.0,
                    boxes >= 0.1.4 && < 0.2.0
@@ -262,7 +262,7 @@ executable psci
 
 executable psc-docs
     build-depends: base >=4 && <5, purescript -any,
-                   optparse-applicative >= 0.10.0, process -any, mtl -any,
+                   optparse-applicative >= 0.12.1, process -any, mtl -any,
                    split -any, ansi-wl-pprint -any, directory -any,
                    filepath -any, Glob -any, transformers -any,
                    transformers-compat -any
@@ -284,7 +284,7 @@ executable psc-publish
     ghc-options: -Wall -O2
 
 executable psc-hierarchy
-    build-depends: base >=4 && <5, purescript -any, optparse-applicative >= 0.10.0,
+    build-depends: base >=4 && <5, purescript -any, optparse-applicative >= 0.12.1,
                    process -any, mtl -any, parsec -any, filepath -any, directory -any,
                    Glob -any
     main-is: Main.hs
@@ -305,7 +305,7 @@ executable psc-bundle
                        mtl -any,
                        transformers -any,
                        transformers-compat -any,
-                       optparse-applicative >= 0.10.0,
+                       optparse-applicative >= 0.12.1,
                        Glob -any
   ghc-options:         -Wall -O2
   hs-source-dirs:      psc-bundle
@@ -323,7 +323,7 @@ executable psc-ide-server
                      , transformers -any
                      , transformers-compat -any
                      , network -any
-                     , optparse-applicative >= 0.10.0
+                     , optparse-applicative >= 0.12.1
                      , stm -any
                      , text -any
                      , base-compat >=0.6.0
@@ -337,7 +337,7 @@ executable psc-ide-client
   build-depends:       base >=4 && <5
                      , mtl -any
                      , text -any
-                     , optparse-applicative >= 0.10.0
+                     , optparse-applicative >= 0.12.1
                      , network -any
                      , base-compat >=0.6.0
   ghc-options:         -Wall -O2


### PR DESCRIPTION
The upgraded library fixes issue #1838 - better errors for unrecognised command line options.