### PR TITLE
Check that passing tests have a Main module

### DIFF
--- a/examples/passing/ExportedInstanceDeclarations.purs
+++ b/examples/passing/ExportedInstanceDeclarations.purs
@@ -1,9 +1,10 @@
 -- Tests that instances for non-exported classes / types do not appear in the
 -- result of `exportedDeclarations`.
-module ExportedInstanceDeclarations
+module Main
   ( Const(..)
   , class Foo
   , foo
+  , main
   ) where
 
 import Prelude


### PR DESCRIPTION
Thought that this should probably come separately. This PR adds an assertion that all the passing tests have a Main module. Previously, if you called the main module something else, it would compile the code, but then run the code in a different Main module left over from the previous test, so any failures at runtime would be missed.