### PR TITLE
Fix #2092, precedence of type application

### DIFF
--- a/examples/passing/TypeOperators.purs
+++ b/examples/passing/TypeOperators.purs
@@ -7,8 +7,11 @@ natty x = x
 
 data Compose f g a = Compose (f (g a))
 
-testPrecedence ∷ ∀ f g. Compose f g ~> Compose f g
-testPrecedence x = x
+testPrecedence1 ∷ ∀ f g. Compose f g ~> Compose f g
+testPrecedence1 x = x
+
+testPrecedence2 ∷ ∀ f g. f ~> g → f ~> g
+testPrecedence2 nat fx = nat fx
 
 swap ∷ ∀ a b. a /\ b → b /\ a
 swap (a /\ b) = b /\ a

--- a/examples/passing/TypeOperators.purs
+++ b/examples/passing/TypeOperators.purs
@@ -5,6 +5,11 @@ import A (type (~>), type (/\), (/\))
 natty ∷ ∀ f. f ~> f
 natty x = x
 
+data Compose f g a = Compose (f (g a))
+
+testPrecedence ∷ ∀ f g. Compose f g ~> Compose f g
+testPrecedence x = x
+
 swap ∷ ∀ a b. a /\ b → b /\ a
 swap (a /\ b) = b /\ a
 

--- a/src/Language/PureScript/Parser/Types.hs
+++ b/src/Language/PureScript/Parser/Types.hs
@@ -82,10 +82,10 @@ parseConstrainedType = do
 parseAnyType :: TokenParser Type
 parseAnyType = P.buildExpressionParser operators (buildPostfixParser postfixTable parseTypeAtom) P.<?> "type"
   where
-  operators = [ [ P.Infix (P.try (parseQualified (Op <$> symbol)) >>= \ident ->
+  operators = [ [ P.Infix (return TypeApp) P.AssocLeft ]
+              , [ P.Infix (P.try (parseQualified (Op <$> symbol)) >>= \ident ->
                     return (BinaryNoParensType (TypeOp ident))) P.AssocRight
                 ]
-              , [ P.Infix (return TypeApp) P.AssocLeft ]
               , [ P.Infix (rarrow >> return function) P.AssocRight ]
               ]
   postfixTable = [ \t -> KindedType t <$> (indented *> doubleColon *> parseKind)


### PR DESCRIPTION
This doesn't change the precedence of `->`, but it adds a test to make sure it binds less tightly than other type operators.