### PR TITLE
Better error message for psc-publish tests

### DIFF
--- a/psc-publish/Main.hs
+++ b/psc-publish/Main.hs
@@ -38,8 +38,8 @@ publish :: Bool -> IO ()
 publish isDryRun =
   if isDryRun
     then do
-      _ <- preparePackage dryRunOptions
+      _ <- unsafePreparePackage dryRunOptions
       putStrLn "Dry run completed, no errors."
     else do
-      pkg <- preparePackage defaultPublishOptions
+      pkg <- unsafePreparePackage defaultPublishOptions
       BL.putStrLn (A.encode pkg)

--- a/src/Language/PureScript/Publish/BoxesHelpers.hs
+++ b/src/Language/PureScript/Publish/BoxesHelpers.hs
@@ -36,3 +36,6 @@ bulletedList f = map (indented . para . ("* " ++) . f)
 
 printToStderr :: Boxes.Box -> IO ()
 printToStderr = hPutStr stderr . Boxes.render
+
+printToStdout :: Boxes.Box -> IO ()
+printToStdout = putStr . Boxes.render

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -10,6 +10,7 @@ module Language.PureScript.Publish.ErrorsWarnings
   , RepositoryFieldError(..)
   , JSONSource(..)
   , printError
+  , printErrorToStdout
   , renderError
   , printWarnings
   , renderWarnings
@@ -87,6 +88,9 @@ data OtherError
 
 printError :: PackageError -> IO ()
 printError = printToStderr . renderError
+
+printErrorToStdout :: PackageError -> IO ()
+printErrorToStdout = printToStdout . renderError
 
 renderError :: PackageError -> Box
 renderError err =


### PR DESCRIPTION
* Uses Either instead of exitFailure inside preparePackage

* Exposes a new unsafePreparePackage which is basically the old
  preparePackage.

* Prints a suggestion to update the git submodules in case of an error
  inside prepare Package

/cc @hdgarrood 