### PR TITLE
0.9 Remove deprecated class import/export syntax

### DIFF
--- a/examples/docs/src/TypeClassWithoutMembers.purs
+++ b/examples/docs/src/TypeClassWithoutMembers.purs
@@ -8,4 +8,4 @@ module Intermediate
   ( module SomeTypeClass )
   where
 
-import SomeTypeClass (SomeClass)
+import SomeTypeClass (class SomeClass)

--- a/examples/failing/MissingClassMemberExport.purs
+++ b/examples/failing/MissingClassMemberExport.purs
@@ -1,5 +1,5 @@
 -- @shouldFailWith TransitiveExportError
-module Test (Foo) where
+module Test (class Foo) where
 
 import Prelude
 

--- a/examples/passing/ImportHiding.purs
+++ b/examples/passing/ImportHiding.purs
@@ -3,7 +3,7 @@ module Main where
 import Control.Monad.Eff.Console
 import Prelude hiding (
   show, -- a value
-  Show, -- a type class
+  class Show, -- a type class
   Unit(..)  -- a constructor
   )
 

--- a/psci/PSCi.hs
+++ b/psci/PSCi.hs
@@ -256,7 +256,6 @@ handleShowImportedModules = do
   showRef (P.TypeOpRef ident) = "type (" ++ N.runIdent ident ++ ")"
   showRef (P.ValueRef ident) = N.runIdent ident
   showRef (P.TypeClassRef pn) = "class " ++ N.runProperName pn
-  showRef (P.ProperRef pn) = pn
   showRef (P.TypeInstanceRef ident) = N.runIdent ident
   showRef (P.ModuleRef name) = "module " ++ N.runModuleName name
   showRef (P.PositionedDeclarationRef _ _ ref) = showRef ref

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -82,10 +82,6 @@ data DeclarationRef
   --
   | ModuleRef ModuleName
   -- |
-  -- An unspecified ProperName ref. This will be replaced with a TypeClassRef
-  -- or TypeRef during name desugaring.
-  | ProperRef String
-  -- |
   -- A declaration reference with source position information
   --
   | PositionedDeclarationRef SourceSpan [Comment] DeclarationRef
@@ -98,7 +94,6 @@ instance Eq DeclarationRef where
   (TypeClassRef name)    == (TypeClassRef name')    = name == name'
   (TypeInstanceRef name) == (TypeInstanceRef name') = name == name'
   (ModuleRef name)       == (ModuleRef name')       = name == name'
-  (ProperRef name)       == (ProperRef name')       = name == name'
   (PositionedDeclarationRef _ _ r) == r' = r == r'
   r == (PositionedDeclarationRef _ _ r') = r == r'
   _ == _ = False

--- a/src/Language/PureScript/AST/Exported.hs
+++ b/src/Language/PureScript/AST/Exported.hs
@@ -132,9 +132,6 @@ isExported (Just exps) decl = any (matches decl) exps
   matches (TypeSynonymDeclaration ident _ _) (TypeRef ident' _)    = ident == ident'
   matches (TypeClassDeclaration ident _ _ _) (TypeClassRef ident') = ident == ident'
 
-  matches (DataDeclaration _ ident _ _)      (ProperRef ident')    = runProperName ident == ident'
-  matches (TypeClassDeclaration ident _ _ _) (ProperRef ident')    = runProperName ident == ident'
-
   matches (FixityDeclaration _ name (Just (Qualified _ (AliasValue _)))) (ValueRef ident') = name == runIdent ident'
   matches (FixityDeclaration _ name (Just (Qualified _ (AliasConstructor _)))) (ValueRef ident') = name == runIdent ident'
   matches (FixityDeclaration _ name (Just (Qualified _ (AliasType _)))) (TypeOpRef ident') = name == runIdent ident'

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -141,8 +141,6 @@ data SimpleErrorMessage
   | UnusedDctorImport (ProperName 'TypeName)
   | UnusedDctorExplicitImport (ProperName 'TypeName) [ProperName 'ConstructorName]
   | DeprecatedOperatorDecl String
-  | DeprecatedClassImport ModuleName (ProperName 'ClassName)
-  | DeprecatedClassExport (ProperName 'ClassName)
   | DuplicateSelectiveImport ModuleName
   | DuplicateImport ModuleName ImportDeclarationType (Maybe ModuleName)
   | DuplicateImportRef String
@@ -328,8 +326,6 @@ errorCode em = case unwrapErrorMessage em of
   UnusedDctorImport{} -> "UnusedDctorImport"
   UnusedDctorExplicitImport{} -> "UnusedDctorExplicitImport"
   DeprecatedOperatorDecl{} -> "DeprecatedOperatorDecl"
-  DeprecatedClassImport{} -> "DeprecatedClassImport"
-  DeprecatedClassExport{} -> "DeprecatedClassExport"
   DuplicateSelectiveImport{} -> "DuplicateSelectiveImport"
   DuplicateImport{} -> "DuplicateImport"
   DuplicateImportRef{} -> "DuplicateImportRef"
@@ -453,7 +449,6 @@ wikiUri e = "https://github.com/purescript/purescript/wiki/Error-Code-" ++ error
 -- TODO Other possible suggestions:
 -- WildcardInferredType - source span not small enough
 -- DuplicateSelectiveImport - would require 2 ranges to remove and 1 insert
--- DeprecatedClassExport, DeprecatedClassImport, would want to replace smaller span?
 errorSuggestion :: SimpleErrorMessage -> Maybe ErrorSuggestion
 errorSuggestion err = case err of
   UnusedImport{} -> emptySuggestion
@@ -934,22 +929,6 @@ prettyPrintSingleError full level showWiki e = flip evalState defaultUnknownMap 
             , line "Support for value-declared operators will be removed in PureScript 0.9."
             ]
 
-    renderSimpleErrorMessage (DeprecatedClassImport mn name) =
-      paras [ line $ "Class import from " ++ runModuleName mn ++ " uses deprecated syntax that omits the 'class' keyword:"
-            , indent $ line $ runProperName name
-            , line "Should instead use the form:"
-            , indent $ line $ "class " ++ runProperName name
-            , line "The deprecated syntax will be removed in PureScript 0.9."
-            ]
-
-    renderSimpleErrorMessage (DeprecatedClassExport name) =
-      paras [ line "Class export uses deprecated syntax that omits the 'class' keyword:"
-            , indent $ line $ runProperName name
-            , line "Should instead use the form:"
-            , indent $ line $ "class " ++ runProperName name
-            , line "The deprecated syntax will be removed in PureScript 0.9."
-            ]
-
     renderSimpleErrorMessage (DuplicateSelectiveImport name) =
       line $ "There is an existing import of " ++ runModuleName name ++ ", consider merging the import lists"
 
@@ -1208,7 +1187,6 @@ prettyPrintRef (TypeRef pn (Just dctors)) = runProperName pn ++ "(" ++ intercala
 prettyPrintRef (TypeOpRef ident) = "type " ++ showIdent ident
 prettyPrintRef (ValueRef ident) = showIdent ident
 prettyPrintRef (TypeClassRef pn) = "class " ++ runProperName pn
-prettyPrintRef (ProperRef name) = name
 prettyPrintRef (TypeInstanceRef ident) = showIdent ident
 prettyPrintRef (ModuleRef name) = "module " ++ runModuleName name
 prettyPrintRef (PositionedDeclarationRef _ _ ref) = prettyPrintExport ref

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -233,10 +233,8 @@ addExplicitImport' decl moduleName imports =
     insertDeclIntoRefs (DataConstructor dtor tn _) refs =
       let
         dtor' = P.ProperName (T.unpack dtor)
-        -- TODO: Get rid of this once typeclasses can't be imported like types
-        refs' = properRefToTypeRef <$> refs
       in
-        updateAtFirstOrPrepend (matchType tn) (insertDtor dtor') (P.TypeRef tn (Just [dtor'])) refs'
+        updateAtFirstOrPrepend (matchType tn) (insertDtor dtor') (P.TypeRef tn (Just [dtor'])) refs
     insertDeclIntoRefs dr refs = List.nubBy ((==) `on` P.prettyPrintRef) (refFromDeclaration dr : refs)
 
     insertDtor dtor (P.TypeRef tn' dtors) =
@@ -246,11 +244,6 @@ addExplicitImport' decl moduleName imports =
         -- import Data.Maybe (Maybe(..)) -> import Data.Maybe (Maybe(Just))
         Nothing -> P.TypeRef tn' Nothing
     insertDtor _ refs = refs
-
-
-    -- TODO: Get rid of this once typeclasses can't be imported like types
-    properRefToTypeRef (P.ProperRef n) = P.TypeRef (P.ProperName n) (Just [])
-    properRefToTypeRef r = r
 
     matchType :: P.ProperName 'P.TypeName -> P.DeclarationRef -> Bool
     matchType tn (P.TypeRef n _) = tn == n

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -154,15 +154,15 @@ parseDeclarationRef :: TokenParser DeclarationRef
 parseDeclarationRef =
   withSourceSpan PositionedDeclarationRef
     $ (ValueRef <$> parseIdent)
-    <|> parseProperRef
+    <|> parseTypeRef
     <|> (TypeClassRef <$> (reserved "class" *> properName))
     <|> (ModuleRef <$> (indented *> reserved "module" *> moduleName))
     <|> (TypeOpRef <$> (indented *> reserved "type" *> parens (Op <$> symbol)))
   where
-  parseProperRef = do
+  parseTypeRef = do
     name <- properName
     dctors <- P.optionMaybe $ parens (symbol' ".." *> pure Nothing <|> Just <$> commaSep properName)
-    return $ maybe (ProperRef (runProperName name)) (TypeRef name) dctors
+    return $ TypeRef name (fromMaybe (Just []) dctors)
 
 parseTypeClassDeclaration :: TokenParser Declaration
 parseTypeClassDeclaration = do


### PR DESCRIPTION
We should wait until the Prelude updates (#2069) are in so we don't temporarily break the publish tests.