### PR TITLE
[WIP][psc-ide] Force computations in worker threads

### DIFF
--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -16,7 +16,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports    #-}
 {-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE BangPatterns      #-}
 
 module Language.PureScript.Ide.State
   ( getLoadedModulenames


### PR DESCRIPTION
Still figuring this out... Is there a more effective way for profiling this other than inserting trace statements thoughout the code and checking what gets evaluated?

It seems to already have an impact though, since the worker threads now take more time to finish on the codebase for pscid.

Before:
```
[Debug] Finished populating Stage2 in TimeSpec {sec = 0, nsec = 1181} 
[Debug] Finished populating Stage3 in TimeSpec {sec = 0, nsec = 1222} 
```

After:
```
[Debug] Finished populating Stage2 in TimeSpec {sec = 0, nsec = 569836} 
[Debug] Finished populating Stage3 in TimeSpec {sec = 0, nsec = 793256} 
```

@nwolverson You noticed major slowdowns while working on atom-ide-purescript, does this help?