### PR TITLE
Qualified constructors are not valid identifiers for operator aliases

### DIFF
--- a/examples/passing/DctorOperatorAlias.purs
+++ b/examples/passing/DctorOperatorAlias.purs
@@ -11,8 +11,13 @@ module Main where
   import Control.Monad.Eff.Console (CONSOLE, log)
   import Test.Assert (ASSERT, assert')
   import Data.List (List(..), (:))
+  import Data.List as L
 
+  -- unqualified
   infixl 6 Cons as !
+
+  -- qualified
+  infixl 6 L.Cons as !!
 
   get1 ∷ ∀ a. a → List a → a
   get1 y xs = case xs of

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -126,8 +126,8 @@ parseFixityDeclaration = do
   name <- symbol
   return $ FixityDeclaration fixity name alias
   where
-  aliased = (Left <$> parseQualified (Ident <$> identifier))
-        <|> (Right <$> parseQualified (ProperName <$> uname))
+  aliased = P.try (Left <$> parseQualified (Ident <$> identifier))
+        <|> (Right <$> parseQualified properName)
 
 parseImportDeclaration :: TokenParser Declaration
 parseImportDeclaration = do


### PR DESCRIPTION
For https://github.com/purescript/purescript/issues/2014