### PR TITLE
Fix some pretty printing issues

### DIFF
--- a/src/Language/PureScript/Parser/Lexer.hs
+++ b/src/Language/PureScript/Parser/Lexer.hs
@@ -69,12 +69,13 @@ module Language.PureScript.Parser.Lexer
   , reservedPsNames
   , reservedTypeNames
   , isSymbolChar
+  , isUnquotedKey
   )
   where
 
 import Prelude hiding (lex)
 
-import Data.Char (isSpace, isAscii, isSymbol)
+import Data.Char (isSpace, isAscii, isSymbol, isAlphaNum)
 
 import Control.Monad (void, guard)
 import Data.Functor.Identity
@@ -534,3 +535,24 @@ reservedTypeNames = [ "forall", "where" ]
 --
 isSymbolChar :: Char -> Bool
 isSymbolChar c = (c `elem` ":!#$%&*+./<=>?@\\^|-~") || (not (isAscii c) && isSymbol c)
+
+
+-- |
+-- The characters allowed in the head of an unquoted record key
+--
+isUnquotedKeyHeadChar :: Char -> Bool
+isUnquotedKeyHeadChar c = (c == '_') || isAlphaNum c
+
+-- |
+-- The characters allowed in the tail of an unquoted record key
+--
+isUnquotedKeyTailChar :: Char -> Bool
+isUnquotedKeyTailChar c = (c `elem` "_'") || isAlphaNum c
+
+-- |
+-- Strings allowed to be left unquoted in a record key
+--
+isUnquotedKey :: String -> Bool
+isUnquotedKey []        = False
+isUnquotedKey (hd : tl) = isUnquotedKeyHeadChar hd &&
+                          all isUnquotedKeyTailChar tl

--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -23,7 +23,7 @@ import Prelude.Compat
 import Control.Monad.State (StateT, modify, get)
 import Data.List (elemIndices, intersperse)
 
-import Language.PureScript.Parser.Lexer (reservedPsNames, isSymbolChar)
+import Language.PureScript.Parser.Lexer (reservedPsNames, isUnquotedKey)
 import Language.PureScript.AST (SourcePos(..), SourceSpan(..))
 
 import Text.PrettyPrint.Boxes
@@ -155,8 +155,8 @@ prettyPrintMany f xs = do
 --
 prettyPrintObjectKey :: String -> String
 prettyPrintObjectKey s | s `elem` reservedPsNames = show s
-                       | any isSymbolChar s = show s
-                       | otherwise = s
+                       | isUnquotedKey s = s
+                       | otherwise = show s
 
 -- | Place a box before another, vertically when the first box takes up multiple lines.
 before :: Box -> Box -> Box

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -41,7 +41,7 @@ prettyPrintValue d (IfThenElse cond th el) =
   // moveRight 2 (vcat left [ text "then " <> prettyPrintValueAtom (d - 1) th
                             , text "else " <> prettyPrintValueAtom (d - 1) el
                             ])
-prettyPrintValue d (Accessor prop val) = prettyPrintValueAtom (d - 1) val <> text ("." ++ show prop)
+prettyPrintValue d (Accessor prop val) = prettyPrintValueAtom (d - 1) val <> text ("." ++ prettyPrintObjectKey prop)
 prettyPrintValue d (ObjectUpdate o ps) = prettyPrintValueAtom (d - 1) o <> text " " <> list '{' '}' (\(key, val) -> text (key ++ " = ") <> prettyPrintValue (d - 1) val) ps
 prettyPrintValue d (App val arg) = prettyPrintValueAtom (d - 1) val `beforeWithSpace` prettyPrintValueAtom (d - 1) arg
 prettyPrintValue d (Abs (Left arg) val) = text ('\\' : showIdent arg ++ " -> ") // moveRight 2 (prettyPrintValue (d - 1) val)


### PR DESCRIPTION
Partially related to #2039

### Old pretty printing behaviour:


**Some keys aren't quoted when they should be:**

~~~purescript
> :t _."a b"
forall t2 t3.
  { a b :: t2                 -- key contains space, should be quoted
  | t3
  }
  -> t2
~~~


**Accessors are always quoted, even when not necessary:**

~~~purescript
> {}.a
Error found:
in module $PSCI
...roperty accessor {}."a"    -- no need for this one to be quoted
~~~


### New pretty printing behaviour:

~~~purescript
> {}.a

-- in record
{ a :: _0
| _1
}

-- as accessor
{}.a
~~~

~~~purescript
> {}."a b"

-- in record
{ "a b" :: _0
| _1
}

-- as accessor
{}."a b"
~~~
