### PR TITLE
Fix prettyprinter for types

### DIFF
--- a/examples/docs/src/TypeOpAliases.purs
+++ b/examples/docs/src/TypeOpAliases.purs
@@ -1,0 +1,18 @@
+module TypeOpAliases where
+
+type AltFn a b = a -> b
+
+infixr 6 type AltFn as ~>
+
+foreign import test1 :: forall a b. a ~> b
+foreign import test2 :: forall a b c. a ~> b ~> c
+foreign import test3 :: forall a b c d. a ~> (b ~> c) ~> d
+foreign import test4 :: forall a b c d. ((a ~> b) ~> c) ~> d
+
+data Tuple a b = Tuple a b
+
+infixl 6 Tuple as ×
+infixl 6 type Tuple as ×
+
+third ∷ ∀ a b c. a × b × c → c
+third (a × b × c) = c

--- a/hierarchy/Main.hs
+++ b/hierarchy/Main.hs
@@ -30,6 +30,7 @@ import System.FilePath ((</>))
 import System.FilePath.Glob (glob)
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (hPutStr, stderr)
+import System.IO.UTF8 (readUTF8File)
 
 import qualified Language.PureScript as P
 import qualified Paths_purescript as Paths
@@ -56,7 +57,7 @@ runModuleName (P.ModuleName pns) = intercalate "_" (P.runProperName `map` pns)
 
 readInput :: [FilePath] -> IO (Either P.MultipleErrors [P.Module])
 readInput paths = do
-  content <- mapM (\path -> (path, ) <$> readFile path) paths
+  content <- mapM (\path -> (path, ) <$> readUTF8File path) paths
   return $ map snd <$> P.parseModulesFromFiles id content
 
 compile :: HierarchyOptions -> IO ()

--- a/psc-bundle/Main.hs
+++ b/psc-bundle/Main.hs
@@ -20,6 +20,7 @@ import System.FilePath (takeFileName, takeDirectory)
 import System.FilePath.Glob (glob)
 import System.Exit (exitFailure)
 import System.IO (stderr, stdout, hPutStrLn, hSetEncoding, utf8)
+import System.IO.UTF8 (readUTF8File)
 import System.Directory (createDirectoryIfMissing)
 
 import Language.PureScript.Bundle
@@ -56,7 +57,7 @@ app Options{..} = do
     hPutStrLn stderr "psc-bundle: No input files."
     exitFailure
   input <- for inputFiles $ \filename -> do
-    js <- liftIO (readFile filename)
+    js <- liftIO (readUTF8File filename)
     mid <- guessModuleIdentifier filename
     length js `seq` return (mid, js)                                            -- evaluate readFile till EOF before returning, not to exhaust file handles
 

--- a/psc-docs/Main.hs
+++ b/psc-docs/Main.hs
@@ -20,6 +20,7 @@ import qualified Language.PureScript as P
 import qualified Paths_purescript as Paths
 import System.Exit (exitFailure)
 import System.IO (hPutStrLn, hPrint, hSetEncoding, stderr, stdout, utf8)
+import System.IO.UTF8 (readUTF8File)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath (takeDirectory)
 import System.FilePath.Glob (glob)
@@ -139,7 +140,7 @@ dumpTags input renderTags = do
   ldump = mapM_ putStrLn
 
 parseFile :: FilePath -> IO (FilePath, String)
-parseFile input = (,) input <$> readFile input
+parseFile input = (,) input <$> readUTF8File input
 
 inputFile :: Parser FilePath
 inputFile = strArgument $

--- a/psci/PSCi/Module.hs
+++ b/psci/PSCi/Module.hs
@@ -6,6 +6,7 @@ import Prelude.Compat
 import qualified Language.PureScript as P
 import PSCi.Types
 import System.FilePath (pathSeparator)
+import System.IO.UTF8 (readUTF8File)
 import Control.Monad
 
 -- | The name of the PSCI support module
@@ -45,7 +46,7 @@ supportModule =
 --
 loadModule :: FilePath -> IO (Either String [P.Module])
 loadModule filename = do
-  content <- readFile filename
+  content <- readUTF8File filename
   return $ either (Left . P.prettyPrintMultipleErrors False) (Right . map snd) $ P.parseModulesFromFiles id [(filename, content)]
 
 -- |
@@ -54,7 +55,7 @@ loadModule filename = do
 loadAllModules :: [FilePath] -> IO (Either P.MultipleErrors [(FilePath, P.Module)])
 loadAllModules files = do
   filesAndContent <- forM files $ \filename -> do
-    content <- readFile filename
+    content <- readUTF8File filename
     return (filename, content)
   return $ P.parseModulesFromFiles id filesAndContent
 

--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -80,7 +80,7 @@ codeToString :: RenderedCode -> String
 codeToString = outputWith elemAsMarkdown
   where
   elemAsMarkdown (Syntax x)  = x
-  elemAsMarkdown (Ident x)   = x
+  elemAsMarkdown (Ident x _) = x
   elemAsMarkdown (Ctor x _)  = x
   elemAsMarkdown (Kind x)    = x
   elemAsMarkdown (Keyword x) = x

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -26,9 +26,9 @@ import Text.Parsec (eof)
 import qualified Language.PureScript as P
 import qualified Language.PureScript.Constants as C
 
-import Language.PureScript.Docs.Types
-import Language.PureScript.Docs.Convert.Single (convertSingleModule, collectBookmarks)
 import Language.PureScript.Docs.Convert.ReExports (updateReExports)
+import Language.PureScript.Docs.Convert.Single (convertSingleModule, collectBookmarks)
+import Language.PureScript.Docs.Types
 
 -- |
 -- Like convertModules, except that it takes a list of modules, together with

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -108,16 +108,17 @@ addDefaultFixity decl@Declaration{..}
   defaultFixity = P.Fixity P.Infixl (-1)
 
 getDeclarationTitle :: P.Declaration -> Maybe String
-getDeclarationTitle (P.ValueDeclaration name _ _ _)          = Just (P.showIdent name)
-getDeclarationTitle (P.ExternDeclaration name _)             = Just (P.showIdent name)
-getDeclarationTitle (P.DataDeclaration _ name _ _)           = Just (P.runProperName name)
-getDeclarationTitle (P.ExternDataDeclaration name _)         = Just (P.runProperName name)
-getDeclarationTitle (P.TypeSynonymDeclaration name _ _)      = Just (P.runProperName name)
-getDeclarationTitle (P.TypeClassDeclaration name _ _ _)      = Just (P.runProperName name)
+getDeclarationTitle (P.ValueDeclaration name _ _ _) = Just (P.showIdent name)
+getDeclarationTitle (P.ExternDeclaration name _) = Just (P.showIdent name)
+getDeclarationTitle (P.DataDeclaration _ name _ _) = Just (P.runProperName name)
+getDeclarationTitle (P.ExternDataDeclaration name _) = Just (P.runProperName name)
+getDeclarationTitle (P.TypeSynonymDeclaration name _ _) = Just (P.runProperName name)
+getDeclarationTitle (P.TypeClassDeclaration name _ _ _) = Just (P.runProperName name)
 getDeclarationTitle (P.TypeInstanceDeclaration name _ _ _ _) = Just (P.showIdent name)
-getDeclarationTitle (P.FixityDeclaration _ name _)           = Just ("(" ++ name ++ ")")
-getDeclarationTitle (P.PositionedDeclaration _ _ d)          = getDeclarationTitle d
-getDeclarationTitle _                                        = Nothing
+getDeclarationTitle (P.FixityDeclaration _ name (Just (P.Qualified _ P.AliasType{}))) = Just ("type (" ++ name ++ ")")
+getDeclarationTitle (P.FixityDeclaration _ name _) = Just ("(" ++ name ++ ")")
+getDeclarationTitle (P.PositionedDeclaration _ _ d) = getDeclarationTitle d
+getDeclarationTitle _ = Nothing
 
 -- | Create a basic Declaration value.
 mkDeclaration :: String -> DeclarationInfo -> Declaration

--- a/src/Language/PureScript/Docs/ParseAndBookmark.hs
+++ b/src/Language/PureScript/Docs/ParseAndBookmark.hs
@@ -16,6 +16,8 @@ import Control.Monad.IO.Class (MonadIO(..))
 
 import Web.Bower.PackageMeta (PackageName)
 
+import System.IO.UTF8 (readUTF8File)
+
 import qualified Language.PureScript as P
 import Language.PureScript.Docs.Types
 import Language.PureScript.Docs.Convert (collectBookmarks)
@@ -80,7 +82,7 @@ fileInfoToString (Local fn) = fn
 fileInfoToString (FromDep _ fn) = fn
 
 parseFile :: FilePath -> IO (FilePath, String)
-parseFile input' = (,) input' <$> readFile input'
+parseFile input' = (,) input' <$> readUTF8File input'
 
 parseAs :: (MonadIO m) => (FilePath -> a) -> FilePath -> m (a, String)
 parseAs g = fmap (first g) . liftIO . parseFile

--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -58,12 +58,12 @@ renderDeclarationWithOptions opts Declaration{..} =
             syntax "("
             <> mintersperse (syntax "," <> sp) (map renderConstraint implies)
             <> syntax ")" <> sp <> syntax "<="
-    AliasDeclaration for (P.Fixity associativity precedence) ->
+    AliasDeclaration for@(P.Qualified _ alias) (P.Fixity associativity precedence) ->
       [ keywordFixity associativity
       , syntax $ show precedence
       , ident $ renderAlias for
       , keyword "as"
-      , ident . tail . init $ declTitle
+      , ident $ adjustAliasName alias declTitle
       ]
 
   where
@@ -77,6 +77,9 @@ renderDeclarationWithOptions opts Declaration{..} =
           (P.showQualified P.runProperName . P.Qualified mn)
           (("type " ++) . P.showQualified P.runProperName . P.Qualified mn)
           alias
+
+  adjustAliasName (P.AliasType{}) title = drop 6 (init title)
+  adjustAliasName _ title = tail (init title)
 
 renderChildDeclaration :: ChildDeclaration -> RenderedCode
 renderChildDeclaration = renderChildDeclarationWithOptions defaultRenderTypeOptions

--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -70,12 +70,12 @@ renderDeclarationWithOptions opts Declaration{..} =
   renderType' = renderTypeWithOptions opts
   renderAlias (P.Qualified mn alias)
     | mn == currentModule opts =
-        P.foldFixityAlias P.runIdent P.runProperName P.runProperName alias
+        P.foldFixityAlias P.runIdent P.runProperName (("type " ++) . P.runProperName) alias
     | otherwise =
         P.foldFixityAlias
           (P.showQualified P.runIdent . P.Qualified mn)
           (P.showQualified P.runProperName . P.Qualified mn)
-          (P.showQualified P.runProperName . P.Qualified mn)
+          (("type " ++) . P.showQualified P.runProperName . P.Qualified mn)
           alias
 
 renderChildDeclaration :: ChildDeclaration -> RenderedCode

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -164,10 +164,17 @@ isType Declaration{..} =
     ExternDataDeclaration{} -> True
     _ -> False
 
-isAlias :: Declaration -> Bool
-isAlias Declaration{..} =
+isValueAlias :: Declaration -> Bool
+isValueAlias Declaration{..} =
   case declInfo of
-    AliasDeclaration{} -> True
+    (AliasDeclaration (P.Qualified _ P.AliasConstructor{}) _) -> True
+    (AliasDeclaration (P.Qualified _ P.AliasValue{}) _) -> True
+    _ -> False
+
+isTypeAlias :: Declaration -> Bool
+isTypeAlias Declaration{..} =
+  case declInfo of
+    (AliasDeclaration (P.Qualified _ P.AliasType{}) _) -> True
     _ -> False
 
 -- | Discard any children which do not satisfy the given predicate.

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -35,6 +35,7 @@ import           Language.PureScript.Ide.Types
 import qualified Language.PureScript.Names            as N
 import qualified Language.PureScript.Parser           as P
 import           System.Directory
+import           System.IO.UTF8                       (readUTF8File)
 
 parseModuleFromFile :: (MonadIO m, MonadError PscIdeError m) =>
                        FilePath -> m D.Module
@@ -42,7 +43,7 @@ parseModuleFromFile fp = do
   exists <- liftIO (doesFileExist fp)
   if exists
     then do
-      content <- liftIO (readFile fp)
+      content <- liftIO (readUTF8File fp)
       let m = do tokens <- P.lex fp content
                  P.runTokenParser "" P.parseModule tokens
       either (throwError . (`ParseError` "File could not be parsed.")) pure m

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -55,7 +55,7 @@ type FixityRecord = (Qualified Ident, SourceSpan, Fixity, Maybe (Qualified Fixit
 --
 rebracket
   :: forall m
-   . (MonadError MultipleErrors m)
+   . MonadError MultipleErrors m
   => [ExternsFile]
   -> [Module]
   -> m [Module]

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,16 +1,3 @@
------------------------------------------------------------------------------
---
--- Module      :  Main
--- License     :  MIT (http://opensource.org/licenses/MIT)
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
--- |
---
------------------------------------------------------------------------------
-
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE TupleSections #-}

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -285,12 +285,20 @@ testCases =
       , ValueShouldHaveTypeSignature (n "ExplicitTypeSignatures") "aNumber"  (ShowFn (P.tyNumber ==))
       ])
 
-    , ("ConstrainedArgument",
-        [ TypeSynonymShouldRenderAs (n "ConstrainedArgument") "WithoutArgs" "forall a. (Partial => a) -> a"
-        , TypeSynonymShouldRenderAs (n "ConstrainedArgument") "WithArgs" "forall a. (Foo a => a) -> a"
-        , TypeSynonymShouldRenderAs (n "ConstrainedArgument") "MultiWithoutArgs" "forall a. ((Partial, Partial) => a) -> a"
-        , TypeSynonymShouldRenderAs (n "ConstrainedArgument") "MultiWithArgs" "forall a b. ((Foo a, Foo b) => a) -> a"
-        ])
+  , ("ConstrainedArgument",
+      [ TypeSynonymShouldRenderAs (n "ConstrainedArgument") "WithoutArgs" "forall a. (Partial => a) -> a"
+      , TypeSynonymShouldRenderAs (n "ConstrainedArgument") "WithArgs" "forall a. (Foo a => a) -> a"
+      , TypeSynonymShouldRenderAs (n "ConstrainedArgument") "MultiWithoutArgs" "forall a. ((Partial, Partial) => a) -> a"
+      , TypeSynonymShouldRenderAs (n "ConstrainedArgument") "MultiWithArgs" "forall a b. ((Foo a, Foo b) => a) -> a"
+      ])
+
+  , ("TypeOpAliases",
+      [ ValueShouldHaveTypeSignature (n "TypeOpAliases") "test1" (renderedType "forall a b. a ~> b")
+      , ValueShouldHaveTypeSignature (n "TypeOpAliases") "test2" (renderedType "forall a b c. a ~> b ~> c")
+      , ValueShouldHaveTypeSignature (n "TypeOpAliases") "test3" (renderedType "forall a b c d. a ~> (b ~> c) ~> d")
+      , ValueShouldHaveTypeSignature (n "TypeOpAliases") "test4" (renderedType "forall a b c d. ((a ~> b) ~> c) ~> d")
+      , ValueShouldHaveTypeSignature (n "TypeOpAliases") "third" (renderedType "forall a b c. a × b × c -> c")
+      ])
   ]
 
   where
@@ -301,3 +309,6 @@ testCases =
 
   isVar varName (P.TypeVar name) | varName == name = True
   isVar _ _ = False
+
+  renderedType expected =
+    ShowFn $ \ty -> codeToString (Docs.renderType ty) == expected

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -285,12 +285,12 @@ testCases =
       , ValueShouldHaveTypeSignature (n "ExplicitTypeSignatures") "aNumber"  (ShowFn (P.tyNumber ==))
       ])
 
-    --, ("ConstrainedArgument",
-    --    [ TypeSynonymShouldRenderAs (n "ConstrainedArgument") "WithoutArgs" "forall a. (Partial => a) -> a"
-    --    , TypeSynonymShouldRenderAs (n "ConstrainedArgument") "WithArgs" "forall a. (Foo a => a) -> a"
-    --    , TypeSynonymShouldRenderAs (n "ConstrainedArgument") "MultiWithoutArgs" "forall a. ((Partial, Partial) => a) -> a"
-    --    , TypeSynonymShouldRenderAs (n "ConstrainedArgument") "MultiWithArgs" "forall a b. ((Foo a, Foo b) => a) -> a"
-    --    ])
+    , ("ConstrainedArgument",
+        [ TypeSynonymShouldRenderAs (n "ConstrainedArgument") "WithoutArgs" "forall a. (Partial => a) -> a"
+        , TypeSynonymShouldRenderAs (n "ConstrainedArgument") "WithArgs" "forall a. (Foo a => a) -> a"
+        , TypeSynonymShouldRenderAs (n "ConstrainedArgument") "MultiWithoutArgs" "forall a. ((Partial, Partial) => a) -> a"
+        , TypeSynonymShouldRenderAs (n "ConstrainedArgument") "MultiWithArgs" "forall a b. ((Foo a, Foo b) => a) -> a"
+        ])
   ]
 
   where

--- a/tests/TestPsci.hs
+++ b/tests/TestPsci.hs
@@ -17,6 +17,7 @@ import System.Exit (exitFailure)
 import System.Console.Haskeline
 import System.FilePath ((</>))
 import System.Directory (getCurrentDirectory)
+import System.IO.UTF8 (readUTF8File)
 import qualified System.FilePath.Glob as Glob
 
 import Test.HUnit
@@ -132,7 +133,7 @@ getPSCiState = do
   jsFiles   <- supportFiles "js"
 
   modulesOrFirstError <- loadAllModules pursFiles
-  foreignFiles <- forM jsFiles (\f -> (f,) <$> readFile f)
+  foreignFiles <- forM jsFiles (\f -> (f,) <$> readUTF8File f)
   Right (foreigns, _) <- runExceptT $ runWriterT $ P.parseForeignModulesFromFiles foreignFiles
   case modulesOrFirstError of
     Left err ->


### PR DESCRIPTION
@paf31 this'll do it. I found out why I was having so many difficulties at last - docs has its own type pretty printer!

I'm not sure rebracketing during docs is the way to go (which is what I've done here) as it means the types may become uglier in the docs than they are in the actual code, but the pretty-printing is a bit funky without it, as quite a few extra sets of parens can get inserted. If we can figure out how to avoid that, rebracketing will be unnecessary.

Maybe the docs pretty printer for types could be made much dumber actually, if it's running where we still have `ParensInType` then I guess it doesn't need to insert its own parens to ensure rendering is correct?