### PR TITLE
New reexports

### DIFF
--- a/psc-ide-server/Main.hs
+++ b/psc-ide-server/Main.hs
@@ -70,7 +70,6 @@ main :: IO ()
 main = do
   Options dir globs outputPath port noWatch debug <- execParser opts
   maybe (pure ()) setCurrentDirectory dir
-  serverState <- newTVarIO emptyPscIdeState
   ideState <- newTVarIO emptyIdeState
   cwd <- getCurrentDirectory
   let fullOutputPath = cwd </> outputPath
@@ -85,7 +84,7 @@ main = do
     void (forkFinally (watcher ideState fullOutputPath) print)
 
   let conf = Configuration {confDebug = debug, confOutputPath = outputPath, confGlobs = globs}
-      env = IdeEnvironment {envStateVar = serverState, ideStateVar = ideState, ideConfiguration = conf}
+      env = IdeEnvironment {ideStateVar = ideState, ideConfiguration = conf}
   startServer port env
   where
     parser =

--- a/psc-ide-server/PROTOCOL.md
+++ b/psc-ide-server/PROTOCOL.md
@@ -30,7 +30,8 @@ to detect all the compiled modules in your project and load them.
 The Load Command returns a string with a summary about the loading process.
 
 ### Type
-The `type` command looks up the type for a given identifier.
+The `type` command looks up the type for a given identifier. It also returns the
+definition position, if it can be found in the passed source files.
 
 **Params:**
  - `search :: String`: The identifier to look for. Only matches on equality.
@@ -50,7 +51,27 @@ The `type` command looks up the type for a given identifier.
 ```
 
 **Result:**
-The possible types are returned in the same format as completions
+The possible types are returned in the same format as completions + eventual position information
+```json
+[
+  {
+  "module": "Data.Array",
+  "identifier": "filter",
+  "type": "forall a. (a -> Boolean) -> Array a -> Array a"
+  },
+  {
+  "module": "Data.Array",
+  "identifier": "filter",
+  "type": "forall a. (a -> Boolean) -> Array a -> Array a",
+  "definedAt":
+    {
+    "name": "/path/to/file",
+    "start": [1, 3],
+    "end": [3, 1]
+    }
+  }
+]
+```
 
 ### Complete
 The `complete` command looks up possible completions/corrections.

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -503,5 +503,7 @@ test-suite tests
                    Language.PureScript.Ide.MatcherSpec
                    Language.PureScript.Ide.RebuildSpec
                    Language.PureScript.Ide.ReexportsSpec
+                   Language.PureScript.Ide.SourceFile.IntegrationSpec
+                   Language.PureScript.Ide.SourceFileSpec
     buildable: True
     hs-source-dirs: tests

--- a/src/Language/PureScript/Ide/CaseSplit.hs
+++ b/src/Language/PureScript/Ide/CaseSplit.hs
@@ -30,7 +30,6 @@ import qualified Language.PureScript                     as P
 
 import           Language.PureScript.Externs
 import           Language.PureScript.Ide.Error
-import           Language.PureScript.Ide.Externs         (unwrapPositioned)
 import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -35,7 +35,7 @@ data Command
       }
     | Complete
       { completeFilters       :: [Filter]
-      , completeMatcher       :: Matcher
+      , completeMatcher       :: Matcher IdeDeclaration
       , completeCurrentModule :: Maybe P.ModuleName
       }
     | Pursuit

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -19,7 +19,7 @@ getCompletions
   -> [Module]
   -> [Match IdeDeclaration]
 getCompletions filters matcher modules =
-  runMatcher matcher (completionsFromModules discardAstInfo (applyFilters filters modules))
+  runMatcher matcher (completionsFromModules discardAnn (applyFilters filters modules))
 
 getExactMatches :: Text -> [Filter] -> [Module] -> [Match IdeDeclarationAnn]
 getExactMatches search filters modules =

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -9,19 +9,24 @@ import           Protolude
 import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.Matcher
 import           Language.PureScript.Ide.Types
+import           Language.PureScript.Ide.Util
 
 -- | Applies the CompletionFilters and the Matcher to the given Modules
 --   and sorts the found Completions according to the Matching Score
-getCompletions :: [Filter] -> Matcher -> [Module] -> [Match]
+getCompletions
+  :: [Filter]
+  -> Matcher IdeDeclaration
+  -> [Module]
+  -> [Match IdeDeclaration]
 getCompletions filters matcher modules =
-  runMatcher matcher (completionsFromModules (applyFilters filters modules))
+  runMatcher matcher (completionsFromModules discardAstInfo (applyFilters filters modules))
 
-getExactMatches :: Text -> [Filter] -> [Module] -> [Match]
+getExactMatches :: Text -> [Filter] -> [Module] -> [Match IdeDeclarationAnn]
 getExactMatches search filters modules =
-  completionsFromModules (applyFilters (equalityFilter search : filters) modules)
+  completionsFromModules identity (applyFilters (equalityFilter search : filters) modules)
 
-completionsFromModules :: [Module] -> [Match]
-completionsFromModules = foldMap completionFromModule
+completionsFromModules :: (IdeDeclarationAnn -> a) -> [Module] -> [Match a]
+completionsFromModules f = foldMap completionFromModule
   where
-    completionFromModule :: Module -> [Match]
-    completionFromModule (moduleName, decls) = map (Match moduleName) decls
+    completionFromModule (moduleName, decls) =
+      map (\x -> Match (moduleName, f x)) decls

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -15,7 +15,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Language.PureScript.Ide.Error
        ( PscIdeError(..)
-       , textError
        ) where
 
 import           Protolude

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -17,13 +17,9 @@
 {-# LANGUAGE FlexibleContexts  #-}
 
 module Language.PureScript.Ide.Externs
-  ( ExternDecl(..),
-    ModuleIdent,
-    readExternFile,
+  ( readExternFile,
     convertExterns,
-    convertModule,
-    unwrapPositioned,
-    unwrapPositionedRef
+    annotateLocations
   ) where
 
 import           Protolude
@@ -47,96 +43,83 @@ readExternFile fp = do
      Nothing -> throwError . GeneralError $ "Parsing the extern at: " <> toS fp <> " failed"
      Just externs -> pure externs
 
-convertExterns :: P.ExternsFile -> ModuleOld
-convertExterns ef = (runModuleNameT moduleName, exportDecls ++ importDecls ++ decls ++ operatorDecls ++ tyOperatorDecls)
+convertExterns :: P.ExternsFile -> (Module, [(P.ModuleName, P.DeclarationRef)])
+convertExterns ef =
+  ((P.efModuleName ef, decls), exportDecls)
   where
-    moduleName = P.efModuleName ef
-    importDecls = convertImport <$> P.efImports ef
+    decls = map
+      (IdeDeclarationAnn emptyAnn)
+      (cleanDeclarations ++ operatorDecls ++ tyOperatorDecls)
     exportDecls = mapMaybe (convertExport . unwrapPositionedRef) (P.efExports ef)
     operatorDecls = convertOperator <$> P.efFixities ef
     tyOperatorDecls = convertTypeOperator <$> P.efTypeFixities ef
-    otherDecls = mapMaybe convertDecl (P.efDeclarations ef)
+    declarations = mapMaybe convertDecl (P.efDeclarations ef)
 
-    typeClassFilter = foldMap removeTypeDeclarationsForClass (filter isTypeClassDeclaration otherDecls)
-    decls = nub $ appEndo typeClassFilter otherDecls
+    typeClassFilter = foldMap removeTypeDeclarationsForClass (filter isTypeClassDeclaration declarations)
+    cleanDeclarations = nub $ appEndo typeClassFilter declarations
 
-removeTypeDeclarationsForClass :: ExternDecl -> Endo [ExternDecl]
-removeTypeDeclarationsForClass (TypeClassDeclaration n) = Endo (filter notDuplicate)
-  where notDuplicate (TypeDeclaration n' _) = runProperNameT n /= runProperNameT n'
-        notDuplicate (TypeSynonymDeclaration n' _) = runProperNameT n /= runProperNameT n'
+removeTypeDeclarationsForClass :: IdeDeclaration -> Endo [IdeDeclaration]
+removeTypeDeclarationsForClass (IdeTypeClass n) = Endo (filter notDuplicate)
+  where notDuplicate (IdeType n' _) = runProperNameT n /= runProperNameT n'
+        notDuplicate (IdeTypeSynonym n' _) = runProperNameT n /= runProperNameT n'
         notDuplicate _ = True
 removeTypeDeclarationsForClass _ = mempty
 
-isTypeClassDeclaration :: ExternDecl -> Bool
-isTypeClassDeclaration TypeClassDeclaration{} = True
+isTypeClassDeclaration :: IdeDeclaration -> Bool
+isTypeClassDeclaration IdeTypeClass{} = True
 isTypeClassDeclaration _ = False
 
-convertImport :: P.ExternsImport -> ExternDecl
-convertImport ei = Dependency
-  (runModuleNameT (P.eiModule ei))
-  []
-  (runModuleNameT <$> P.eiImportedAs ei)
-
-convertExport :: P.DeclarationRef -> Maybe ExternDecl
-convertExport (P.ModuleRef mn) = Just (Export (runModuleNameT mn))
+convertExport :: P.DeclarationRef -> Maybe (P.ModuleName, P.DeclarationRef)
+convertExport (P.ReExportRef m r) = Just (m, r)
 convertExport _ = Nothing
 
-convertDecl :: P.ExternsDeclaration -> Maybe ExternDecl
-convertDecl P.EDType{..} = Just $ TypeDeclaration edTypeName edTypeKind
-convertDecl P.EDTypeSynonym{..} = Just $
-  TypeSynonymDeclaration edTypeSynonymName edTypeSynonymType
+convertDecl :: P.ExternsDeclaration -> Maybe IdeDeclaration
+convertDecl P.EDType{..} = Just (IdeType edTypeName edTypeKind)
+convertDecl P.EDTypeSynonym{..} =
+  Just (IdeTypeSynonym edTypeSynonymName edTypeSynonymType)
 convertDecl P.EDDataConstructor{..} = Just $
-  DataConstructor (runProperNameT edDataCtorName) edDataCtorTypeCtor edDataCtorType
+  IdeDataConstructor edDataCtorName edDataCtorTypeCtor edDataCtorType
 convertDecl P.EDValue{..} = Just $
-  ValueDeclaration (runIdentT edValueName) edValueType
-convertDecl P.EDClass{..} = Just $ TypeClassDeclaration edClassName
+  IdeValue edValueName edValueType
+convertDecl P.EDClass{..} = Just (IdeTypeClass edClassName)
 convertDecl P.EDInstance{} = Nothing
 
-convertOperator :: P.ExternsFixity -> ExternDecl
+convertOperator :: P.ExternsFixity -> IdeDeclaration
 convertOperator P.ExternsFixity{..} =
-  ValueOperator
+  IdeValueOperator
     efOperator
     (toS (P.showQualified (either P.runIdent P.runProperName) efAlias))
     efPrecedence
     efAssociativity
 
-convertTypeOperator :: P.ExternsTypeFixity -> ExternDecl
+convertTypeOperator :: P.ExternsTypeFixity -> IdeDeclaration
 convertTypeOperator P.ExternsTypeFixity{..} =
-  TypeOperator
+  IdeTypeOperator
     efTypeOperator
     (toS (P.showQualified P.runProperName efTypeAlias))
     efTypePrecedence
     efTypeAssociativity
 
-unwrapPositioned :: P.Declaration -> P.Declaration
-unwrapPositioned (P.PositionedDeclaration _ _ x) = x
-unwrapPositioned x = x
-
-unwrapPositionedRef :: P.DeclarationRef -> P.DeclarationRef
-unwrapPositionedRef (P.PositionedDeclarationRef _ _ x) = x
-unwrapPositionedRef x = x
-
-convertModule :: Map (Either Text Text) P.SourceSpan -> ModuleOld -> Module
-convertModule ast (mn, decls) =
-  (P.moduleNameFromString (toS mn), mapMaybe convertDeclaration decls)
-  where convertDeclaration :: ExternDecl -> Maybe IdeDeclarationAnn
-        convertDeclaration d = case d of
-          ValueDeclaration i t ->
-            annotateValue i (IdeValue i t)
-          TypeDeclaration i k ->
-            annotateType (runProperNameT i) (IdeType i k)
-          TypeSynonymDeclaration i t ->
-            annotateType (runProperNameT i) (IdeTypeSynonym i t)
-          DataConstructor i tn t ->
-            annotateValue i (IdeDataConstructor i tn t)
-          TypeClassDeclaration i ->
-            annotateType (runProperNameT i) (IdeTypeClass i)
-          ValueOperator n i p a ->
-            annotateValue i (IdeValueOperator n i p a)
-          TypeOperator n i p a ->
-            annotateType i (IdeTypeOperator n i p a)
-          Dependency{} -> Nothing
-          ModuleDecl _ _ -> Nothing
-          Export _ -> Nothing
-        annotateValue x = Just . IdeDeclarationAnn (Map.lookup (Left x) ast)
-        annotateType x = Just . IdeDeclarationAnn (Map.lookup (Right x) ast)
+annotateLocations :: Map (Either Text Text) P.SourceSpan -> Module -> Module
+annotateLocations ast (moduleName, decls) =
+  (moduleName, map convertDeclaration decls)
+  where
+    convertDeclaration :: IdeDeclarationAnn -> IdeDeclarationAnn
+    convertDeclaration (IdeDeclarationAnn ann d) = case d of
+      IdeValue i t ->
+        annotateValue (runIdentT i) (IdeValue i t)
+      IdeType i k ->
+        annotateType (runProperNameT i) (IdeType i k)
+      IdeTypeSynonym i t ->
+        annotateType (runProperNameT i) (IdeTypeSynonym i t)
+      IdeDataConstructor i tn t ->
+        annotateValue (runProperNameT i) (IdeDataConstructor i tn t)
+      IdeTypeClass i ->
+        annotateType (runProperNameT i) (IdeTypeClass i)
+      IdeValueOperator n i p a ->
+        annotateValue i (IdeValueOperator n i p a)
+      IdeTypeOperator n i p a ->
+        annotateType i (IdeTypeOperator n i p a)
+      where
+        annotateValue x = IdeDeclarationAnn (ann {annLocation = Map.lookup (Left x) ast})
+        annotateType x = IdeDeclarationAnn (ann {annLocation = Map.lookup (Right x) ast})

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -65,8 +65,9 @@ identFilter predicate search =
     filter (not . null . snd) . fmap filterModuleDecls
   where
     filterModuleDecls :: Module -> Module
-    filterModuleDecls (moduleIdent,decls) =
-        (moduleIdent, filter (`predicate` search) decls)
+    filterModuleDecls (moduleIdent, decls) =
+        (moduleIdent, filter (flip predicate search . getDeclaration) decls)
+    getDeclaration (IdeDeclarationAnn _ d) = d
 
 runFilter :: Filter -> [Module] -> [Module]
 runFilter (Filter f)= appEndo f

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -20,7 +20,6 @@ module Language.PureScript.Ide.Filter
        , moduleFilter
        , prefixFilter
        , equalityFilter
-       , runFilter
        , applyFilters
        ) where
 
@@ -70,7 +69,7 @@ identFilter predicate search =
     getDeclaration (IdeDeclarationAnn _ d) = d
 
 runFilter :: Filter -> [Module] -> [Module]
-runFilter (Filter f)= appEndo f
+runFilter (Filter f) = appEndo f
 
 applyFilters :: [Filter] -> [Module] -> [Module]
 applyFilters = runFilter . fold

--- a/src/Language/PureScript/Ide/Matcher.hs
+++ b/src/Language/PureScript/Ide/Matcher.hs
@@ -18,8 +18,9 @@
 
 module Language.PureScript.Ide.Matcher
        ( Matcher
-       , flexMatcher
        , runMatcher
+       -- for tests
+       , flexMatcher
        ) where
 
 import           Protolude

--- a/src/Language/PureScript/Ide/Matcher.hs
+++ b/src/Language/PureScript/Ide/Matcher.hs
@@ -14,6 +14,7 @@
 
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE FlexibleInstances          #-}
 
 module Language.PureScript.Ide.Matcher
        ( Matcher
@@ -32,23 +33,22 @@ import           Text.EditDistance
 import           Text.Regex.TDFA               ((=~))
 
 
-type ScoredMatch = (Match, Double)
+type ScoredMatch a = (Match a, Double)
 
-newtype Matcher = Matcher (Endo [Match]) deriving (Monoid)
+newtype Matcher a = Matcher (Endo [Match a]) deriving (Monoid)
 
-instance FromJSON Matcher where
+instance FromJSON (Matcher IdeDeclaration) where
   parseJSON = withObject "matcher" $ \o -> do
     (matcher :: Maybe Text) <- o .:? "matcher"
     case matcher of
       Just "flex" -> do
         params <- o .: "params"
-        search <- params .: "search"
-        pure $ flexMatcher search
+        flexMatcher <$> params .: "search"
       Just "distance" -> do
         params <- o .: "params"
-        search <- params .: "search"
-        maxDist <- params .: "maximumDistance"
-        pure $ distanceMatcher search maxDist
+        distanceMatcher
+          <$> params .: "search"
+          <*> params .: "maximumDistance"
       Just _ -> mzero
       Nothing -> return mempty
 
@@ -59,37 +59,37 @@ instance FromJSON Matcher where
 -- Examples:
 --   flMa matches flexMatcher. Score: 14.28
 --   sons matches sortCompletions. Score: 6.25
-flexMatcher :: Text -> Matcher
+flexMatcher :: Text -> Matcher IdeDeclaration
 flexMatcher p = mkMatcher (flexMatch p)
 
-distanceMatcher :: Text -> Int -> Matcher
+distanceMatcher :: Text -> Int -> Matcher IdeDeclaration
 distanceMatcher q maxDist = mkMatcher (distanceMatcher' q maxDist)
 
-distanceMatcher' :: Text -> Int -> [Match] -> [ScoredMatch]
+distanceMatcher' :: Text -> Int -> [Match IdeDeclaration] -> [ScoredMatch IdeDeclaration]
 distanceMatcher' q maxDist = mapMaybe go
   where
     go m = let d = dist (T.unpack y)
-               y = identifierFromMatch m
+               y = identifierFromIdeDeclaration (unwrapMatch m)
           in if d <= maxDist
              then Just (m, 1 / fromIntegral d)
              else Nothing
     dist = levenshteinDistance defaultEditCosts (T.unpack q)
 
-mkMatcher :: ([Match] -> [ScoredMatch]) -> Matcher
+mkMatcher :: ([Match a] -> [ScoredMatch a]) -> Matcher a
 mkMatcher matcher = Matcher . Endo  $ fmap fst . sortCompletions . matcher
 
-runMatcher :: Matcher -> [Match] -> [Match]
+runMatcher :: Matcher a -> [Match a] -> [Match a]
 runMatcher (Matcher m)= appEndo m
 
-sortCompletions :: [ScoredMatch] -> [ScoredMatch]
+sortCompletions :: [ScoredMatch a] -> [ScoredMatch a]
 sortCompletions = sortBy (flip compare `on` snd)
 
-flexMatch :: Text -> [Match] -> [ScoredMatch]
+flexMatch :: Text -> [Match IdeDeclaration] -> [ScoredMatch IdeDeclaration]
 flexMatch = mapMaybe . flexRate
 
-flexRate :: Text -> Match -> Maybe ScoredMatch
+flexRate :: Text -> Match IdeDeclaration -> Maybe (ScoredMatch IdeDeclaration)
 flexRate p c = do
-  score <- flexScore p (identifierFromMatch c)
+  score <- flexScore p (identifierFromIdeDeclaration (unwrapMatch c))
   return (c, score)
 
 -- FlexMatching ala Sublime.

--- a/src/Language/PureScript/Ide/Pursuit.hs
+++ b/src/Language/PureScript/Ide/Pursuit.hs
@@ -14,7 +14,10 @@
 
 {-# LANGUAGE OverloadedStrings   #-}
 
-module Language.PureScript.Ide.Pursuit where
+module Language.PureScript.Ide.Pursuit
+  ( searchPursuitForDeclarations
+  , findPackagesForModuleIdent
+  ) where
 
 import           Protolude
 

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -93,5 +93,14 @@ resolveReexports modules m =
      then replaced
      else resolveReexports modules replaced
 
-resolveReexports2 :: Map Text [ExternDecl] -> ModuleOld -> Module
-resolveReexports2 decls = convertModule . resolveReexports decls
+resolveReexports2
+  :: Map Text [ExternDecl]
+  -> AstData P.SourceSpan
+  -> ModuleOld
+  -> Module
+resolveReexports2 decls (AstData ast) oldModule =
+  let
+    moduleName = P.moduleNameFromString (toS (fst oldModule))
+    astData = fromMaybe Map.empty (Map.lookup moduleName ast)
+  in
+    convertModule astData (resolveReexports decls oldModule)

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -14,93 +14,105 @@
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports    #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 module Language.PureScript.Ide.Reexports
-  ( resolveReexports2
-  -- for tests
-  , getReexports
-  , replaceReexport
-  , replaceReexports
+  ( resolveReexports
+  , prettyPrintReexportResult
+  , reexportHasFailures
+  , ReexportResult(..)
   ) where
-
 
 import           Protolude
 
-import           Data.List                     (union)
 import qualified Data.Map                      as Map
 import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Externs
+import           Language.PureScript.Ide.Util
 import qualified Language.PureScript as P
 
-getReexports :: ModuleOld -> [ExternDecl]
-getReexports (mn, decls)= concatMap getExport decls
-  where getExport d
-          | (Export mn') <- d
-          , mn /= mn' = replaceExportWithAliases decls mn'
-          | otherwise = []
+-- | Contains the module with resolved reexports, and eventual failures
+data ReexportResult a
+  = ReexportResult
+  { reResolved :: a
+  , reFailed :: [(P.ModuleName, P.DeclarationRef)]
+  } deriving (Show, Eq, Functor)
 
-dependencyToExport :: ExternDecl -> ExternDecl
-dependencyToExport (Dependency m _ _) = Export m
-dependencyToExport decl = decl
+-- | Uses the passed formatter to format the resolved module, and adds eventual
+-- failures
+prettyPrintReexportResult
+  :: (a -> Text)
+  -- ^ Formatter for the resolved result
+  -> ReexportResult a
+  -- ^ The Result to be pretty printed
+  -> Text
+prettyPrintReexportResult f ReexportResult{..}
+  | null reFailed =
+      "Successfully resolved reexports for " <> f reResolved
+  | otherwise =
+      "Failed to resolve reexports for "
+      <> f reResolved
+      <> foldMap (\(mn, ref) -> runModuleNameT mn <> show ref) reFailed
 
-replaceExportWithAliases :: [ExternDecl] -> ModuleIdent -> [ExternDecl]
-replaceExportWithAliases decls ident =
-  case filter isMatch decls of
-    [] -> [Export ident]
-    aliases -> map dependencyToExport aliases
-  where isMatch d
-          | Dependency _ _ (Just alias) <- d
-          , alias == ident = True
-          | otherwise = False
+-- | Whether any Refs couldn't be resolved
+reexportHasFailures :: ReexportResult a -> Bool
+reexportHasFailures = not . null . reFailed
 
-replaceReexport :: ExternDecl -> ModuleOld -> ModuleOld -> ModuleOld
-replaceReexport e@(Export _) (m, decls) (_, newDecls) =
-  (m, filter (/= e) decls `union` newDecls)
-replaceReexport _ _ _ = P.internalError "Should only get Exports here"
-
-emptyModule :: ModuleOld
-emptyModule = ("Empty", [])
-
-isExport :: ExternDecl -> Bool
-isExport (Export _) = True
-isExport _ = False
-
-removeExportDecls :: ModuleOld -> ModuleOld
-removeExportDecls = fmap (filter (not . isExport))
-
-replaceReexports :: ModuleOld -> Map ModuleIdent [ExternDecl] -> ModuleOld
-replaceReexports m db = result
+-- | Resolves Reexports for a given Module, by looking up the reexported values
+-- from the passed in Map
+resolveReexports
+  :: Map P.ModuleName [IdeDeclarationAnn]
+  -- ^ Modules to search for the reexported declarations
+  -> (Module, [(P.ModuleName, P.DeclarationRef)])
+  -- ^ The module to resolve reexports for, aswell as the references to resolve
+  -> ReexportResult Module
+resolveReexports modules ((moduleName, decls), refs) =
+  ReexportResult (moduleName, decls <> concat resolvedRefs) failedRefs
   where
-    reexports = getReexports m
-    result = foldl go (removeExportDecls m) reexports
+    (failedRefs, resolvedRefs) = partitionEithers (resolveRef' <$> refs)
+    resolveRef' x@(mn, r) = case Map.lookup mn modules of
+      Nothing -> Left x
+      Just decls' -> first (mn,) (resolveRef decls' r)
 
-    go :: ModuleOld -> ExternDecl -> ModuleOld
-    go m' re@(Export name) = replaceReexport re m' (getModule name)
-    go _ _ = P.internalError "Should only get Exports here"
+resolveRef
+  :: [IdeDeclarationAnn]
+  -> P.DeclarationRef
+  -> Either P.DeclarationRef [IdeDeclarationAnn]
+resolveRef decls ref = case ref of
+  P.TypeRef tn mdtors ->
+    case findRef (\case IdeType name _ -> name == tn; _ -> False) of
+      Nothing -> Left ref
+      Just d -> Right $ d : case mdtors of
+          Nothing ->
+            -- If the dataconstructor field inside the TypeRef is Nothing, that
+            -- means that all data constructors are exported, so we need to look
+            -- those up ourselfes
+            findDtors tn
+          Just dtors -> mapMaybe lookupDtor dtors
+  P.ValueRef i ->
+    findWrapped (\case IdeValue i' _ -> i' == i; _ -> False)
+  P.TypeOpRef name ->
+    findWrapped (\case IdeTypeOperator n _ _ _ -> n == name; _ -> False)
+  P.ValueOpRef name ->
+    findWrapped (\case IdeValueOperator n _ _ _ -> n == name; _ -> False)
+  P.TypeClassRef name ->
+    findWrapped (\case IdeTypeClass n -> n == name; _ -> False)
+  _ ->
+    Left ref
+  where
+    findWrapped = wrapSingle . findRef
+    wrapSingle = maybe (Left ref) (Right . pure)
+    findRef f = find (f . discardAnn) decls
 
-    getModule :: ModuleIdent -> ModuleOld
-    getModule name = clean res
+    lookupDtor name =
+      findRef (\case IdeDataConstructor name' _ _ -> name == name'
+                     _ -> False)
+
+    findDtors tn = filter (f . discardAnn) decls
       where
-        res = fromMaybe emptyModule $ (name , ) <$> Map.lookup name db
-        -- we have to do this because keeping self exports in will result in
-        -- infinite loops
-        clean (mn, decls) = (mn,) (filter (/= Export mn) decls)
-
-resolveReexports :: Map ModuleIdent [ExternDecl] -> ModuleOld -> ModuleOld
-resolveReexports modules m =
-  let replaced = replaceReexports m modules
-  in if null (getReexports replaced)
-     then replaced
-     else resolveReexports modules replaced
-
-resolveReexports2
-  :: Map Text [ExternDecl]
-  -> AstData P.SourceSpan
-  -> ModuleOld
-  -> Module
-resolveReexports2 decls (AstData ast) oldModule =
-  let
-    moduleName = P.moduleNameFromString (toS (fst oldModule))
-    astData = fromMaybe Map.empty (Map.lookup moduleName ast)
-  in
-    convertModule astData (resolveReexports decls oldModule)
+        f :: IdeDeclaration -> Bool
+        f decl
+          | (IdeDataConstructor _ tn' _) <- decl
+          , tn == tn' = True
+          | otherwise = False

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -25,7 +25,6 @@ import           Protolude
 import qualified Language.PureScript                  as P
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Util
-import           Language.PureScript.Ide.Externs      (unwrapPositionedRef)
 import           Language.PureScript.Ide.Types
 import           System.FilePath
 import           System.IO.UTF8                       (readUTF8File)

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -29,10 +29,11 @@ module Language.PureScript.Ide.State
   , getAllModules2
   , getStage1
   , setStage1
-  , getStage2
-  , setStage2
+  , getStage3
+  , setStage3
   , populateStage2
-  , populateStage2STM
+  , populateStage3
+  , populateStage3STM
   ) where
 
 import           Protolude
@@ -44,6 +45,7 @@ import qualified Data.Map.Lazy                     as M
 import           Language.PureScript.Externs
 import           Language.PureScript.Ide.Externs
 import           Language.PureScript.Ide.Reexports
+import           Language.PureScript.Ide.SourceFile
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
 import qualified Language.PureScript as P
@@ -58,7 +60,7 @@ resetIdeState = do
   liftIO . atomically $ do
     writeTVar stateVar emptyPscIdeState
     writeTVar ideVar emptyIdeState
-    setStage2STM ideVar emptyStage2
+    setStage3STM ideVar emptyStage3
 
 -- | Gets the loaded Modulenames
 getLoadedModulenames :: Ide m => m [P.ModuleName]
@@ -106,7 +108,6 @@ insertModuleSTM ref (fp, module') =
 
 -- | Retrieves Stage1 from the State.
 --  This includes loaded Externfiles
--- (TODO: as soon as we actually parse the modules) aswell as the parsed modules
 getStage1 :: Ide m => m Stage1
 getStage1 = do
   st <- ideStateVar <$> ask
@@ -124,19 +125,14 @@ setStage1 s1 = do
     x {ideStage1 = s1}
   pure ()
 
--- TODO: Soon to be Stage3
 -- | Retrieves Stage2 from the State.
--- This includes the denormalized Declarations and cached rebuilds
 getStage2 :: Ide m => m Stage2
 getStage2 = do
   st <- ideStateVar <$> ask
-  fmap ideStage2 . liftIO . readTVarIO $ st
+  liftIO (atomically (getStage2STM st))
 
--- | Sets Stage2 inside the compiler
-setStage2 :: Ide m => Stage2 -> m ()
-setStage2 s2 = do
-  st <- ideStateVar <$> ask
-  liftIO . atomically $ setStage2STM st s2
+getStage2STM ::  TVar IdeState -> STM Stage2
+getStage2STM ref = ideStage2 <$> readTVar ref
 
 -- | STM version of setStage2
 setStage2STM :: TVar IdeState -> Stage2 -> STM ()
@@ -145,21 +141,44 @@ setStage2STM ref s2 = do
     x {ideStage2 = s2}
   pure ()
 
+-- | Retrieves Stage3 from the State.
+-- This includes the denormalized Declarations and cached rebuilds
+getStage3 :: Ide m => m Stage3
+getStage3 = do
+  st <- ideStateVar <$> ask
+  fmap ideStage3 . liftIO . readTVarIO $ st
+
+-- | Sets Stage3 inside the compiler
+setStage3 :: Ide m => Stage3 -> m ()
+setStage3 s3 = do
+  st <- ideStateVar <$> ask
+  liftIO . atomically $ setStage3STM st s3
+
+-- | STM version of setStage3
+setStage3STM :: TVar IdeState -> Stage3 -> STM ()
+setStage3STM ref s3 = do
+  modifyTVar ref $ \x ->
+    x {ideStage3 = s3}
+  pure ()
+
 -- | Checks if the given ModuleName matches the last rebuild cache and if it
 -- does returns all loaded definitions + the definitions inside the rebuild
 -- cache
-getAllModules2 :: Ide m => Maybe P.ModuleName -> m [(P.ModuleName, [IdeDeclaration])]
+getAllModules2 :: Ide m => Maybe P.ModuleName -> m [Module]
 getAllModules2 mmoduleName = do
-  declarations <- s2Declarations <$> getStage2
+  declarations <- s3Declarations <$> getStage3
   rebuild <- cachedRebuild
   case mmoduleName of
     Nothing -> pure (M.toList declarations)
     Just moduleName ->
       case rebuild of
         Just (cachedModulename, ef)
-          | cachedModulename == moduleName ->
-            pure . M.toList $
-              M.insert moduleName (snd . convertModule . convertExterns $ ef) declarations
+          | cachedModulename == moduleName -> do
+              (AstData asts) <- s2AstData <$> getStage2
+              let ast = fromMaybe M.empty (M.lookup moduleName asts)
+              pure . M.toList $
+                M.insert moduleName
+                (snd . convertModule ast . convertExterns $ ef) declarations
         _ -> pure (M.toList declarations)
 
 -- | Adds an ExternsFile into psc-ide's State Stage1. This does not populate the
@@ -182,14 +201,14 @@ cacheRebuild :: Ide m => ExternsFile -> m ()
 cacheRebuild ef = do
   st <- ideStateVar <$> ask
   liftIO . atomically . modifyTVar st $ \x ->
-    x { ideStage2 = (ideStage2 x) {
-          s2CachedRebuild = Just (efModuleName ef, ef)}}
+    x { ideStage3 = (ideStage3 x) {
+          s3CachedRebuild = Just (efModuleName ef, ef)}}
 
 -- | Retrieves the rebuild cache
 cachedRebuild :: Ide m => m (Maybe (P.ModuleName, ExternsFile))
-cachedRebuild = s2CachedRebuild <$> getStage2
+cachedRebuild = s3CachedRebuild <$> getStage3
 
--- | Resolves reexports and populates Stage2 with data to be used in queries.
+-- | Extracts source spans from the parsed ASTs
 populateStage2 :: (Ide m, MonadLogger m) => m ()
 populateStage2 = do
   st <- ideStateVar <$> ask
@@ -203,9 +222,28 @@ populateStage2 = do
 -- | STM version of populateStage2
 populateStage2STM :: TVar IdeState -> STM ()
 populateStage2STM ref = do
+  modules <- s1Modules <$> getStage1STM ref
+  let spans = map (\((P.Module ss _ _ decls _), _) -> M.fromList (concatMap (extractSpans ss) decls)) modules
+  setStage2STM ref (Stage2 (AstData spans))
+
+-- | Resolves reexports and populates Stage3 with data to be used in queries.
+populateStage3 :: (Ide m, MonadLogger m) => m ()
+populateStage3 = do
+  st <- ideStateVar <$> ask
+  duration <- liftIO $ do
+    start <- getTime Monotonic
+    atomically (populateStage3STM st)
+    end <- getTime Monotonic
+    pure (Prelude.show (diffTimeSpec start end))
+  $(logDebug) $ "Finished populating Stage3 in " <> toS duration
+
+-- | STM version of populateStage3
+populateStage3STM :: TVar IdeState -> STM ()
+populateStage3STM ref = do
   externs <- s1Externs <$> getStage1STM ref
+  asts <- s2AstData <$> getStage2STM ref
   -- Build the "old" ExternDecl format
   let modules = M.mapKeys runModuleNameT (M.map (snd . convertExterns) externs)
       -- Convert ExternDecl into IdeDeclaration
-      declarations = resolveReexports2 modules <$> M.toList modules
-  setStage2STM ref (Stage2 (M.fromList declarations) Nothing)
+      declarations = resolveReexports2 modules asts <$> M.toList modules
+  setStage3STM ref (Stage3 (M.fromList declarations) Nothing)

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -13,6 +13,7 @@
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveFoldable    #-}
 
 module Language.PureScript.Ide.Types where
 
@@ -67,8 +68,17 @@ data IdeDeclaration
   | IdeTypeOperator (P.OpName 'P.TypeOpName) Ident P.Precedence P.Associativity
   deriving (Show, Eq, Ord)
 
-type Module = (P.ModuleName, [IdeDeclaration])
+data IdeDeclarationAnn = IdeDeclarationAnn AstInfo IdeDeclaration
+  deriving (Show, Eq, Ord)
+
+type Module = (P.ModuleName, [IdeDeclarationAnn])
 type ModuleOld = (Text, [ExternDecl])
+
+type AstInfo = Maybe P.SourceSpan
+
+newtype AstData a =
+  AstData (Map P.ModuleName (Map (Either Text Text) a))
+  deriving (Show, Eq, Ord, Functor, Foldable)
 
 data Configuration =
   Configuration
@@ -97,16 +107,20 @@ emptyPscIdeState = PscIdeState M.empty
 data IdeState = IdeState
   { ideStage1 :: Stage1
   , ideStage2 :: Stage2
+  , ideStage3 :: Stage3
   }
 
 emptyIdeState :: IdeState
-emptyIdeState = IdeState emptyStage1 emptyStage2
+emptyIdeState = IdeState emptyStage1 emptyStage2 emptyStage3
 
 emptyStage1 :: Stage1
 emptyStage1 = Stage1 M.empty M.empty
 
 emptyStage2 :: Stage2
-emptyStage2 = Stage2 M.empty Nothing
+emptyStage2 = Stage2 (AstData M.empty)
+
+emptyStage3 :: Stage3
+emptyStage3 = Stage3 M.empty Nothing
 
 data Stage1 = Stage1
   { s1Externs :: M.Map P.ModuleName P.ExternsFile
@@ -114,19 +128,31 @@ data Stage1 = Stage1
   }
 
 data Stage2 = Stage2
-  { s2Declarations :: M.Map P.ModuleName [IdeDeclaration]
-  , s2CachedRebuild :: Maybe (P.ModuleName, P.ExternsFile)
+  { s2AstData :: AstData P.SourceSpan
   }
 
-data Match = Match P.ModuleName IdeDeclaration
-           deriving (Show, Eq)
+data Stage3 = Stage3
+  { s3Declarations :: M.Map P.ModuleName [IdeDeclarationAnn]
+  , s3CachedRebuild :: Maybe (P.ModuleName, P.ExternsFile)
+  }
+
+newtype Match a = Match (P.ModuleName, a)
+           deriving (Show, Eq, Functor)
 
 newtype Completion =
   Completion (ModuleIdent, Ident, Text)
   deriving (Show,Eq)
 
+newtype Info =
+  Info (ModuleIdent, Ident, Text, Maybe P.SourceSpan)
+  deriving (Show,Eq)
+
+instance ToJSON Info where
+  toJSON (Info (m, d, t, sourceSpan)) =
+    object ["module" .= m, "identifier" .= d, "type" .= t, "definedAt" .= sourceSpan]
+
 instance ToJSON Completion where
-  toJSON (Completion (m,d,t)) =
+  toJSON (Completion (m, d, t)) =
     object ["module" .= m, "identifier" .= d, "type" .= t]
 
 data ModuleImport =
@@ -165,6 +191,7 @@ identifierFromDeclarationRef _ = ""
 
 data Success =
   CompletionResult [Completion]
+  | InfoResult [Info]
   | TextResult Text
   | MultilineTextResult [Text]
   | PursuitResult [PursuitResponse]
@@ -179,6 +206,7 @@ encodeSuccess res =
 
 instance ToJSON Success where
   toJSON (CompletionResult cs) = encodeSuccess cs
+  toJSON (InfoResult i) = encodeSuccess i
   toJSON (TextResult t) = encodeSuccess t
   toJSON (MultilineTextResult ts) = encodeSuccess ts
   toJSON (PursuitResult resp) = encodeSuccess resp

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -17,11 +17,13 @@
 module Language.PureScript.Ide.Util
   ( identifierFromIdeDeclaration
   , unwrapMatch
+  , unwrapPositioned
+  , unwrapPositionedRef
   , completionFromMatch
   , infoFromMatch
   , encodeT
   , decodeT
-  , discardAstInfo
+  , discardAnn
   , module Language.PureScript.Ide.Conversions
   ) where
 
@@ -35,16 +37,16 @@ import           Language.PureScript.Ide.Conversions
 
 identifierFromIdeDeclaration :: IdeDeclaration -> Text
 identifierFromIdeDeclaration d = case d of
-  IdeValue name _ -> name
+  IdeValue name _ -> runIdentT name
   IdeType name _ -> runProperNameT name
   IdeTypeSynonym name _ -> runProperNameT name
-  IdeDataConstructor name _ _ -> name
+  IdeDataConstructor name _ _ -> runProperNameT name
   IdeTypeClass name -> runProperNameT name
   IdeValueOperator op _ _ _ -> runOpNameT op
   IdeTypeOperator op _ _ _ -> runOpNameT op
 
-discardAstInfo :: IdeDeclarationAnn -> IdeDeclaration
-discardAstInfo (IdeDeclarationAnn _ d) = d
+discardAnn :: IdeDeclarationAnn -> IdeDeclaration
+discardAnn (IdeDeclarationAnn _ d) = d
 
 unwrapMatch :: Match a -> a
 unwrapMatch (Match (_, ed)) = ed
@@ -54,13 +56,15 @@ completionFromMatch = Completion . completionFromMatch'
 
 completionFromMatch' :: Match IdeDeclaration -> (Text, Text, Text)
 completionFromMatch' (Match (m', d)) = case d of
-  IdeValue name type' -> (m, name, prettyTypeT type')
+  IdeValue name type' -> (m, runIdentT name, prettyTypeT type')
   IdeType name kind -> (m, runProperNameT name, toS (P.prettyPrintKind kind))
   IdeTypeSynonym name kind -> (m, runProperNameT name, prettyTypeT kind)
-  IdeDataConstructor name _ type' -> (m, name, prettyTypeT type')
+  IdeDataConstructor name _ type' -> (m, runProperNameT name, prettyTypeT type')
   IdeTypeClass name -> (m, runProperNameT name, "class")
-  IdeValueOperator op ref precedence associativity -> (m, runOpNameT op, showFixity precedence associativity ref op)
-  IdeTypeOperator op ref precedence associativity -> (m, runOpNameT op, showFixity precedence associativity ref op)
+  IdeValueOperator op ref precedence associativity ->
+    (m, runOpNameT op, showFixity precedence associativity ref op)
+  IdeTypeOperator op ref precedence associativity ->
+    (m, runOpNameT op, showFixity precedence associativity ref op)
   where
     m = runModuleNameT m'
     showFixity p a r o =
@@ -71,8 +75,8 @@ completionFromMatch' (Match (m', d)) = case d of
       in T.unwords [asso, show p, r, "as", runOpNameT o]
 
 infoFromMatch :: Match IdeDeclarationAnn -> Info
-infoFromMatch (Match (m, (IdeDeclarationAnn ss d))) =
-  Info (a, b, c, ss)
+infoFromMatch (Match (m, (IdeDeclarationAnn ann d))) =
+  Info (a, b, c, annLocation ann)
   where
     (a, b, c) = completionFromMatch' (Match (m, d))
 
@@ -81,3 +85,11 @@ encodeT = toS . decodeUtf8 . encode
 
 decodeT :: (FromJSON a) => Text -> Maybe a
 decodeT = decode . encodeUtf8 . toS
+
+unwrapPositioned :: P.Declaration -> P.Declaration
+unwrapPositioned (P.PositionedDeclaration _ _ x) = x
+unwrapPositioned x = x
+
+unwrapPositionedRef :: P.DeclarationRef -> P.DeclarationRef
+unwrapPositionedRef (P.PositionedDeclarationRef _ _ x) = x
+unwrapPositionedRef x = x

--- a/src/Language/PureScript/Ide/Watcher.hs
+++ b/src/Language/PureScript/Ide/Watcher.hs
@@ -33,7 +33,7 @@ reloadFile ref ev = do
   case ef' of
     Left _ -> pure ()
     Right ef -> do
-      atomically (insertExternsSTM ref ef *> populateStage2STM ref)
+      atomically (insertExternsSTM ref ef *> populateStage3STM ref)
       putStrLn ("Reloaded File at: " ++ fp)
 
 -- | Installs filewatchers for the given directory and reloads ExternsFiles when

--- a/src/Language/PureScript/Ide/Watcher.hs
+++ b/src/Language/PureScript/Ide/Watcher.hs
@@ -12,7 +12,9 @@
 -- File watcher for externs files
 -----------------------------------------------------------------------------
 
-module Language.PureScript.Ide.Watcher where
+module Language.PureScript.Ide.Watcher
+ ( watcher
+ ) where
 
 import           Protolude
 
@@ -33,7 +35,7 @@ reloadFile ref ev = do
   case ef' of
     Left _ -> pure ()
     Right ef -> do
-      atomically (insertExternsSTM ref ef *> populateStage3STM ref)
+      void $ atomically (insertExternsSTM ref ef *> populateStage3STM ref)
       putStrLn ("Reloaded File at: " ++ fp)
 
 -- | Installs filewatchers for the given directory and reloads ExternsFiles when

--- a/tests/Language/PureScript/Ide/FilterSpec.hs
+++ b/tests/Language/PureScript/Ide/FilterSpec.hs
@@ -9,7 +9,7 @@ import qualified Language.PureScript as P
 import           Test.Hspec
 
 value :: Text -> IdeDeclarationAnn
-value s = IdeDeclarationAnn Nothing $ IdeValue s P.REmpty
+value s = IdeDeclarationAnn emptyAnn (IdeValue (P.Ident (toS s)) P.REmpty)
 
 moduleA, moduleB :: Module
 moduleA = (P.moduleNameFromString "Module.A", [value "function1"])
@@ -19,13 +19,13 @@ modules :: [Module]
 modules = [moduleA, moduleB]
 
 runEq :: Text -> [Module]
-runEq s = runFilter (equalityFilter s) modules
+runEq s = applyFilters [equalityFilter s] modules
 
 runPrefix :: Text -> [Module]
-runPrefix s = runFilter (prefixFilter s) modules
+runPrefix s = applyFilters [prefixFilter s] modules
 
 runModule :: [P.ModuleName] -> [Module]
-runModule ms = runFilter (moduleFilter ms) modules
+runModule ms = applyFilters [moduleFilter ms] modules
 
 spec :: Spec
 spec = do

--- a/tests/Language/PureScript/Ide/FilterSpec.hs
+++ b/tests/Language/PureScript/Ide/FilterSpec.hs
@@ -8,8 +8,8 @@ import           Language.PureScript.Ide.Types
 import qualified Language.PureScript as P
 import           Test.Hspec
 
-value :: Text -> IdeDeclaration
-value s = IdeValue s $ P.TypeWildcard $ P.SourceSpan "" (P.SourcePos 0 0) (P.SourcePos 0 0)
+value :: Text -> IdeDeclarationAnn
+value s = IdeDeclarationAnn Nothing $ IdeValue s P.REmpty
 
 moduleA, moduleB :: Module
 moduleA = (P.moduleNameFromString "Module.A", [value "function1"])

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -68,11 +68,11 @@ spec = do
   describe "import commands" $ do
     let simpleFileImports = let (_, _, i, _) = splitSimpleFile in i
         addValueImport i mn is =
-          prettyPrintImportSection (addExplicitImport' (IdeValue i wildcard) mn is)
+          prettyPrintImportSection (addExplicitImport' (IdeValue (P.Ident i) wildcard) mn is)
         addOpImport op mn is =
           prettyPrintImportSection (addExplicitImport' (IdeValueOperator op "" 2 P.Infix) mn is)
         addDtorImport i t mn is =
-          prettyPrintImportSection (addExplicitImport' (IdeDataConstructor i t wildcard) mn is)
+          prettyPrintImportSection (addExplicitImport' (IdeDataConstructor (P.ProperName i) t wildcard) mn is)
     it "adds an implicit unqualified import" $
       shouldBe
         (addImplicitImport' simpleFileImports (P.moduleNameFromString "Data.Map"))

--- a/tests/Language/PureScript/Ide/Integration.hs
+++ b/tests/Language/PureScript/Ide/Integration.hs
@@ -37,11 +37,13 @@ module Language.PureScript.Ide.Integration
        , getFlexCompletions
        , getFlexCompletionsInModule
        , getType
+       , getInfo
        , rebuildModule
        , reset
          -- checking results
        , resultIsSuccess
        , parseCompletions
+       , parseInfo
        , parseTextResult
        ) where
 
@@ -53,6 +55,7 @@ import           Data.Aeson.Types
 import qualified Data.Text                    as T
 import qualified Data.Vector                  as V
 import           Language.PureScript.Ide.Util
+import qualified Language.PureScript          as P
 import           System.Directory
 import           System.FilePath
 import           System.IO.Error              (mkIOError, userErrorType)
@@ -68,7 +71,7 @@ startServer = do
   pdir <- projectDirectory
   -- Turn off filewatching since it creates race condition in a testing environment
   (_, _, _, procHandle) <- createProcess $
-    (shell "psc-ide-server --no-watch") {cwd = Just pdir}
+    (shell "psc-ide-server --no-watch src/*.purs") {cwd = Just pdir}
   threadDelay 500000 -- give the server 500ms to start up
   return procHandle
 
@@ -91,10 +94,7 @@ compileTestProject :: IO Bool
 compileTestProject = do
   pdir <- projectDirectory
   (_, _, _, procHandle) <- createProcess $
-    (shell . toS $ "psc " <> fileGlob) { cwd = Just pdir
-                                       , std_out = CreatePipe
-                                       , std_err = CreatePipe
-                                       }
+    (shell . toS $ "psc " <> fileGlob) { cwd = Just pdir }
   r <- tryNTimes 5 (getProcessExitCode procHandle)
   pure (fromMaybe False (isSuccess <$> r))
 
@@ -166,6 +166,9 @@ getFlexCompletionsInModule q m = parseCompletions <$> sendCommand (completion []
 
 getType :: Text -> IO [(Text, Text, Text)]
 getType q = parseCompletions <$> sendCommand (typeC q [])
+
+getInfo :: Text -> IO [P.SourceSpan]
+getInfo q = parseInfo <$> sendCommand (typeC q [])
 
 addImport :: Text -> FilePath -> FilePath -> IO Text
 addImport identifier fp outfp = sendCommand (addImportC identifier fp outfp)
@@ -259,6 +262,10 @@ completionParser = withArray "res" $ \cs ->
            ty <- o .: "type"
            pure (module', ident, ty)) (V.toList cs)
 
+infoParser :: Value -> Parser [P.SourceSpan]
+infoParser = withArray "res" $ \cs ->
+  mapM (withObject "info" $ \o -> o .: "definedAt") (V.toList cs)
+
 valueFromText :: Text -> Value
 valueFromText = fromJust . decode . toS
 
@@ -268,6 +275,10 @@ resultIsSuccess = isRight . join . first toS . parseEither unwrapResult . valueF
 parseCompletions :: Text -> [(Text, Text, Text)]
 parseCompletions s =
   fromJust $ join (rightToMaybe <$> parseMaybe (withResult completionParser) (valueFromText s))
+
+parseInfo :: Text -> [P.SourceSpan]
+parseInfo s =
+  fromJust $ join (rightToMaybe <$> parseMaybe (withResult infoParser) (valueFromText s))
 
 parseTextResult :: Text -> Text
 parseTextResult s =

--- a/tests/Language/PureScript/Ide/Integration.hs
+++ b/tests/Language/PureScript/Ide/Integration.hs
@@ -72,7 +72,7 @@ startServer = do
   -- Turn off filewatching since it creates race condition in a testing environment
   (_, _, _, procHandle) <- createProcess $
     (shell "psc-ide-server --no-watch src/*.purs") {cwd = Just pdir}
-  threadDelay 500000 -- give the server 500ms to start up
+  threadDelay 2000000 -- give the server 2s to start up
   return procHandle
 
 stopServer :: ProcessHandle -> IO ()

--- a/tests/Language/PureScript/Ide/MatcherSpec.hs
+++ b/tests/Language/PureScript/Ide/MatcherSpec.hs
@@ -12,17 +12,17 @@ import           Language.PureScript.Ide.Types
 import           Test.Hspec
 
 value :: Text -> IdeDeclaration
-value s = IdeValue s $ P.TypeWildcard $ P.SourceSpan "" (P.SourcePos 0 0) (P.SourcePos 0 0)
+value s = IdeValue s P.REmpty
 
-firstResult, secondResult, fiult :: Match
-firstResult = Match (P.moduleNameFromString "Match") (value "firstResult")
-secondResult = Match (P.moduleNameFromString "Match") (value "secondResult")
-fiult = Match (P.moduleNameFromString "Match") (value "fiult")
+firstResult, secondResult, fiult :: Match IdeDeclaration
+firstResult = Match (P.moduleNameFromString "Match", value "firstResult")
+secondResult = Match (P.moduleNameFromString "Match", value "secondResult")
+fiult = Match (P.moduleNameFromString "Match", value "fiult")
 
-completions :: [Match]
+completions :: [Match IdeDeclaration]
 completions = [firstResult, secondResult, fiult]
 
-runFlex :: Text -> [Match]
+runFlex :: Text -> [Match IdeDeclaration]
 runFlex s = runMatcher (flexMatcher s) completions
 
 setup :: IO ()

--- a/tests/Language/PureScript/Ide/MatcherSpec.hs
+++ b/tests/Language/PureScript/Ide/MatcherSpec.hs
@@ -12,7 +12,7 @@ import           Language.PureScript.Ide.Types
 import           Test.Hspec
 
 value :: Text -> IdeDeclaration
-value s = IdeValue s P.REmpty
+value s = IdeValue (P.Ident (toS s)) P.REmpty
 
 firstResult, secondResult, fiult :: Match IdeDeclaration
 firstResult = Match (P.moduleNameFromString "Match", value "firstResult")

--- a/tests/Language/PureScript/Ide/ReexportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ReexportsSpec.hs
@@ -2,78 +2,63 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 module Language.PureScript.Ide.ReexportsSpec where
 
+import qualified Prelude as Prelude
 import           Protolude
 
-import qualified Data.Map                          as Map
+import qualified Data.Map as Map
 import           Language.PureScript.Ide.Reexports
 import           Language.PureScript.Ide.Types
 import qualified Language.PureScript as P
 import           Test.Hspec
 
-wildcard :: P.Type
-wildcard = P.TypeWildcard $ P.SourceSpan "" (P.SourcePos 0 0) (P.SourcePos 0 0)
+m :: Prelude.String -> P.ModuleName
+m = P.moduleNameFromString
 
-decl1 :: ExternDecl
-decl1 = ValueDeclaration "filter" wildcard
-decl2 :: ExternDecl
-decl2 = ValueDeclaration "map" wildcard
-decl3 :: ExternDecl
-decl3 = ValueDeclaration "catMaybe" wildcard
-dep1 :: ExternDecl
-dep1 = Dependency "Test.Foo" [] (Just "T")
-dep2 :: ExternDecl
-dep2 = Dependency "Test.Bar" [] (Just "T")
+d :: IdeDeclaration -> IdeDeclarationAnn
+d = IdeDeclarationAnn emptyAnn
 
-circularModule :: ModuleOld
-circularModule = ("Circular", [Export "Circular"])
+valueA, typeA, classA, dtorA1, dtorA2 :: IdeDeclarationAnn
+valueA = d (IdeValue (P.Ident "valueA") P.REmpty)
+typeA = d (IdeType (P.ProperName "TypeA") P.Star)
+classA = d (IdeTypeClass (P.ProperName "ClassA"))
+dtorA1 = d (IdeDataConstructor (P.ProperName "DtorA1") (P.ProperName "TypeA") P.REmpty)
+dtorA2 = d (IdeDataConstructor (P.ProperName "DtorA2") (P.ProperName "TypeA") P.REmpty)
 
-module1 :: ModuleOld
-module1 = ("Module1", [Export "Module2", Export "Module3", decl1])
+env :: Map P.ModuleName [IdeDeclarationAnn]
+env = Map.fromList
+  [ (m "A", [valueA, typeA, classA, dtorA1, dtorA2])
+  ]
 
-module2 :: ModuleOld
-module2 = ("Module2", [decl2])
+type Refs = [(P.ModuleName, P.DeclarationRef)]
 
-module3 :: ModuleOld
-module3 = ("Module3", [decl3])
+succTestCases :: [(Text, Module, Refs, Module)]
+succTestCases =
+  [ ("resolves a value reexport", (m "C", []), [(m "A", P.ValueRef (P.Ident "valueA"))], (m "C", [valueA]))
+  , ("resolves a type reexport with explicit data constructors"
+    , (m "C", []), [(m "A", P.TypeRef (P.ProperName "TypeA") (Just [P.ProperName "DtorA1"]))], (m "C", [typeA, dtorA1]))
+  , ("resolves a type reexport with implicit data constructors"
+    , (m "C", []), [(m "A", P.TypeRef (P.ProperName "TypeA") Nothing)], (m "C", [typeA, dtorA1, dtorA2]))
+  , ("resolves a class reexport", (m "C", []), [(m "A", P.TypeClassRef (P.ProperName "ClassA"))], (m "C", [classA]))
+  ]
 
-module4 :: ModuleOld
-module4 = ("Module4", [Export "T", decl1, dep1, dep2])
-
-result :: ModuleOld
-result = ("Module1", [decl1, decl2, Export "Module3"])
-
-db :: Map ModuleIdent [ExternDecl]
-db = Map.fromList [module1, module2, module3]
-
-shouldBeEqualSorted :: ModuleOld -> ModuleOld -> Expectation
-shouldBeEqualSorted (n1, d1) (n2, d2) = (n1, sort d1) `shouldBe` (n2, sort d2)
+failTestCases :: [(Text, Module, Refs)]
+failTestCases =
+  [ ("fails to resolve a non existing value", (m "C", []), [(m "A", P.ValueRef (P.Ident "valueB"))])
+  , ("fails to resolve a non existing type reexport" , (m "C", []), [(m "A", P.TypeRef (P.ProperName "TypeB") Nothing)])
+  , ("fails to resolve a non existing class reexport", (m "C", []), [(m "A", P.TypeClassRef (P.ProperName "ClassB"))])
+  ]
 
 spec :: Spec
-spec =
-  describe "Reexports" $ do
-    it "finds all reexports" $
-      getReexports module1 `shouldBe` [Export "Module2", Export "Module3"]
-
-    it "replaces a reexport with another module" $
-      replaceReexport (Export "Module2") module1 module2 `shouldBeEqualSorted` result
-
-    it "adds another module even if there is no export statement" $
-      replaceReexport (Export "Module2") ("Module1", [decl1, Export "Module3"]) module2
-      `shouldBeEqualSorted` result
-
-    it "only adds a declaration once" $
-      let replaced = replaceReexport (Export "Module2") module1 module2
-      in replaceReexport (Export "Module2") replaced module2  `shouldBeEqualSorted` result
-
-    it "replaces all Exports with their corresponding declarations" $
-      replaceReexports module1 db `shouldBe` ("Module1", [decl1, decl2, decl3])
-
-    it "does not list itself as a reexport" $
-      getReexports circularModule `shouldBe` []
-
-    it "does not include circular references when replacing reexports" $
-      replaceReexports circularModule (uncurry Map.singleton circularModule )
-      `shouldBe` ("Circular", [])
-
-    it "replaces exported aliases with imported module" $
-      getReexports module4 `shouldBe` [Export "Test.Foo", Export "Test.Bar"]
+spec = do
+  describe "Successful Reexports" $
+    for_ succTestCases $ \(desc, initial, refs, result) ->
+      it (toS desc) $ do
+        let reResult = resolveReexports env (initial, refs)
+        reResolved reResult `shouldBe` result
+        reResult `shouldSatisfy` not . reexportHasFailures
+  describe "Failed Reexports" $
+    for_ failTestCases $ \(desc, initial, refs) ->
+      it (toS desc) $ do
+        let reResult = resolveReexports env (initial, refs)
+        reFailed reResult `shouldBe` refs
+        reResult `shouldSatisfy` reexportHasFailures

--- a/tests/Language/PureScript/Ide/SourceFile/IntegrationSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFile/IntegrationSpec.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Language.PureScript.Ide.SourceFile.IntegrationSpec where
+
+
+import           Protolude
+
+import qualified Data.Text                           as T
+import qualified Language.PureScript.Ide.Integration as Integration
+import qualified Language.PureScript                 as P
+import           Test.Hspec
+
+setup :: IO ()
+setup = void (Integration.reset *> Integration.loadAll)
+
+spec :: Spec
+spec = beforeAll_ setup $ do
+  describe "Sourcefile Integration" $ do
+    it "finds a value declaration" $ do
+      testCase "sfValue" (3, 1)
+    it "finds a type declaration" $ do
+      testCase "SFType" (5, 1)
+    it "finds a data declaration" $ do
+      testCase "SFData" (7, 1)
+    it "finds a data constructor" $ do
+      testCase "SFOne" (7, 1)
+    it "finds a typeclass" $ do
+      testCase "SFClass" (9, 1)
+    it "finds a typeclass member" $ do
+      testCase "sfShow" (10, 3)
+
+testCase :: Text -> (Int, Int) -> IO ()
+testCase s (x, y) = do
+  (P.SourceSpan f (P.SourcePos l c) _):_ <- Integration.getInfo s
+  toS f `shouldSatisfy` T.isSuffixOf "SourceFileSpec.purs"
+  (l, c) `shouldBe` (x, y)

--- a/tests/Language/PureScript/Ide/SourceFileSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFileSpec.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Language.PureScript.Ide.SourceFileSpec where
+
+import           Protolude
+
+import qualified Language.PureScript as P
+import           Language.PureScript.Ide.SourceFile
+import           Test.Hspec
+
+span0, span1, span2 :: P.SourceSpan
+span0 = P.SourceSpan "ModuleLevel" (P.SourcePos 0 0) (P.SourcePos 1 1)
+span1 = P.SourceSpan "" (P.SourcePos 1 1) (P.SourcePos 2 2)
+span2 = P.SourceSpan "" (P.SourcePos 2 2) (P.SourcePos 3 3)
+
+value1, synonym1, class1, class2, data1, data2, foreign1, foreign2, member1 :: P.Declaration
+value1 = P.ValueDeclaration (P.Ident "value1") P.Public [] (Left [])
+synonym1 = P.TypeSynonymDeclaration (P.ProperName "Synonym1") [] P.REmpty
+class1 = P.TypeClassDeclaration (P.ProperName "Class1") [] [] []
+class2 = P.TypeClassDeclaration (P.ProperName "Class2") [] []
+  [P.PositionedDeclaration span2 [] member1]
+data1 = P.DataDeclaration P.Newtype (P.ProperName "Data1") [] []
+data2 = P.DataDeclaration P.Data (P.ProperName "Data2") [] [(P.ProperName "Cons1", [])]
+foreign1 = P.ExternDeclaration (P.Ident "foreign1") P.REmpty
+foreign2 = P.ExternDataDeclaration (P.ProperName "Foreign2") P.Star
+member1 = P.TypeDeclaration (P.Ident "member1") P.REmpty
+
+spec :: Spec
+spec = do
+  describe "Extracting Spans" $ do
+    it "extracts a span for a value declaration" $
+      extractSpans span0 (P.PositionedDeclaration span1 [] value1) `shouldBe` [(Left "value1", span1)]
+    it "extracts a span for a type synonym declaration" $
+      extractSpans span0 (P.PositionedDeclaration span1 [] synonym1) `shouldBe` [(Right "Synonym1", span1)]
+    it "extracts a span for a typeclass declaration" $
+      extractSpans span0 (P.PositionedDeclaration span1 [] class1) `shouldBe` [(Right "Class1", span1)]
+    it "extracts spans for a typeclass declaration and its members" $
+      extractSpans span0 (P.PositionedDeclaration span1 [] class2) `shouldBe` [(Right "Class2", span1), (Left "member1", span2)]
+    it "extracts a span for a data declaration" $
+      extractSpans span0 (P.PositionedDeclaration span1 [] data1) `shouldBe` [(Right "Data1", span1)]
+    it "extracts spans for a data declaration and its constructors" $
+      extractSpans span0 (P.PositionedDeclaration span1 [] data2) `shouldBe` [(Right "Data2", span1), (Left "Cons1", span1)]
+    it "extracts a span for a foreign declaration" $
+      extractSpans span0 (P.PositionedDeclaration span1 [] foreign1) `shouldBe` [(Left "foreign1", span1)]
+    it "extracts a span for a data foreign declaration" $
+      extractSpans span0 (P.PositionedDeclaration span1 [] foreign2) `shouldBe` [(Right "Foreign2", span1)]

--- a/tests/support/pscide/src/RebuildSpecWithForeign.js
+++ b/tests/support/pscide/src/RebuildSpecWithForeign.js
@@ -1,3 +1,1 @@
-// module RebuildSpecWithForeign
-
 exports.f = 5;

--- a/tests/support/pscide/src/SourceFileSpec.purs
+++ b/tests/support/pscide/src/SourceFileSpec.purs
@@ -1,0 +1,10 @@
+module SourceFileSpec where
+
+sfValue = "sfValue"
+
+type SFType = String
+
+data SFData = SFOne | SFTwo | SFThree
+
+class SFClass a where
+  sfShow :: a -> String


### PR DESCRIPTION
after #2210.

This cleans up some of the cruft left from #2193. In particular we can finally get rid of the `ModuleOld` data type, by using the machinery introduced with  #2191 to resolve reexports.