### PR TITLE
Fix issue 2128

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -71,6 +71,7 @@ This file lists the contributors to the PureScript compiler project, and the ter
 - [@zudov](https://github.com/zudov) (Konstantin Zudov) My existing contributions and all future contributions until further notice are Copyright Konstantin Zudov, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 - [@LiamGoodacre](https://github.com/LiamGoodacre) (Liam Goodacre) My existing contributions and all future contributions until further notice are Copyright Liam Goodacre, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 - [@bsermons](https://github.com/bsermons) (Brian Sermons) My existing contributions and all future contributions until further notice are Copyright Brian Sermons, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
+- [@bmjames](https://github.com/bmjames) (Ben James) My existing contributions and all future contributions until further notice are Copyright Ben James, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 
 ### Companies
 

--- a/examples/failing/2128-class.purs
+++ b/examples/failing/2128-class.purs
@@ -1,0 +1,5 @@
+-- @shouldFailWith ErrorParsingModule
+module Main where
+
+class Foo a where
+  foo :: a -> !!!

--- a/examples/failing/2128-instance.purs
+++ b/examples/failing/2128-instance.purs
@@ -1,0 +1,8 @@
+-- @shouldFailWith ErrorParsingModule
+module Main where
+
+class Foo a where
+  foo :: a
+
+instance fooInt :: Foo Int where
+  foo = !!!

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -183,7 +183,7 @@ parseTypeClassDeclaration = do
   className <- indented *> properName
   idents <- P.many (indented *> kindedIdent)
   members <- P.option [] $ do
-    P.try $ indented *> reserved "where"
+    indented *> reserved "where"
     indented *> mark (P.many (same *> positioned parseTypeDeclaration))
   return $ TypeClassDeclaration className idents implies members
 
@@ -207,7 +207,7 @@ parseTypeInstanceDeclaration :: TokenParser Declaration
 parseTypeInstanceDeclaration = do
   instanceDecl <- parseInstanceDeclaration
   members <- P.option [] $ do
-    P.try $ indented *> reserved "where"
+    indented *> reserved "where"
     mark (P.many (same *> positioned parseValueDeclaration))
   return $ instanceDecl (ExplicitInstance members)
 

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -182,8 +182,8 @@ parseTypeClassDeclaration = do
     return implies
   className <- indented *> properName
   idents <- P.many (indented *> kindedIdent)
-  members <- P.option [] . P.try $ do
-    indented *> reserved "where"
+  members <- P.option [] $ do
+    P.try $ indented *> reserved "where"
     indented *> mark (P.many (same *> positioned parseTypeDeclaration))
   return $ TypeClassDeclaration className idents implies members
 
@@ -206,8 +206,8 @@ parseInstanceDeclaration = do
 parseTypeInstanceDeclaration :: TokenParser Declaration
 parseTypeInstanceDeclaration = do
   instanceDecl <- parseInstanceDeclaration
-  members <- P.option [] . P.try $ do
-    indented *> reserved "where"
+  members <- P.option [] $ do
+    P.try $ indented *> reserved "where"
     mark (P.many (same *> positioned parseValueDeclaration))
   return $ instanceDecl (ExplicitInstance members)
 


### PR DESCRIPTION
This is intended to fix #2128.

That issue relates to the error messaging from the parser; the two failing cases I have added need to be compiled manually to demonstrate that the error message is accurate:

    [nix-shell:~/purescript]$ psc examples/failing/2128-instance.purs
    Error found:
    at /home/ben/purescript/examples/failing/2128-instance.purs line 8, column 9 - line 8, column 9

      Unable to parse module:
      unexpected !!!
      expecting expression

and

    [nix-shell:~/purescript]$ psc examples/failing/2128-class.purs
    Error found:
    at /home/ben/purescript/examples/failing/2128-class.purs line 5, column 15 - line 5, column 15

      Unable to parse module:
      unexpected !!!
      expecting qualifier, proper name, (, {, _, "forall", "\8704" or identifier

If you think the testing should be improved to guard automatically against a regression, please could you give me some guidance on how to approach that?