### PR TITLE
NoImplicitPrelude, enable some global extensions

### DIFF
--- a/psc-ide-server/Main.hs
+++ b/psc-ide-server/Main.hs
@@ -12,7 +12,6 @@
 -- The server accepting commands for psc-ide
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}

--- a/psci/PSCi/Directive.hs
+++ b/psci/PSCi/Directive.hs
@@ -1,18 +1,6 @@
------------------------------------------------------------------------------
---
--- Module      :  Directive
--- Copyright   :
--- License     :  MIT
---
--- Maintainer  :
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Directives for PSCI.
 --
------------------------------------------------------------------------------
-
 module PSCi.Directive where
 
 import Prelude ()
@@ -116,4 +104,3 @@ help =
   , (Show,    "import",   "Show all imported modules")
   , (Show,    "loaded",   "Show all loaded modules")
   ]
-

--- a/psci/PSCi/IO.hs
+++ b/psci/PSCi/IO.hs
@@ -1,17 +1,3 @@
------------------------------------------------------------------------------
---
--- Module      :  IO
--- Copyright   :  (c) 2013-14 Phil Freeman, (c) 2014 Gary Burgess, and other contributors
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
--- |
---
------------------------------------------------------------------------------
-
 module PSCi.IO where
 
 import Prelude ()

--- a/psci/PSCi/Parser.hs
+++ b/psci/PSCi/Parser.hs
@@ -1,18 +1,6 @@
------------------------------------------------------------------------------
---
--- Module      :  Parser
--- Copyright   :  (c) Phil Freeman 2014
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Parser for PSCI.
 --
------------------------------------------------------------------------------
-
 module PSCi.Parser
   ( parseCommand
   ) where

--- a/psci/PSCi/Types.hs
+++ b/psci/PSCi/Types.hs
@@ -1,18 +1,6 @@
------------------------------------------------------------------------------
---
--- Module      :  Types
--- Copyright   :  (c) Phil Freeman 2014
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Type declarations and associated basic functions for PSCI.
 --
------------------------------------------------------------------------------
-
 module PSCi.Types where
 
 import Prelude ()

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -264,7 +264,23 @@ library
 
                      System.IO.UTF8
 
-    extensions:      DataKinds
+    extensions:      ConstraintKinds
+                     DataKinds
+                     DeriveFunctor
+                     EmptyDataDecls
+                     FlexibleContexts
+                     GeneralizedNewtypeDeriving
+                     KindSignatures
+                     LambdaCase
+                     MultiParamTypeClasses
+                     NoImplicitPrelude
+                     PatternGuards
+                     PatternSynonyms
+                     RankNTypes
+                     RecordWildCards
+                     ScopedTypeVariables
+                     TupleSections
+                     ViewPatterns
     exposed: True
     buildable: True
     hs-source-dirs: src

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -269,7 +269,6 @@ library
                      DeriveFunctor
                      EmptyDataDecls
                      FlexibleContexts
-                     GeneralizedNewtypeDeriving
                      KindSignatures
                      LambdaCase
                      MultiParamTypeClasses

--- a/src/Control/Monad/Logger.hs
+++ b/src/Control/Monad/Logger.hs
@@ -1,33 +1,20 @@
------------------------------------------------------------------------------
---
--- Module      :  Control.Monad.Logger
--- Author      :  Phil Freeman
--- License     :  MIT (http://opensource.org/licenses/MIT)
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
--- | A replacement for WriterT IO which uses mutable references.
---
------------------------------------------------------------------------------
-
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 
+-- |
+-- A replacement for WriterT IO which uses mutable references.
+--
 module Control.Monad.Logger where
 
-import Prelude ()
 import Prelude.Compat
 
-import Data.IORef
-
 import Control.Monad (ap)
-import Control.Monad.IO.Class
-import Control.Monad.Writer.Class
 import Control.Monad.Base (MonadBase(..))
+import Control.Monad.IO.Class
 import Control.Monad.Trans.Control (MonadBaseControl(..))
+import Control.Monad.Writer.Class
+
+import Data.IORef
 
 -- | A replacement for WriterT IO which uses mutable references.
 newtype Logger w a = Logger { runLogger :: IORef w -> IO a }

--- a/src/Control/Monad/Supply.hs
+++ b/src/Control/Monad/Supply.hs
@@ -1,31 +1,16 @@
------------------------------------------------------------------------------
---
--- Module      :  Control.Monad.Supply
--- Copyright   :  (c) Phil Freeman 2014
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Fresh variable supply
 --
------------------------------------------------------------------------------
-
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
 module Control.Monad.Supply where
 
-import Prelude ()
 import Prelude.Compat
 
-import Data.Functor.Identity
-
-import Control.Monad.State
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Reader
+import Control.Monad.State
 import Control.Monad.Writer
+
+import Data.Functor.Identity
 
 newtype SupplyT m a = SupplyT { unSupplyT :: StateT Integer m a }
   deriving (Functor, Applicative, Monad, MonadTrans, MonadError e, MonadWriter w, MonadReader r)

--- a/src/Control/Monad/Supply.hs
+++ b/src/Control/Monad/Supply.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 -- |
 -- Fresh variable supply
 --

--- a/src/Control/Monad/Supply/Class.hs
+++ b/src/Control/Monad/Supply/Class.hs
@@ -1,24 +1,24 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
-
 -- |
 -- A class for monads supporting a supply of fresh names
 --
 module Control.Monad.Supply.Class where
 
+import Prelude.Compat
+
 import Control.Monad.Supply
 import Control.Monad.State
 
-class (Monad m) => MonadSupply m where
+class Monad m => MonadSupply m where
   fresh :: m Integer
 
-instance (Monad m) => MonadSupply (SupplyT m) where
+instance Monad m => MonadSupply (SupplyT m) where
   fresh = SupplyT $ do
     n <- get
     put (n + 1)
     return n
 
-instance (MonadSupply m) => MonadSupply (StateT s m) where
+instance MonadSupply m => MonadSupply (StateT s m) where
   fresh = lift fresh
 
-freshName :: (MonadSupply m) => m String
+freshName :: MonadSupply m => m String
 freshName = fmap (('$' :) . show) fresh

--- a/src/Language/PureScript.hs
+++ b/src/Language/PureScript.hs
@@ -1,31 +1,19 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript
--- Copyright   :  (c) 2013-14 Phil Freeman, (c) 2014 Gary Burgess, and other contributors
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- The main compiler module
 --
------------------------------------------------------------------------------
-
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Language.PureScript
   ( module P
   , version
   ) where
 
+
+import Control.Monad.Supply as P
+
 import Data.Version (Version)
 
 import Language.PureScript.AST as P
-import Language.PureScript.Crash as P
 import Language.PureScript.Comments as P
+import Language.PureScript.Crash as P
 import Language.PureScript.Environment as P
 import Language.PureScript.Errors as P hiding (indent)
 import Language.PureScript.Kinds as P
@@ -38,7 +26,6 @@ import Language.PureScript.Parser as P
 import Language.PureScript.Pretty as P
 import Language.PureScript.Renamer as P
 import Language.PureScript.Sugar as P
-import Control.Monad.Supply as P
 import Language.PureScript.TypeChecker as P
 import Language.PureScript.Types as P
 

--- a/src/Language/PureScript/AST/Binders.hs
+++ b/src/Language/PureScript/AST/Binders.hs
@@ -3,6 +3,8 @@
 --
 module Language.PureScript.AST.Binders where
 
+import Prelude.Compat
+
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.AST.Literals
 import Language.PureScript.Names

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -1,22 +1,18 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE LambdaCase #-}
 
 -- |
 -- Data types for modules and declarations
 --
 module Language.PureScript.AST.Declarations where
 
-import Prelude ()
 import Prelude.Compat
+
+import Control.Monad.Identity
 
 import Data.Aeson.TH
 import Data.List (nub, (\\))
 import Data.Maybe (mapMaybe)
-
 import qualified Data.Map as M
-
-import Control.Monad.Identity
 
 import Language.PureScript.AST.Binders
 import Language.PureScript.AST.Literals

--- a/src/Language/PureScript/AST/Exported.hs
+++ b/src/Language/PureScript/AST/Exported.hs
@@ -3,7 +3,10 @@ module Language.PureScript.AST.Exported
   , isExported
   ) where
 
+import Prelude.Compat
+
 import Control.Category ((>>>))
+
 import Data.Maybe (mapMaybe)
 
 import Language.PureScript.AST.Declarations

--- a/src/Language/PureScript/AST/Literals.hs
+++ b/src/Language/PureScript/AST/Literals.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE DeriveFunctor #-}
-
 -- |
 -- The core functional representation for literal values.
 --
 module Language.PureScript.AST.Literals where
+
+import Prelude.Compat
 
 -- |
 -- Data type for literal values. Parameterised so it can be used for Exprs and

--- a/src/Language/PureScript/AST/Operators.hs
+++ b/src/Language/PureScript/AST/Operators.hs
@@ -5,6 +5,8 @@
 --
 module Language.PureScript.AST.Operators where
 
+import Prelude.Compat
+
 import Data.Aeson ((.=))
 import qualified Data.Aeson as A
 

--- a/src/Language/PureScript/AST/SourcePos.hs
+++ b/src/Language/PureScript/AST/SourcePos.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- |
@@ -7,7 +5,6 @@
 --
 module Language.PureScript.AST.SourcePos where
 
-import Prelude ()
 import Prelude.Compat
 
 import Data.Aeson ((.=), (.:))

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -1,20 +1,17 @@
-{-# LANGUAGE ScopedTypeVariables #-}
-
 -- |
 -- AST traversal helpers
 --
 module Language.PureScript.AST.Traversals where
 
-import Prelude ()
 import Prelude.Compat
-
-import Data.Maybe (mapMaybe)
-import Data.List (mapAccumL)
-import Data.Foldable (fold)
-import qualified Data.Set as S
 
 import Control.Monad
 import Control.Arrow ((***), (+++))
+
+import Data.Foldable (fold)
+import Data.List (mapAccumL)
+import Data.Maybe (mapMaybe)
+import qualified Data.Set as S
 
 import Language.PureScript.AST.Binders
 import Language.PureScript.AST.Literals

--- a/src/Language/PureScript/Bundle.hs
+++ b/src/Language/PureScript/Bundle.hs
@@ -1,25 +1,9 @@
------------------------------------------------------------------------------
---
--- Module      :  psc-bundle
--- Copyright   :  (c) Phil Freeman 2015
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
--- | Bundles compiled PureScript modules for the browser.
+-- |
+-- Bundles compiled PureScript modules for the browser.
 --
 -- This module takes as input the individual generated modules from 'Language.PureScript.Make' and
 -- performs dead code elimination, filters empty modules,
 -- and generates the final Javascript bundle.
------------------------------------------------------------------------------
-
-{-# LANGUAGE PatternGuards #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-
 module Language.PureScript.Bundle (
      bundle
    , ModuleIdentifier(..)
@@ -30,19 +14,18 @@ module Language.PureScript.Bundle (
    , getExportedIdentifiers
 ) where
 
-import Prelude ()
 import Prelude.Compat
-
-import Data.List (nub, stripPrefix)
-import Data.Maybe (mapMaybe, catMaybes)
-import Data.Generics (everything, everywhere, mkQ, mkT)
-import Data.Graph
-import Data.Version (showVersion)
-
-import qualified Data.Set as S
 
 import Control.Monad
 import Control.Monad.Error.Class
+
+import Data.Generics (everything, everywhere, mkQ, mkT)
+import Data.Graph
+import Data.List (nub, stripPrefix)
+import Data.Maybe (mapMaybe, catMaybes)
+import Data.Version (showVersion)
+import qualified Data.Set as S
+
 import Language.JavaScript.Parser
 import Language.JavaScript.Parser.AST
 

--- a/src/Language/PureScript/CodeGen.hs
+++ b/src/Language/PureScript/CodeGen.hs
@@ -1,20 +1,8 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.CodeGen
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- A collection of modules related to code generation:
 --
 --  [@Language.PureScript.CodeGen.JS@] Code generator for Javascript
 --
------------------------------------------------------------------------------
-
 module Language.PureScript.CodeGen (module C) where
 
 import Language.PureScript.CodeGen.JS as C

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 -- |
 -- This module generates code in the simplified Javascript intermediate representation from Purescript code
 --
@@ -12,14 +7,7 @@ module Language.PureScript.CodeGen.JS
   , moduleToJs
   ) where
 
-import Prelude ()
 import Prelude.Compat
-
-import Data.List ((\\), delete, intersect)
-import Data.Maybe (isNothing, fromMaybe)
-import qualified Data.Map as M
-import qualified Data.Foldable as F
-import qualified Data.Traversable as T
 
 import Control.Arrow ((&&&))
 import Control.Monad (replicateM, forM, void)
@@ -27,14 +15,20 @@ import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Reader (MonadReader, asks)
 import Control.Monad.Supply.Class
 
-import Language.PureScript.Crash
+import Data.List ((\\), delete, intersect)
+import Data.Maybe (isNothing, fromMaybe)
+import qualified Data.Foldable as F
+import qualified Data.Map as M
+import qualified Data.Traversable as T
+
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.CodeGen.JS.AST as AST
 import Language.PureScript.CodeGen.JS.Common as Common
-import Language.PureScript.CoreFn
-import Language.PureScript.Names
-import Language.PureScript.Errors
 import Language.PureScript.CodeGen.JS.Optimizer
+import Language.PureScript.CoreFn
+import Language.PureScript.Crash
+import Language.PureScript.Errors
+import Language.PureScript.Names
 import Language.PureScript.Options
 import Language.PureScript.Traversals (sndM)
 import qualified Language.PureScript.Constants as C

--- a/src/Language/PureScript/CodeGen/JS/AST.hs
+++ b/src/Language/PureScript/CodeGen/JS/AST.hs
@@ -3,14 +3,13 @@
 --
 module Language.PureScript.CodeGen.JS.AST where
 
-import Prelude ()
 import Prelude.Compat
 
 import Control.Monad.Identity
 
+import Language.PureScript.AST (SourceSpan(..))
 import Language.PureScript.Comments
 import Language.PureScript.Traversals
-import Language.PureScript.AST (SourceSpan(..))
 
 -- |
 -- Built-in unary operators

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -3,6 +3,8 @@
 --
 module Language.PureScript.CodeGen.JS.Common where
 
+import Prelude.Compat
+
 import Data.Char
 import Data.List (intercalate)
 

--- a/src/Language/PureScript/CodeGen/JS/Optimizer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-
 -- |
 -- This module optimizes code in the simplified-Javascript intermediate representation.
 --
@@ -23,22 +21,20 @@
 --
 module Language.PureScript.CodeGen.JS.Optimizer (optimize) where
 
-import Prelude ()
 import Prelude.Compat
 
 import Control.Monad.Reader (MonadReader, ask, asks)
 import Control.Monad.Supply.Class (MonadSupply)
 
 import Language.PureScript.CodeGen.JS.AST
+import Language.PureScript.CodeGen.JS.Optimizer.Blocks
+import Language.PureScript.CodeGen.JS.Optimizer.Common
+import Language.PureScript.CodeGen.JS.Optimizer.Inliner
+import Language.PureScript.CodeGen.JS.Optimizer.MagicDo
+import Language.PureScript.CodeGen.JS.Optimizer.TCO
+import Language.PureScript.CodeGen.JS.Optimizer.Unused
 import Language.PureScript.Options
 import qualified Language.PureScript.Constants as C
-
-import Language.PureScript.CodeGen.JS.Optimizer.Common
-import Language.PureScript.CodeGen.JS.Optimizer.TCO
-import Language.PureScript.CodeGen.JS.Optimizer.MagicDo
-import Language.PureScript.CodeGen.JS.Optimizer.Inliner
-import Language.PureScript.CodeGen.JS.Optimizer.Unused
-import Language.PureScript.CodeGen.JS.Optimizer.Blocks
 
 -- |
 -- Apply a series of optimizer passes to simplified Javascript code

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/Blocks.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/Blocks.hs
@@ -1,22 +1,12 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.CodeGen.JS.Optimizer.Blocks
--- Copyright   :  (c) Phil Freeman 2013-14
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Optimizer steps for simplifying Javascript blocks
 --
------------------------------------------------------------------------------
-
 module Language.PureScript.CodeGen.JS.Optimizer.Blocks
   ( collapseNestedBlocks
   , collapseNestedIfs
   ) where
+
+import Prelude.Compat
 
 import Language.PureScript.CodeGen.JS.AST
 

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/Common.hs
@@ -3,6 +3,8 @@
 --
 module Language.PureScript.CodeGen.JS.Optimizer.Common where
 
+import Prelude.Compat
+
 import Data.Maybe (fromMaybe)
 
 import Language.PureScript.Crash

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/Inliner.hs
@@ -12,16 +12,16 @@ module Language.PureScript.CodeGen.JS.Optimizer.Inliner
   , evaluateIifes
   ) where
 
-import Prelude ()
 import Prelude.Compat
 
 import Control.Monad.Supply.Class (MonadSupply, freshName)
+
 import Data.Maybe (fromMaybe)
 
 import Language.PureScript.CodeGen.JS.AST
 import Language.PureScript.CodeGen.JS.Common
-import Language.PureScript.Names
 import Language.PureScript.CodeGen.JS.Optimizer.Common
+import Language.PureScript.Names
 import qualified Language.PureScript.Constants as C
 
 -- TODO: Potential bug:

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/MagicDo.hs
@@ -4,6 +4,8 @@
 --
 module Language.PureScript.CodeGen.JS.Optimizer.MagicDo (magicDo) where
 
+import Prelude.Compat
+
 import Data.List (nub)
 import Data.Maybe (fromJust, isJust)
 

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/TCO.hs
@@ -1,19 +1,9 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.CodeGen.JS.Optimizer.TCO
--- Copyright   :  (c) Phil Freeman 2013-14
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- This module implements tail call elimination.
 --
------------------------------------------------------------------------------
-
 module Language.PureScript.CodeGen.JS.Optimizer.TCO (tco) where
+
+import Prelude.Compat
 
 import Data.Monoid
 

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/Unused.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/Unused.hs
@@ -1,27 +1,16 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.CodeGen.JS.Optimizer.Unused
--- Copyright   :  (c) Phil Freeman 2013-14
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Removes unused variables
 --
------------------------------------------------------------------------------
-
 module Language.PureScript.CodeGen.JS.Optimizer.Unused
   ( removeCodeAfterReturnStatements
   , removeUnusedArg
   , removeUndefinedApp
   ) where
 
+import Prelude.Compat
+
 import Language.PureScript.CodeGen.JS.AST
 import Language.PureScript.CodeGen.JS.Optimizer.Common
-
 import qualified Language.PureScript.Constants as C
 
 removeCodeAfterReturnStatements :: JS -> JS

--- a/src/Language/PureScript/Comments.hs
+++ b/src/Language/PureScript/Comments.hs
@@ -5,6 +5,8 @@
 --
 module Language.PureScript.Comments where
 
+import Prelude.Compat
+
 import Data.Aeson.TH
 
 data Comment

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -1,8 +1,7 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE PatternSynonyms #-}
-
 -- | Various constants which refer to things in the Prelude
 module Language.PureScript.Constants where
+
+import Prelude.Compat
 
 import Language.PureScript.Names
 

--- a/src/Language/PureScript/CoreFn.hs
+++ b/src/Language/PureScript/CoreFn.hs
@@ -5,11 +5,11 @@ module Language.PureScript.CoreFn (
   module C
 ) where
 
+import Language.PureScript.AST.Literals as C
 import Language.PureScript.CoreFn.Ann as C
 import Language.PureScript.CoreFn.Binders as C
 import Language.PureScript.CoreFn.Desugar as C
 import Language.PureScript.CoreFn.Expr as C
-import Language.PureScript.AST.Literals as C
 import Language.PureScript.CoreFn.Meta as C
 import Language.PureScript.CoreFn.Module as C
 import Language.PureScript.CoreFn.Traversals as C

--- a/src/Language/PureScript/CoreFn/Ann.hs
+++ b/src/Language/PureScript/CoreFn/Ann.hs
@@ -1,23 +1,11 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.CoreFn.Ann
--- Copyright   :  (c) 2013-14 Phil Freeman, (c) 2014 Gary Burgess, and other contributors
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>, Gary Burgess <gary.burgess@gmail.com>
--- Stability   :  experimental
--- Portability :
---
--- | Type alias for basic annotations
---
------------------------------------------------------------------------------
-
 module Language.PureScript.CoreFn.Ann where
 
+import Prelude.Compat
+
 import Language.PureScript.AST.SourcePos
+import Language.PureScript.Comments
 import Language.PureScript.CoreFn.Meta
 import Language.PureScript.Types
-import Language.PureScript.Comments
 
 -- |
 -- Type alias for basic annotations

--- a/src/Language/PureScript/CoreFn/Binders.hs
+++ b/src/Language/PureScript/CoreFn/Binders.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE DeriveFunctor #-}
-
 -- |
 -- The core functional representation for binders
 --
 module Language.PureScript.CoreFn.Binders where
+
+import Prelude.Compat
 
 import Language.PureScript.AST.Literals
 import Language.PureScript.Names

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -1,30 +1,28 @@
 module Language.PureScript.CoreFn.Desugar (moduleToCoreFn) where
 
-import Prelude ()
 import Prelude.Compat
 
+import Control.Arrow (second, (***))
 
 import Data.Function (on)
 import Data.List (sort, sortBy, nub)
 import Data.Maybe (mapMaybe)
 import qualified Data.Map as M
 
-import Control.Arrow (second, (***))
-
-import Language.PureScript.Crash
+import Language.PureScript.AST.Literals
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.AST.Traversals
+import Language.PureScript.Comments
 import Language.PureScript.CoreFn.Ann
 import Language.PureScript.CoreFn.Binders
 import Language.PureScript.CoreFn.Expr
-import Language.PureScript.AST.Literals
 import Language.PureScript.CoreFn.Meta
 import Language.PureScript.CoreFn.Module
+import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Names
 import Language.PureScript.Sugar.TypeClasses (typeClassMemberName, superClassDictionaryNames)
 import Language.PureScript.Types
-import Language.PureScript.Comments
 import qualified Language.PureScript.AST as A
 
 -- |

--- a/src/Language/PureScript/CoreFn/Expr.hs
+++ b/src/Language/PureScript/CoreFn/Expr.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE DeriveFunctor #-}
-
 -- |
 -- The core functional representation
 --
 module Language.PureScript.CoreFn.Expr where
 
+import Prelude.Compat
+
 import Control.Arrow ((***))
 
-import Language.PureScript.CoreFn.Binders
 import Language.PureScript.AST.Literals
+import Language.PureScript.CoreFn.Binders
 import Language.PureScript.Names
 
 -- |

--- a/src/Language/PureScript/CoreFn/Meta.hs
+++ b/src/Language/PureScript/CoreFn/Meta.hs
@@ -3,6 +3,8 @@
 --
 module Language.PureScript.CoreFn.Meta where
 
+import Prelude.Compat
+
 import Language.PureScript.Names
 
 -- |

--- a/src/Language/PureScript/CoreFn/Module.hs
+++ b/src/Language/PureScript/CoreFn/Module.hs
@@ -1,24 +1,15 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.CoreFn.Module
--- Copyright   :  (c) 2013-14 Phil Freeman, (c) 2014 Gary Burgess, and other contributors
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>, Gary Burgess <gary.burgess@gmail.com>
--- Stability   :  experimental
--- Portability :
---
--- | The CoreFn module representation
---
------------------------------------------------------------------------------
-
 module Language.PureScript.CoreFn.Module where
+
+import Prelude.Compat
 
 import Language.PureScript.Comments
 import Language.PureScript.CoreFn.Expr
 import Language.PureScript.Names
 import Language.PureScript.Types
 
+-- |
+-- The CoreFn module representation
+--
 data Module a = Module
   { moduleComments :: [Comment]
   , moduleName :: ModuleName

--- a/src/Language/PureScript/CoreFn/Traversals.hs
+++ b/src/Language/PureScript/CoreFn/Traversals.hs
@@ -3,11 +3,13 @@
 --
 module Language.PureScript.CoreFn.Traversals where
 
+import Prelude.Compat
+
 import Control.Arrow (second, (***), (+++))
 
+import Language.PureScript.AST.Literals
 import Language.PureScript.CoreFn.Binders
 import Language.PureScript.CoreFn.Expr
-import Language.PureScript.AST.Literals
 
 everywhereOnValues :: (Bind a -> Bind a) ->
                       (Expr a -> Expr a) ->

--- a/src/Language/PureScript/Crash.hs
+++ b/src/Language/PureScript/Crash.hs
@@ -1,5 +1,7 @@
 module Language.PureScript.Crash where
 
+import Prelude.Compat
+
 -- | Exit with an error message and a crash report link.
 internalError :: String -> a
 internalError =

--- a/src/Language/PureScript/Docs.hs
+++ b/src/Language/PureScript/Docs.hs
@@ -6,9 +6,9 @@ module Language.PureScript.Docs (
   module Docs
 ) where
 
-import Language.PureScript.Docs.Types as Docs
-import Language.PureScript.Docs.RenderedCode.Types as Docs
-import Language.PureScript.Docs.RenderedCode.Render as Docs
 import Language.PureScript.Docs.Convert as Docs
-import Language.PureScript.Docs.Render as Docs
 import Language.PureScript.Docs.ParseAndBookmark as Docs
+import Language.PureScript.Docs.Render as Docs
+import Language.PureScript.Docs.RenderedCode.Render as Docs
+import Language.PureScript.Docs.RenderedCode.Types as Docs
+import Language.PureScript.Docs.Types as Docs

--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE FlexibleContexts #-}
-
 module Language.PureScript.Docs.AsMarkdown
   ( renderModulesAsMarkdown
   , Docs
@@ -9,19 +6,18 @@ module Language.PureScript.Docs.AsMarkdown
   , codeToString
   ) where
 
-import Prelude ()
 import Prelude.Compat
 
 import Control.Monad (unless, zipWithM_)
-import Control.Monad.Writer (Writer, tell, execWriter)
 import Control.Monad.Error.Class (MonadError)
+import Control.Monad.Writer (Writer, tell, execWriter)
+
 import Data.Foldable (for_)
 import Data.List (partition)
 
-import qualified Language.PureScript as P
-
-import Language.PureScript.Docs.Types
 import Language.PureScript.Docs.RenderedCode
+import Language.PureScript.Docs.Types
+import qualified Language.PureScript as P
 import qualified Language.PureScript.Docs.Convert as Convert
 import qualified Language.PureScript.Docs.Render as Render
 

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleContexts #-}
 
 -- | Functions for converting PureScript ASTs into values of the data types
 -- from Language.PureScript.Docs.
@@ -11,24 +9,23 @@ module Language.PureScript.Docs.Convert
   , collectBookmarks
   ) where
 
-import Prelude ()
 import Prelude.Compat
 
 import Control.Arrow ((&&&), second)
 import Control.Category ((>>>))
 import Control.Monad
+import Control.Monad.Error.Class (MonadError)
 import Control.Monad.State (runStateT)
 import Control.Monad.Writer.Strict (runWriterT)
-import Control.Monad.Error.Class (MonadError)
 import qualified Data.Map as Map
-
-import Text.Parsec (eof)
-import qualified Language.PureScript as P
-import qualified Language.PureScript.Constants as C
 
 import Language.PureScript.Docs.Convert.ReExports (updateReExports)
 import Language.PureScript.Docs.Convert.Single (convertSingleModule, collectBookmarks)
 import Language.PureScript.Docs.Types
+import qualified Language.PureScript as P
+import qualified Language.PureScript.Constants as C
+
+import Text.Parsec (eof)
 
 -- |
 -- Like convertModules, except that it takes a list of modules, together with

--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -1,29 +1,24 @@
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE FlexibleContexts #-}
-
 module Language.PureScript.Docs.Convert.ReExports
   ( updateReExports
   ) where
 
-import Prelude ()
 import Prelude.Compat
 
+import Control.Arrow ((&&&), first, second)
 import Control.Monad
-import Control.Monad.Trans.State.Strict (execState)
+import Control.Monad.Reader.Class (MonadReader, ask)
 import Control.Monad.State.Class (MonadState, gets, modify)
 import Control.Monad.Trans.Reader (runReaderT)
-import Control.Monad.Reader.Class (MonadReader, ask)
-import Control.Arrow ((&&&), first, second)
-import Data.Either
-import Data.Maybe (mapMaybe)
-import Data.Map (Map)
-import qualified Data.Map as Map
-import Data.Monoid ((<>))
+import Control.Monad.Trans.State.Strict (execState)
 
-import qualified Language.PureScript as P
+import Data.Either
+import Data.Map (Map)
+import Data.Maybe (mapMaybe)
+import Data.Monoid ((<>))
+import qualified Data.Map as Map
 
 import Language.PureScript.Docs.Types
+import qualified Language.PureScript as P
 
 -- |
 -- Given:

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -1,26 +1,21 @@
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE FlexibleContexts #-}
 
 module Language.PureScript.Docs.Convert.Single
   ( convertSingleModule
   , collectBookmarks
   ) where
 
-import Prelude ()
 import Prelude.Compat
-import Data.Maybe (mapMaybe, isNothing)
 
-import Control.Monad
 import Control.Category ((>>>))
+import Control.Monad
+
 import Data.Either
 import Data.List (nub, isPrefixOf, isSuffixOf)
-
-import qualified Language.PureScript as P
+import Data.Maybe (mapMaybe, isNothing)
 
 import Language.PureScript.Docs.Types
+import qualified Language.PureScript as P
 
 -- |
 -- Convert a single Module, but ignore re-exports; any re-exported types or

--- a/src/Language/PureScript/Docs/ParseAndBookmark.hs
+++ b/src/Language/PureScript/Docs/ParseAndBookmark.hs
@@ -1,26 +1,22 @@
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE FlexibleContexts #-}
-
 module Language.PureScript.Docs.ParseAndBookmark
   ( parseAndBookmark
   ) where
 
-import Prelude ()
 import Prelude.Compat
 
-import qualified Data.Map as M
 import Control.Arrow (first)
-
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.IO.Class (MonadIO(..))
 
-import Web.Bower.PackageMeta (PackageName)
+import qualified Data.Map as M
+
+import Language.PureScript.Docs.Convert (collectBookmarks)
+import Language.PureScript.Docs.Types
+import qualified Language.PureScript as P
 
 import System.IO.UTF8 (readUTF8File)
 
-import qualified Language.PureScript as P
-import Language.PureScript.Docs.Types
-import Language.PureScript.Docs.Convert (collectBookmarks)
+import Web.Bower.PackageMeta (PackageName)
 
 -- |
 -- Given:

--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE RecordWildCards #-}
-
--- | Functions for creating `RenderedCode` values from data types in
+-- |
+-- Functions for creating `RenderedCode` values from data types in
 -- Language.PureScript.Docs.Types.
 --
 -- These functions are the ones that are used in markdown/html documentation
@@ -10,13 +9,15 @@
 
 module Language.PureScript.Docs.Render where
 
+import Prelude.Compat
+
 import Data.Maybe (maybeToList)
 import Data.Monoid ((<>))
-import qualified Language.PureScript as P
 
-import Language.PureScript.Docs.Types
 import Language.PureScript.Docs.RenderedCode
+import Language.PureScript.Docs.Types
 import Language.PureScript.Docs.Utils.MonoidExtras
+import qualified Language.PureScript as P
 
 renderDeclaration :: Declaration -> RenderedCode
 renderDeclaration = renderDeclarationWithOptions defaultRenderTypeOptions

--- a/src/Language/PureScript/Docs/RenderedCode.hs
+++ b/src/Language/PureScript/Docs/RenderedCode.hs
@@ -2,10 +2,7 @@
 -- | Data types and functions for representing a simplified form of PureScript
 -- code, intended for use in e.g. HTML documentation.
 
-module Language.PureScript.Docs.RenderedCode (
-  module RenderedCode
-) where
+module Language.PureScript.Docs.RenderedCode (module RenderedCode) where
 
 import Language.PureScript.Docs.RenderedCode.Types as RenderedCode
 import Language.PureScript.Docs.RenderedCode.Render as RenderedCode
-

--- a/src/Language/PureScript/Docs/RenderedCode/Render.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Render.hs
@@ -1,33 +1,31 @@
 -- | Functions for producing RenderedCode values from PureScript Type values.
 
-module Language.PureScript.Docs.RenderedCode.Render (
-    renderType,
-    renderTypeAtom,
-    renderRow,
-    renderKind,
-    RenderTypeOptions(..),
-    defaultRenderTypeOptions,
-    renderTypeWithOptions
-) where
+module Language.PureScript.Docs.RenderedCode.Render
+  ( renderType
+  , renderTypeAtom
+  , renderRow
+  , renderKind
+  , RenderTypeOptions(..)
+  , defaultRenderTypeOptions
+  , renderTypeWithOptions
+  ) where
 
-import Prelude ()
 import Prelude.Compat
 
-import Data.Monoid ((<>))
 import Data.Maybe (fromMaybe)
+import Data.Monoid ((<>))
 
 import Control.Arrow ((<+>))
-import Control.PatternArrows
+import Control.PatternArrows as PA
 
 import Language.PureScript.Crash
-import Language.PureScript.Names
-import Language.PureScript.Types
-import Language.PureScript.Kinds
-import Language.PureScript.Pretty.Kinds
-import Language.PureScript.Environment
-
 import Language.PureScript.Docs.RenderedCode.Types
 import Language.PureScript.Docs.Utils.MonoidExtras
+import Language.PureScript.Environment
+import Language.PureScript.Kinds
+import Language.PureScript.Names
+import Language.PureScript.Pretty.Kinds
+import Language.PureScript.Types
 
 typeLiterals :: Pattern () Type RenderedCode
 typeLiterals = mkPattern match
@@ -184,9 +182,10 @@ renderKind = kind . prettyPrintKind
 -- Render code representing a Type, as it should appear inside parentheses
 --
 renderTypeAtom :: Type -> RenderedCode
-renderTypeAtom =
-  fromMaybe (internalError "Incomplete pattern") . pattern matchTypeAtom () . preprocessType defaultRenderTypeOptions
-
+renderTypeAtom
+  = fromMaybe (internalError "Incomplete pattern")
+  . PA.pattern matchTypeAtom ()
+  . preprocessType defaultRenderTypeOptions
 
 -- |
 -- Render code representing a Type
@@ -207,5 +206,7 @@ defaultRenderTypeOptions =
     }
 
 renderTypeWithOptions :: RenderTypeOptions -> Type -> RenderedCode
-renderTypeWithOptions opts =
-  fromMaybe (internalError "Incomplete pattern") . pattern matchType () . preprocessType opts
+renderTypeWithOptions opts
+  = fromMaybe (internalError "Incomplete pattern")
+  . PA.pattern matchType ()
+  . preprocessType opts

--- a/src/Language/PureScript/Docs/RenderedCode/Types.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Data types and functions for representing a simplified form of PureScript
@@ -32,12 +31,12 @@ module Language.PureScript.Docs.RenderedCode.Types
  , keywordFixity
  ) where
 
-import Prelude ()
 import Prelude.Compat
 
-import qualified Data.Aeson as A
-import Data.Aeson.BetterErrors
 import Control.Monad.Error.Class (MonadError(..))
+
+import Data.Aeson.BetterErrors
+import qualified Data.Aeson as A
 
 import qualified Language.PureScript as P
 

--- a/src/Language/PureScript/Docs/RenderedCode/Types.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Data types and functions for representing a simplified form of PureScript

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE RankNTypes #-}
 
 module Language.PureScript.Docs.Types
   ( module Language.PureScript.Docs.Types
@@ -9,24 +6,25 @@ module Language.PureScript.Docs.Types
   )
   where
 
-import Prelude ()
 import Prelude.Compat
 
 import Control.Arrow (first, (***))
 import Control.Monad (when)
-import Data.Maybe (mapMaybe)
-import Data.Version
+
 import Data.Aeson ((.=))
-import qualified Data.Aeson as A
 import Data.Aeson.BetterErrors
-import Text.ParserCombinators.ReadP (readP_to_S)
-import Data.Text (Text)
 import Data.ByteString.Lazy (ByteString)
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import Data.Version
+import qualified Data.Aeson as A
 import qualified Data.Text as T
 
-import Web.Bower.PackageMeta hiding (Version, displayError)
-
 import qualified Language.PureScript as P
+
+import Text.ParserCombinators.ReadP (readP_to_S)
+
+import Web.Bower.PackageMeta hiding (Version, displayError)
 
 import Language.PureScript.Docs.RenderedCode as ReExports
   (RenderedCode, asRenderedCode,

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -3,11 +3,13 @@
 
 module Language.PureScript.Environment where
 
-import Data.Maybe (fromMaybe)
+import Prelude.Compat
+
 import Data.Aeson.TH
+import Data.Maybe (fromMaybe)
+import qualified Data.Aeson as A
 import qualified Data.Map as M
 import qualified Data.Text as T
-import qualified Data.Aeson as A
 
 import Language.PureScript.Crash
 import Language.PureScript.Kinds

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -1,41 +1,35 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Language.PureScript.Errors where
 
-import Prelude ()
 import Prelude.Compat
 
-import Data.Ord (comparing)
-import Data.Char (isSpace)
-import Data.Either (lefts, rights)
-import Data.List (intercalate, transpose, nub, nubBy, sortBy, partition)
-import Data.Foldable (fold)
-import Data.Maybe (maybeToList)
-
-import qualified Data.Map as M
-
+import Control.Arrow ((&&&))
 import Control.Monad
-import Control.Monad.Writer
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Trans.State.Lazy
-import Control.Arrow ((&&&))
+import Control.Monad.Writer
 
-import Language.PureScript.Crash
+import Data.Char (isSpace)
+import Data.Either (lefts, rights)
+import Data.Foldable (fold)
+import Data.List (intercalate, transpose, nub, nubBy, sortBy, partition)
+import Data.Maybe (maybeToList)
+import Data.Ord (comparing)
+import qualified Data.Map as M
+
 import Language.PureScript.AST
+import Language.PureScript.Crash
+import Language.PureScript.Kinds
+import Language.PureScript.Names
 import Language.PureScript.Pretty
 import Language.PureScript.Types
-import Language.PureScript.Names
-import Language.PureScript.Kinds
-import qualified Language.PureScript.Constants as C
 import qualified Language.PureScript.Bundle as Bundle
-
-import qualified Text.PrettyPrint.Boxes as Box
+import qualified Language.PureScript.Constants as C
 
 import qualified Text.Parsec as P
 import qualified Text.Parsec.Error as PE
+import qualified Text.PrettyPrint.Boxes as Box
 import Text.Parsec.Error (Message(..))
 
 -- | A type of error messages

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Language.PureScript.Errors where

--- a/src/Language/PureScript/Errors/JSON.hs
+++ b/src/Language/PureScript/Errors/JSON.hs
@@ -1,22 +1,7 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Errors.JSON
--- Copyright   :  (c) 2013-15 Phil Freeman, (c) 2014-15 Gary Burgess
--- License     :  MIT (http://opensource.org/licenses/MIT)
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
--- |
---
------------------------------------------------------------------------------
-
 {-# LANGUAGE TemplateHaskell #-}
 
 module Language.PureScript.Errors.JSON where
 
-import Prelude ()
 import Prelude.Compat
 
 import qualified Data.Aeson.TH as A

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -1,9 +1,8 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 -- |
--- This module generates code for \"externs\" files, i.e. files containing only foreign import declarations.
+-- This module generates code for \"externs\" files, i.e. files containing only
+-- foreign import declarations.
 --
 module Language.PureScript.Externs
   ( ExternsFile(..)
@@ -14,24 +13,22 @@ module Language.PureScript.Externs
   , applyExternsFileToEnvironment
   ) where
 
-import Prelude ()
 import Prelude.Compat
 
+import Data.Aeson.TH
+import Data.Foldable (fold)
 import Data.List (find, foldl')
 import Data.Maybe (mapMaybe, maybeToList, fromMaybe)
-import Data.Foldable (fold)
 import Data.Version (showVersion)
-import Data.Aeson.TH
-
 import qualified Data.Map as M
 
-import Language.PureScript.Crash
 import Language.PureScript.AST
+import Language.PureScript.Crash
 import Language.PureScript.Environment
-import Language.PureScript.Names
-import Language.PureScript.Types
 import Language.PureScript.Kinds
+import Language.PureScript.Names
 import Language.PureScript.TypeClassDictionaries
+import Language.PureScript.Types
 
 import Paths_purescript as Paths
 

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -12,13 +12,9 @@
 -- Interface for the psc-ide-server
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PackageImports        #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TupleSections         #-}
 
 module Language.PureScript.Ide
        ( handleCommand

--- a/src/Language/PureScript/Ide/CaseSplit.hs
+++ b/src/Language/PureScript/Ide/CaseSplit.hs
@@ -12,14 +12,8 @@
 -- Casesplitting and adding function clauses
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PackageImports        #-}
-{-# LANGUAGE RecordWildCards       #-}
 
 module Language.PureScript.Ide.CaseSplit
        ( WildcardAnnotations()

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -12,9 +12,7 @@
 -- Datatypes for the commands psc-ide accepts
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
 
 module Language.PureScript.Ide.Command where
 

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -17,6 +17,7 @@ module Language.PureScript.Ide.Error
        (ErrorMsg, PscIdeError(..), textError)
        where
 
+import           Prelude.Compat
 import           Data.Aeson
 import           Data.Monoid
 import           Data.Text                     (Text, pack)

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -12,11 +12,7 @@
 -- Handles externs files for psc-ide
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
 
 module Language.PureScript.Ide.Externs
   ( ExternDecl(..),

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -12,9 +12,7 @@
 -- Filters for psc-ide commands
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
 
 module Language.PureScript.Ide.Filter
        ( Filter

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -12,6 +12,7 @@
 -- Filters for psc-ide commands
 -----------------------------------------------------------------------------
 
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
 
 module Language.PureScript.Ide.Filter

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -12,10 +12,6 @@
 -- Provides functionality to manage imports
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PackageImports        #-}
 
@@ -34,6 +30,7 @@ module Language.PureScript.Ide.Imports
        )
        where
 
+import           Prelude.Compat
 import           Control.Applicative                ((<|>))
 import           Control.Monad.Error.Class
 import           Control.Monad.IO.Class

--- a/src/Language/PureScript/Ide/Matcher.hs
+++ b/src/Language/PureScript/Ide/Matcher.hs
@@ -12,6 +12,7 @@
 -- Matchers for psc-ide commands
 -----------------------------------------------------------------------------
 
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
 
 module Language.PureScript.Ide.Matcher

--- a/src/Language/PureScript/Ide/Matcher.hs
+++ b/src/Language/PureScript/Ide/Matcher.hs
@@ -12,9 +12,7 @@
 -- Matchers for psc-ide commands
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
 
 module Language.PureScript.Ide.Matcher
        ( Matcher

--- a/src/Language/PureScript/Ide/Pursuit.hs
+++ b/src/Language/PureScript/Ide/Pursuit.hs
@@ -13,7 +13,6 @@
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Language.PureScript.Ide.Pursuit where
 

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -1,12 +1,9 @@
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PackageImports        #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE TupleSections         #-}
 
 module Language.PureScript.Ide.Rebuild where
+
+import           Prelude.Compat
 
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.State

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -14,8 +14,6 @@
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternGuards     #-}
-{-# LANGUAGE TupleSections     #-}
 
 module Language.PureScript.Ide.Reexports where
 

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -12,8 +12,6 @@
 -- Getting declarations from PureScript sourcefiles
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 
 module Language.PureScript.Ide.SourceFile where

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -12,13 +12,9 @@
 -- Functions to access psc-ide's state
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PackageImports        #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TupleSections         #-}
 
 module Language.PureScript.Ide.State where
 

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -12,11 +12,7 @@
 -- Type definitions for psc-ide
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE ConstraintKinds            #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
 
 module Language.PureScript.Ide.Types where
 

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -16,6 +16,7 @@
 
 module Language.PureScript.Ide.Util where
 
+import           Prelude.Compat
 import           Data.Aeson
 import           Data.Text                     (Text)
 import qualified Data.Text                     as T

--- a/src/Language/PureScript/Kinds.hs
+++ b/src/Language/PureScript/Kinds.hs
@@ -2,7 +2,6 @@
 
 module Language.PureScript.Kinds where
 
-import Prelude ()
 import Prelude.Compat
 
 import qualified Data.Aeson.TH as A

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -1,30 +1,24 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE PatternGuards #-}
-
 -- |
 -- This module implements a simple linting pass on the PureScript AST.
 --
 module Language.PureScript.Linter (lint, module L) where
 
-import Prelude ()
 import Prelude.Compat
+
+import Control.Monad.Writer.Class
 
 import Data.List (nub, (\\))
 import Data.Maybe (mapMaybe)
 import Data.Monoid
-
 import qualified Data.Set as S
 
-import Control.Monad.Writer.Class
-
-import Language.PureScript.Crash
 import Language.PureScript.AST
-import Language.PureScript.Names
+import Language.PureScript.Crash
 import Language.PureScript.Errors
-import Language.PureScript.Types
 import Language.PureScript.Linter.Exhaustive as L
 import Language.PureScript.Linter.Imports as L
+import Language.PureScript.Names
+import Language.PureScript.Types
 
 -- | Lint the PureScript AST.
 -- |

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 -- |
 -- Module for exhaustivity checking over pattern matching definitions
 -- The algorithm analyses the clauses of a definition one by one from top
@@ -11,31 +8,30 @@ module Language.PureScript.Linter.Exhaustive
   ( checkExhaustiveExpr
   ) where
 
-import Prelude ()
 import Prelude.Compat
 
-import qualified Data.Map as M
-import Data.Maybe (fromMaybe)
-import Data.List (foldl', sortBy, nub)
-import Data.Function (on)
-
-import Control.Monad (unless)
 import Control.Applicative
 import Control.Arrow (first, second)
+import Control.Monad (unless)
 import Control.Monad.Writer.Class
 
-import Language.PureScript.Crash
-import qualified Language.PureScript.Constants as C
+import Data.Function (on)
+import Data.List (foldl', sortBy, nub)
+import Data.Maybe (fromMaybe)
+import qualified Data.Map as M
+
 import Language.PureScript.AST.Binders
-import Language.PureScript.AST.Literals
 import Language.PureScript.AST.Declarations
+import Language.PureScript.AST.Literals
+import Language.PureScript.Crash
 import Language.PureScript.Environment
-import Language.PureScript.Names as P
+import Language.PureScript.Errors
 import Language.PureScript.Kinds
+import Language.PureScript.Names as P
 import Language.PureScript.Pretty.Values (prettyPrintBinderAtom)
 import Language.PureScript.Traversals
 import Language.PureScript.Types as P
-import Language.PureScript.Errors
+import qualified Language.PureScript.Constants as C
 
 -- | There are two modes of failure for the redundancy check:
 --

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -1,13 +1,9 @@
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE FlexibleContexts #-}
-
 module Language.PureScript.Linter.Imports
   ( lintImports
   , Name(..)
   , UsedImports()
   ) where
 
-import Prelude ()
 import Prelude.Compat
 
 import Control.Monad (unless, when)
@@ -23,12 +19,10 @@ import qualified Data.Map as M
 import Language.PureScript.AST.Declarations
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.Crash
-import Language.PureScript.Names as P
-
 import Language.PureScript.Errors
+import Language.PureScript.Names as P
 import Language.PureScript.Sugar.Names.Env
 import Language.PureScript.Sugar.Names.Imports
-
 import qualified Language.PureScript.Constants as C
 
 -- | Imported name used in some type or expression.

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -1,10 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Language.PureScript.Make
@@ -23,56 +16,41 @@ module Language.PureScript.Make
   , buildMakeActions
   ) where
 
-import Prelude ()
 import Prelude.Compat
 
 import Control.Applicative ((<|>))
-import Control.Monad hiding (sequence)
-import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Writer.Class (MonadWriter(..))
-import Control.Monad.Trans.Class (MonadTrans(..))
-import Control.Monad.Trans.Except
-import Control.Monad.IO.Class
-import Control.Monad.Reader (MonadReader(..), ReaderT(..), asks)
-import Control.Monad.Logger
-import Control.Monad.Supply
-import Control.Monad.Base (MonadBase(..))
-import Control.Monad.Trans.Control (MonadBaseControl(..))
-
 import Control.Concurrent.Lifted as C
+import Control.Monad hiding (sequence)
+import Control.Monad.Base (MonadBase(..))
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.IO.Class
+import Control.Monad.Logger
+import Control.Monad.Reader (MonadReader(..), ReaderT(..), asks)
+import Control.Monad.Supply
+import Control.Monad.Trans.Class (MonadTrans(..))
+import Control.Monad.Trans.Control (MonadBaseControl(..))
+import Control.Monad.Trans.Except
+import Control.Monad.Writer.Class (MonadWriter(..))
 
+import Data.Aeson (encode, decode)
+import Data.Either (partitionEithers)
+import Data.Foldable (for_)
 import Data.List (foldl', sort)
 import Data.Maybe (fromMaybe, catMaybes)
-import Data.Either (partitionEithers)
-import Data.Time.Clock
 import Data.String (fromString)
-import Data.Foldable (for_)
+import Data.Time.Clock
 import Data.Traversable (for)
 import Data.Version (showVersion)
-import Data.Aeson (encode, decode)
 import qualified Data.ByteString.Lazy as B
 import qualified Data.ByteString.UTF8 as BU8
-import qualified Data.Set as S
 import qualified Data.Map as M
+import qualified Data.Set as S
 
-import qualified Text.Parsec as Parsec
-
-import SourceMap.Types
-import SourceMap
-
-import System.Directory
-       (doesFileExist, getModificationTime, createDirectoryIfMissing, getCurrentDirectory)
-import System.FilePath ((</>), takeDirectory, makeRelative, splitPath, normalise)
-import System.IO.Error (tryIOError)
-import System.IO.UTF8 (readUTF8File, writeUTF8File)
-
-import qualified Language.JavaScript.Parser as JS
-
-import Language.PureScript.Crash
 import Language.PureScript.AST
-import Language.PureScript.Externs
+import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Errors
+import Language.PureScript.Externs
 import Language.PureScript.Linter
 import Language.PureScript.ModuleDependencies
 import Language.PureScript.Names
@@ -82,13 +60,24 @@ import Language.PureScript.Pretty.Common(SMap(..))
 import Language.PureScript.Renamer
 import Language.PureScript.Sugar
 import Language.PureScript.TypeChecker
-import qualified Language.PureScript.Constants as C
+import qualified Language.JavaScript.Parser as JS
 import qualified Language.PureScript.Bundle as Bundle
+import qualified Language.PureScript.CodeGen.JS as J
+import qualified Language.PureScript.Constants as C
+import qualified Language.PureScript.CoreFn as CF
 import qualified Language.PureScript.Parser as PSParser
 
-import qualified Language.PureScript.CodeGen.JS as J
-import qualified Language.PureScript.CoreFn as CF
 import qualified Paths_purescript as Paths
+
+import SourceMap
+import SourceMap.Types
+
+import System.Directory (doesFileExist, getModificationTime, createDirectoryIfMissing, getCurrentDirectory)
+import System.FilePath ((</>), takeDirectory, makeRelative, splitPath, normalise)
+import System.IO.Error (tryIOError)
+import System.IO.UTF8 (readUTF8File, writeUTF8File)
+
+import qualified Text.Parsec as Parsec
 
 -- | Progress messages from the make process
 data ProgressMessage

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Language.PureScript.Make

--- a/src/Language/PureScript/ModuleDependencies.hs
+++ b/src/Language/PureScript/ModuleDependencies.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE FlexibleContexts #-}
-
 -- |
 -- Provides the ability to sort modules based on module dependencies
 --
-module Language.PureScript.ModuleDependencies (
-  sortModules,
-  ModuleGraph
-) where
+module Language.PureScript.ModuleDependencies
+  ( sortModules
+  , ModuleGraph
+  ) where
+
+import Prelude.Compat
 
 import Control.Monad.Error.Class (MonadError(..))
 
@@ -14,11 +14,11 @@ import Data.Graph
 import Data.List (nub)
 import Data.Maybe (fromMaybe)
 
-import Language.PureScript.Crash
 import Language.PureScript.AST
+import Language.PureScript.Crash
+import Language.PureScript.Errors
 import Language.PureScript.Names
 import Language.PureScript.Types
-import Language.PureScript.Errors
 
 -- | A list of modules with their transitive dependencies
 type ModuleGraph = [(ModuleName, [ModuleName])]

--- a/src/Language/PureScript/Names.hs
+++ b/src/Language/PureScript/Names.hs
@@ -1,19 +1,18 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE KindSignatures #-}
 
 -- |
 -- Data types for names
 --
 module Language.PureScript.Names where
 
+import Prelude.Compat
+
 import Control.Monad (liftM)
 import Control.Monad.Supply.Class
 
-import Data.List
 import Data.Aeson
 import Data.Aeson.TH
+import Data.List
 
 -- |
 -- Names for value identifiers

--- a/src/Language/PureScript/Options.hs
+++ b/src/Language/PureScript/Options.hs
@@ -1,19 +1,9 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Options
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- The data type of compiler options
 --
------------------------------------------------------------------------------
-
 module Language.PureScript.Options where
+
+import Prelude.Compat
 
 -- |
 -- The data type of compiler options

--- a/src/Language/PureScript/Parser.hs
+++ b/src/Language/PureScript/Parser.hs
@@ -1,13 +1,3 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Parser
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- A collection of parsers for core data types:
 --
@@ -23,14 +13,12 @@
 --
 --  [@Language.PureScript.Parser.Common@] Common parsing utility functions
 --
------------------------------------------------------------------------------
-
 module Language.PureScript.Parser (module P) where
 
 import Language.PureScript.Parser.Common as P
-import Language.PureScript.Parser.Types as P
-import Language.PureScript.Parser.State as P
-import Language.PureScript.Parser.Kinds as P
-import Language.PureScript.Parser.Lexer as P
 import Language.PureScript.Parser.Declarations as P
 import Language.PureScript.Parser.JS as P
+import Language.PureScript.Parser.Kinds as P
+import Language.PureScript.Parser.Lexer as P
+import Language.PureScript.Parser.State as P
+import Language.PureScript.Parser.Types as P

--- a/src/Language/PureScript/Parser/Common.hs
+++ b/src/Language/PureScript/Parser/Common.hs
@@ -1,19 +1,18 @@
-{-# LANGUAGE FlexibleContexts #-}
-
 -- |
--- Constants, and utility functions to be used when parsing
+-- Constants and utility functions to be used when parsing
 --
 module Language.PureScript.Parser.Common where
+
+import Prelude.Compat
 
 import Control.Applicative
 import Control.Monad (guard)
 
+import Language.PureScript.AST.SourcePos
 import Language.PureScript.Comments
+import Language.PureScript.Names
 import Language.PureScript.Parser.Lexer
 import Language.PureScript.Parser.State
-import Language.PureScript.Names
-
-import Language.PureScript.AST.SourcePos
 
 import qualified Text.Parsec as P
 

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -1,22 +1,18 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-
 -- |
 -- Parsers for module definitions and declarations
 --
-module Language.PureScript.Parser.Declarations (
-    parseDeclaration,
-    parseModule,
-    parseModules,
-    parseModulesFromFiles,
-    parseValue,
-    parseGuard,
-    parseBinder,
-    parseBinderNoParens,
-    parseImportDeclaration',
-    parseLocalDeclaration
-) where
+module Language.PureScript.Parser.Declarations
+  ( parseDeclaration
+  , parseModule
+  , parseModules
+  , parseModulesFromFiles
+  , parseValue
+  , parseGuard
+  , parseBinder
+  , parseBinderNoParens
+  , parseImportDeclaration'
+  , parseLocalDeclaration
+  ) where
 
 import Prelude hiding (lex)
 
@@ -541,7 +537,7 @@ parseBinderAtom = P.choice
   , parseArrayBinder
   , ParensInBinder <$> parens parseBinder
   ] P.<?> "binder"
-  
+
 -- |
 -- Parse a binder as it would appear in a top level declaration
 --

--- a/src/Language/PureScript/Parser/JS.hs
+++ b/src/Language/PureScript/Parser/JS.hs
@@ -1,37 +1,23 @@
------------------------------------------------------------------------------
---
--- Module      :  Foreign
--- Copyright   :  (c) 2013-14 Phil Freeman, (c) 2014 Gary Burgess, and other contributors
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>, Gary Burgess <gary.burgess@gmail.com>
--- Stability   :  experimental
--- Portability :
---
--- |
---
------------------------------------------------------------------------------
-
-{-# LANGUAGE FlexibleContexts #-}
-
 module Language.PureScript.Parser.JS
   ( ForeignJS()
   , parseForeignModulesFromFiles
   ) where
 
-import Prelude ()
 import Prelude.Compat hiding (lex)
 
 import Control.Monad (forM_, when, msum)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Writer.Class (MonadWriter(..))
+
 import Data.Function (on)
 import Data.List (sortBy, groupBy)
+import qualified Data.Map as M
+
 import Language.PureScript.Errors
 import Language.PureScript.Names
 import Language.PureScript.Parser.Common
 import Language.PureScript.Parser.Lexer
-import qualified Data.Map as M
+
 import qualified Text.Parsec as PS
 
 type ForeignJS = String

--- a/src/Language/PureScript/Parser/Kinds.hs
+++ b/src/Language/PureScript/Parser/Kinds.hs
@@ -1,28 +1,14 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Parser.Kinds
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- A parser for kinds
 --
------------------------------------------------------------------------------
+module Language.PureScript.Parser.Kinds (parseKind) where
 
-module Language.PureScript.Parser.Kinds (
-    parseKind
-) where
-
-import Prelude ()
 import Prelude.Compat
 
 import Language.PureScript.Kinds
 import Language.PureScript.Parser.Common
 import Language.PureScript.Parser.Lexer
+
 import qualified Text.Parsec as P
 import qualified Text.Parsec.Expr as P
 

--- a/src/Language/PureScript/Parser/Lexer.hs
+++ b/src/Language/PureScript/Parser/Lexer.hs
@@ -1,20 +1,6 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Parser.Lexer
--- Copyright   :  (c) Phil Freeman 2014
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- The first step in the parsing process - turns source code into a list of lexemes
 --
------------------------------------------------------------------------------
-
-{-# LANGUAGE TupleSections #-}
-
 module Language.PureScript.Parser.Lexer
   ( PositionedToken(..)
   , Token()
@@ -75,15 +61,14 @@ module Language.PureScript.Parser.Lexer
 
 import Prelude hiding (lex)
 
-import Data.Char (isSpace, isAscii, isSymbol, isAlphaNum)
-
+import Control.Applicative
 import Control.Monad (void, guard)
+
+import Data.Char (isSpace, isAscii, isSymbol, isAlphaNum)
 import Data.Functor.Identity
 
-import Control.Applicative
-
-import Language.PureScript.Parser.State
 import Language.PureScript.Comments
+import Language.PureScript.Parser.State
 
 import qualified Text.Parsec as P
 import qualified Text.Parsec.Token as PT

--- a/src/Language/PureScript/Parser/State.hs
+++ b/src/Language/PureScript/Parser/State.hs
@@ -1,19 +1,9 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Parser.State
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- State for the parser monad
 --
------------------------------------------------------------------------------
-
 module Language.PureScript.Parser.State where
+
+import Prelude.Compat
 
 import qualified Text.Parsec as P
 

--- a/src/Language/PureScript/Parser/Types.hs
+++ b/src/Language/PureScript/Parser/Types.hs
@@ -1,21 +1,22 @@
-module Language.PureScript.Parser.Types (
-    parseType,
-    parsePolyType,
-    noWildcards,
-    parseTypeAtom
-) where
+module Language.PureScript.Parser.Types
+  ( parseType
+  , parsePolyType
+  , noWildcards
+  , parseTypeAtom
+  ) where
+
+import Prelude.Compat
 
 import Control.Applicative
 import Control.Monad (when, unless)
 
+import Language.PureScript.AST.SourcePos
+import Language.PureScript.Environment
 import Language.PureScript.Names
-import Language.PureScript.Types
 import Language.PureScript.Parser.Common
 import Language.PureScript.Parser.Kinds
 import Language.PureScript.Parser.Lexer
-import Language.PureScript.Environment
-
-import Language.PureScript.AST.SourcePos
+import Language.PureScript.Types
 
 import qualified Text.Parsec as P
 import qualified Text.Parsec.Expr as P

--- a/src/Language/PureScript/Pretty.hs
+++ b/src/Language/PureScript/Pretty.hs
@@ -1,13 +1,3 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Pretty
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- A collection of pretty printers for core data types:
 --
@@ -19,11 +9,9 @@
 --
 --  [@Language.PureScript.Pretty.JS@] Pretty printer for values, used for code generation
 --
------------------------------------------------------------------------------
-
 module Language.PureScript.Pretty (module P) where
 
-import Language.PureScript.Pretty.Kinds as P
-import Language.PureScript.Pretty.Values as P
-import Language.PureScript.Pretty.Types as P
 import Language.PureScript.Pretty.JS as P
+import Language.PureScript.Pretty.Kinds as P
+import Language.PureScript.Pretty.Types as P
+import Language.PureScript.Pretty.Values as P

--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -1,30 +1,16 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Pretty.Common
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Common pretty-printing utility functions
 --
------------------------------------------------------------------------------
-
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
 module Language.PureScript.Pretty.Common where
 
-import Prelude ()
 import Prelude.Compat
 
 import Control.Monad.State (StateT, modify, get)
+
 import Data.List (elemIndices, intersperse)
 
-import Language.PureScript.Parser.Lexer (reservedPsNames, isUnquotedKey)
 import Language.PureScript.AST (SourcePos(..), SourceSpan(..))
+import Language.PureScript.Parser.Lexer (reservedPsNames, isUnquotedKey)
 
 import Text.PrettyPrint.Boxes
 

--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 -- |
 -- Common pretty-printing utility functions
 --

--- a/src/Language/PureScript/Pretty/JS.hs
+++ b/src/Language/PureScript/Pretty/JS.hs
@@ -1,44 +1,29 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Pretty.JS
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Pretty printer for the Javascript AST
 --
------------------------------------------------------------------------------
+module Language.PureScript.Pretty.JS
+  ( prettyPrintJS
+  , prettyPrintJSWithSourceMaps
+  ) where
 
-module Language.PureScript.Pretty.JS (
-    prettyPrintJS, prettyPrintJSWithSourceMaps
-) where
-
-import Prelude ()
 import Prelude.Compat
-
-import Data.Maybe (fromMaybe)
 
 import Control.Arrow ((<+>))
 import Control.Monad.State hiding (sequence)
 import Control.PatternArrows
 import qualified Control.Arrow as A
 
-import Language.PureScript.Crash
-import Language.PureScript.CodeGen.JS.AST
-import Language.PureScript.CodeGen.JS.Common
-import Language.PureScript.Pretty.Common
-import Language.PureScript.Comments
-
+import Data.Maybe (fromMaybe)
+import Data.Monoid
 
 import Language.PureScript.AST (SourceSpan(..))
+import Language.PureScript.CodeGen.JS.AST
+import Language.PureScript.CodeGen.JS.Common
+import Language.PureScript.Comments
+import Language.PureScript.Crash
+import Language.PureScript.Pretty.Common
 
 import Numeric
-
-import Data.Monoid
 
 literals :: (Emit gen) => Pattern PrinterState JS gen
 literals = mkPattern' match'

--- a/src/Language/PureScript/Pretty/Kinds.hs
+++ b/src/Language/PureScript/Pretty/Kinds.hs
@@ -1,26 +1,16 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Pretty.Kinds
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Pretty printer for kinds
 --
------------------------------------------------------------------------------
+module Language.PureScript.Pretty.Kinds
+  ( prettyPrintKind
+  ) where
 
-module Language.PureScript.Pretty.Kinds (
-    prettyPrintKind
-) where
-
-import Data.Maybe (fromMaybe)
+import Prelude.Compat
 
 import Control.Arrow (ArrowPlus(..))
-import Control.PatternArrows
+import Control.PatternArrows as PA
+
+import Data.Maybe (fromMaybe)
 
 import Language.PureScript.Crash
 import Language.PureScript.Kinds
@@ -48,7 +38,9 @@ funKind = mkPattern match
 
 -- | Generate a pretty-printed string representing a Kind
 prettyPrintKind :: Kind -> String
-prettyPrintKind = fromMaybe (internalError "Incomplete pattern") . pattern matchKind ()
+prettyPrintKind
+  = fromMaybe (internalError "Incomplete pattern")
+  . PA.pattern matchKind ()
   where
   matchKind :: Pattern () Kind String
   matchKind = buildPrettyPrinter operators (typeLiterals <+> fmap parens matchKind)

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -10,18 +10,20 @@ module Language.PureScript.Pretty.Types
   , prettyPrintRow
   ) where
 
-import Data.Maybe (fromMaybe)
+import Prelude.Compat
 
 import Control.Arrow ((<+>))
-import Control.PatternArrows
+import Control.PatternArrows as PA
+
+import Data.Maybe (fromMaybe)
 
 import Language.PureScript.Crash
-import Language.PureScript.Types
-import Language.PureScript.Names
+import Language.PureScript.Environment
 import Language.PureScript.Kinds
+import Language.PureScript.Names
 import Language.PureScript.Pretty.Common
 import Language.PureScript.Pretty.Kinds
-import Language.PureScript.Environment
+import Language.PureScript.Types
 
 import Text.PrettyPrint.Boxes hiding ((<+>))
 
@@ -147,14 +149,20 @@ forall_ = mkPattern match
   match _ = Nothing
 
 typeAtomAsBox :: Type -> Box
-typeAtomAsBox = fromMaybe (internalError "Incomplete pattern") . pattern matchTypeAtom () . insertPlaceholders
+typeAtomAsBox
+  = fromMaybe (internalError "Incomplete pattern")
+  . PA.pattern matchTypeAtom ()
+  . insertPlaceholders
 
 -- | Generate a pretty-printed string representing a Type, as it should appear inside parentheses
 prettyPrintTypeAtom :: Type -> String
 prettyPrintTypeAtom = render . typeAtomAsBox
 
 typeAsBox :: Type -> Box
-typeAsBox = fromMaybe (internalError "Incomplete pattern") . pattern matchType () . insertPlaceholders
+typeAsBox
+  = fromMaybe (internalError "Incomplete pattern")
+  . PA.pattern matchType ()
+  . insertPlaceholders
 
 -- | Generate a pretty-printed string representing a Type
 prettyPrintType :: Type -> String

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -1,16 +1,18 @@
 -- |
 -- Pretty printer for values
 --
-module Language.PureScript.Pretty.Values (
-    prettyPrintValue,
-    prettyPrintBinder,
-    prettyPrintBinderAtom
-) where
+module Language.PureScript.Pretty.Values
+  ( prettyPrintValue
+  , prettyPrintBinder
+  , prettyPrintBinderAtom
+  ) where
+
+import Prelude.Compat
 
 import Control.Arrow (second)
 
-import Language.PureScript.Crash
 import Language.PureScript.AST
+import Language.PureScript.Crash
 import Language.PureScript.Names
 import Language.PureScript.Pretty.Common
 import Language.PureScript.Pretty.Types (typeAsBox, typeAtomAsBox)

--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Language.PureScript.Publish
   ( preparePackage
@@ -23,47 +20,46 @@ module Language.PureScript.Publish
   , getResolvedDependencies
   ) where
 
-import Prelude ()
 import Prelude.Compat hiding (userError)
 
-import Data.Maybe
-import Data.Char (isSpace)
-import Data.List (stripPrefix, isSuffixOf, (\\), nubBy)
-import Data.List.Split (splitOn)
-import Data.List.NonEmpty (NonEmpty(..))
-import Data.Version
-import Data.Function (on)
-import Data.Foldable (traverse_)
-import Safe (headMay)
+import Control.Arrow ((***))
+import Control.Category ((>>>))
+import Control.Exception (catch, try)
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
+import Control.Monad.Writer.Strict
+
 import Data.Aeson.BetterErrors
+import Data.Char (isSpace)
+import Data.Foldable (traverse_)
+import Data.Function (on)
+import Data.List (stripPrefix, isSuffixOf, (\\), nubBy)
+import Data.List.NonEmpty (NonEmpty(..))
+import Data.List.Split (splitOn)
+import Data.Maybe
+import Data.Version
+import qualified Data.SPDX as SPDX
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
-import qualified Data.SPDX as SPDX
 
-import Control.Category ((>>>))
-import Control.Arrow ((***))
-import Control.Exception (catch, try)
-import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
-import Control.Monad.Trans.Except
-import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Writer.Strict
+import Safe (headMay)
 
 import System.Directory (doesFileExist, findExecutable)
-import System.Process (readProcess)
 import System.Exit (exitFailure)
 import System.FilePath (pathSeparator)
+import System.Process (readProcess)
 import qualified System.FilePath.Glob as Glob
 import qualified System.Info
 
-import Web.Bower.PackageMeta (PackageMeta(..), BowerError(..), PackageName,
-                              runPackageName, parsePackageName, Repository(..))
+import Web.Bower.PackageMeta (PackageMeta(..), BowerError(..), PackageName, runPackageName, parsePackageName, Repository(..))
 import qualified Web.Bower.PackageMeta as Bower
 
+import Language.PureScript.Publish.ErrorsWarnings
+import Language.PureScript.Publish.Utils
 import qualified Language.PureScript as P (version)
 import qualified Language.PureScript.Docs as D
-import Language.PureScript.Publish.Utils
-import Language.PureScript.Publish.ErrorsWarnings
 
 data PublishOptions = PublishOptions
   { -- | How to obtain the version tag and version that the data being

--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Language.PureScript.Publish

--- a/src/Language/PureScript/Publish/BoxesHelpers.hs
+++ b/src/Language/PureScript/Publish/BoxesHelpers.hs
@@ -4,7 +4,10 @@ module Language.PureScript.Publish.BoxesHelpers
   , module Language.PureScript.Publish.BoxesHelpers
   ) where
 
+import Prelude.Compat
+
 import System.IO (hPutStr, stderr)
+
 import qualified Text.PrettyPrint.Boxes as Boxes
 
 width :: Int

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Language.PureScript.Publish.ErrorsWarnings
   ( PackageError(..)
@@ -16,26 +15,24 @@ module Language.PureScript.Publish.ErrorsWarnings
   , renderWarnings
   ) where
 
-import Prelude ()
 import Prelude.Compat
 
+import Control.Exception (IOException)
+
 import Data.Aeson.BetterErrors
-import Data.Version
-import Data.Maybe
-import Data.Monoid
 import Data.List (intersperse, intercalate)
 import Data.List.NonEmpty (NonEmpty(..))
+import Data.Maybe
+import Data.Monoid
+import Data.Version
 import qualified Data.List.NonEmpty as NonEmpty
-
 import qualified Data.Text as T
 
-import Control.Exception (IOException)
-import Web.Bower.PackageMeta (BowerError, PackageName, runPackageName, showBowerError)
-import qualified Web.Bower.PackageMeta as Bower
-
+import Language.PureScript.Publish.BoxesHelpers
 import qualified Language.PureScript as P
 
-import Language.PureScript.Publish.BoxesHelpers
+import Web.Bower.PackageMeta (BowerError, PackageName, runPackageName, showBowerError)
+import qualified Web.Bower.PackageMeta as Bower
 
 -- | An error which meant that it was not possible to retrieve metadata for a
 -- package.

--- a/src/Language/PureScript/Publish/Utils.hs
+++ b/src/Language/PureScript/Publish/Utils.hs
@@ -1,12 +1,15 @@
 
 module Language.PureScript.Publish.Utils where
 
-import Data.List
+import Prelude.Compat
+
 import Data.Either (partitionEithers)
+import Data.List
+
 import System.Directory
 import System.Exit (exitFailure)
-import System.IO (hPutStrLn, stderr)
 import System.FilePath (pathSeparator)
+import System.IO (hPutStrLn, stderr)
 import qualified System.FilePath.Glob as Glob
 
 -- | Glob relative to the current directory, and produce relative pathnames.

--- a/src/Language/PureScript/Renamer.hs
+++ b/src/Language/PureScript/Renamer.hs
@@ -1,26 +1,20 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 -- |
 -- Renaming pass that prevents shadowing of local identifiers.
 --
 module Language.PureScript.Renamer (renameInModules) where
 
-import Prelude ()
 import Prelude.Compat
 
 import Control.Monad.State
 
 import Data.List (find)
 import Data.Maybe (fromJust, fromMaybe)
-
 import qualified Data.Map as M
 import qualified Data.Set as S
 
 import Language.PureScript.CoreFn
 import Language.PureScript.Names
 import Language.PureScript.Traversals
-
 import qualified Language.PureScript.Constants as C
 
 -- |

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -1,35 +1,19 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Sugar
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Desugaring passes
 --
------------------------------------------------------------------------------
-
-{-# LANGUAGE FlexibleContexts #-}
-
 module Language.PureScript.Sugar (desugar, module S) where
 
-import Prelude ()
 import Prelude.Compat
 
-import Control.Monad
 import Control.Category ((>>>))
+import Control.Monad
 import Control.Monad.Error.Class (MonadError())
-import Control.Monad.Writer.Class (MonadWriter())
 import Control.Monad.Supply.Class
+import Control.Monad.Writer.Class (MonadWriter())
 
 import Language.PureScript.AST
 import Language.PureScript.Errors
 import Language.PureScript.Externs
-
 import Language.PureScript.Sugar.BindingGroups as S
 import Language.PureScript.Sugar.CaseDeclarations as S
 import Language.PureScript.Sugar.DoNotation as S

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE LambdaCase #-}
-
 -- |
 -- This module implements the desugaring pass which creates binding groups from sets of
 -- mutually-recursive value declarations and mutually-recursive type declarations.
@@ -13,7 +9,6 @@ module Language.PureScript.Sugar.BindingGroups
   , collapseBindingGroupsModule
   ) where
 
-import Prelude ()
 import Prelude.Compat
 
 import Control.Monad ((<=<))

--- a/src/Language/PureScript/Sugar/CaseDeclarations.hs
+++ b/src/Language/PureScript/Sugar/CaseDeclarations.hs
@@ -1,30 +1,26 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 -- |
 -- This module implements the desugaring pass which replaces top-level binders with
 -- case expressions.
 --
-module Language.PureScript.Sugar.CaseDeclarations (
-    desugarCases,
-    desugarCasesModule
-) where
+module Language.PureScript.Sugar.CaseDeclarations
+  ( desugarCases
+  , desugarCasesModule
+  ) where
 
-import Prelude ()
 import Prelude.Compat
 
-import Language.PureScript.Crash
-import Data.Maybe (catMaybes, mapMaybe)
 import Data.List (nub, groupBy, foldl1')
+import Data.Maybe (catMaybes, mapMaybe)
 
 import Control.Monad ((<=<), forM, replicateM, join, unless)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Supply.Class
 
-import Language.PureScript.Names
 import Language.PureScript.AST
+import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Errors
+import Language.PureScript.Names
 import Language.PureScript.Traversals
 import Language.PureScript.TypeChecker.Monad (guardWith)
 

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -1,26 +1,20 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 -- |
 -- This module implements the desugaring pass which replaces do-notation statements with
 -- appropriate calls to bind from the Prelude.Monad type class.
 --
-module Language.PureScript.Sugar.DoNotation (
-    desugarDoModule
-) where
+module Language.PureScript.Sugar.DoNotation (desugarDoModule) where
 
-import Prelude ()
 import Prelude.Compat
-
-import Language.PureScript.Crash
-import Language.PureScript.Names
-import Language.PureScript.AST
-import Language.PureScript.Errors
-
-import qualified Language.PureScript.Constants as C
 
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Supply.Class
+
+
+import Language.PureScript.AST
+import Language.PureScript.Crash
+import Language.PureScript.Errors
+import Language.PureScript.Names
+import qualified Language.PureScript.Constants as C
 
 -- |
 -- Replace all @DoNotationBind@ and @DoNotationValue@ constructors with applications of the Prelude.bind function,

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-
 module Language.PureScript.Sugar.Names
   ( desugarImports
   , desugarImportsWithEnv
@@ -13,32 +8,30 @@ module Language.PureScript.Sugar.Names
   , Exports(..)
   ) where
 
-import Prelude ()
 import Prelude.Compat
-
-import Data.List (find, nub)
-import Data.Maybe (fromMaybe, mapMaybe)
 
 import Control.Arrow (first)
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Writer (MonadWriter(..), censor)
 import Control.Monad.State.Lazy
+import Control.Monad.Writer (MonadWriter(..), censor)
 
+import Data.List (find, nub)
+import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
 
-import Language.PureScript.Crash
 import Language.PureScript.AST
-import Language.PureScript.Names
-import Language.PureScript.Types
+import Language.PureScript.Crash
 import Language.PureScript.Errors
-import Language.PureScript.Traversals
 import Language.PureScript.Externs
-import Language.PureScript.Sugar.Names.Env
-import Language.PureScript.Sugar.Names.Imports
-import Language.PureScript.Sugar.Names.Exports
 import Language.PureScript.Linter.Imports
+import Language.PureScript.Names
+import Language.PureScript.Sugar.Names.Env
+import Language.PureScript.Sugar.Names.Exports
+import Language.PureScript.Sugar.Names.Imports
+import Language.PureScript.Traversals
+import Language.PureScript.Types
 
 -- |
 -- Replaces all local names with qualified names within a list of modules. The

--- a/src/Language/PureScript/Sugar/Names/Env.hs
+++ b/src/Language/PureScript/Sugar/Names/Env.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Language.PureScript.Sugar.Names.Env
   ( ImportRecord(..)
   , ImportProvenance(..)
@@ -21,21 +18,23 @@ module Language.PureScript.Sugar.Names.Env
   , checkImportConflicts
   ) where
 
+import Prelude.Compat
+
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Writer.Class (MonadWriter(..))
+
 import Data.Function (on)
 import Data.List (groupBy, sortBy, nub, delete)
 import Data.Maybe (fromJust)
 import qualified Data.Map as M
 import qualified Data.Set as S
 
-import Control.Monad
-import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Writer.Class (MonadWriter(..))
-
 import Language.PureScript.AST
 import Language.PureScript.Crash
-import Language.PureScript.Names
 import Language.PureScript.Environment
 import Language.PureScript.Errors
+import Language.PureScript.Names
 
 -- |
 -- The details for an import: the name of the thing that is being imported

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -1,31 +1,23 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE LambdaCase #-}
-
 module Language.PureScript.Sugar.Names.Exports
   ( findExportable
   , resolveExports
   ) where
 
-import Prelude ()
 import Prelude.Compat
-
-import Data.List (find, intersect)
-import Data.Maybe (fromMaybe, mapMaybe)
-import Data.Foldable (traverse_)
 
 import Control.Monad
 import Control.Monad.Writer.Class (MonadWriter(..))
 import Control.Monad.Error.Class (MonadError(..))
 
+import Data.Foldable (traverse_)
+import Data.List (find, intersect)
+import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Map as M
 
-import Language.PureScript.Crash
 import Language.PureScript.AST
-import Language.PureScript.Names
+import Language.PureScript.Crash
 import Language.PureScript.Errors
+import Language.PureScript.Names
 import Language.PureScript.Sugar.Names.Env
 
 -- |

--- a/src/Language/PureScript/Sugar/Names/Imports.hs
+++ b/src/Language/PureScript/Sugar/Names/Imports.hs
@@ -1,35 +1,28 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE LambdaCase #-}
-
 module Language.PureScript.Sugar.Names.Imports
   ( resolveImports
   , resolveModuleImport
   , findImports
   ) where
 
-import Prelude ()
 import Prelude.Compat
-
-import Data.Foldable (traverse_, for_)
-import Data.Function (on)
-import Data.List (find, sortBy, groupBy, (\\))
-import Data.Maybe (fromMaybe, isNothing)
-import Data.Traversable (for)
 
 import Control.Arrow (first)
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Writer (MonadWriter(..))
 
+import Data.Foldable (traverse_, for_)
+import Data.Function (on)
+import Data.List (find, sortBy, groupBy, (\\))
+import Data.Maybe (fromMaybe, isNothing)
+import Data.Traversable (for)
 import qualified Data.Map as M
 import qualified Data.Set as S
 
-import Language.PureScript.Crash
 import Language.PureScript.AST
-import Language.PureScript.Names
+import Language.PureScript.Crash
 import Language.PureScript.Errors
+import Language.PureScript.Names
 import Language.PureScript.Sugar.Names.Env
 
 -- |

--- a/src/Language/PureScript/Sugar/ObjectWildcards.hs
+++ b/src/Language/PureScript/Sugar/ObjectWildcards.hs
@@ -1,12 +1,7 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE PatternGuards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+module Language.PureScript.Sugar.ObjectWildcards
+  ( desugarObjectConstructors
+  ) where
 
-module Language.PureScript.Sugar.ObjectWildcards (
-  desugarObjectConstructors
-) where
-
-import Prelude ()
 import Prelude.Compat
 
 import Control.Monad (forM)

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
-
 -- |
 -- This module implements the desugaring pass which reapplies binary operators based
 -- on their fixity data and removes explicit parentheses.
@@ -15,7 +10,6 @@ module Language.PureScript.Sugar.Operators
   , removeSignedLiterals
   ) where
 
-import Prelude ()
 import Prelude.Compat
 
 import Language.PureScript.AST

--- a/src/Language/PureScript/Sugar/Operators/Binders.hs
+++ b/src/Language/PureScript/Sugar/Operators/Binders.hs
@@ -1,6 +1,5 @@
 module Language.PureScript.Sugar.Operators.Binders where
 
-import Prelude ()
 import Prelude.Compat
 
 import Language.PureScript.AST

--- a/src/Language/PureScript/Sugar/Operators/Common.hs
+++ b/src/Language/PureScript/Sugar/Operators/Common.hs
@@ -1,10 +1,5 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE PatternGuards #-}
-
 module Language.PureScript.Sugar.Operators.Common where
 
-import Prelude ()
 import Prelude.Compat
 
 import Control.Monad.State

--- a/src/Language/PureScript/Sugar/Operators/Expr.hs
+++ b/src/Language/PureScript/Sugar/Operators/Expr.hs
@@ -1,9 +1,5 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Language.PureScript.Sugar.Operators.Expr where
 
-import Prelude ()
 import Prelude.Compat
 
 import Data.Functor.Identity

--- a/src/Language/PureScript/Sugar/Operators/Types.hs
+++ b/src/Language/PureScript/Sugar/Operators/Types.hs
@@ -1,6 +1,5 @@
 module Language.PureScript.Sugar.Operators.Types where
 
-import Prelude ()
 import Prelude.Compat
 
 import Language.PureScript.AST

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 -- |
 -- This module implements the desugaring pass which creates type synonyms for type class dictionaries
 -- and dictionary expressions for type class instances.
@@ -12,7 +8,6 @@ module Language.PureScript.Sugar.TypeClasses
   , superClassDictionaryNames
   ) where
 
-import Prelude ()
 import Prelude.Compat
 
 import Language.PureScript.Crash

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -1,29 +1,23 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternGuards #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
 -- This module implements the generic deriving elaboration that takes place during desugaring.
 --
 module Language.PureScript.Sugar.TypeClasses.Deriving (deriveInstances) where
 
-import Prelude ()
 import Prelude.Compat
+
+import Control.Arrow (second)
+import Control.Monad (replicateM)
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Supply.Class (MonadSupply)
 
 import Data.List (foldl', find, sortBy)
 import Data.Maybe (fromMaybe)
 import Data.Ord (comparing)
 
-import Control.Arrow (second)
-import Control.Monad (replicateM)
-import Control.Monad.Supply.Class (MonadSupply)
-import Control.Monad.Error.Class (MonadError(..))
-
-import Language.PureScript.Crash
 import Language.PureScript.AST
+import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Errors
 import Language.PureScript.Names

--- a/src/Language/PureScript/Sugar/TypeDeclarations.hs
+++ b/src/Language/PureScript/Sugar/TypeDeclarations.hs
@@ -1,27 +1,11 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Sugar.TypeDeclarations
--- Copyright   :  (c) 2013-15 Phil Freeman, (c) 2014-15 Gary Burgess
--- License     :  MIT (http://opensource.org/licenses/MIT)
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
--- This module implements the desugaring pass which replaces top-level type declarations with
--- type annotations on the corresponding expression.
+-- This module implements the desugaring pass which replaces top-level type
+-- declarations with type annotations on the corresponding expression.
 --
------------------------------------------------------------------------------
+module Language.PureScript.Sugar.TypeDeclarations
+  ( desugarTypeDeclarationsModule
+  ) where
 
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
-module Language.PureScript.Sugar.TypeDeclarations (
-    desugarTypeDeclarationsModule
-) where
-
-import Prelude ()
 import Prelude.Compat
 
 import Control.Monad (forM)

--- a/src/Language/PureScript/Traversals.hs
+++ b/src/Language/PureScript/Traversals.hs
@@ -1,20 +1,6 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.Traversals
--- Copyright   :  (c) 2014 Phil Freeman
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- | Common functions for implementing generic traversals
---
------------------------------------------------------------------------------
-
 module Language.PureScript.Traversals where
 
-import Prelude ()
 import Prelude.Compat
 
 fstM :: (Functor f) => (a -> f c) -> (a, b) -> f (c, b)
@@ -39,4 +25,3 @@ eitherM _ g (Right b) = Right <$> g b
 
 defS :: (Monad m) => st -> val -> m (st, val)
 defS s val = return (s, val)
-

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -1,35 +1,25 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE PatternGuards #-}
 
 -- |
 -- The top-level type checker, which checks all declarations in a module.
 --
-module Language.PureScript.TypeChecker (
-    module T,
-    typeCheckModule
-) where
+module Language.PureScript.TypeChecker
+  ( module T
+  , typeCheckModule
+  ) where
 
-import Prelude ()
 import Prelude.Compat
 
-import Language.PureScript.TypeChecker.Monad as T
-import Language.PureScript.TypeChecker.Kinds as T
-import Language.PureScript.TypeChecker.Types as T
-import Language.PureScript.TypeChecker.Synonyms as T
-
-import Data.Maybe
-import Data.List (nub, nubBy, (\\), sort, group)
-import Data.Foldable (for_, traverse_)
-
-import qualified Data.Map as M
-
 import Control.Monad (when, unless, void, forM, forM_)
-import Control.Monad.Supply.Class (MonadSupply)
-import Control.Monad.State.Class (MonadState(..), modify)
 import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.State.Class (MonadState(..), modify)
+import Control.Monad.Supply.Class (MonadSupply)
 import Control.Monad.Writer.Class (MonadWriter(..))
+
+import Data.Foldable (for_, traverse_)
+import Data.List (nub, nubBy, (\\), sort, group)
+import Data.Maybe
+import qualified Data.Map as M
 
 import Language.PureScript.AST
 import Language.PureScript.Crash
@@ -39,6 +29,10 @@ import Language.PureScript.Kinds
 import Language.PureScript.Linter
 import Language.PureScript.Names
 import Language.PureScript.Traversals
+import Language.PureScript.TypeChecker.Kinds as T
+import Language.PureScript.TypeChecker.Monad as T
+import Language.PureScript.TypeChecker.Synonyms as T
+import Language.PureScript.TypeChecker.Types as T
 import Language.PureScript.TypeClassDictionaries
 import Language.PureScript.Types
 

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -1,26 +1,25 @@
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE FlexibleContexts #-}
-
 -- |
 -- Type class entailment
 --
-module Language.PureScript.TypeChecker.Entailment (Context, replaceTypeClassDictionaries) where
+module Language.PureScript.TypeChecker.Entailment
+  ( Context
+  , replaceTypeClassDictionaries
+  ) where
 
-import Prelude ()
 import Prelude.Compat
+
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.State
+import Control.Monad.Supply.Class (MonadSupply(..))
+import Control.Monad.Writer
 
 import Data.Function (on)
 import Data.List (minimumBy, sortBy, groupBy)
 import Data.Maybe (maybeToList, mapMaybe)
 import qualified Data.Map as M
 
-import Control.Monad.State
-import Control.Monad.Writer
-import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Supply.Class (MonadSupply(..))
-
-import Language.PureScript.Crash
 import Language.PureScript.AST
+import Language.PureScript.Crash
 import Language.PureScript.Errors
 import Language.PureScript.Names
 import Language.PureScript.TypeChecker.Unify

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -1,9 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE RankNTypes #-}
 
 -- |
 -- This module implements the kind checker
@@ -15,16 +10,15 @@ module Language.PureScript.TypeChecker.Kinds
   , kindsOfAll
   ) where
 
-import Prelude ()
 import Prelude.Compat
-
-import qualified Data.Map as M
 
 import Control.Arrow (second)
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Writer.Class (MonadWriter(..))
 import Control.Monad.State
+import Control.Monad.Writer.Class (MonadWriter(..))
+
+import qualified Data.Map as M
 
 import Language.PureScript.Crash
 import Language.PureScript.Environment

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 
 -- |
@@ -9,16 +6,15 @@
 --
 module Language.PureScript.TypeChecker.Monad where
 
-import Prelude ()
 import Prelude.Compat
+
+import Control.Arrow (second)
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.State
+import Control.Monad.Writer.Class (MonadWriter(..), listen, censor)
 
 import Data.Maybe
 import qualified Data.Map as M
-
-import Control.Arrow (second)
-import Control.Monad.State
-import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Writer.Class (MonadWriter(..), listen, censor)
 
 import Language.PureScript.Environment
 import Language.PureScript.Errors

--- a/src/Language/PureScript/TypeChecker/Rows.hs
+++ b/src/Language/PureScript/TypeChecker/Rows.hs
@@ -1,34 +1,17 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.TypeChecker.Rows
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Functions relating to type checking for rows
 --
------------------------------------------------------------------------------
+module Language.PureScript.TypeChecker.Rows
+  ( checkDuplicateLabels
+  ) where
 
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE CPP #-}
+import Prelude.Compat
 
-module Language.PureScript.TypeChecker.Rows (
-    checkDuplicateLabels
-) where
-
-import Data.List
-
-#if __GLASGOW_HASKELL__ < 710
-import Control.Applicative
-#endif
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Class (MonadState(..))
+
+import Data.List
 
 import Language.PureScript.AST
 import Language.PureScript.Errors

--- a/src/Language/PureScript/TypeChecker/Skolems.hs
+++ b/src/Language/PureScript/TypeChecker/Skolems.hs
@@ -1,45 +1,30 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.TypeChecker.Skolems
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Functions relating to skolemization used during typechecking
 --
------------------------------------------------------------------------------
+module Language.PureScript.TypeChecker.Skolems
+  ( newSkolemConstant
+  , introduceSkolemScope
+  , newSkolemScope
+  , skolemize
+  , skolemizeTypesInValue
+  , skolemEscapeCheck
+  ) where
 
-{-# LANGUAGE FlexibleContexts #-}
-
-module Language.PureScript.TypeChecker.Skolems (
-    newSkolemConstant,
-    introduceSkolemScope,
-    newSkolemScope,
-    skolemize,
-    skolemizeTypesInValue,
-    skolemEscapeCheck
-) where
-
-import Prelude ()
 import Prelude.Compat
-
-import Data.List (nub, (\\))
-import Data.Monoid
-import Data.Functor.Identity (Identity(), runIdentity)
 
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Class (MonadState(..), gets, modify)
 
-import Language.PureScript.Crash
+import Data.Functor.Identity (Identity(), runIdentity)
+import Data.List (nub, (\\))
+import Data.Monoid
+
 import Language.PureScript.AST
+import Language.PureScript.Crash
 import Language.PureScript.Errors
+import Language.PureScript.Traversals (defS)
 import Language.PureScript.TypeChecker.Monad
 import Language.PureScript.Types
-import Language.PureScript.Traversals (defS)
 
 -- |
 -- Generate a new skolem constant

--- a/src/Language/PureScript/TypeChecker/Subsumption.hs
+++ b/src/Language/PureScript/TypeChecker/Subsumption.hs
@@ -1,36 +1,20 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.TypeChecker.Subsumption
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
 -- |
 -- Subsumption checking
 --
------------------------------------------------------------------------------
+module Language.PureScript.TypeChecker.Subsumption
+  ( subsumes
+  ) where
 
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE CPP #-}
+import Prelude.Compat
 
-module Language.PureScript.TypeChecker.Subsumption (
-    subsumes
-) where
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.State.Class (MonadState(..))
 
 import Data.List (sortBy)
 import Data.Ord (comparing)
 
-#if __GLASGOW_HASKELL__ < 710
-import Control.Applicative
-#endif
-import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.State.Class (MonadState(..))
-
-import Language.PureScript.Crash
 import Language.PureScript.AST
+import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Errors
 import Language.PureScript.TypeChecker.Monad

--- a/src/Language/PureScript/TypeChecker/Synonyms.hs
+++ b/src/Language/PureScript/TypeChecker/Synonyms.hs
@@ -1,35 +1,19 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.TypeChecker.Synonyms
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
+{-# LANGUAGE GADTs #-}
+
 -- |
 -- Functions for replacing fully applied type synonyms
 --
------------------------------------------------------------------------------
+module Language.PureScript.TypeChecker.Synonyms
+  ( replaceAllTypeSynonyms
+  ) where
 
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PatternGuards #-}
-{-# LANGUAGE GADTs #-}
-
-module Language.PureScript.TypeChecker.Synonyms (
-    replaceAllTypeSynonyms
-) where
-
-import Prelude ()
 import Prelude.Compat
-
-import Data.Maybe (fromMaybe)
-import qualified Data.Map as M
 
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State
+
+import Data.Maybe (fromMaybe)
+import qualified Data.Map as M
 
 import Language.PureScript.Environment
 import Language.PureScript.Errors

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -1,8 +1,4 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections #-}
 
 -- |
 -- This module implements the type checker
@@ -28,22 +24,21 @@ module Language.PureScript.TypeChecker.Types
       Check a function of a given type returns a value of another type when applied to its arguments
 -}
 
-import Prelude ()
 import Prelude.Compat
+
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.State.Class (MonadState(..), gets)
+import Control.Monad.Supply.Class (MonadSupply)
+import Control.Monad.Writer.Class (MonadWriter(..))
 
 import Data.Either (lefts, rights)
 import Data.List (transpose, nub, (\\), partition, delete)
 import Data.Maybe (fromMaybe)
 import qualified Data.Map as M
 
-import Control.Monad
-import Control.Monad.State.Class (MonadState(..), gets)
-import Control.Monad.Supply.Class (MonadSupply)
-import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Writer.Class (MonadWriter(..))
-
-import Language.PureScript.Crash
 import Language.PureScript.AST
+import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Errors
 import Language.PureScript.Kinds

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -1,47 +1,30 @@
------------------------------------------------------------------------------
---
--- Module      :  Language.PureScript.TypeChecker.Unify
--- Copyright   :  (c) Phil Freeman 2013
--- License     :  MIT
---
--- Maintainer  :  Phil Freeman <paf31@cantab.net>
--- Stability   :  experimental
--- Portability :
---
+{-# LANGUAGE FlexibleInstances #-}
+
 -- |
 -- Functions and instances relating to unification
 --
------------------------------------------------------------------------------
+module Language.PureScript.TypeChecker.Unify
+  ( freshType
+  , solveType
+  , substituteType
+  , unknownsInType
+  , unifyTypes
+  , unifyRows
+  , unifiesWith
+  , replaceVarWithUnknown
+  , replaceTypeWildcards
+  , varIfUnknown
+  ) where
 
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE CPP #-}
+import Prelude.Compat
 
-module Language.PureScript.TypeChecker.Unify (
-    freshType,
-    solveType,
-    substituteType,
-    unknownsInType,
-    unifyTypes,
-    unifyRows,
-    unifiesWith,
-    replaceVarWithUnknown,
-    replaceTypeWildcards,
-    varIfUnknown
-) where
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.State.Class (MonadState(..), gets, modify)
+import Control.Monad.Writer.Class (MonadWriter(..))
 
 import Data.List (nub, sort)
 import qualified Data.Map as M
-
-#if __GLASGOW_HASKELL__ < 710
-import Control.Applicative
-#endif
-import Control.Monad
-import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Writer.Class (MonadWriter(..))
-import Control.Monad.State.Class (MonadState(..), gets, modify)
 
 import Language.PureScript.Crash
 import Language.PureScript.Errors

--- a/src/Language/PureScript/TypeClassDictionaries.hs
+++ b/src/Language/PureScript/TypeClassDictionaries.hs
@@ -1,5 +1,7 @@
 module Language.PureScript.TypeClassDictionaries where
 
+import Prelude.Compat
+
 import Language.PureScript.Names
 import Language.PureScript.Types
 

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 -- |
@@ -39,7 +40,7 @@ data Type
   -- |
   -- A type wildcard, as would appear in a partial type synonym
   --
-  | TypeWildcard (SourceSpan)
+  | TypeWildcard SourceSpan
   -- |
   -- A type constructor
   --

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 -- |
@@ -6,19 +5,18 @@
 --
 module Language.PureScript.Types where
 
-import Prelude ()
 import Prelude.Compat
+
+import Control.Monad ((<=<))
 
 import Data.List (nub)
 import Data.Maybe (fromMaybe)
 import qualified Data.Aeson as A
 import qualified Data.Aeson.TH as A
 
-import Control.Monad ((<=<))
-
-import Language.PureScript.Names
-import Language.PureScript.Kinds
 import Language.PureScript.AST.SourcePos
+import Language.PureScript.Kinds
+import Language.PureScript.Names
 
 -- |
 -- An identifier for the scope of a skolem variable

--- a/src/System/IO/UTF8.hs
+++ b/src/System/IO/UTF8.hs
@@ -1,6 +1,6 @@
-module System.IO.UTF8
+module System.IO.UTF8 where
 
-where
+import Prelude.Compat
 
 import System.IO ( IOMode(..)
                  , hGetContents


### PR DESCRIPTION
Resolves #1672 

The only extension here I'd consider controversial is `PatternSynonyms`, as it reserves the name `pattern`, but I think we're going to be using them more in the future, so probably worth it? The rest are pretty widely used already.

I didn't turn GADTs on, which was suggested in the issue, because doing so resulted in compilation errors.