### PR TITLE
#1712, fast recompilation in psc-ide-server

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -212,6 +212,7 @@ library
                      Language.PureScript.Ide.SourceFile
                      Language.PureScript.Ide.Watcher
                      Language.PureScript.Ide.Reexports
+                     Language.PureScript.Ide.Rebuild
 
                      Control.Monad.Logger
                      Control.Monad.Supply

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -33,18 +33,10 @@ import           Language.PureScript.Ide.Reexports
 import           Language.PureScript.Ide.SourceFile
 import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Types
+import           Language.PureScript.Ide.Rebuild
 import           System.Directory
 import           System.FilePath
 import           System.Exit
-
-import           Control.Monad (unless)
-import           Control.Monad.Trans.Except
-import           Control.Monad.Trans.Reader (runReaderT)
-import qualified Control.Monad.Logger as Logger
-import qualified Language.PureScript as P
-import qualified Language.PureScript.Externs as P
-import qualified Language.PureScript.CoreFn as CF
-import qualified Language.PureScript.CodeGen.JS as J
 
 handleCommand :: (PscIde m, MonadLogger m, MonadError PscIdeError m) =>
                  Command -> m Success
@@ -68,46 +60,11 @@ handleCommand (CaseSplit l b e wca t) =
     caseSplit l b e wca t
 handleCommand (AddClause l wca) =
     pure $ addClause l wca
-handleCommand (Rebuild path) =
-    rebuildFile path
+handleCommand (Rebuild file outFile) =
+    rebuildFile file outFile
 handleCommand Cwd =
     TextResult . T.pack <$> liftIO getCurrentDirectory
 handleCommand Quit = liftIO exitSuccess
-
-rebuildFile
-  :: (PscIde m, MonadLogger m, MonadError PscIdeError m)
-  => FilePath
-  -> m Success
-rebuildFile path = do
-  externs <- M.elems <$> getExternFiles
-
-  let initEnv = foldl' (flip P.applyExternsFileToEnvironment) P.initEnvironment externs
-
-  input <- liftIO $ readFile path
-
-  _ <- case map snd <$> P.parseModulesFromFiles id [(path, input)] of
-         Left parseError ->
-           throwError . GeneralError $ P.prettyPrintMultipleErrors False parseError
-         Right [m] -> do
-           (resultMay, _) <- liftIO . Logger.runLogger' . runExceptT . flip runReaderT P.defaultOptions $ do
-             ((P.Module ss coms moduleName elaborated exps, env), nextVar) <- P.runSupplyT 0 $ do
-               [desugared] <- P.desugar externs [ P.addDefaultImport (P.ModuleName [P.ProperName "Prim"]) m ]
-               P.runCheck' initEnv $ P.typeCheckModule desugared
-             regrouped <- P.createBindingGroups moduleName . P.collapseBindingGroups $ elaborated
-             let mod' = P.Module ss coms moduleName regrouped exps
-                 corefn = CF.moduleToCoreFn env mod'
-                 [renamed] = P.renameInModules [corefn]
-             unless (null . CF.moduleForeign $ renamed)
-               . throwError
-               . P.errorMessage
-               $ P.MissingFFIModule moduleName
-             P.evalSupplyT nextVar $ P.prettyPrintJS <$> J.moduleToJs renamed Nothing
-           case resultMay of
-             Left errs -> throwError . GeneralError . P.prettyPrintMultipleErrors False $ errs
-             Right js -> liftIO $ writeFile ("output" </> P.runModuleName (P.getModuleName m) </> "index.js") js
-         Right _ -> throwError . GeneralError $ "Please define exactly one module."
-
-  return $ TextResult "OK"
 
 findCompletions :: (PscIde m, MonadLogger m) =>
                    [Filter] -> Matcher -> m Success

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -37,6 +37,14 @@ import           System.Directory
 import           System.FilePath
 import           System.Exit
 
+import           Control.Monad (unless)
+import           Control.Monad.Trans.Except
+import           Control.Monad.Trans.Reader (runReaderT)
+import qualified Control.Monad.Logger as Logger
+import qualified Language.PureScript as P
+import qualified Language.PureScript.Externs as P
+import qualified Language.PureScript.CoreFn as CF
+import qualified Language.PureScript.CodeGen.JS as J
 
 handleCommand :: (PscIde m, MonadLogger m, MonadError PscIdeError m) =>
                  Command -> m Success
@@ -60,9 +68,46 @@ handleCommand (CaseSplit l b e wca t) =
     caseSplit l b e wca t
 handleCommand (AddClause l wca) =
     pure $ addClause l wca
+handleCommand (Rebuild path) =
+    rebuildFile path
 handleCommand Cwd =
     TextResult . T.pack <$> liftIO getCurrentDirectory
 handleCommand Quit = liftIO exitSuccess
+
+rebuildFile
+  :: (PscIde m, MonadLogger m, MonadError PscIdeError m)
+  => FilePath
+  -> m Success
+rebuildFile path = do
+  externs <- M.elems <$> getExternFiles
+
+  let initEnv = foldl' (flip P.applyExternsFileToEnvironment) P.initEnvironment externs
+
+  input <- liftIO $ readFile path
+
+  _ <- case map snd <$> P.parseModulesFromFiles id [(path, input)] of
+         Left parseError ->
+           throwError . GeneralError $ P.prettyPrintMultipleErrors False parseError
+         Right [m] -> do
+           (resultMay, _) <- liftIO . Logger.runLogger' . runExceptT . flip runReaderT P.defaultOptions $ do
+             ((P.Module ss coms moduleName elaborated exps, env), nextVar) <- P.runSupplyT 0 $ do
+               [desugared] <- P.desugar externs [ P.addDefaultImport (P.ModuleName [P.ProperName "Prim"]) m ]
+               P.runCheck' initEnv $ P.typeCheckModule desugared
+             regrouped <- P.createBindingGroups moduleName . P.collapseBindingGroups $ elaborated
+             let mod' = P.Module ss coms moduleName regrouped exps
+                 corefn = CF.moduleToCoreFn env mod'
+                 [renamed] = P.renameInModules [corefn]
+             unless (null . CF.moduleForeign $ renamed)
+               . throwError
+               . P.errorMessage
+               $ P.MissingFFIModule moduleName
+             P.evalSupplyT nextVar $ P.prettyPrintJS <$> J.moduleToJs renamed Nothing
+           case resultMay of
+             Left errs -> throwError . GeneralError . P.prettyPrintMultipleErrors False $ errs
+             Right js -> liftIO $ writeFile ("output" </> P.runModuleName (P.getModuleName m) </> "index.js") js
+         Right _ -> throwError . GeneralError $ "Please define exactly one module."
+
+  return $ TextResult "OK"
 
 findCompletions :: (PscIde m, MonadLogger m) =>
                    [Filter] -> Matcher -> m Success

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -35,7 +35,10 @@ data Command
     | AddClause {
       addClauseLine          :: Text
       , addClauseAnnotations :: WildcardAnnotations}
-    | Rebuild FilePath -- ^ Rebuild the specified file using the loaded externs
+    | Rebuild FilePath (Maybe FilePath) -- ^ Rebuild the specified file using
+                                        -- the loaded externs and output the
+                                        -- generated JS to the specified
+                                        -- location
     | Cwd
     | Quit
 
@@ -100,6 +103,7 @@ instance FromJSON Command where
                                  else noAnnotations)
       "rebuild" -> do
         params <- o .: "params"
-        filePath <- params .: "filepath"
-        return $ Rebuild filePath
+        filePath <- params .: "file"
+        outPath <- params .:? "outfile"
+        return $ Rebuild filePath outPath
       _ -> mzero

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -35,6 +35,7 @@ data Command
     | AddClause {
       addClauseLine          :: Text
       , addClauseAnnotations :: WildcardAnnotations}
+    | Rebuild FilePath -- ^ Rebuild the specified file using the loaded externs
     | Cwd
     | Quit
 
@@ -97,5 +98,8 @@ instance FromJSON Command where
         return $ AddClause line (if annotations
                                  then explicitAnnotations
                                  else noAnnotations)
+      "rebuild" -> do
+        params <- o .: "params"
+        filePath <- params .: "filepath"
+        return $ Rebuild filePath
       _ -> mzero
-

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PackageImports        #-}
 {-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE RecordWildCards       #-}
 
 module Language.PureScript.Ide.Rebuild where
 
@@ -16,7 +17,7 @@ import           Control.Monad.Error.Class
 import           Control.Monad.Reader.Class
 import           Data.Foldable
 import qualified Data.Map.Lazy                      as M
-import           Data.Maybe (fromMaybe)
+import           Data.Maybe (fromMaybe, mapMaybe)
 import           Control.Monad.IO.Class
 import           "monad-logger" Control.Monad.Logger
 import           Control.Monad.Trans.Except
@@ -35,38 +36,61 @@ rebuildFile
   -> Maybe FilePath
   -> m Success
 rebuildFile path outpath = do
-  externs <- M.elems <$> getExternFiles
+
+  input <- liftIO $ readFile path
+
+  m <- case map snd <$> P.parseModulesFromFiles id [(path, input)] of
+         Left parseError ->
+           throwError . GeneralError $ P.prettyPrintMultipleErrors False parseError
+         Right [m] -> pure m
+         Right _ -> throwError . GeneralError $ "Please define exactly one module."
+
+  let externFilter mn _ = mn /= P.getModuleName m
+
+  externs <- sortExterns . M.filterWithKey externFilter =<< getExternFiles
 
   outputDirectory <- confOutputPath . envConfiguration <$> ask
 
   let initEnv = foldl' (flip P.applyExternsFileToEnvironment) P.initEnvironment externs
 
-  input <- liftIO $ readFile path
-
-  _ <- case map snd <$> P.parseModulesFromFiles id [(path, input)] of
-         Left parseError ->
-           throwError . GeneralError $ P.prettyPrintMultipleErrors False parseError
-         Right [m] -> do
-           (resultMay, _) <- liftIO . Logger.runLogger' . runExceptT . flip runReaderT P.defaultOptions $ do
-             ((P.Module ss coms moduleName elaborated exps, env), nextVar) <- P.runSupplyT 0 $ do
-               [desugared] <- P.desugar externs [ P.addDefaultImport (P.ModuleName [P.ProperName "Prim"]) m ]
-               P.runCheck' initEnv $ P.typeCheckModule desugared
-             regrouped <- P.createBindingGroups moduleName . P.collapseBindingGroups $ elaborated
-             let mod' = P.Module ss coms moduleName regrouped exps
-                 corefn = CF.moduleToCoreFn env mod'
-                 [renamed] = P.renameInModules [corefn]
-             unless (null . CF.moduleForeign $ renamed)
-               . throwError
-               . P.errorMessage
-               $ P.MissingFFIModule moduleName
-             P.evalSupplyT nextVar $ P.prettyPrintJS <$> J.moduleToJs renamed Nothing
-           case resultMay of
-             Left errs ->
-               throwError . GeneralError . P.prettyPrintMultipleErrors False $ errs
-             Right js -> do
-               let jsPath = fromMaybe
-                     (outputDirectory </> P.runModuleName (P.getModuleName m) </> "index.js") outpath
-               liftIO $ writeFile jsPath js
-         Right _ -> throwError . GeneralError $ "Please define exactly one module."
+  (resultMay, _) <- liftIO . Logger.runLogger' . runExceptT . flip runReaderT P.defaultOptions $ do
+    ((P.Module ss coms moduleName elaborated exps, env), nextVar) <- P.runSupplyT 0 $ do
+      [desugared] <- P.desugar externs [ P.addDefaultImport (P.ModuleName [P.ProperName "Prim"]) m ]
+      P.runCheck' initEnv $ P.typeCheckModule desugared
+    regrouped <- P.createBindingGroups moduleName . P.collapseBindingGroups $ elaborated
+    let mod' = P.Module ss coms moduleName regrouped exps
+        corefn = CF.moduleToCoreFn env mod'
+        [renamed] = P.renameInModules [corefn]
+    unless (null . CF.moduleForeign $ renamed)
+      . throwError
+      . P.errorMessage
+      $ P.MissingFFIModule moduleName
+    P.evalSupplyT nextVar $ P.prettyPrintJS <$> J.moduleToJs renamed Nothing
+  case resultMay of
+    Left errs ->
+      throwError . GeneralError . P.prettyPrintMultipleErrors False $ errs
+    Right js -> do
+      let jsPath = fromMaybe
+            (outputDirectory </> P.runModuleName (P.getModuleName m) </> "index.js") outpath
+      liftIO $ writeFile jsPath js
 
   return $ TextResult "OK"
+
+sortExterns
+  :: (PscIde m, MonadError PscIdeError m)
+     => M.Map P.ModuleName P.ExternsFile
+     -> m [P.ExternsFile]
+sortExterns ex = do
+  sorted' <- runExceptT . P.sortModules . map mkShallowModule .M.elems $ ex
+  case sorted' of
+    Left _ -> throwError (GeneralError "There was a cycle in the dependencies")
+    Right (sorted, _) ->
+       pure $ mapMaybe getExtern sorted
+  where
+    mkShallowModule P.ExternsFile{..} =
+      P.Module undefined [] efModuleName (map mkImport efImports) Nothing
+    mkImport (P.ExternsImport mn it iq) =
+      P.ImportDeclaration mn it iq False
+    getExtern m = M.lookup (P.getModuleName m) ex
+
+

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PackageImports        #-}
+{-# LANGUAGE TupleSections         #-}
+
+module Language.PureScript.Ide.Rebuild where
+
+import           Language.PureScript.Ide.State
+import           Language.PureScript.Ide.Types
+import           Language.PureScript.Ide.Error
+
+import           Control.Monad (unless)
+import           Control.Monad.Error.Class
+import           Control.Monad.Reader.Class
+import           Data.Foldable
+import qualified Data.Map.Lazy                      as M
+import           Data.Maybe (fromMaybe)
+import           Control.Monad.IO.Class
+import           "monad-logger" Control.Monad.Logger
+import           Control.Monad.Trans.Except
+import           Control.Monad.Trans.Reader (runReaderT)
+import qualified Control.Monad.Logger as Logger
+import qualified Language.PureScript as P
+import qualified Language.PureScript.Externs as P
+import qualified Language.PureScript.CoreFn as CF
+import qualified Language.PureScript.CodeGen.JS as J
+
+import           System.FilePath
+
+rebuildFile
+  :: (PscIde m, MonadLogger m, MonadError PscIdeError m)
+  => FilePath
+  -> Maybe FilePath
+  -> m Success
+rebuildFile path outpath = do
+  externs <- M.elems <$> getExternFiles
+
+  outputDirectory <- confOutputPath . envConfiguration <$> ask
+
+  let initEnv = foldl' (flip P.applyExternsFileToEnvironment) P.initEnvironment externs
+
+  input <- liftIO $ readFile path
+
+  _ <- case map snd <$> P.parseModulesFromFiles id [(path, input)] of
+         Left parseError ->
+           throwError . GeneralError $ P.prettyPrintMultipleErrors False parseError
+         Right [m] -> do
+           (resultMay, _) <- liftIO . Logger.runLogger' . runExceptT . flip runReaderT P.defaultOptions $ do
+             ((P.Module ss coms moduleName elaborated exps, env), nextVar) <- P.runSupplyT 0 $ do
+               [desugared] <- P.desugar externs [ P.addDefaultImport (P.ModuleName [P.ProperName "Prim"]) m ]
+               P.runCheck' initEnv $ P.typeCheckModule desugared
+             regrouped <- P.createBindingGroups moduleName . P.collapseBindingGroups $ elaborated
+             let mod' = P.Module ss coms moduleName regrouped exps
+                 corefn = CF.moduleToCoreFn env mod'
+                 [renamed] = P.renameInModules [corefn]
+             unless (null . CF.moduleForeign $ renamed)
+               . throwError
+               . P.errorMessage
+               $ P.MissingFFIModule moduleName
+             P.evalSupplyT nextVar $ P.prettyPrintJS <$> J.moduleToJs renamed Nothing
+           case resultMay of
+             Left errs ->
+               throwError . GeneralError . P.prettyPrintMultipleErrors False $ errs
+             Right js -> do
+               let jsPath = fromMaybe
+                     (outputDirectory </> P.runModuleName (P.getModuleName m) </> "index.js") outpath
+               liftIO $ writeFile jsPath js
+         Right _ -> throwError . GeneralError $ "Please define exactly one module."
+
+  return $ TextResult "OK"

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -37,6 +37,10 @@ getExternFiles = do
   stateVar <- envStateVar <$> ask
   liftIO (externsFiles <$> readTVarIO stateVar)
 
+getExternFile :: (PscIde m) =>
+                 ModuleName -> m (Maybe ExternsFile)
+getExternFile mn = M.lookup mn <$> getExternFiles
+
 getAllDecls :: (PscIde m) => m [ExternDecl]
 getAllDecls = concat <$> getPscIdeState
 


### PR DESCRIPTION
@kRITZCREEK  and I are still working on this, but I'll put the code here for early review anyway.

Still to do:

- [x] Get all transitive dependencies and topologically sort them in the "load all" command
- [ ] Pass warnings back to the editor
- [ ] Handle foreign modules
- [x] Move code into its own module
- [x] Make output file into a command parameter