### PR TITLE
Tighten source-spans to token end position

### DIFF
--- a/examples/failing/OverlappingReExport.purs
+++ b/examples/failing/OverlappingReExport.purs
@@ -7,4 +7,4 @@ module B where
 
 module C (module A, module M2) where
   import A
-  import qualified B as M2
+  import B as M2

--- a/examples/failing/SuggestComposition.purs
+++ b/examples/failing/SuggestComposition.purs
@@ -4,4 +4,4 @@ module SuggestComposition where
 
 import Prelude
 
-f = g . g where g = (+1)
+f = g . g where g = (_ + 1)

--- a/examples/passing/2049.purs
+++ b/examples/passing/2049.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console (log)
+
+data List a = Cons a (List a) | Nil
+
+infixr 6 Cons as :
+
+f :: List { x :: Int, y :: Int } -> Int
+f ( r@{ x } : _) = x + r.y
+
+main = log "Done"

--- a/examples/passing/AutoPrelude2.purs
+++ b/examples/passing/AutoPrelude2.purs
@@ -1,7 +1,7 @@
 module Main where
 
 import Prelude
-import qualified Prelude as P
+import Prelude as P
 import Control.Monad.Eff.Console
 
 f :: forall a. a -> a

--- a/examples/passing/ConstraintInference.purs
+++ b/examples/passing/ConstraintInference.purs
@@ -2,6 +2,6 @@ module Main where
 
 import Prelude
 
-shout = Control.Monad.Eff.Console.log <<< (<> "!") <<< show
+shout = Control.Monad.Eff.Console.log <<< (_ <> "!") <<< show
 
 main = shout "Done"

--- a/examples/passing/ContextSimplification.purs
+++ b/examples/passing/ContextSimplification.purs
@@ -3,7 +3,7 @@ module Main where
 import Prelude
 import Control.Monad.Eff.Console
 
-shout = log <<< (<> "!") <<< show
+shout = log <<< (_ <> "!") <<< show
 
 -- Here, we should simplify the context so that only one Show
 -- constraint is added.

--- a/examples/passing/ModuleExportQualified.purs
+++ b/examples/passing/ModuleExportQualified.purs
@@ -3,7 +3,7 @@ module A (module Prelude) where
 
 module Main where
   import Control.Monad.Eff.Console
-  import qualified A as B
+  import A as B
 
   main = do
     print (B.show 1.0)

--- a/examples/passing/MonadState.purs
+++ b/examples/passing/MonadState.purs
@@ -58,4 +58,4 @@ modify f =
     same :: forall a. (a -> a) -> (a -> a)
     same = id
 
-main = print $ runState 0 (modify (+ 1))
+main = print $ runState 0 (modify (_ + 1))

--- a/examples/passing/OperatorSections.purs
+++ b/examples/passing/OperatorSections.purs
@@ -4,14 +4,14 @@ import Prelude
 import Test.Assert
 
 main = do
-  assert $ (/ 2.0) 4.0 == 2.0
-  assert $ (2.0 /) 4.0 == 0.5
-  assert $ (`const` 1.0) 2.0 == 2.0
-  assert $ (1.0 `const`) 2.0 == 1.0
+  assert $ (_ / 2.0) 4.0 == 2.0
+  assert $ (2.0 / _) 4.0 == 0.5
+  assert $ (_ `const` 1.0) 2.0 == 2.0
+  assert $ (1.0 `const` _) 2.0 == 1.0
   let foo = { x: 2.0 }
-  assert $ (/ foo.x) 4.0 == 2.0
-  assert $ (foo.x /) 4.0 == 0.5
+  assert $ (_ / foo.x) 4.0 == 2.0
+  assert $ (foo.x / _) 4.0 == 0.5
   let (//) x y = x.x / y.x
-  assert $ (// foo { x = 4.0 }) { x: 4.0 } == 1.0
-  assert $ (foo { x = 4.0 } //) { x: 4.0 } == 1.0
+  assert $ (_ // foo { x = 4.0 }) { x: 4.0 } == 1.0
+  assert $ (foo { x = 4.0 } // _) { x: 4.0 } == 1.0
   Control.Monad.Eff.Console.log "Done!"

--- a/examples/passing/OptionalQualified.purs
+++ b/examples/passing/OptionalQualified.purs
@@ -1,7 +1,6 @@
 module Main where
 
--- qualified import with the "qualified" keyword
-import qualified Prelude as P
+import Prelude as P
 
 -- qualified import without the "qualified" keyword
 import Control.Monad.Eff.Console as Console

--- a/examples/passing/QualifiedQualifiedImports.purs
+++ b/examples/passing/QualifiedQualifiedImports.purs
@@ -1,6 +1,6 @@
 module Main where
 
 -- qualified import with qualified imported names
-import qualified Control.Monad.Eff.Console (log) as Console
+import Control.Monad.Eff.Console (log) as Console
 
 main = Console.log "Success!"

--- a/examples/passing/ReExportQualified.purs
+++ b/examples/passing/ReExportQualified.purs
@@ -6,7 +6,7 @@ module B where
 
 module C (module A, module M2) where
   import A
-  import qualified B as M2
+  import B as M2
 
 module Main where
 

--- a/psc-bundle/Main.hs
+++ b/psc-bundle/Main.hs
@@ -6,7 +6,6 @@
 -- | Bundles compiled PureScript modules for the browser.
 module Main (main) where
 
-import Data.Maybe
 import Data.Traversable (for)
 import Data.Version (showVersion)
 
@@ -36,7 +35,6 @@ data Options = Options
   , optionsEntryPoints :: [String]
   , optionsMainModule  :: Maybe String
   , optionsNamespace   :: String
-  , optionsRequirePath :: Maybe FilePath
   } deriving Show
 
 -- | Given a filename, assuming it is in the correct place on disk, infer a ModuleIdentifier.
@@ -63,7 +61,7 @@ app Options{..} = do
 
   let entryIds = map (`ModuleIdentifier` Regular) optionsEntryPoints
 
-  bundle input entryIds optionsMainModule optionsNamespace optionsRequirePath
+  bundle input entryIds optionsMainModule optionsNamespace
 
 -- | Command line options parser.
 options :: Parser Options
@@ -72,7 +70,6 @@ options = Options <$> some inputFile
                   <*> many entryPoint
                   <*> optional mainModule
                   <*> namespace
-                  <*> optional requirePath
   where
   inputFile :: Parser FilePath
   inputFile = strArgument $
@@ -104,19 +101,12 @@ options = Options <$> some inputFile
     <> showDefault
     <> help "Specify the namespace that PureScript modules will be exported to when running in the browser."
 
-  requirePath :: Parser FilePath
-  requirePath = strOption $
-       short 'r'
-    <> long "require-path"
-    <> help "The path prefix used in require() calls in the generated JavaScript [deprecated]"
-
 -- | Make it go.
 main :: IO ()
 main = do
   hSetEncoding stdout utf8
   hSetEncoding stderr utf8
   opts <- execParser (info (version <*> helper <*> options) infoModList)
-  when (isJust (optionsRequirePath opts)) $ hPutStrLn stderr "The require-path option is deprecated and will be removed in PureScript 0.9."
   output <- runExceptT (app opts)
   case output of
     Left err -> do

--- a/psc/Main.hs
+++ b/psc/Main.hs
@@ -119,12 +119,6 @@ outputDirectory = strOption $
   <> showDefault
   <> help "The output directory"
 
-requirePath :: Parser (Maybe FilePath)
-requirePath = optional $ strOption $
-     short 'r'
-  <> long "require-path"
-  <> help "The path prefix to use for require() calls in the generated JavaScript [deprecated]"
-
 noTco :: Parser Bool
 noTco = switch $
      long "no-tco"
@@ -175,7 +169,6 @@ options = P.Options <$> noTco
                     <*> noOpts
                     <*> verboseErrors
                     <*> (not <$> comments)
-                    <*> requirePath
                     <*> sourceMaps
 
 pscMakeOptions :: Parser PSCMakeOptions

--- a/psci/PSCi/Completion.hs
+++ b/psci/PSCi/Completion.hs
@@ -7,7 +7,6 @@ import Prelude.Compat
 
 import Data.Maybe (mapMaybe)
 import Data.List (nub, nubBy, sortBy, isPrefixOf, stripPrefix)
-import Data.Char (isUpper)
 import Data.Function (on)
 
 import Control.Arrow (second)
@@ -87,10 +86,8 @@ directiveArg _ Kind        = [CtxType]
 completeImport :: [String] -> String -> [CompletionContext]
 completeImport ws w' =
   case (ws, w') of
-    (["import"], w) | headSatisfies isUpper w -> [CtxModule]
-    (["import"], _)                           -> [CtxModule, CtxFixed "qualified"]
-    (["import", "qualified"], _)              -> [CtxModule]
-    _                                         -> []
+    (["import"], _) -> [CtxModule]
+    _               -> []
 
 headSatisfies :: (a -> Bool) -> [a] -> Bool
 headSatisfies p str =

--- a/psci/PSCi/Module.hs
+++ b/psci/PSCi/Module.hs
@@ -98,7 +98,7 @@ createTemporaryModuleForImports PSCiState{psciImportedModules = imports} =
     P.Module (P.internalModuleSourceSpan "<internal>") [] moduleName (importDecl `map` imports) Nothing
 
 importDecl :: ImportedModule -> P.Declaration
-importDecl (mn, declType, asQ) = P.ImportDeclaration mn declType asQ False
+importDecl (mn, declType, asQ) = P.ImportDeclaration mn declType asQ
 
 indexFile :: FilePath
 indexFile = ".psci_modules" ++ pathSeparator : "index.js"

--- a/psci/PSCi/Parser.hs
+++ b/psci/PSCi/Parser.hs
@@ -107,7 +107,7 @@ psciLet = Decls <$> (P.reserved "let" *> P.indented *> manyDecls)
 -- :show import works, for example.
 psciImport :: P.TokenParser Command
 psciImport = do
-  (mn, declType, asQ, _) <- P.parseImportDeclaration'
+  (mn, declType, asQ) <- P.parseImportDeclaration'
   return $ Import (mn, declType, asQ)
 
 -- | Any other declaration that we don't need a 'special case' parser for

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -360,10 +360,6 @@ data Expr
   --
   | Parens Expr
   -- |
-  -- Operator section. This will be removed during desugaring and replaced with lambda.
-  --
-  | OperatorSection Expr (Either Expr Expr)
-  -- |
   -- An object property getter (e.g. `_.x`). This will be removed during
   -- desugaring and expanded into a lambda that reads a property from an object.
   --

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -47,9 +47,9 @@ getModuleName (Module _ _ name _ _) = name
 addDefaultImport :: ModuleName -> Module -> Module
 addDefaultImport toImport m@(Module ss coms mn decls exps)  =
   if isExistingImport `any` decls || mn == toImport then m
-  else Module ss coms mn (ImportDeclaration toImport Implicit Nothing False : decls) exps
+  else Module ss coms mn (ImportDeclaration toImport Implicit Nothing : decls) exps
   where
-  isExistingImport (ImportDeclaration mn' _ _ _) | mn' == toImport = True
+  isExistingImport (ImportDeclaration mn' _ _) | mn' == toImport = True
   isExistingImport (PositionedDeclaration _ _ d) = isExistingImport d
   isExistingImport _ = False
 
@@ -198,9 +198,8 @@ data Declaration
   | FixityDeclaration Fixity String (Maybe (Qualified FixityAlias))
   -- |
   -- A module import (module name, qualified/unqualified/hiding, optional "qualified as" name)
-  -- TODO: also a boolean specifying whether the old `qualified` syntax was used, so a warning can be raised in desugaring (remove for 0.9)
   --
-  | ImportDeclaration ModuleName ImportDeclarationType (Maybe ModuleName) Bool
+  | ImportDeclaration ModuleName ImportDeclarationType (Maybe ModuleName)
   -- |
   -- A type class declaration (name, argument, implies, member declarations)
   --

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -47,8 +47,6 @@ everywhereOnValues f g h = (f', g', h')
   g' (UnaryMinus v) = g (UnaryMinus (g' v))
   g' (BinaryNoParens op v1 v2) = g (BinaryNoParens (g' op) (g' v1) (g' v2))
   g' (Parens v) = g (Parens (g' v))
-  g' (OperatorSection op (Left v)) = g (OperatorSection (g' op) (Left $ g' v))
-  g' (OperatorSection op (Right v)) = g (OperatorSection (g' op) (Right $ g' v))
   g' (TypeClassDictionaryConstructorApp name v) = g (TypeClassDictionaryConstructorApp name (g' v))
   g' (Accessor prop v) = g (Accessor prop (g' v))
   g' (ObjectUpdate obj vs) = g (ObjectUpdate (g' obj) (map (fmap g') vs))
@@ -116,8 +114,6 @@ everywhereOnValuesTopDownM f g h = (f' <=< f, g' <=< g, h' <=< h)
   g' (UnaryMinus v) = UnaryMinus <$> (g v >>= g')
   g' (BinaryNoParens op v1 v2) = BinaryNoParens <$> (g op >>= g') <*> (g v1 >>= g') <*> (g v2 >>= g')
   g' (Parens v) = Parens <$> (g v >>= g')
-  g' (OperatorSection op (Left v)) = OperatorSection <$> (g op >>= g') <*> (Left <$> (g v >>= g'))
-  g' (OperatorSection op (Right v)) = OperatorSection <$> (g op >>= g') <*> (Right <$> (g v >>= g'))
   g' (TypeClassDictionaryConstructorApp name v) = TypeClassDictionaryConstructorApp name <$> (g v >>= g')
   g' (Accessor prop v) = Accessor prop <$> (g v >>= g')
   g' (ObjectUpdate obj vs) = ObjectUpdate <$> (g obj >>= g') <*> traverse (sndM (g' <=< g)) vs
@@ -185,8 +181,6 @@ everywhereOnValuesM f g h = (f', g', h')
   g' (UnaryMinus v) = (UnaryMinus <$> g' v) >>= g
   g' (BinaryNoParens op v1 v2) = (BinaryNoParens <$> g' op <*> g' v1 <*> g' v2) >>= g
   g' (Parens v) = (Parens <$> g' v) >>= g
-  g' (OperatorSection op (Left v)) = (OperatorSection <$> g' op <*> (Left <$> g' v)) >>= g
-  g' (OperatorSection op (Right v)) = (OperatorSection <$> g' op <*> (Right <$> g' v)) >>= g
   g' (TypeClassDictionaryConstructorApp name v) = (TypeClassDictionaryConstructorApp name <$> g' v) >>= g
   g' (Accessor prop v) = (Accessor prop <$> g' v) >>= g
   g' (ObjectUpdate obj vs) = (ObjectUpdate <$> g' obj <*> traverse (sndM g') vs) >>= g
@@ -259,8 +253,6 @@ everythingOnValues (<>) f g h i j = (f', g', h', i', j')
   g' v@(UnaryMinus v1) = g v <> g' v1
   g' v@(BinaryNoParens op v1 v2) = g v <> g' op <> g' v1 <> g' v2
   g' v@(Parens v1) = g v <> g' v1
-  g' v@(OperatorSection op (Left v1)) = g v <> g' op <> g' v1
-  g' v@(OperatorSection op (Right v1)) = g v <> g' op <> g' v1
   g' v@(TypeClassDictionaryConstructorApp _ v1) = g v <> g' v1
   g' v@(Accessor _ v1) = g v <> g' v1
   g' v@(ObjectUpdate obj vs) = foldl (<>) (g v <> g' obj) (map (g' . snd) vs)
@@ -338,8 +330,6 @@ everythingWithContextOnValues s0 r0 (<>) f g h i j = (f'' s0, g'' s0, h'' s0, i'
   g' s (UnaryMinus v1) = g'' s v1
   g' s (BinaryNoParens op v1 v2) = g'' s op <> g'' s v1 <> g'' s v2
   g' s (Parens v1) = g'' s v1
-  g' s (OperatorSection op (Left v)) = g'' s op <> g'' s v
-  g' s (OperatorSection op (Right v)) = g'' s op <> g'' s v
   g' s (TypeClassDictionaryConstructorApp _ v1) = g'' s v1
   g' s (Accessor _ v1) = g'' s v1
   g' s (ObjectUpdate obj vs) = foldl (<>) (g'' s obj) (map (g'' s . snd) vs)
@@ -419,8 +409,6 @@ everywhereWithContextOnValuesM s0 f g h i j = (f'' s0, g'' s0, h'' s0, i'' s0, j
   g' s (UnaryMinus v) = UnaryMinus <$> g'' s v
   g' s (BinaryNoParens op v1 v2) = BinaryNoParens <$> g'' s op <*> g'' s v1 <*> g'' s v2
   g' s (Parens v) = Parens <$> g'' s v
-  g' s (OperatorSection op (Left v)) = OperatorSection <$> g'' s op <*> (Left <$> g'' s v)
-  g' s (OperatorSection op (Right v)) = OperatorSection <$> g'' s op <*> (Right <$> g'' s v)
   g' s (TypeClassDictionaryConstructorApp name v) = TypeClassDictionaryConstructorApp name <$> g'' s v
   g' s (Accessor prop v) = Accessor prop <$> g'' s v
   g' s (ObjectUpdate obj vs) = ObjectUpdate <$> g'' s obj <*> traverse (sndM (g'' s)) vs
@@ -510,8 +498,6 @@ everythingWithScope f g h i j = (f'', g'', h'', i'', \s -> snd . j'' s)
   g' s (UnaryMinus v1) = g'' s v1
   g' s (BinaryNoParens op v1 v2) = g'' s op <> g'' s v1 <> g'' s v2
   g' s (Parens v1) = g'' s v1
-  g' s (OperatorSection op (Left v)) = g'' s op <> g'' s v
-  g' s (OperatorSection op (Right v)) = g'' s op <> g'' s v
   g' s (TypeClassDictionaryConstructorApp _ v1) = g'' s v1
   g' s (Accessor _ v1) = g'' s v1
   g' s (ObjectUpdate obj vs) = g'' s obj <> foldMap (g'' s . snd) vs

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -109,9 +109,8 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
   --
   importToJs :: M.Map ModuleName (Ann, ModuleName) -> ModuleName -> m JS
   importToJs mnLookup mn' = do
-    path <- asks optionsRequirePath
     let ((ss, _, _, _), mnSafe) = fromMaybe (internalError "Missing value in mnLookup") $ M.lookup mn' mnLookup
-    let moduleBody = JSApp Nothing (JSVar Nothing "require") [JSStringLiteral Nothing (fromMaybe ".." path </> runModuleName mn')]
+    let moduleBody = JSApp Nothing (JSVar Nothing "require") [JSStringLiteral Nothing (".." </> runModuleName mn')]
     withPos ss $ JSVariableIntroduction Nothing (moduleNameToJs mnSafe) (Just moduleBody)
 
   -- |

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -230,7 +230,7 @@ findQualModules decls =
 -- Desugars import declarations from AST to CoreFn representation.
 --
 importToCoreFn :: A.Declaration -> Maybe (Ann, ModuleName)
-importToCoreFn (A.ImportDeclaration name _ _ _) = Just (nullAnn, name)
+importToCoreFn (A.ImportDeclaration name _ _) = Just (nullAnn, name)
 importToCoreFn (A.PositionedDeclaration ss _ d) =
   ((,) (Just ss, [], Nothing, Nothing) . snd) <$> importToCoreFn d
 importToCoreFn _ = Nothing

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -142,7 +142,6 @@ data SimpleErrorMessage
   | UnusedDctorExplicitImport (ProperName 'TypeName) [ProperName 'ConstructorName]
   | DeprecatedOperatorDecl String
   | DeprecatedOperatorSection Expr (Either Expr Expr)
-  | DeprecatedQualifiedSyntax ModuleName ModuleName
   | DeprecatedClassImport ModuleName (ProperName 'ClassName)
   | DeprecatedClassExport (ProperName 'ClassName)
   | DuplicateSelectiveImport ModuleName
@@ -331,7 +330,6 @@ errorCode em = case unwrapErrorMessage em of
   UnusedDctorExplicitImport{} -> "UnusedDctorExplicitImport"
   DeprecatedOperatorDecl{} -> "DeprecatedOperatorDecl"
   DeprecatedOperatorSection{} -> "DeprecatedOperatorSection"
-  DeprecatedQualifiedSyntax{} -> "DeprecatedQualifiedSyntax"
   DeprecatedClassImport{} -> "DeprecatedClassImport"
   DeprecatedClassExport{} -> "DeprecatedClassExport"
   DuplicateSelectiveImport{} -> "DuplicateSelectiveImport"
@@ -463,8 +461,6 @@ errorSuggestion err = case err of
   UnusedImport{} -> emptySuggestion
   RedundantEmptyHidingImport{} -> emptySuggestion
   DuplicateImport{} -> emptySuggestion
-  DeprecatedQualifiedSyntax name qualName -> suggest $
-    "import " ++ runModuleName name ++ " as " ++ runModuleName qualName
   UnusedExplicitImport mn _ qual refs -> suggest $ importSuggestion mn refs qual
   ImplicitImport mn refs -> suggest $ importSuggestion mn refs Nothing
   ImplicitQualifiedImport mn asModule refs -> suggest $ importSuggestion mn refs (Just asModule)
@@ -951,13 +947,6 @@ prettyPrintSingleError full level showWiki e = flip evalState defaultUnknownMap 
         renderOperator (PositionedValue _ _ ex) = renderOperator ex
         renderOperator (Var (Qualified _ (Op ident))) = line ident
         renderOperator other = Box.hcat Box.top [ line "`", prettyPrintValue valueDepth other, line "`" ]
-    renderSimpleErrorMessage (DeprecatedQualifiedSyntax name qualName) =
-      paras [ line "Import uses the deprecated 'qualified' syntax:"
-            , indent $ line $ "import qualified " ++ runModuleName name ++ " as " ++ runModuleName qualName
-            , line "Should instead use the form:"
-            , indent $ line $ "import " ++ runModuleName name ++ " as " ++ runModuleName qualName
-            , line "The deprecated syntax will be removed in PureScript 0.9."
-            ]
 
     renderSimpleErrorMessage (DeprecatedClassImport mn name) =
       paras [ line $ "Class import from " ++ runModuleName mn ++ " uses deprecated syntax that omits the 'class' keyword:"

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -25,7 +25,6 @@ import Control.Arrow ((&&&))
 import Language.PureScript.Crash
 import Language.PureScript.AST
 import Language.PureScript.Pretty
-import Language.PureScript.Pretty.Common (before)
 import Language.PureScript.Types
 import Language.PureScript.Names
 import Language.PureScript.Kinds
@@ -141,7 +140,6 @@ data SimpleErrorMessage
   | UnusedDctorImport (ProperName 'TypeName)
   | UnusedDctorExplicitImport (ProperName 'TypeName) [ProperName 'ConstructorName]
   | DeprecatedOperatorDecl String
-  | DeprecatedOperatorSection Expr (Either Expr Expr)
   | DeprecatedClassImport ModuleName (ProperName 'ClassName)
   | DeprecatedClassExport (ProperName 'ClassName)
   | DuplicateSelectiveImport ModuleName
@@ -329,7 +327,6 @@ errorCode em = case unwrapErrorMessage em of
   UnusedDctorImport{} -> "UnusedDctorImport"
   UnusedDctorExplicitImport{} -> "UnusedDctorExplicitImport"
   DeprecatedOperatorDecl{} -> "DeprecatedOperatorDecl"
-  DeprecatedOperatorSection{} -> "DeprecatedOperatorSection"
   DeprecatedClassImport{} -> "DeprecatedClassImport"
   DeprecatedClassExport{} -> "DeprecatedClassExport"
   DuplicateSelectiveImport{} -> "DuplicateSelectiveImport"
@@ -455,7 +452,7 @@ wikiUri e = "https://github.com/purescript/purescript/wiki/Error-Code-" ++ error
 -- TODO Other possible suggestions:
 -- WildcardInferredType - source span not small enough
 -- DuplicateSelectiveImport - would require 2 ranges to remove and 1 insert
--- DeprecatedClassExport, DeprecatedClassImport, DeprecatedOperatorSection, would want to replace smaller span?
+-- DeprecatedClassExport, DeprecatedClassImport, would want to replace smaller span?
 errorSuggestion :: SimpleErrorMessage -> Maybe ErrorSuggestion
 errorSuggestion err = case err of
   UnusedImport{} -> emptySuggestion
@@ -922,31 +919,6 @@ prettyPrintSingleError full level showWiki e = flip evalState defaultUnknownMap 
             , indent $ line $ "infixl 9 someFunction as " ++ name
             , line "Support for value-declared operators will be removed in PureScript 0.9."
             ]
-
-    renderSimpleErrorMessage (DeprecatedOperatorSection op val) =
-      paras [ line "An operator section uses legacy syntax. Operator sections are now written using anonymous function syntax:"
-            , indent $ foldr1 before $
-                case val of
-                  Left l ->
-                    [ line "("
-                    , prettyPrintValue valueDepth l
-                    , line " "
-                    , renderOperator op
-                    , line " _)"
-                    ]
-                  Right r ->
-                    [ line "(_ "
-                    , renderOperator op
-                    , line " "
-                    , prettyPrintValue valueDepth r
-                    , line ")"
-                    ]
-            , line "Support for legacy operator sections will be removed in PureScript 0.9."
-            ]
-      where
-        renderOperator (PositionedValue _ _ ex) = renderOperator ex
-        renderOperator (Var (Qualified _ (Op ident))) = line ident
-        renderOperator other = Box.hcat Box.top [ line "`", prettyPrintValue valueDepth other, line "`" ]
 
     renderSimpleErrorMessage (DeprecatedClassImport mn name) =
       paras [ line $ "Class import from " ++ runModuleName mn ++ " uses deprecated syntax that omits the 'class' keyword:"

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -165,7 +165,7 @@ moduleToExternsFile (Module _ _ mn ds (Just exps)) env = ExternsFile{..}
   fixityDecl _ = Nothing
 
   importDecl :: Declaration -> Maybe ExternsImport
-  importDecl (ImportDeclaration m mt qmn _) = Just (ExternsImport m mt qmn)
+  importDecl (ImportDeclaration m mt qmn) = Just (ExternsImport m mt qmn)
   importDecl (PositionedDeclaration _ _ d) = importDecl d
   importDecl _ = Nothing
 

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -95,9 +95,9 @@ parseImportsWithModuleName ls = do
   (P.Module _ _ mn decls _) <- moduleParse ls
   pure (mn, concatMap mkImport (unwrapPositioned <$> decls))
   where
-    mkImport (P.ImportDeclaration mn (P.Explicit refs) qual _) =
+    mkImport (P.ImportDeclaration mn (P.Explicit refs) qual) =
       [Import mn (P.Explicit (unwrapPositionedRef <$> refs)) qual]
-    mkImport (P.ImportDeclaration mn it qual _) = [Import mn it qual]
+    mkImport (P.ImportDeclaration mn it qual) = [Import mn it qual]
     mkImport _ = []
 
 sliceImportSection :: [Text] -> Either String (P.ModuleName, [Text], [Import], [Text])
@@ -348,8 +348,7 @@ parseImport :: Text -> Maybe Import
 parseImport t =
   case P.lex "<psc-ide>" (T.unpack t)
        >>= P.runTokenParser "<psc-ide>" P.parseImportDeclaration' of
-    Right (mn, P.Explicit refs, mmn, _) ->
+    Right (mn, P.Explicit refs, mmn) ->
       Just (Import mn (P.Explicit (unwrapPositionedRef <$> refs)) mmn)
-    Right (mn, idt, mmn, _) -> Just (Import mn idt mmn)
+    Right (mn, idt, mmn) -> Just (Import mn idt mmn)
     Left _ -> Nothing
-

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -78,7 +78,7 @@ sortExterns m ex = do
     mkShallowModule P.ExternsFile{..} =
       P.Module undefined [] efModuleName (map mkImport efImports) Nothing
     mkImport (P.ExternsImport mn it iq) =
-      P.ImportDeclaration mn it iq False
+      P.ImportDeclaration mn it iq
     getExtern mn = M.lookup mn ex
     -- Sort a list so its elements appear in the same order as in another list.
     inOrderOf :: (Ord a) => [a] -> [a] -> [a]

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -68,14 +68,14 @@ getImportsForFile fp = do
   let imports = getImports module'
   pure (mkModuleImport . unwrapPositionedImport <$> imports)
   where
-    mkModuleImport (D.ImportDeclaration mn importType' qualifier _) =
+    mkModuleImport (D.ImportDeclaration mn importType' qualifier) =
       ModuleImport
       (T.pack (N.runModuleName mn))
       importType'
       (T.pack . N.runModuleName <$> qualifier)
     mkModuleImport _ = error "Shouldn't have gotten anything but Imports here"
-    unwrapPositionedImport (D.ImportDeclaration mn importType' qualifier b) =
-      D.ImportDeclaration mn (unwrapImportType importType') qualifier b
+    unwrapPositionedImport (D.ImportDeclaration mn importType' qualifier) =
+      D.ImportDeclaration mn (unwrapImportType importType') qualifier
     unwrapPositionedImport x = x
     unwrapImportType (D.Explicit decls) = D.Explicit (map unwrapPositionedRef decls)
     unwrapImportType (D.Hiding decls)   = D.Hiding (map unwrapPositionedRef decls)

--- a/src/Language/PureScript/Ide/Watcher.hs
+++ b/src/Language/PureScript/Ide/Watcher.hs
@@ -12,44 +12,37 @@
 -- File watcher for externs files
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE RecordWildCards #-}
-
 module Language.PureScript.Ide.Watcher where
-
-import           Prelude                         ()
-import           Prelude.Compat
 
 import           Control.Concurrent              (threadDelay)
 import           Control.Concurrent.STM
 import           Control.Monad
 import           Control.Monad.Trans.Except
-import qualified Data.Map                        as M
-import           Data.Maybe                      (isJust)
-import           Language.PureScript.Externs
 import           Language.PureScript.Ide.Externs
 import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Types
+import           Prelude
 import           System.FilePath
 import           System.FSNotify
 
+-- | Reloads an ExternsFile from Disc. If the Event indicates the ExternsFile
+-- was deleted we don't do anything.
+reloadFile :: TVar PscIdeState -> Event -> IO ()
+reloadFile _ Removed{} = pure ()
+reloadFile stateVar ev = do
+  let fp = eventPath ev
+  ef' <- runExceptT (readExternFile fp)
+  case ef' of
+    Left _ -> pure ()
+    Right ef -> do
+      atomically (insertModule' stateVar ef)
+      putStrLn ("Reloaded File at: " ++ fp)
 
-reloadFile :: TVar PscIdeState -> FilePath -> IO ()
-reloadFile stateVar fp = do
-  (Right ef@ExternsFile{..}) <- runExceptT $ readExternFile fp
-  reloaded <- atomically $ do
-    st <- readTVar stateVar
-    if isLoaded efModuleName st
-      then
-        insertModule' stateVar ef *> pure True
-      else
-        pure False
-  when reloaded $ putStrLn $ "Reloaded File at: " ++ fp
-  where
-    isLoaded name st = isJust (M.lookup name (externsFiles st))
-
+-- | Installs filewatchers for the given directory and reloads ExternsFiles when
+-- they change on disc
 watcher :: TVar PscIdeState -> FilePath -> IO ()
-watcher stateVar fp = withManager $ \mgr -> do
+watcher stateVar fp = withManagerConf (defaultConfig { confDebounce = NoDebounce }) $ \mgr -> do
   _ <- watchTree mgr fp
     (\ev -> takeFileName (eventPath ev) == "externs.json")
-    (reloadFile stateVar . eventPath)
-  forever (threadDelay 10000)
+    (reloadFile stateVar)
+  forever (threadDelay 100000)

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -71,7 +71,6 @@ lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDecl
       go d | Just i <- getDeclIdent d
            , i `S.member` s = errorMessage (ShadowedName i)
            | otherwise = mempty
-    stepE _ (OperatorSection op val) = errorMessage $ DeprecatedOperatorSection op val
     stepE _ _ = mempty
 
     stepB :: S.Set Ident -> Binder -> MultipleErrors

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -112,8 +112,8 @@ lintImports (Module _ _ mn mdecls mexports) env usedImps = do
   where
 
   countOpenImports :: Declaration -> Int
-  countOpenImports (ImportDeclaration mn' Implicit Nothing _) | not (isPrim mn') = 1
-  countOpenImports (ImportDeclaration mn' (Hiding _) Nothing _) | not (isPrim mn') = 1
+  countOpenImports (ImportDeclaration mn' Implicit Nothing) | not (isPrim mn') = 1
+  countOpenImports (ImportDeclaration mn' (Hiding _) Nothing) | not (isPrim mn') = 1
   countOpenImports (PositionedDeclaration _ _ d) = countOpenImports d
   countOpenImports _ = 0
 

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -42,7 +42,7 @@ import Control.Monad.Trans.Control (MonadBaseControl(..))
 import Control.Concurrent.Lifted as C
 
 import Data.List (foldl', sort)
-import Data.Maybe (fromMaybe, catMaybes, isJust)
+import Data.Maybe (fromMaybe, catMaybes)
 import Data.Either (partitionEithers)
 import Data.Time.Clock
 import Data.String (fromString)
@@ -181,9 +181,6 @@ make :: forall m. (Monad m, MonadBaseControl IO m, MonadReader Options m, MonadE
      -> [Module]
      -> m Environment
 make ma@MakeActions{..} ms = do
-  requirePath <- asks optionsRequirePath
-  when (isJust requirePath) $ tell $ errorMessage DeprecatedRequirePath
-
   checkModuleNamesAreUnique
 
   (sorted, graph) <- sortModules ms

--- a/src/Language/PureScript/ModuleDependencies.hs
+++ b/src/Language/PureScript/ModuleDependencies.hs
@@ -47,7 +47,7 @@ sortModules ms = do
   -- Extract module names that have been brought into scope by an `as` import.
   extractQualAs :: Declaration -> [ModuleName]
   extractQualAs (PositionedDeclaration _ _ d) = extractQualAs d
-  extractQualAs (ImportDeclaration _ _ (Just am) _) = [am]
+  extractQualAs (ImportDeclaration _ _ (Just am)) = [am]
   extractQualAs _ = []
 
 -- |
@@ -65,7 +65,7 @@ usedModules ams d =
   where
 
   forDecls :: Declaration -> [ModuleName]
-  forDecls (ImportDeclaration mn _ _ _) =
+  forDecls (ImportDeclaration mn _ _) =
     -- Regardless of whether an imported module is qualified we still need to
     -- take into account its import to build an accurate list of dependencies.
     [mn]

--- a/src/Language/PureScript/Options.hs
+++ b/src/Language/PureScript/Options.hs
@@ -39,9 +39,6 @@ data Options = Options {
     -- Remove the comments from the generated js
   , optionsNoComments :: Bool
     -- |
-    -- The path to prepend to require statements
-  , optionsRequirePath :: Maybe FilePath
-    -- |
     -- Generate soure maps
   , optionsSourceMaps :: Bool
   } deriving Show
@@ -49,4 +46,4 @@ data Options = Options {
 -- |
 -- Default make options
 defaultOptions :: Options
-defaultOptions = Options False False Nothing False False False Nothing False
+defaultOptions = Options False False Nothing False False False False

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -52,7 +52,11 @@ withSourceSpan f p = do
   comments <- C.readComments
   x <- p
   end <- P.getPosition
-  let sp = SourceSpan (P.sourceName start) (toSourcePos start) (toSourcePos end)
+  input <- P.getInput
+  let end' = case input of
+        pt:_ -> ptPrevEndPos pt
+        _ -> Nothing
+  let sp = SourceSpan (P.sourceName start) (toSourcePos start) (toSourcePos $ fromMaybe end end')
   return $ f sp comments x
 
 kindedIdent :: TokenParser (String, Maybe Kind)
@@ -271,6 +275,7 @@ parseModulesFromFiles toFilePath input = do
   -- to a different spark.
   inParallel :: [Either P.ParseError (k, [Module])] -> [Either P.ParseError (k, [Module])]
   inParallel = withStrategy (parList rseq)
+
 
 toPositionedError :: P.ParseError -> ErrorMessage
 toPositionedError perr = ErrorMessage [ PositionedError (SourceSpan name start end) ] (ErrorParsingModule perr)

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -483,7 +483,7 @@ parseVarOrNamedBinder = do
   -- TODO: once operator aliases are finalized in 0.9, this 'try' won't be needed
   -- any more since identifiers in binders won't be 'Op's.
   name <- P.try C.parseIdent
-  let parseNamedBinder = NamedBinder name <$> (at *> C.indented *> parseBinder)
+  let parseNamedBinder = NamedBinder name <$> (at *> C.indented *> parseBinderAtom)
   parseNamedBinder <|> return (VarBinder name)
 
 parseNullBinder :: TokenParser Binder
@@ -515,26 +515,28 @@ parseBinder =
           return (BinaryNoParensBinder op)) P.AssocRight
       ]
     ]
+
   -- TODO: parsePolyType when adding support for polymorphic types
   postfixTable = [ \b -> flip TypedBinder b <$> (indented *> doubleColon *> parseType)
                  ]
-  parseBinderAtom :: TokenParser Binder
-  parseBinderAtom = P.choice
-                    [ parseNullBinder
-                    , LiteralBinder <$> parseCharLiteral
-                    , LiteralBinder <$> parseStringLiteral
-                    , LiteralBinder <$> parseBooleanLiteral
-                    , parseNumberLiteral
-                    , parseVarOrNamedBinder
-                    , parseConstructorBinder
-                    , parseObjectBinder
-                    , parseArrayBinder
-                    , ParensInBinder <$> parens parseBinder
-                    ] P.<?> "binder"
 
   parseOpBinder :: TokenParser Binder
   parseOpBinder = OpBinder <$> parseQualified (Op <$> symbol)
 
+parseBinderAtom :: TokenParser Binder
+parseBinderAtom = P.choice
+  [ parseNullBinder
+  , LiteralBinder <$> parseCharLiteral
+  , LiteralBinder <$> parseStringLiteral
+  , LiteralBinder <$> parseBooleanLiteral
+  , parseNumberLiteral
+  , parseVarOrNamedBinder
+  , parseConstructorBinder
+  , parseObjectBinder
+  , parseArrayBinder
+  , ParensInBinder <$> parens parseBinder
+  ] P.<?> "binder"
+  
 -- |
 -- Parse a binder as it would appear in a top level declaration
 --

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -132,28 +132,19 @@ parseFixityDeclaration = do
 
 parseImportDeclaration :: TokenParser Declaration
 parseImportDeclaration = do
-  (mn, declType, asQ, isOldSyntax) <- parseImportDeclaration'
-  return $ ImportDeclaration mn declType asQ isOldSyntax
+  (mn, declType, asQ) <- parseImportDeclaration'
+  return $ ImportDeclaration mn declType asQ
 
-parseImportDeclaration' :: TokenParser (ModuleName, ImportDeclarationType, Maybe ModuleName, Bool)
+parseImportDeclaration' :: TokenParser (ModuleName, ImportDeclarationType, Maybe ModuleName)
 parseImportDeclaration' = do
   reserved "import"
   indented
-  qualImport <|> stdImport
+  moduleName' <- moduleName
+  declType <- reserved "hiding" *> qualifyingList Hiding <|> qualifyingList Explicit
+  qName <- P.optionMaybe qualifiedName
+  return (moduleName', declType, qName)
   where
-  stdImport = do
-    moduleName' <- moduleName
-    declType <- reserved "hiding" *> qualifyingList Hiding <|> qualifyingList Explicit
-    qName <- P.optionMaybe qualifiedName
-    return (moduleName', declType, qName, False)
   qualifiedName = reserved "as" *> moduleName
-  qualImport = do
-    reserved "qualified"
-    indented
-    moduleName' <- moduleName
-    declType <- qualifyingList Explicit
-    qName <- qualifiedName
-    return (moduleName', declType, Just qName, True)
   qualifyingList expectedType = do
     declType <- P.optionMaybe (expectedType <$> (indented *> parens (commaSep parseDeclarationRef)))
     return $ fromMaybe Implicit declType

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -373,7 +373,7 @@ parseValueAtom = P.choice
                  , Literal <$> parseStringLiteral
                  , Literal <$> parseBooleanLiteral
                  , Literal <$> parseArrayLiteral parseValue
-                 , Literal <$> P.try (parseObjectLiteral parseIdentifierAndValue)
+                 , Literal <$> parseObjectLiteral parseIdentifierAndValue
                  , parseAbs
                  , P.try parseConstructor
                  , P.try parseVar
@@ -382,7 +382,6 @@ parseValueAtom = P.choice
                  , parseDo
                  , parseLet
                  , P.try $ Parens <$> parens parseValue
-                 , parseOperatorSection
                  , parseHole
                  ]
 
@@ -392,12 +391,6 @@ parseValueAtom = P.choice
 parseInfixExpr :: TokenParser Expr
 parseInfixExpr = P.between tick tick parseValue
                  <|> Var <$> parseQualified (Op <$> symbol)
-
-parseOperatorSection :: TokenParser Expr
-parseOperatorSection = parens $ left <|> right
-  where
-  right = OperatorSection <$> parseInfixExpr <* indented <*> (Right <$> indexersAndAccessors)
-  left = flip OperatorSection <$> (Left <$> indexersAndAccessors) <* indented <*> parseInfixExpr
 
 parseHole :: TokenParser Expr
 parseHole = Hole <$> holeLit

--- a/src/Language/PureScript/Parser/State.hs
+++ b/src/Language/PureScript/Parser/State.hs
@@ -26,5 +26,3 @@ data ParseState = ParseState {
     --
     indentationLevel :: P.Column
   } deriving Show
-
-

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -68,7 +68,6 @@ prettyPrintValue _ (Hole name) = text "?" <> text name
 prettyPrintValue d expr@AnonymousArgument{} = prettyPrintValueAtom d expr
 prettyPrintValue d expr@Constructor{} = prettyPrintValueAtom d expr
 prettyPrintValue d expr@Var{} = prettyPrintValueAtom d expr
-prettyPrintValue d expr@OperatorSection{} = prettyPrintValueAtom d expr
 prettyPrintValue d expr@BinaryNoParens{} = prettyPrintValueAtom d expr
 prettyPrintValue d expr@Parens{} = prettyPrintValueAtom d expr
 prettyPrintValue d expr@UnaryMinus{} = prettyPrintValueAtom d expr
@@ -80,8 +79,6 @@ prettyPrintValueAtom d (Literal l) = prettyPrintLiteralValue d l
 prettyPrintValueAtom _ AnonymousArgument = text "_"
 prettyPrintValueAtom _ (Constructor name) = text $ runProperName (disqualify name)
 prettyPrintValueAtom _ (Var ident) = text $ showIdent (disqualify ident)
-prettyPrintValueAtom d (OperatorSection op (Right val)) = ((text "(" <> prettyPrintValue (d - 1) op) `beforeWithSpace` prettyPrintValue (d - 1) val) `before` text ")"
-prettyPrintValueAtom d (OperatorSection op (Left val)) = ((text "(" <> prettyPrintValue (d - 1) val) `beforeWithSpace` prettyPrintValue (d - 1) op) `before` text ")"
 prettyPrintValueAtom d (BinaryNoParens op lhs rhs) =
   prettyPrintValue (d - 1) lhs `beforeWithSpace` printOp op `beforeWithSpace` prettyPrintValue (d - 1) rhs
   where

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -67,7 +67,6 @@ desugar :: (MonadSupply m, MonadError MultipleErrors m, MonadWriter MultipleErro
 desugar externs =
   map removeSignedLiterals
     >>> traverse desugarObjectConstructors
-    >=> traverse desugarOperatorSections
     >=> traverse desugarDoModule
     >=> desugarCasesModule
     >=> desugarTypeDeclarationsModule

--- a/src/Language/PureScript/Sugar/Names/Imports.hs
+++ b/src/Language/PureScript/Sugar/Names/Imports.hs
@@ -15,7 +15,7 @@ import Prelude.Compat
 import Data.Foldable (traverse_, for_)
 import Data.Function (on)
 import Data.List (find, sortBy, groupBy, (\\))
-import Data.Maybe (fromMaybe, isNothing, fromJust)
+import Data.Maybe (fromMaybe, isNothing)
 import Data.Traversable (for)
 
 import Control.Arrow (first)
@@ -43,8 +43,7 @@ findImports
   -> m (M.Map ModuleName [(Maybe SourceSpan, ImportDeclarationType, Maybe ModuleName)])
 findImports = foldM (go Nothing) M.empty
   where
-  go pos result (ImportDeclaration mn typ qual isOldSyntax) = do
-    when isOldSyntax . tell . errorMessage $ DeprecatedQualifiedSyntax mn (fromJust qual)
+  go pos result (ImportDeclaration mn typ qual) = do
     let imp = (pos, typ, qual)
     return $ M.insert mn (maybe [imp] (imp :) (mn `M.lookup` result)) result
   go _ result (PositionedDeclaration pos _ d) = warnAndRethrowWithPosition pos $ go (Just pos) result d
@@ -137,13 +136,13 @@ resolveImports env (Module ss coms currentModule decls exps) =
   updateImportRef :: Declaration -> m Declaration
   updateImportRef (PositionedDeclaration pos com d) =
     warnAndRethrowWithPosition pos $ PositionedDeclaration pos com <$> updateImportRef d
-  updateImportRef (ImportDeclaration mn typ qual isOldSyntax) = do
+  updateImportRef (ImportDeclaration mn typ qual) = do
     modExports <- getExports env mn
     typ' <- case typ of
       Implicit -> return Implicit
       Explicit refs -> Explicit <$> updateProperRef mn modExports `traverse` refs
       Hiding refs -> Hiding <$> updateProperRef mn modExports `traverse` refs
-    return $ ImportDeclaration mn typ' qual isOldSyntax
+    return $ ImportDeclaration mn typ' qual
   updateImportRef other = return other
 
   updateProperRef :: ModuleName -> Exports -> DeclarationRef -> m DeclarationRef

--- a/src/Language/PureScript/Sugar/ObjectWildcards.hs
+++ b/src/Language/PureScript/Sugar/ObjectWildcards.hs
@@ -39,10 +39,12 @@ desugarObjectConstructors (Module ss coms mn ds exts) = Module ss coms mn <$> ma
   desugarExpr (Parens b)
     | b' <- stripPositionInfo b
     , BinaryNoParens op val u <- b'
-    , isAnonymousArgument u = return $ OperatorSection op (Left val)
+    , isAnonymousArgument u = do arg <- freshIdent'
+                                 return $ Abs (Left arg) $ App (App op val) (Var (Qualified Nothing arg))
     | b' <- stripPositionInfo b
     , BinaryNoParens op u val <- b'
-    , isAnonymousArgument u = return $ OperatorSection op (Right val)
+    , isAnonymousArgument u = do arg <- freshIdent'
+                                 return $ Abs (Left arg) $ App (App op (Var (Qualified Nothing arg))) val
   desugarExpr (Literal (ObjectLiteral ps)) = wrapLambda (Literal . ObjectLiteral) ps
   desugarExpr (ObjectUpdate u ps) | isAnonymousArgument u = do
     obj <- freshIdent'

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -13,7 +13,6 @@
 module Language.PureScript.Sugar.Operators
   ( rebracket
   , removeSignedLiterals
-  , desugarOperatorSections
   ) where
 
 import Prelude ()
@@ -32,7 +31,6 @@ import Language.PureScript.Types
 
 import Control.Monad ((<=<))
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Supply.Class
 
 import Data.Function (on)
 import Data.Functor.Identity
@@ -259,28 +257,6 @@ customOperatorTable fixities =
     groups = groupBy ((==) `on` (\(_, p, _) -> p)) sorted
   in
     map (map (\(name, _, a) -> (name, a))) groups
-
-desugarOperatorSections
-  :: forall m
-   . (MonadSupply m, MonadError MultipleErrors m)
-  => Module
-  -> m Module
-desugarOperatorSections (Module ss coms mn ds exts) =
-  Module ss coms mn <$> traverse goDecl ds <*> pure exts
-  where
-
-  goDecl :: Declaration -> m Declaration
-  (goDecl, _, _) = everywhereOnValuesM return goExpr return
-
-  goExpr :: Expr -> m Expr
-  goExpr (OperatorSection op eVal) = do
-    arg <- freshIdent'
-    let var = Var (Qualified Nothing arg)
-        f2 a b = Abs (Left arg) $ App (App op a) b
-    return $ case eVal of
-      Left  val -> f2 val var
-      Right val -> f2 var val
-  goExpr other = return other
 
 updateTypes
   :: forall m

--- a/tests/TestPsci.hs
+++ b/tests/TestPsci.hs
@@ -60,7 +60,6 @@ completionTestData =
   -- import should complete module names
   , ("import Control.Monad.E",    map ("import Control.Monad.Eff" ++) ["", ".Unsafe", ".Class", ".Console"])
   , ("import Control.Monad.Eff.", map ("import Control.Monad.Eff" ++) [".Unsafe", ".Class", ".Console"])
-  , ("import qualified Control.Monad.Eff.", map ("import qualified Control.Monad.Eff" ++) [".Unsafe", ".Class", ".Console"])
 
   -- :load, :module should complete file paths
   , (":l tests/support/psci/", [":l tests/support/psci/Sample.purs"])
@@ -91,8 +90,7 @@ completionTestData =
 
   -- a few other import tests
   , ("impor", ["import"])
-  , ("import q", ["import qualified"])
-  , ("import ", map ("import " ++) supportModules ++ ["import qualified"])
+  , ("import ", map ("import " ++) supportModules)
   , ("import Prelude ", [])
 
   -- String and number literals should not be completed


### PR DESCRIPTION
An attempt at #1702. Don't seem to get much help from parsec here, this is bit of a fudge - and (at least?) the Parsec parsers used for string & number literals still consume whitespace (`lexeme` itself eats whitespace). I don't see any way around that other than not using `LanguageDef`.