### PR TITLE
Combine multiple export refs for types

### DIFF
--- a/examples/passing/2138.purs
+++ b/examples/passing/2138.purs
@@ -1,0 +1,7 @@
+module Main where
+
+import Control.Monad.Eff.Console (log)
+
+import Lib (A(B,C))
+
+main = log "Done"

--- a/examples/passing/2138/Lib.purs
+++ b/examples/passing/2138/Lib.purs
@@ -1,0 +1,3 @@
+module Lib (A(..), A) where
+
+data A = B | C

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -21,6 +21,7 @@ tested-with: GHC==7.10.3
 
 extra-source-files: examples/passing/*.purs
                   , examples/passing/2018/*.purs
+                  , examples/passing/2138/*.purs
                   , examples/passing/ClassRefSyntax/*.purs
                   , examples/passing/DctorOperatorAlias/*.purs
                   , examples/passing/ExplicitImportReExport/*.purs

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -577,7 +577,7 @@ prettyPrintSingleError full level showWiki e = flip evalState defaultUnknownMap 
       paras [ line $ "Cannot import " ++ printName (Qualified Nothing name) ++ " from module " ++ runModuleName mn
             , line "It either does not exist or the module does not export it."
             ]
-    renderSimpleErrorMessage (UnknownImportDataConstructor mn dcon tcon) =
+    renderSimpleErrorMessage (UnknownImportDataConstructor mn tcon dcon) =
       line $ "Module " ++ runModuleName mn ++ " does not export data constructor " ++ runProperName dcon ++ " for type " ++ runProperName tcon
     renderSimpleErrorMessage (UnknownExport name) =
       line $ "Cannot export unknown " ++ printName (Qualified Nothing name)


### PR DESCRIPTION
Resolves #2138.

Also fixed the error message so it refers to the type constructor and data constructor the right way around.