### PR TITLE
Improve license errors in psc-publish

### DIFF
--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -216,8 +216,12 @@ getBowerRepositoryInfo = either (userError . BadRepositoryField) return . tryExt
 
 checkLicense :: PackageMeta -> PrepareM ()
 checkLicense pkgMeta =
-  unless (any isValidSPDX (bowerLicense pkgMeta))
-    (userError NoLicenseSpecified)
+  case bowerLicense pkgMeta of
+    [] ->
+      userError NoLicenseSpecified
+    ls ->
+      unless (any isValidSPDX ls)
+        (userError InvalidLicense)
 
 -- |
 -- Check if a string is a valid SPDX license expression.

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -240,6 +240,7 @@ spdxExamples :: [Box]
 spdxExamples =
   map (indented . para)
     [ "* \"MIT\""
+    , "* \"Apache-2.0\""
     , "* \"BSD-2-Clause\""
     , "* \"GPL-2.0+\""
     , "* \"(GPL-3.0 OR MIT)\""


### PR DESCRIPTION
Currently, you get the 'no license specified' error even if you do
specify a license but it's not a valid SPDX license expression. There
is quite a lot of code in the wild which specifies a license but does
not use the SPDX format, and in these cases the error is not very good.

This PR does three things:
* adds a new error type to differentiate between these two cases
* removes the (now redundant) LicenseNotFound constructor
* Adds `Apache-2.0` to the SPDX license suggestions, as there seem to be quite a few packages that have `Apache 2.0` in their `license` field (i.e. with a space rather than a hyphen).