### PR TITLE
Default require path to ../, warn from psc

### DIFF
--- a/psc-bundle/Main.hs
+++ b/psc-bundle/Main.hs
@@ -119,8 +119,7 @@ options = Options <$> some inputFile
   requirePath = strOption $
        short 'r'
     <> long "require-path"
-    <> Opts.value ""
-    <> help "The path prefix used in require() calls in the generated JavaScript"
+    <> help "The path prefix used in require() calls in the generated JavaScript [deprecated]"
 
 -- | Make it go.
 main :: IO ()

--- a/psc-bundle/Main.hs
+++ b/psc-bundle/Main.hs
@@ -125,6 +125,7 @@ options = Options <$> some inputFile
 main :: IO ()
 main = do
   opts <- execParser (info (version <*> helper <*> options) infoModList)
+  when (optionsRequirePath opts /= Nothing) $ hPutStrLn stderr "The require-path option is deprecated and will be removed in PureScript 0.9."
   output <- runExceptT (app opts)
   case output of
     Left err -> do

--- a/psc/Main.hs
+++ b/psc/Main.hs
@@ -138,7 +138,7 @@ requirePath :: Parser (Maybe FilePath)
 requirePath = optional $ strOption $
      short 'r'
   <> long "require-path"
-  <> help "The path prefix to use for require() calls in the generated JavaScript"
+  <> help "The path prefix to use for require() calls in the generated JavaScript [deprecated]"
 
 noTco :: Parser Bool
 noTco = switch $

--- a/src/Language/PureScript/Bundle.hs
+++ b/src/Language/PureScript/Bundle.hs
@@ -141,7 +141,7 @@ checkImportPath :: Maybe FilePath -> String -> ModuleIdentifier -> S.Set String 
 checkImportPath _ "./foreign" m _ =
   Right (ModuleIdentifier (moduleName m) Foreign)
 checkImportPath requirePath name _ names
-  | Just name' <- stripPrefix (fromMaybe "" requirePath) name
+  | Just name' <- stripPrefix (fromMaybe "../" requirePath) name
   , name' `S.member` names = Right (ModuleIdentifier name' Regular)
 checkImportPath _ name _ _ = Left name
 

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -111,7 +111,7 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
   importToJs mnLookup mn' = do
     path <- asks optionsRequirePath
     let ((ss, _, _, _), mnSafe) = fromMaybe (internalError "Missing value in mnLookup") $ M.lookup mn' mnLookup
-    let moduleBody = JSApp Nothing (JSVar Nothing "require") [JSStringLiteral Nothing (maybe id (</>) path $ runModuleName mn')]
+    let moduleBody = JSApp Nothing (JSVar Nothing "require") [JSStringLiteral Nothing (fromMaybe ".." path </> runModuleName mn')]
     withPos ss $ JSVariableIntroduction Nothing (moduleNameToJs mnSafe) (Just moduleBody)
 
   -- |

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -148,6 +148,7 @@ data SimpleErrorMessage
   | CaseBinderLengthDiffers Int [Binder]
   | IncorrectAnonymousArgument
   | InvalidOperatorInBinder Ident Ident
+  | DeprecatedRequirePath
   deriving (Show)
 
 -- | Error message hints, providing more detailed information about failure.
@@ -328,6 +329,7 @@ errorCode em = case unwrapErrorMessage em of
   CaseBinderLengthDiffers{} -> "CaseBinderLengthDiffers"
   IncorrectAnonymousArgument -> "IncorrectAnonymousArgument"
   InvalidOperatorInBinder{} -> "InvalidOperatorInBinder"
+  DeprecatedRequirePath{} -> "DeprecatedRequirePath"
 
 -- |
 -- A stack trace for an error
@@ -973,6 +975,9 @@ prettyPrintSingleError full level showWiki e = flip evalState defaultUnknownMap 
       paras $ [ line $ "Operator " ++ showIdent op ++ " cannot be used in a pattern as it is an alias for function " ++ showIdent fn ++ "."
               , line "Only aliases for data constructors may be used in patterns."
               ]
+
+    renderSimpleErrorMessage DeprecatedRequirePath =
+      line "The require-path option is deprecated and will be removed in PureScript 0.9."
 
     renderHint :: ErrorMessageHint -> Box.Box -> Box.Box
     renderHint (ErrorUnifyingTypes t1 t2) detail =

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -150,6 +150,9 @@ make :: forall m. (Monad m, MonadBaseControl IO m, MonadReader Options m, MonadE
      -> [Module]
      -> m Environment
 make MakeActions{..} ms = do
+  requirePath <- asks optionsRequirePath
+  when (requirePath /= Nothing) $ tell $ errorMessage DeprecatedRequirePath
+
   checkModuleNamesAreUnique
 
   (sorted, graph) <- sortModules ms


### PR DESCRIPTION
#1698 

Does this need a warning from psc-bundle too?

Incidentally I noticed that if you specified a non-empty require path not ending in `/` (e.g. just `..`), `psc` and `psc-bundle` would behave differently.