### PR TITLE
Bump dependency on bower-json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - mkdir -p .cabal-sandbox
   - cabal sandbox init --sandbox .cabal-sandbox
   # Download stackage cabal.config, not sure whether filtering is necessary
-  - if [ -n "$STACKAGE" ]; then curl https://www.stackage.org/$STACKAGE/cabal.config | egrep -v 'purescript|sourcemap' > cabal.config; fi
+  - if [ -n "$STACKAGE" ]; then curl https://www.stackage.org/$STACKAGE/cabal.config | egrep -v 'purescript|sourcemap|bower-json' > cabal.config; fi
   - cabal install --only-dependencies --enable-tests
   - cabal install hpc-coveralls
   # Snapshot state of the sandbox now, so we don't need to make new one for test install

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -68,7 +68,7 @@ library
                    boxes >= 0.1.4 && < 0.2.0,
                    aeson >= 0.8 && < 0.12,
                    vector -any,
-                   bower-json >= 0.7,
+                   bower-json >= 0.8,
                    aeson-better-errors >= 0.8,
                    bytestring -any,
                    text -any,

--- a/stack-lts-5.yaml
+++ b/stack-lts-5.yaml
@@ -1,5 +1,6 @@
 resolver: lts-5.4
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+- bower-json-0.8.0
 flags: {}

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: nightly-2016-02-25
+resolver: nightly-2016-03-17


### PR DESCRIPTION
bower-json-0.8.0 fixes parsing of license, main, and moduleType fields.
In particular, we need the license field for #1714.