### PR TITLE
[psc-ide] Fix unicode encoding of json responses

### DIFF
--- a/psc-ide-client/Main.hs
+++ b/psc-ide-client/Main.hs
@@ -5,16 +5,15 @@ import           Prelude             ()
 import           Prelude.Compat
 
 import           Control.Exception
-import           Data.Text           (Text)
-import qualified Data.Text           as T
-import qualified Data.Text.IO        as T
-import           Data.Version        (showVersion)
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.Text.IO          as T
+import           Data.Version          (showVersion)
 import           Network
 import           Options.Applicative
 import           System.Exit
 import           System.IO
 
-import qualified Paths_purescript    as Paths
+import qualified Paths_purescript      as Paths
 
 data Options = Options
   { optionsPort :: PortID
@@ -41,16 +40,7 @@ client port = do
                   ("Couldn't connect to psc-ide-server on port: " ++
                    show port ++ " Error: " ++ show e) >>
               exitFailure)
-    cmd <- T.getLine
-    -- Temporary fix for emacs windows bug
-    let cleanedCmd = removeSurroundingTicks cmd
-    --
-    T.hPutStrLn h cleanedCmd
-    res <- T.hGetLine h
-    putStrLn (T.unpack res)
+    T.hPutStrLn h =<< T.getLine
+    BS8.putStrLn =<< BS8.hGetLine h
     hFlush stdout
     hClose h
-
--- TODO: Fix this in the emacs plugin by using a real process over shellcommands
-removeSurroundingTicks :: Text -> Text
-removeSurroundingTicks = T.dropWhile (== '\'') . T.dropWhileEnd (== '\'')

--- a/psc-ide-server/Main.hs
+++ b/psc-ide-server/Main.hs
@@ -23,9 +23,11 @@ module Main where
 
 import           Protolude
 
+import qualified Data.Aeson as Aeson
 import           Control.Concurrent.STM
 import           "monad-logger" Control.Monad.Logger
 import qualified Data.Text.IO                      as T
+import qualified Data.ByteString.Lazy.Char8        as BS8
 import           Data.Version                      (showVersion)
 import           Language.PureScript.Ide
 import           Language.PureScript.Ide.Util
@@ -121,9 +123,8 @@ startServer port env = withSocketsDo $ do
               -- $(logDebug) ("Answer was: " <> T.pack (show result))
               liftIO (hFlush stdout)
               case result of
-                -- What function can I use to clean this up?
-                Right r  -> liftIO $ T.hPutStrLn h (encodeT r)
-                Left err -> liftIO $ T.hPutStrLn h (encodeT err)
+                Right r  -> liftIO $ BS8.hPutStrLn h (Aeson.encode r)
+                Left err -> liftIO $ BS8.hPutStrLn h (Aeson.encode err)
             Nothing -> do
               $(logDebug) ("Parsing the command failed. Command: " <> cmd)
               liftIO $ do

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -428,6 +428,8 @@ executable psc-ide-server
   other-modules:       Paths_purescript
   other-extensions:
   build-depends:       base >=4 && <5,
+                       aeson >= 0.8 && < 0.12,
+                       bytestring -any,
                        purescript -any,
                        base-compat >=0.6.0,
                        directory -any,
@@ -450,6 +452,7 @@ executable psc-ide-client
   other-extensions:
   build-depends:       base >=4 && <5,
                        base-compat >=0.6.0,
+                       bytestring -any,
                        mtl -any,
                        network -any,
                        optparse-applicative >= 0.12.1,


### PR DESCRIPTION
Fixes https://github.com/FrigoEU/psc-ide-vim/issues/15 for me. Apparently converting from ByteString -> Text broke the json encoding.