### PR TITLE
Elaborate re-exports

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -80,19 +80,25 @@ data DeclarationRef
   --
   | ModuleRef ModuleName
   -- |
+  -- A value re-exported from another module. These will be inserted during
+  -- elaboration in name desugaring.
+  --
+  | ReExportRef ModuleName DeclarationRef
+  -- |
   -- A declaration reference with source position information
   --
   | PositionedDeclarationRef SourceSpan [Comment] DeclarationRef
   deriving (Show, Read)
 
 instance Eq DeclarationRef where
-  (TypeRef name dctors)  == (TypeRef name' dctors') = name == name' && dctors == dctors'
-  (TypeOpRef name)       == (TypeOpRef name')       = name == name'
-  (ValueRef name)        == (ValueRef name')        = name == name'
-  (ValueOpRef name)      == (ValueOpRef name')      = name == name'
-  (TypeClassRef name)    == (TypeClassRef name')    = name == name'
+  (TypeRef name dctors) == (TypeRef name' dctors') = name == name' && dctors == dctors'
+  (TypeOpRef name) == (TypeOpRef name') = name == name'
+  (ValueRef name) == (ValueRef name') = name == name'
+  (ValueOpRef name) == (ValueOpRef name') = name == name'
+  (TypeClassRef name) == (TypeClassRef name') = name == name'
   (TypeInstanceRef name) == (TypeInstanceRef name') = name == name'
-  (ModuleRef name)       == (ModuleRef name')       = name == name'
+  (ModuleRef name) == (ModuleRef name') = name == name'
+  (ReExportRef mn ref) == (ReExportRef mn' ref') = mn == mn' && ref == ref'
   (PositionedDeclarationRef _ _ r) == r' = r == r'
   r == (PositionedDeclarationRef _ _ r') = r == r'
   _ == _ = False

--- a/src/Language/PureScript/Sugar/Names/Imports.hs
+++ b/src/Language/PureScript/Sugar/Names/Imports.hs
@@ -207,6 +207,7 @@ resolveImport importModule exps imps impQual = resolveByType
     return $ imp { importedTypeClasses = typeClasses' }
   importRef _ _ TypeInstanceRef{} = internalError "TypeInstanceRef in importRef"
   importRef _ _ ModuleRef{} = internalError "ModuleRef in importRef"
+  importRef _ _ ReExportRef{} = internalError "ReExportRef in importRef"
 
   -- Find all exported data constructors for a given type
   allExportedDataConstructors
@@ -218,7 +219,7 @@ resolveImport importModule exps imps impQual = resolveByType
 
   -- Add something to an import resolution list
   updateImports
-    :: (Ord a)
+    :: Ord a
     => M.Map (Qualified a) [ImportRecord a]
     -> M.Map a b
     -> (b -> ModuleName)


### PR DESCRIPTION
I forgot I worked on this until @kRITZCREEK mentioned something in IRC a minute ago.

Basically, in its current state, this doesn't do anything visible. But it should enable us to remove or improve a ton of code that currently has to figure out things with re-exports and the like - so docs, publish, ide, and psci should all be able to benefit from this change I think.

Opening this to see if it looks like it will help @kRITZCREEK out now, as he's looking at fixing up some name related code in ide.