### PR TITLE
Fix #1978, disallow generalization over constraints for mutually-recursive functions

### DIFF
--- a/examples/failing/Generalization1.purs
+++ b/examples/failing/Generalization1.purs
@@ -1,0 +1,11 @@
+-- @shouldFailWith CannotGeneralizeRecursiveFunction
+module Main where
+
+import Prelude
+
+foo 0 x _ = x
+foo n x y = x <> bar (n - 1) x y
+
+bar 0 x _ = x
+bar n x y = y <> foo (n - 1) x y
+

--- a/examples/passing/Generalization1.purs
+++ b/examples/passing/Generalization1.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console (print)
+
+main = do
+  print (sum 1.0 2.0)
+  print (sum 1 2)
+
+sum x y = x + y

--- a/examples/passing/Generalization2.purs
+++ b/examples/passing/Generalization2.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console (print)
+
+main = do
+  print (test 3 [1, 2])
+
+test n m | n <= 1 = m
+         | otherwise = test (n - 1) (m <> m)
+

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -234,7 +234,7 @@ typeCheckAll moduleName _ ds = traverse go ds <* traverse_ checkFixities ds
   go (ValueDeclaration name nameKind [] (Right val)) =
     warnAndRethrow (addHint (ErrorInValueDeclaration name)) $ do
       valueIsNotDefined moduleName name
-      [(_, (val', ty))] <- typesOf moduleName [(name, val)]
+      [(_, (val', ty))] <- typesOf NonRecursiveBindingGroup moduleName [(name, val)]
       addValue moduleName name ty nameKind
       return $ ValueDeclaration name nameKind [] $ Right val'
   go ValueDeclaration{} = internalError "Binders were not desugared"
@@ -242,7 +242,7 @@ typeCheckAll moduleName _ ds = traverse go ds <* traverse_ checkFixities ds
     warnAndRethrow (addHint (ErrorInBindingGroup (map (\(ident, _, _) -> ident) vals))) $ do
       for_ (map (\(ident, _, _) -> ident) vals) $ \name ->
         valueIsNotDefined moduleName name
-      tys <- typesOf moduleName $ map (\(ident, _, ty) -> (ident, ty)) vals
+      tys <- typesOf RecursiveBindingGroup moduleName $ map (\(ident, _, ty) -> (ident, ty)) vals
       vals' <- forM [ (name, val, nameKind, ty)
                     | (name, nameKind, _) <- vals
                     , (name', (val, ty)) <- tys

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -2,14 +2,16 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 
 -- |
 -- This module implements the type checker
 --
-module Language.PureScript.TypeChecker.Types (
-    typesOf
-) where
+module Language.PureScript.TypeChecker.Types
+  ( typesOf
+  , BindingGroupType(..)
+  ) where
 
 {-
   The following functions represent the corresponding type checking judgements:
@@ -35,6 +37,7 @@ import Data.List (transpose, nub, (\\), partition, delete)
 import Data.Maybe (fromMaybe)
 import qualified Data.Map as M
 
+import Control.Arrow ((***))
 import Control.Monad
 import Control.Monad.State.Class (MonadState(..), gets)
 import Control.Monad.Supply.Class (MonadSupply)
@@ -59,50 +62,48 @@ import Language.PureScript.TypeChecker.Unify
 import Language.PureScript.TypeClassDictionaries
 import Language.PureScript.Types
 
+data BindingGroupType
+  = RecursiveBindingGroup
+  | NonRecursiveBindingGroup
+  deriving (Show, Eq, Ord)
+
 -- | Infer the types of multiple mutually-recursive values, and return elaborated values including
 -- type class dictionaries and type annotations.
-typesOf ::
-  (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) =>
-  ModuleName ->
-  [(Ident, Expr)] ->
-  m [(Ident, (Expr, Type))]
-typesOf moduleName vals = do
-  tys <- fmap tidyUp . liftUnifyWarnings replace $ do
-    (untyped, typed, dict, untypedDict) <- typeDictionaryForBindingGroup moduleName vals
-    ds1 <- parU typed $ \e -> checkTypedBindingGroupElement moduleName e dict
-    ds2 <- forM untyped $ \e -> typeForBindingGroupElement e dict untypedDict
-    return (map (\x -> (False, x)) ds1 ++ map (\x -> (True, x)) ds2)
+typesOf
+  :: (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
+  => BindingGroupType
+  -> ModuleName
+  -> [(Ident, Expr)]
+  -> m [(Ident, (Expr, Type))]
+typesOf bindingGroupType moduleName vals = do
+  (untyped, typed, dict, untypedDict) <- typeDictionaryForBindingGroup moduleName vals
+  -- Check types of values with type annotations
+  ds1 <- parU typed $ \e -> checkTypedBindingGroupElement moduleName e dict
+  -- Infer types of values without type annotations
+  ds2 <- typesForBindingGroupElement bindingGroupType moduleName untyped dict untypedDict
 
-  forM tys $ \(shouldGeneralize, (ident, (val, ty))) -> do
-    -- Replace type class dictionary placeholders with actual dictionaries
-    (val', unsolved) <- replaceTypeClassDictionaries shouldGeneralize moduleName val
-    let unsolvedTypeVars = nub $ unknownsInType ty
-    -- Generalize and constrain the type
-    let generalized = generalize unsolved ty
-    -- Make sure any unsolved type constraints only use type variables which appear
-    -- unknown in the inferred type.
-    when shouldGeneralize $ do
-      tell . errorMessage $ MissingTypeDeclaration ident generalized
-      forM_ unsolved $ \(_, (className, classTys)) -> do
-        let constraintTypeVars = nub $ foldMap unknownsInType classTys
-        when (any (`notElem` unsolvedTypeVars) constraintTypeVars) $
-          throwError . errorMessage $ NoInstanceFound className classTys
+  forM (ds1 ++ ds2) $ \(ident, (val, ty)) -> do
     -- Check skolem variables did not escape their scope
-    skolemEscapeCheck val'
+    skolemEscapeCheck val
     -- Check rows do not contain duplicate labels
-    checkDuplicateLabels val'
-    return (ident, (foldr (Abs . Left . fst) val' unsolved, generalized))
+    checkDuplicateLabels val
+    return (ident, (val, ty))
+
+-- | Lift errors and warnings and apply the final substitution
+withCurrentSubstitution
+  :: (MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
+  => m [(Expr, Type)]
+  -> m [(Expr, Type)]
+withCurrentSubstitution = fmap applyCurrentSubstitution . liftUnifyWarnings replace
   where
-  -- | Generalize type vars using forall and add inferred constraints
-  generalize unsolved = varIfUnknown . constrain unsolved
-  -- | Add any unsolved constraints
-  constrain [] = id
-  constrain cs = ConstrainedType (map snd cs)
-  -- Apply the substitution that was returned from runUnify to both types and (type-annotated) values
-  tidyUp (ts, sub) = map (\(b, (i, (val, ty))) -> (b, (i, (overTypes (substituteType sub) val, substituteType sub ty)))) ts
-  -- Replace all the wildcards types with their inferred types
-  replace sub (ErrorMessage hints (WildcardInferredType ty)) = ErrorMessage hints . WildcardInferredType $ substituteType sub ty
-  replace _ em = em
+    -- Apply the substitution that was returned from runUnify to both types and (type-annotated) values
+    applyCurrentSubstitution :: ([(Expr, Type)], Substitution) -> [(Expr, Type)]
+    applyCurrentSubstitution (ts, sub) = map (overTypes (substituteType sub) *** substituteType sub) ts
+
+    -- Replace all the wildcards types with their inferred types
+    replace :: Substitution -> ErrorMessage -> ErrorMessage
+    replace sub (ErrorMessage hints (WildcardInferredType ty)) = ErrorMessage hints . WildcardInferredType $ substituteType sub ty
+    replace _ em = em
 
 type TypeData = M.Map (ModuleName, Ident) (Type, NameKind, NameVisibility)
 
@@ -140,18 +141,22 @@ checkTypedBindingGroupElement ::
   TypeData ->
   m (Ident, (Expr, Type))
 checkTypedBindingGroupElement mn (ident, (val', ty, checkType)) dict = do
-  -- Replace type wildcards
-  ty' <- replaceTypeWildcards ty
-  -- Kind check
-  (kind, args) <- kindOfWithScopedVars ty
-  checkTypeKind ty kind
-  -- Check the type with the new names in scope
-  ty'' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty'
-  val'' <- if checkType
-           then withScopedTypeVars mn args $ bindNames dict $ TypedValue True <$> check val' ty'' <*> pure ty''
-           else return (TypedValue False val' ty'')
-  return (ident, (val'', ty''))
+  [(val'', ty'')] <- withCurrentSubstitution $ do
+    -- Replace type wildcards
+    ty' <- replaceTypeWildcards ty
+    -- Kind check
+    (kind, args) <- kindOfWithScopedVars ty
+    checkTypeKind ty kind
+    -- Check the type with the new names in scope
+    ty'' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty'
+    val'' <- if checkType
+             then withScopedTypeVars mn args $ bindNames dict $ TypedValue True <$> check val' ty'' <*> pure ty''
+             else return (TypedValue False val' ty'')
+    return [(val'', ty'')]
+  (val''', _) <- replaceTypeClassDictionaries False mn val''
+  return (ident, (val''', ty''))
 
+-- | TODO: This duplication should only be necessary until we add let generalization properly.
 typeForBindingGroupElement ::
   (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) =>
   (Ident, Expr) ->
@@ -163,6 +168,66 @@ typeForBindingGroupElement (ident, val) dict untypedDict = do
   TypedValue _ val' ty <- bindNames dict $ infer val
   unifyTypes ty $ fromMaybe (internalError "name not found in dictionary") (lookup ident untypedDict)
   return (ident, (TypedValue True val' ty, ty))
+
+typesForBindingGroupElement
+  :: forall m
+   . (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
+  => BindingGroupType
+  -> ModuleName
+  -> [(Ident, Expr)]
+  -> TypeData
+  -> UntypedData
+  -> m [(Ident, (Expr, Type))]
+typesForBindingGroupElement bindingGroupType mn ds dict untypedDict =
+  do
+    ds' <- withCurrentSubstitution . forM ds $ \(ident, val) -> do
+      -- Infer the type with the new names in scope
+      TypedValue _ val' ty <- bindNames dict $ infer val
+      unifyTypes ty $ fromMaybe (internalError "name not found in dictionary") (lookup ident untypedDict)
+      return (val', ty)
+    zipWithM generalize ds ds'
+  where
+    generalize :: (Ident, unused) -> (Expr, Type) -> m (Ident, (Expr, Type))
+    generalize (ident, _) (val', ty) = do
+      -- Replace type class dictionary placeholders with actual dictionaries
+      (val'', unsolved) <- replaceTypeClassDictionaries True mn val'
+      let unsolvedTypeVars = nub $ unknownsInType ty
+
+      -- Generalize and constrain the type
+      let generalized = varIfUnknown . constrain unsolved $ ty
+
+      tell . errorMessage $ MissingTypeDeclaration ident generalized
+
+      -- Make sure any unsolved type constraints only use type variables which appear
+      -- unknown in the inferred type.
+      forM_ unsolved $ \(_, (className, classTys)) -> do
+        let constraintTypeVars = nub $ foldMap unknownsInType classTys
+        when (any (`notElem` unsolvedTypeVars) constraintTypeVars) $
+          throwError . errorMessage $ NoInstanceFound className classTys
+
+      -- For non-recursive binding groups and recursive binding groups of size
+      -- one, we can generalize over constraints.
+      -- For recursive binding groups of size > 1, we throw an error here for
+      -- now.
+      val''' <- case bindingGroupType of
+                  RecursiveBindingGroup
+                    | M.size dict > 1 && not (null unsolved) ->
+                        throwError
+                        . errorMessage
+                        $ CannotGeneralizeRecursiveFunction ident generalized
+                    | otherwise ->
+                        -- Add function binders to bring dictionaries into scope
+                        return $ foldr (Abs . Left . fst)
+                                       (Let [ ValueDeclaration ident Private [] (Right val'') ]
+                                            (Var (Qualified Nothing ident)))
+                                       unsolved
+                  NonRecursiveBindingGroup ->
+                    return $ foldr (Abs . Left . fst) val'' unsolved
+      return (ident, (TypedValue True val''' generalized, generalized))
+
+    -- | Add any unsolved constraints
+    constrain [] = id
+    constrain cs = ConstrainedType (map snd cs)
 
 -- | Check if a value contains a type annotation
 isTyped :: (Ident, Expr) -> Either (Ident, Expr) (Ident, (Expr, Type, Bool))
@@ -179,7 +244,7 @@ overTypes f = let (_, f', _) = everywhereOnValues id g id in f'
   g (TypedValue checkTy val t) = TypedValue checkTy val (f t)
   g (TypeClassDictionary (nm, tys) sco) = TypeClassDictionary (nm, map f tys) sco
   g other = other
-  
+
 -- | Check the kind of a type, failing if it is not of kind *.
 checkTypeKind ::
   (MonadState CheckState m, MonadError MultipleErrors m) =>


### PR DESCRIPTION
This should be ready to review finally. This doesn't do let generalization yet, but it does the following things:

- Disallow generalization over constraints for mutually-recursive functions, since I can't think of a simple way to generate code for mutually recursive functions where we need to introduce new constraints, without running the type checker twice.
- Allow generalization over constraints for self-recursive functions. These get code gen'd as a let binding with a monomorphic helper function. This is more in line with the typing judgments.
- Allow generalization over constraints for non-recursive functions. This is the same as before.