### PR TITLE
Do not solve for unknowns in rows during instance solving

### DIFF
--- a/examples/passing/RowPolyInstanceContext.purs
+++ b/examples/passing/RowPolyInstanceContext.purs
@@ -9,13 +9,13 @@ class T s m where
 data S s a = S (s -> { new :: s, ret :: a })
 
 instance st :: T s (S s) where
-  state f = S $ \s -> { new: f s, ret: unit }
+  state f = S \s -> { new: f s, ret: unit }
 
-test1 :: forall r . S { foo :: String | r } Unit
-test1 = state $ \o -> o { foo = o.foo <> "!" }
+test1 :: forall r. S { foo :: String | r } Unit
+test1 = state \o -> o { foo = o.foo <> "!" } :: { foo :: String | r }
 
-test2 :: forall m r . (T { foo :: String | r } m) => m Unit
-test2 = state $ \o -> o { foo = o.foo <> "!" }
+test2 :: forall m r. T { foo :: String | r } m => m Unit
+test2 = state \o -> o { foo = o.foo <> "!" } :: { foo :: String | r }
 
 main = do
   let t1 = test1

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -202,8 +202,7 @@ typeHeadsAreEqual m r1@RCons{} r2@RCons{} =
   where
   go :: [(String, Type)] -> Type -> [(String, Type)] -> Type -> Maybe [(String, Type)]
   go [] REmpty            [] REmpty            = Just []
-  go [] (TUnknown _)      _  _                 = Just []
-  go [] (TypeVar v1)      [] (TypeVar v2)      | v1 == v2 = Just []
+  go [] (TUnknown u1)     [] (TUnknown u2)     | u1 == u2 = Just []
   go [] (Skolem _ s1 _ _) [] (Skolem _ s2 _ _) | s1 == s2 = Just []
   go sd r                 [] (TypeVar v)       = Just [(v, rowFromList (sd, r))]
   go _  _                 _  _                 = Nothing

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -173,13 +173,11 @@ unifiesWith r1@RCons{}           r2@RCons{} =
   in all (uncurry unifiesWith) int && go sd1 r1' sd2 r2'
   where
   go :: [(String, Type)] -> Type -> [(String, Type)] -> Type -> Bool
-  go [] REmpty          [] REmpty          = True
-  go [] (TypeVar v1)    [] (TypeVar v2)    = v1 == v2
+  go [] (TUnknown u1)     [] (TUnknown u2)     = u1 == u2
   go [] (Skolem _ s1 _ _) [] (Skolem _ s2 _ _) = s1 == s2
-  go [] (TUnknown _)    _  _               = True
-  go _  _               [] (TUnknown _)    = True
-  go _  (TUnknown _)    _  (TUnknown _)    = True
-  go _  _               _  _               = False
+  go [] (TypeVar v1)      [] (TypeVar v2)      = v1 == v2
+  go [] REmpty            [] REmpty            = True
+  go _  _                 _  _                 = False
 unifiesWith _ _ = False
 
 -- |


### PR DESCRIPTION
Fixes #2236

This updates the constraint solver to make rows work like regular types. For some reason, rows were left out when things were fixed to disallow unknowns in possible solutions.

#2236 demonstrates how this can lead to differences between checking and inference mode when unknowns are allowed.

The downside is that this breaks quite a lot of stuff, especially `MonadEff`. Let's discuss the pros and cons of merging this into 0.9.3.



