### PR TITLE
Combine the sdist and coverage builds. Avoid .tix files during deployment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       os: linux
       dist: trusty
       sudo: required
-      env: BUILD_TYPE=normal COVERAGE=true DEPLOY=true
+      env: BUILD_TYPE=normal DEPLOY=true
 
     # - compiler: cc-linux-nightly-normal
     #   os: linux
@@ -31,7 +31,7 @@ matrix:
       os: linux
       dist: trusty
       sudo: required
-      env: BUILD_TYPE=sdist
+      env: BUILD_TYPE=sdist COVERAGE=true
 
     - compiler: cc-linux-lts-haddock
       os: linux


### PR DESCRIPTION
Fixes #2181.

Hopefully, running coverage during the `sdist` build isn't an issue.