### PR TITLE
Add tests for warnings & fix some warnings

### DIFF
--- a/examples/warning/DuplicateExportRef.purs
+++ b/examples/warning/DuplicateExportRef.purs
@@ -1,0 +1,30 @@
+-- @shouldWarnWith DuplicateExportRef
+-- @shouldWarnWith DuplicateExportRef
+-- @shouldWarnWith DuplicateExportRef
+-- @shouldWarnWith DuplicateExportRef
+-- @shouldWarnWith DuplicateExportRef
+-- @shouldWarnWith DuplicateExportRef
+-- @shouldWarnWith DuplicateExportRef
+module Main
+  ( X(X, X), X
+  , fn, fn
+  , (!), (!)
+  , class Y, class Y
+  , Natural, type (~>), type (~>)
+  , module Prelude, module Prelude
+  ) where
+
+import Prelude (Unit)
+
+data X = X
+
+fn :: X -> X -> X
+fn _ _ = X
+
+infix 2 fn as !
+
+class Y a
+
+type Natural f g = forall a. f a -> g a
+
+infixl 1 type Natural as ~>

--- a/examples/warning/DuplicateImport.purs
+++ b/examples/warning/DuplicateImport.purs
@@ -1,0 +1,10 @@
+-- @shouldWarnWith DuplicateImport
+module Main where
+
+import Prelude (Unit, unit, pure)
+import Prelude (Unit, unit, pure)
+
+import Control.Monad.Eff (Eff)
+
+main :: Eff () Unit
+main = pure unit

--- a/examples/warning/DuplicateImportRef.purs
+++ b/examples/warning/DuplicateImportRef.purs
@@ -1,0 +1,18 @@
+-- @shouldWarnWith DuplicateImportRef
+-- @shouldWarnWith DuplicateImportRef
+-- @shouldWarnWith DuplicateImportRef
+-- @shouldWarnWith DuplicateImportRef
+module Main where
+
+import Prelude
+  ( Unit, Unit
+  , unit, unit
+  , class Functor, class Functor
+  , (<>), (<>)
+  )
+
+u :: Unit
+u = unit <> unit
+
+fid :: forall f a. Functor f => f a -> f a
+fid fa = fa

--- a/examples/warning/DuplicateSelectiveImport.purs
+++ b/examples/warning/DuplicateSelectiveImport.purs
@@ -1,0 +1,10 @@
+-- @shouldWarnWith DuplicateSelectiveImport
+module Main where
+
+import Prelude (Unit, unit)
+import Prelude (pure)
+
+import Control.Monad.Eff (Eff)
+
+main :: Eff () Unit
+main = pure unit

--- a/examples/warning/HidingImport.purs
+++ b/examples/warning/HidingImport.purs
@@ -1,0 +1,9 @@
+-- @shouldWarnWith HidingImport
+-- @shouldWarnWith HidingImport
+module Main where
+
+import Prelude hiding (one)
+import Control.Monad.Eff hiding (runPure)
+
+main :: Eff () Unit
+main = pure unit

--- a/examples/warning/ImplicitImport.purs
+++ b/examples/warning/ImplicitImport.purs
@@ -1,0 +1,9 @@
+-- @shouldWarnWith ImplicitImport
+-- @shouldWarnWith ImplicitImport
+module Main where
+
+import Prelude
+import Control.Monad.Eff
+
+main :: Eff () Unit
+main = pure unit

--- a/examples/warning/ImplicitQualifiedImport.purs
+++ b/examples/warning/ImplicitQualifiedImport.purs
@@ -1,0 +1,11 @@
+-- @shouldWarnWith ImplicitQualifiedImport
+-- @shouldWarnWith ImplicitQualifiedImport
+module Main where
+
+import Data.Unit
+
+import Control.Monad.Eff as E
+import Control.Monad.Eff.Console as E
+
+main :: E.Eff (console :: E.CONSOLE) Unit
+main = E.log "test"

--- a/examples/warning/MissingTypeDeclaration.purs
+++ b/examples/warning/MissingTypeDeclaration.purs
@@ -1,0 +1,4 @@
+-- @shouldWarnWith MissingTypeDeclaration
+module Main where
+
+x = 0

--- a/examples/warning/OverlappingInstances.purs
+++ b/examples/warning/OverlappingInstances.purs
@@ -1,0 +1,17 @@
+-- @shouldWarnWith OverlappingInstances
+module Main where
+
+class Test a where
+  test :: a -> a
+
+instance testRefl :: Test a where
+  test x = x
+
+instance testInt :: Test Int where
+  test _ = 0
+
+-- The OverlappingInstances instances warning only arises when there are two
+-- choices for a dictionary, not when the instances are defined. So without
+-- `value` this module would not raise a warning.
+value :: Int
+value = test 1

--- a/examples/warning/OverlappingPattern.purs
+++ b/examples/warning/OverlappingPattern.purs
@@ -1,0 +1,15 @@
+-- @shouldWarnWith OverlappingPattern
+-- @shouldWarnWith OverlappingPattern
+module Main where
+
+data X = A | B
+
+pat1 :: X -> Boolean
+pat1 A = true
+pat1 A = true
+pat1 B = false
+
+pat2 :: X -> Boolean
+pat2 A = true
+pat2 _ = false
+pat2 B = false

--- a/examples/warning/ScopeShadowing.purs
+++ b/examples/warning/ScopeShadowing.purs
@@ -1,0 +1,13 @@
+-- @shouldWarnWith ScopeShadowing
+module Main where
+
+import Prelude
+
+-- No warning at the definition, only when the name is later resolved
+data Unit = Unit
+
+-- This is only a warning as the `Prelude` import is implicit. If `Unit` was
+-- named explicitly in an import list, then this refernce to `Unit`
+-- would be a `ScopeConflict` error instead.
+test :: Unit
+test = const Unit unit

--- a/examples/warning/ShadowedTypeVar.purs
+++ b/examples/warning/ShadowedTypeVar.purs
@@ -1,0 +1,5 @@
+-- @shouldWarnWith ShadowedTypeVar
+module Main where
+
+f :: forall a. (forall a. a -> a) -> a -> a
+f g x = g x

--- a/examples/warning/UnnecessaryFFIModule.js
+++ b/examples/warning/UnnecessaryFFIModule.js
@@ -1,0 +1,1 @@
+exports.out = null;

--- a/examples/warning/UnnecessaryFFIModule.purs
+++ b/examples/warning/UnnecessaryFFIModule.purs
@@ -1,0 +1,5 @@
+-- @shouldWarnWith UnnecessaryFFIModule
+module Main where
+
+t :: Boolean
+t = true

--- a/examples/warning/UnusedDctorExplicitImport.purs
+++ b/examples/warning/UnusedDctorExplicitImport.purs
@@ -1,0 +1,8 @@
+-- @shouldWarnWith UnusedDctorExplicitImport
+module Main where
+
+import Data.Ordering (Ordering(EQ, LT))
+
+f :: Ordering -> Ordering
+f EQ = EQ
+f x = x

--- a/examples/warning/UnusedDctorImportAll.purs
+++ b/examples/warning/UnusedDctorImportAll.purs
@@ -1,0 +1,7 @@
+-- @shouldWarnWith UnusedDctorImport
+module Main where
+
+import Data.Ordering (Ordering(..))
+
+f :: Ordering -> Ordering
+f x = x

--- a/examples/warning/UnusedDctorImportExplicit.purs
+++ b/examples/warning/UnusedDctorImportExplicit.purs
@@ -1,0 +1,7 @@
+-- @shouldWarnWith UnusedDctorImport
+module Main where
+
+import Data.Ordering (Ordering(EQ))
+
+f :: Ordering -> Ordering
+f x = x

--- a/examples/warning/UnusedExplicitImport.purs
+++ b/examples/warning/UnusedExplicitImport.purs
@@ -1,0 +1,8 @@
+-- @shouldWarnWith UnusedExplicitImport
+module Main where
+
+import Prelude (Unit, unit, pure, bind)
+import Control.Monad.Eff (Eff)
+
+main :: Eff () Unit
+main = pure unit

--- a/examples/warning/UnusedFFIImplementations.js
+++ b/examples/warning/UnusedFFIImplementations.js
@@ -1,0 +1,2 @@
+exports.yes = true;
+exports.no = false;

--- a/examples/warning/UnusedFFIImplementations.purs
+++ b/examples/warning/UnusedFFIImplementations.purs
@@ -1,0 +1,4 @@
+-- @shouldWarnWith UnusedFFIImplementations
+module Main where
+
+foreign import yes :: Boolean

--- a/examples/warning/UnusedImport.purs
+++ b/examples/warning/UnusedImport.purs
@@ -1,0 +1,14 @@
+-- @shouldWarnWith UnusedImport
+-- @shouldWarnWith UnusedImport
+-- @shouldWarnWith UnusedImport
+module Main where
+
+import Data.Unit (Unit, unit)
+
+-- All of the below are unused
+import Control.Monad.Eff
+import Control.Monad.Eff.Console as Console
+import Test.Assert ()
+
+main :: Unit
+main = unit

--- a/examples/warning/UnusedTypeVar.purs
+++ b/examples/warning/UnusedTypeVar.purs
@@ -1,0 +1,5 @@
+-- @shouldWarnWith UnusedTypeVar
+module Main where
+
+f :: forall a b. a -> a
+f x = x

--- a/examples/warning/WildcardInferredType.purs
+++ b/examples/warning/WildcardInferredType.purs
@@ -1,0 +1,23 @@
+-- @shouldWarnWith WildcardInferredType
+-- @shouldWarnWith WildcardInferredType
+-- @shouldWarnWith WildcardInferredType
+-- @shouldWarnWith WildcardInferredType
+module Main where
+
+x :: Int
+x = 0 :: _
+
+y :: _
+y = 0
+
+z :: Int
+z =
+  let n :: _
+      n = 0
+  in n
+
+w :: Int
+w = n
+  where
+  n :: _
+  n = 0

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -66,6 +66,8 @@ extra-source-files: examples/passing/*.purs
                   , examples/failing/InstanceExport/*.purs
                   , examples/failing/OrphanInstance/*.purs
                   , examples/failing/OverlappingReExport/*.purs
+                  , examples/warning/*.purs
+                  , examples/warning/*.js
                   , examples/docs/bower_components/purescript-prelude/src/*.purs
                   , examples/docs/bower.json
                   , examples/docs/src/*.purs

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -127,7 +127,6 @@ data SimpleErrorMessage
   | DuplicateImportRef Name
   | DuplicateExportRef Name
   | IntOutOfRange Integer String Integer Integer
-  | RedundantEmptyHidingImport ModuleName
   | ImplicitQualifiedImport ModuleName ModuleName [DeclarationRef]
   | ImplicitImport ModuleName [DeclarationRef]
   | HidingImport ModuleName [DeclarationRef]
@@ -297,7 +296,6 @@ errorCode em = case unwrapErrorMessage em of
   DuplicateImportRef{} -> "DuplicateImportRef"
   DuplicateExportRef{} -> "DuplicateExportRef"
   IntOutOfRange{} -> "IntOutOfRange"
-  RedundantEmptyHidingImport{} -> "RedundantEmptyHidingImport"
   ImplicitQualifiedImport{} -> "ImplicitQualifiedImport"
   ImplicitImport{} -> "ImplicitImport"
   HidingImport{} -> "HidingImport"
@@ -418,7 +416,6 @@ wikiUri e = "https://github.com/purescript/purescript/wiki/Error-Code-" ++ error
 errorSuggestion :: SimpleErrorMessage -> Maybe ErrorSuggestion
 errorSuggestion err = case err of
   UnusedImport{} -> emptySuggestion
-  RedundantEmptyHidingImport{} -> emptySuggestion
   DuplicateImport{} -> emptySuggestion
   UnusedExplicitImport mn _ qual refs -> suggest $ importSuggestion mn refs qual
   ImplicitImport mn refs -> suggest $ importSuggestion mn refs Nothing
@@ -867,9 +864,6 @@ prettyPrintSingleError full level showWiki e = flip evalState defaultUnknownMap 
     renderSimpleErrorMessage (IntOutOfRange value backend lo hi) =
       paras [ line $ "Integer value " ++ show value ++ " is out of range for the " ++ backend ++ " backend."
             , line $ "Acceptable values fall within the range " ++ show lo ++ " to " ++ show hi ++ " (inclusive)." ]
-
-    renderSimpleErrorMessage (RedundantEmptyHidingImport mn) =
-      line $ "The import for module " ++ runModuleName mn ++ " is redundant as all members have been explicitly hidden."
 
     renderSimpleErrorMessage msg@(ImplicitQualifiedImport importedModule asModule _) =
       paras [ line $ "Module " ++ runModuleName importedModule ++ " was imported as " ++ runModuleName asModule ++ " with unspecified imports."

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -111,7 +111,7 @@ desugarImportsWithEnv externs modules = do
     warnAndRethrow (addHint (ErrorInModule mn)) $ do
       let (_, imps, exps) = fromMaybe (internalError "Module is missing in renameInModule'") $ M.lookup mn env
       (m', used) <- flip runStateT M.empty $ renameInModule env imps (elaborateExports exps m)
-      lintImports m env used
+      lintImports m' env used
       return m'
 
 -- |

--- a/src/Language/PureScript/Sugar/Names/Common.hs
+++ b/src/Language/PureScript/Sugar/Names/Common.hs
@@ -43,15 +43,17 @@ warnDuplicateRefs pos toError refs = do
   -- referenced type is used in the duplicate check - constructors are handled
   -- separately
   deleteCtors :: DeclarationRef -> DeclarationRef
+  deleteCtors (PositionedDeclarationRef ss com ref) =
+    PositionedDeclarationRef ss com (deleteCtors ref)
   deleteCtors (TypeRef pn _) = TypeRef pn Nothing
   deleteCtors other = other
 
   -- Extracts the names of duplicate constructor references from TypeRefs.
   extractCtors :: SourceSpan -> DeclarationRef -> Maybe [(SourceSpan, Name)]
+  extractCtors _ (PositionedDeclarationRef pos' _ ref) = extractCtors pos' ref
   extractCtors pos' (TypeRef _ (Just dctors)) =
     let dupes = dctors \\ nub dctors
     in if null dupes then Nothing else Just $ ((pos',) . DctorName) <$> dupes
-  extractCtors _ (PositionedDeclarationRef pos' _ ref) = extractCtors pos' ref
   extractCtors _ _ = Nothing
 
   -- Converts a DeclarationRef into a name for an error message.

--- a/tests/TestCompiler.hs
+++ b/tests/TestCompiler.hs
@@ -27,7 +27,7 @@ import qualified Language.PureScript as P
 
 import Data.Char (isSpace)
 import Data.Function (on)
-import Data.List (sort, stripPrefix, intercalate, groupBy, sortBy)
+import Data.List (sort, stripPrefix, intercalate, groupBy, sortBy, minimumBy)
 import Data.Maybe (mapMaybe)
 import Data.Time.Clock (UTCTime())
 import Data.Tuple (swap)
@@ -58,31 +58,40 @@ main = hspec spec
 spec :: Spec
 spec = do
 
-  (supportExterns, passingTestCases, failingTestCases) <- runIO $ do
+  (supportExterns, passingTestCases, warningTestCases, failingTestCases) <- runIO $ do
     cwd <- getCurrentDirectory
     let passing = cwd </> "examples" </> "passing"
+    let warning = cwd </> "examples" </> "warning"
     let failing = cwd </> "examples" </> "failing"
     let supportDir = cwd </> "tests" </> "support" </> "bower_components"
     let supportFiles ext = Glob.globDir1 (Glob.compile ("purescript-*/**/*." ++ ext)) supportDir
     passingFiles <- getTestFiles passing <$> testGlob passing
+    warningFiles <- getTestFiles warning <$> testGlob warning
     failingFiles <- getTestFiles failing <$> testGlob failing
     supportPurs <- supportFiles "purs"
     supportPursFiles <- readInput supportPurs
     supportExterns <- runExceptT $ do
       modules <- ExceptT . return $ P.parseModulesFromFiles id supportPursFiles
       foreigns <- inferForeignModules modules
-      externs <- ExceptT . runTest $ P.make (makeActions foreigns) (map snd modules)
+      externs <- ExceptT . fmap fst . runTest $ P.make (makeActions foreigns) (map snd modules)
       return (zip (map snd modules) externs)
     case supportExterns of
       Left errs -> fail (P.prettyPrintMultipleErrors False errs)
-      Right externs -> return (externs, passingFiles, failingFiles)
+      Right externs -> return (externs, passingFiles, warningFiles, failingFiles)
 
-  context ("Passing examples") $ do
+  context "Passing examples" $
     forM_ passingTestCases $ \testPurs ->
       it ("'" <> takeFileName (getTestMain testPurs) <> "' should compile and run without error") $
         assertCompiles supportExterns testPurs
 
-  context ("Failing examples") $ do
+  context "Warning examples" $
+    forM_ warningTestCases $ \testPurs -> do
+      let mainPath = getTestMain testPurs
+      expectedWarnings <- runIO $ getShouldWarnWith mainPath
+      it ("'" <> takeFileName mainPath <> "' should compile with warning(s) '" <> intercalate "', '" expectedWarnings <> "'") $
+        assertCompilesWithWarnings supportExterns testPurs expectedWarnings
+
+  context "Failing examples" $
     forM_ failingTestCases $ \testPurs -> do
       let mainPath = getTestMain testPurs
       expectedFailures <- runIO $ getShouldFailWith mainPath
@@ -100,8 +109,7 @@ spec = do
   -- .purs files and the .js files for the test case.
   getTestFiles :: FilePath -> [FilePath] -> [[FilePath]]
   getTestFiles baseDir
-    = map (filter ((== ".purs") . takeExtensions))
-    . map (map (baseDir </>))
+    = map (filter ((== ".purs") . takeExtensions) . map (baseDir </>))
     . groupBy ((==) `on` extractPrefix)
     . sortBy (compare `on` extractPrefix)
     . map (makeRelative baseDir)
@@ -110,7 +118,7 @@ spec = do
   -- by the file with the shortest path name, as everything but the main file
   -- will be under a subdirectory.
   getTestMain :: [FilePath] -> FilePath
-  getTestMain = head . sortBy (compare `on` length)
+  getTestMain = minimumBy (compare `on` length)
 
   -- Extracts the filename part of a .purs file, or if the file is in a
   -- subdirectory, the first part of that directory path.
@@ -125,9 +133,17 @@ spec = do
   -- Scans a file for @shouldFailWith directives in the comments, used to
   -- determine expected failures
   getShouldFailWith :: FilePath -> IO [String]
-  getShouldFailWith = fmap extractFailWiths . readUTF8File
+  getShouldFailWith = extractPragma "shouldFailWith"
+
+  -- Scans a file for @shouldWarnWith directives in the comments, used to
+  -- determine expected warnings
+  getShouldWarnWith :: FilePath -> IO [String]
+  getShouldWarnWith = extractPragma "shouldWarnWith"
+
+  extractPragma :: String -> FilePath -> IO [String]
+  extractPragma pragma = fmap go . readUTF8File
     where
-    extractFailWiths = lines >>> mapMaybe (stripPrefix "-- @shouldFailWith ") >>> map trim
+    go = lines >>> mapMaybe (stripPrefix ("-- @" ++ pragma ++ " ")) >>> map trim
 
 inferForeignModules
   :: MonadIO m
@@ -168,16 +184,14 @@ readInput inputFiles = forM inputFiles $ \inputFile -> do
   text <- readUTF8File inputFile
   return (inputFile, text)
 
-type TestM = WriterT [(FilePath, String)] IO
-
-runTest :: P.Make a -> IO (Either P.MultipleErrors a)
-runTest = fmap fst . P.runMake P.defaultOptions
+runTest :: P.Make a -> IO (Either P.MultipleErrors a, P.MultipleErrors)
+runTest = P.runMake P.defaultOptions
 
 compile
   :: [(P.Module, P.ExternsFile)]
   -> [FilePath]
   -> ([P.Module] -> IO ())
-  -> IO (Either P.MultipleErrors [P.ExternsFile])
+  -> IO (Either P.MultipleErrors [P.ExternsFile], P.MultipleErrors)
 compile supportExterns inputFiles check = silence $ runTest $ do
   fs <- liftIO $ readInput inputFiles
   ms <- P.parseModulesFromFiles id fs
@@ -192,18 +206,30 @@ assert
   :: [(P.Module, P.ExternsFile)]
   -> [FilePath]
   -> ([P.Module] -> IO ())
-  -> (Either P.MultipleErrors [P.ExternsFile] -> IO (Maybe String))
+  -> (Either P.MultipleErrors P.MultipleErrors -> IO (Maybe String))
   -> Expectation
 assert supportExterns inputFiles check f = do
-  e <- compile supportExterns inputFiles check
-  maybeErr <- f e
+  (e, w) <- compile supportExterns inputFiles check
+  maybeErr <- f (const w <$> e)
   maybe (return ()) expectationFailure maybeErr
+
+checkMain :: [P.Module] -> IO ()
+checkMain ms =
+  unless (any ((== P.moduleNameFromString "Main") . P.getModuleName) ms)
+    (fail "Main module missing")
+
+checkShouldFailWith :: [String] -> P.MultipleErrors -> Maybe String
+checkShouldFailWith expected errs =
+  let actual = map P.errorCode $ P.runMultipleErrors errs
+  in if sort expected == sort actual
+    then Nothing
+    else Just $ "Expected these errors: " ++ show expected ++ ", but got these: " ++ show actual
 
 assertCompiles
   :: [(P.Module, P.ExternsFile)]
   -> [FilePath]
   -> Expectation
-assertCompiles supportExterns inputFiles = do
+assertCompiles supportExterns inputFiles =
   assert supportExterns inputFiles checkMain $ \e ->
     case e of
       Left errs -> return . Just . P.prettyPrintMultipleErrors False $ errs
@@ -219,17 +245,32 @@ assertCompiles supportExterns inputFiles = do
             | otherwise -> return $ Just $ "Test did not finish with 'Done':\n\n" <> out
           Just (ExitFailure _, _, err) -> return $ Just err
           Nothing -> return $ Just "Couldn't find node.js executable"
+
+assertCompilesWithWarnings
+  :: [(P.Module, P.ExternsFile)]
+  -> [FilePath]
+  -> [String]
+  -> Expectation
+assertCompilesWithWarnings supportExterns inputFiles shouldWarnWith =
+  assert supportExterns inputFiles checkMain $ \e ->
+    case e of
+      Left errs ->
+        return . Just . P.prettyPrintMultipleErrors False $ errs
+      Right warnings ->
+        return
+          . fmap (printAllWarnings warnings)
+          $ checkShouldFailWith shouldWarnWith warnings
+
   where
-  checkMain ms =
-    unless (any ((== P.moduleNameFromString "Main") . P.getModuleName) ms)
-      (fail "Main module missing")
+  printAllWarnings warnings =
+    (<> "\n\n" <> P.prettyPrintMultipleErrors False warnings)
 
 assertDoesNotCompile
   :: [(P.Module, P.ExternsFile)]
   -> [FilePath]
   -> [String]
   -> Expectation
-assertDoesNotCompile supportExterns inputFiles shouldFailWith = do
+assertDoesNotCompile supportExterns inputFiles shouldFailWith =
   assert supportExterns inputFiles noPreCheck $ \e ->
     case e of
       Left errs ->
@@ -243,9 +284,3 @@ assertDoesNotCompile supportExterns inputFiles shouldFailWith = do
 
   where
   noPreCheck = const (return ())
-
-  checkShouldFailWith expected errs =
-    let actual = map P.errorCode $ P.runMultipleErrors errs
-    in if sort expected == sort actual
-      then Nothing
-      else Just $ "Expected these errors: " ++ show expected ++ ", but got these: " ++ show actual


### PR DESCRIPTION
This isn't a comprehensive test suite for the warnings, but I think it's the majority of them. The main one that I know for sure needs covering is the `ShadowedName` stuff.

I removed the `RedundantEmptyHidingImport` check, as it wasn't working, and you'd have to work really hard for that case to arise now anyway, thanks to the unused import warnings. The only way it can happen is if you import a module, `hiding` everything, and are re-exporting that module from the current module.

The fixes I speak of are things that I inadvertently broke during #2090 - had an `unless'` function that was actually `when'`, ran the import linter on the wrong version of a module, etc.