### PR TITLE
Import suggestions for UnusedDctorImport's

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -108,8 +108,8 @@ data SimpleErrorMessage
   | ImportHidingModule ModuleName
   | UnusedImport ModuleName
   | UnusedExplicitImport ModuleName [String] (Maybe ModuleName) [DeclarationRef]
-  | UnusedDctorImport (ProperName 'TypeName)
-  | UnusedDctorExplicitImport (ProperName 'TypeName) [ProperName 'ConstructorName]
+  | UnusedDctorImport ModuleName (ProperName 'TypeName) (Maybe ModuleName) [DeclarationRef]
+  | UnusedDctorExplicitImport ModuleName (ProperName 'TypeName) [ProperName 'ConstructorName] (Maybe ModuleName) [DeclarationRef]
   | DuplicateSelectiveImport ModuleName
   | DuplicateImport ModuleName ImportDeclarationType (Maybe ModuleName)
   | DuplicateImportRef Name

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -288,6 +288,8 @@ errorSuggestion err = case err of
   UnusedImport{} -> emptySuggestion
   DuplicateImport{} -> emptySuggestion
   UnusedExplicitImport mn _ qual refs -> suggest $ importSuggestion mn refs qual
+  UnusedDctorImport mn _ qual refs -> suggest $ importSuggestion mn refs qual
+  UnusedDctorExplicitImport mn _ _ qual refs -> suggest $ importSuggestion mn refs qual
   ImplicitImport mn refs -> suggest $ importSuggestion mn refs Nothing
   ImplicitQualifiedImport mn asModule refs -> suggest $ importSuggestion mn refs (Just asModule)
   HidingImport mn refs -> suggest $ importSuggestion mn refs Nothing
@@ -756,12 +758,18 @@ prettyPrintSingleError (PPEOptions codeColor full level showWiki) e = flip evalS
             , line "It could be replaced with:"
             , indent $ line $ markCode $ showSuggestion msg ]
 
-    renderSimpleErrorMessage (UnusedDctorImport name) =
-      line $ "The import of type " ++ markCode (runProperName name) ++ " includes data constructors but only the type is used"
+    renderSimpleErrorMessage msg@(UnusedDctorImport mn name _ _) =
+      paras [line $ "The import of type " ++ markCode (runProperName name)
+                    ++ " from module " ++ markCode (runModuleName mn) ++ " includes data constructors but only the type is used"
+            , line "It could be replaced with:"
+            , indent $ line $ markCode $ showSuggestion msg ]
 
-    renderSimpleErrorMessage (UnusedDctorExplicitImport name names) =
-      paras [ line $ "The import of type " ++ markCode (runProperName name) ++ " includes the following unused data constructors:"
-            , indent $ paras $ map (line . markCode . runProperName) names ]
+    renderSimpleErrorMessage msg@(UnusedDctorExplicitImport mn name names _ _) =
+      paras [ line $ "The import of type " ++ markCode (runProperName name)
+                     ++ " from module " ++ markCode (runModuleName mn) ++ " includes the following unused data constructors:"
+            , indent $ paras $ map (line . markCode . runProperName) names
+            , line "It could be replaced with:"
+            , indent $ line $ markCode $ showSuggestion msg ]
 
     renderSimpleErrorMessage (DuplicateSelectiveImport name) =
       line $ "There is an existing import of " ++ markCode (runModuleName name) ++ ", consider merging the import lists"

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -245,10 +245,10 @@ lintImportDecl env mni qualifierName names declType allowImplicit =
       -- If we've not already warned a type is unused, check its data constructors
       unless' (runProperName tn `notElem` usedNames) $
         case (c, dctors `intersect` allCtors) of
-          (_, []) | c /= Just [] -> warn (UnusedDctorImport tn)
+          (_, []) | c /= Just [] -> warn (UnusedDctorImport mni tn qualifierName allRefs)
           (Just ctors, dctors') ->
             let ddiff = ctors \\ dctors'
-            in unless' (null ddiff) $ warn $ UnusedDctorExplicitImport tn ddiff
+            in unless' (null ddiff) $ warn $ UnusedDctorExplicitImport mni tn ddiff qualifierName allRefs
           _ -> return False
 
     return (didWarn || or didWarn')


### PR DESCRIPTION
This one has been annoying me for some time, especially because psc-ide's import functionality imports both the type constructor and data constructor automatically. This is the correct behavior a lot of the time, but just as often I want to import only the type constructor and then I need to go and manually correct the warning, very annoying! I'm getting more familiar with the compiler so I thought I'd take a stab at this.

I added the same suggestion for UnusedDctorImport and UnusedDctorExplicitImport as is already used for UnusedExplicitImport. I added the moduleName, possible qualification for the module and the used declaration references to both data constructors, and then use them to make the import suggestion. Maybe it's worth it to pull this moduleName/qual/declrefs into a type synonym or something, but I wasn't sure if that would have any real value at this point.