### PR TITLE
Update PSCi `:show import`

### DIFF
--- a/psci/PSCi.hs
+++ b/psci/PSCi.hs
@@ -243,9 +243,8 @@ handleShowImportedModules = do
   where
   showModules = return . unlines . sort . map showModule
   showModule (mn, declType, asQ) =
-    "import " ++ case asQ of
-      Just mn' -> "qualified " ++ N.runModuleName mn ++ " as " ++ N.runModuleName mn'
-      Nothing  -> N.runModuleName mn ++ " " ++ showDeclType declType
+    "import " ++ N.runModuleName mn ++ showDeclType declType ++
+    foldMap (\mn' -> " as " ++ N.runModuleName mn') asQ
 
   showDeclType P.Implicit = ""
   showDeclType (P.Explicit refs) = refsList refs


### PR DESCRIPTION
For #2040
* Removed deprecated `qualified` keyword
* Added imported names list to qualified imports