### PR TITLE
Fix #1889, improve performance by avoiding whitespace operations on large strings

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -1181,31 +1181,32 @@ prettyPrintRef (PositionedDeclarationRef _ _ ref) = prettyPrintExport ref
 -- Pretty print multiple errors
 --
 prettyPrintMultipleErrors :: Bool -> MultipleErrors -> String
-prettyPrintMultipleErrors full = renderBox . prettyPrintMultipleErrorsBox full
+prettyPrintMultipleErrors full = unlines . map renderBox . prettyPrintMultipleErrorsBox full
 
 -- |
 -- Pretty print multiple warnings
 --
-prettyPrintMultipleWarnings :: Bool -> MultipleErrors ->  String
-prettyPrintMultipleWarnings full = renderBox . prettyPrintMultipleWarningsBox full
+prettyPrintMultipleWarnings :: Bool -> MultipleErrors -> String
+prettyPrintMultipleWarnings full = unlines . map renderBox . prettyPrintMultipleWarningsBox full
 
 -- | Pretty print warnings as a Box
-prettyPrintMultipleWarningsBox :: Bool -> MultipleErrors -> Box.Box
+prettyPrintMultipleWarningsBox :: Bool -> MultipleErrors -> [Box.Box]
 prettyPrintMultipleWarningsBox full = prettyPrintMultipleErrorsWith Warning "Warning found:" "Warning" full
 
 -- | Pretty print errors as a Box
-prettyPrintMultipleErrorsBox :: Bool -> MultipleErrors -> Box.Box
+prettyPrintMultipleErrorsBox :: Bool -> MultipleErrors -> [Box.Box]
 prettyPrintMultipleErrorsBox full = prettyPrintMultipleErrorsWith Error "Error found:" "Error" full
 
-prettyPrintMultipleErrorsWith :: Level -> String -> String -> Bool -> MultipleErrors -> Box.Box
+prettyPrintMultipleErrorsWith :: Level -> String -> String -> Bool -> MultipleErrors -> [Box.Box]
 prettyPrintMultipleErrorsWith level intro _ full (MultipleErrors [e]) =
   let result = prettyPrintSingleError full level True e
-  in Box.vcat Box.left [ Box.text intro
-                       , result
-                       ]
+  in [ Box.vcat Box.left [ Box.text intro
+                         , result
+                         ]
+     ]
 prettyPrintMultipleErrorsWith level _ intro full (MultipleErrors es) =
   let result = map (prettyPrintSingleError full level True) es
-  in Box.vsep 1 Box.left $ concat $ zipWith withIntro [1 :: Int ..] result
+  in concat $ zipWith withIntro [1 :: Int ..] result
   where
   withIntro i err = [ Box.text (intro ++ " " ++ show i ++ " of " ++ show (length es) ++ ":")
                     , Box.moveRight 2 err

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -190,7 +190,7 @@ displayUserError e = case e of
   CompileError err ->
     vcat
       [ para "Compile error:"
-      , indented (P.prettyPrintMultipleErrorsBox False err)
+      , indented (vcat (P.prettyPrintMultipleErrorsBox False err))
       ]
   DirtyWorkingTree ->
     para (


### PR DESCRIPTION
Before, we were combining warnings into one huge string, and then carving out the excess whitespace. Now we carve and then combine, which halves the Halogen build time (was 16s, now 8s) on my machine.

It's not as fast as #1948, which gets down to about 6s, but we keep all of the warning output.