### PR TITLE
Fix #2252, instantiate types in array literals before unification

### DIFF
--- a/examples/passing/2252.purs
+++ b/examples/passing/2252.purs
@@ -1,18 +1,15 @@
 module Main where
-
+	
 import Control.Monad.Eff.Console (log)
 
 data T a = T
-
--- inferred as `Array t0`
-xs :: _
-xs = [T, T, T]
+	 
+ti :: T Int
+ti = T
 
 t :: forall a. T a
 t = T
 
--- inferred as `Array (forall a. T a)`
-xs' :: _
-xs' = [t, t, t]
+xs = [ti, t, t]
 
 main = log "Done"

--- a/examples/passing/2252.purs
+++ b/examples/passing/2252.purs
@@ -1,0 +1,18 @@
+module Main where
+
+import Control.Monad.Eff.Console (log)
+
+data T a = T
+
+-- inferred as `Array t0`
+xs :: _
+xs = [T, T, T]
+
+t :: forall a. T a
+t = T
+
+-- inferred as `Array (forall a. T a)`
+xs' :: _
+xs' = [t, t, t]
+
+main = log "Done"

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -251,8 +251,11 @@ infer' v@(Literal (BooleanLiteral _)) = return $ TypedValue True v tyBoolean
 infer' (Literal (ArrayLiteral vals)) = do
   ts <- traverse infer vals
   els <- freshType
-  forM_ ts $ \(TypedValue _ _ t) -> unifyTypes els t
-  return $ TypedValue True (Literal (ArrayLiteral ts)) (TypeApp tyArray els)
+  ts' <- forM ts $ \(TypedValue ch val t) -> do
+    (val', t') <- instantiatePolyTypeWithUnknowns val t
+    unifyTypes els t'
+    return (TypedValue ch val' t')
+  return $ TypedValue True (Literal (ArrayLiteral ts')) (TypeApp tyArray els)
 infer' (Literal (ObjectLiteral ps)) = do
   ensureNoDuplicateProperties ps
   ts <- traverse (infer . snd) ps


### PR DESCRIPTION
cc @garyb 

We just need to make sure we instantiate types before unifying. There are some more places like this, and I'm going to try to fix them in another PR.