### PR TITLE
Require types to be exported if an type operator alias is

### DIFF
--- a/examples/failing/TypeOperatorAliasNoExport.purs
+++ b/examples/failing/TypeOperatorAliasNoExport.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith TransitiveExportError
+module Test (type (×)) where
+
+data Tuple a b = Tuple a b
+
+infixl 6 type Tuple as ×

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -232,6 +232,15 @@ foldFixityAlias f _ _ (AliasValue name) = f name
 foldFixityAlias _ g _ (AliasConstructor name) = g name
 foldFixityAlias _ _ h (AliasType name) = h name
 
+getValueAlias :: FixityAlias -> Maybe (Either Ident (ProperName 'ConstructorName))
+getValueAlias (AliasValue name) = Just $ Left name
+getValueAlias (AliasConstructor name) = Just $ Right name
+getValueAlias _ = Nothing
+
+getTypeAlias :: FixityAlias -> Maybe (ProperName 'TypeName)
+getTypeAlias (AliasType name) = Just name
+getTypeAlias _ = Nothing
+
 -- | The members of a type class instance declaration
 data TypeInstanceBody
   -- | This is a derived instance


### PR DESCRIPTION
Another thing that should have been done in the original PR. Pretty sure this should be the last of it though, once the other prettyprint PR is merged too.