### PR TITLE
Use (..) for data constructors in suggestion

### DIFF
--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -213,7 +213,15 @@ lintImportDecl env mni qualifierName names declType allowImplicit =
   checkImplicit warning =
     if null allRefs
     then unused
-    else warn (warning mni allRefs)
+    else warn (warning mni (map simplifyTypeRef allRefs))
+    where
+    -- Replace explicit type refs with data constructor lists from listing the
+    -- used constructors explicity `T(X, Y, [...])` to `T(..)` for suggestion
+    -- message.
+    simplifyTypeRef :: DeclarationRef -> DeclarationRef
+    simplifyTypeRef (TypeRef name (Just dctors))
+      | not (null dctors) = TypeRef name Nothing
+    simplifyTypeRef other = other
 
   checkExplicit
     :: [DeclarationRef]


### PR DESCRIPTION
This is something I find rather annoying about the current warnings, particularly if the type only has one constructor, or if it has many constructors. I always go though and manually edit the suggestion to use `X(..)` rather than explicit lists, and since there is no conflict problem here (adding a data constructor would be a breaking change) there's no real requirement for listing them explicitly.