### PR TITLE
More portable shebang line in test-everything.sh

### DIFF
--- a/core-tests/test-everything.sh
+++ b/core-tests/test-everything.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Because `/bin/bash` doesn't exist on my NixOS box.