### PR TITLE
[psc-ide] Return JSON errors for cycles in module dependencies

### DIFF
--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -144,7 +144,8 @@ sortExterns m ex = do
            . M.elems
            . M.delete (P.getModuleName m) $ ex
   case sorted' of
-    Left _ -> throwError (GeneralError "There was a cycle in the dependencies")
+    Left err ->
+      throwError (RebuildError (toJSONErrors False P.Error err))
     Right (sorted, graph) -> do
       let deps = fromJust (List.lookup (P.getModuleName m) graph)
       pure $ mapMaybe getExtern (deps `inOrderOf` map P.getModuleName sorted)


### PR DESCRIPTION
We want to return the proper JSON formatted error in the case of a cycle in the rebuild dependencies.

fixes kRITZCREEK/pscid#20