### PR TITLE
Fix #1991, instantiate polymorphic types before unification

### DIFF
--- a/examples/passing/1991.purs
+++ b/examples/passing/1991.purs
@@ -1,0 +1,20 @@
+module Main where
+
+import Prelude
+
+singleton :: forall a. a -> Array a
+singleton x = [x]
+
+empty :: forall a. Array a
+empty = []
+
+foldMap :: forall a m. (Semigroup m) => (a -> m) -> Array a -> m
+foldMap f [a, b, c, d, e] = f a <> f b <> f c <> f d <> f e
+
+regression :: Array Int
+regression =
+  let as = [1,2,3,4,5]
+      as' = foldMap (\x -> if 1 < x && x < 4 then singleton x else empty) as
+  in as'
+                  
+main = Control.Monad.Eff.Console.log "Done"

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -179,7 +179,7 @@ overTypes f = let (_, f', _) = everywhereOnValues id g id in f'
   g (TypedValue checkTy val t) = TypedValue checkTy val (f t)
   g (TypeClassDictionary (nm, tys) sco) = TypeClassDictionary (nm, map f tys) sco
   g other = other
-  
+
 -- | Check the kind of a type, failing if it is not of kind *.
 checkTypeKind ::
   (MonadState CheckState m, MonadError MultipleErrors m) =>
@@ -283,8 +283,10 @@ infer' (IfThenElse cond th el) = do
   cond' <- check cond tyBoolean
   th'@(TypedValue _ _ thTy) <- infer th
   el'@(TypedValue _ _ elTy) <- infer el
-  unifyTypes thTy elTy
-  return $ TypedValue True (IfThenElse cond' th' el') thTy
+  (th'', thTy') <- instantiatePolyTypeWithUnknowns th' thTy
+  (el'', elTy') <- instantiatePolyTypeWithUnknowns el' elTy
+  unifyTypes thTy' elTy'
+  return $ TypedValue True (IfThenElse cond' th'' el'') thTy'
 infer' (Let ds val) = do
   (ds', val'@(TypedValue _ _ valTy)) <- inferLetBinding [] ds val infer
   return $ TypedValue True (Let ds' val') valTy


### PR DESCRIPTION
This is a symptom of a bigger problem, which is that unification should only really ever happen on monotypes. For now, this should fix the immediate issue. I'm tracking the bigger issue elsewhere.

Tested with Halogen and Thermite.