### PR TITLE
Safer installation from source in INSTALL.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,8 @@ If you would like to contribute, please consider the issues in the current miles
 Please follow the following guidelines:
 
 - Add at least a test to `examples/passing/` and possibly to `examples/failing`.
-- Build the binaries and libs with `cabal build`
-- Install the binaries and libs with `cabal install`.
-- Run `cabal configure --enable-tests && cabal build && cabal test` to build the test suite. You will need `npm` and `node` on your PATH to run the tests.
+- Build the binaries and libs with `stack build`
+- Run the test suite with `stack test`. You will need `npm` and `node` on your PATH to run the tests.
 - Build the core libraries by running the script in `core-tests`.
 
 ## Code Review

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,16 +27,19 @@ GHC 7.10.1 or newer is required to compile from source. The easiest way is to
 use stack:
 
 ```
-$ stack install --resolver=nightly purescript
+$ stack update
+$ stack unpack purescript
+$ cd purescript-x.y.z  # (replace x.y.z with whichever version you just downloaded)
+$ stack install
 ```
 
 This will then copy the compiler and utilities into `~/.local/bin`.
 
 
-If you don't have stack installed yet there are install instructions
+If you don't have stack installed, there are install instructions
 [here](https://github.com/commercialhaskell/stack/blob/master/doc/install_and_upgrade.md).
 
-If you don't have ghc installed yet, stack will prompt you to run `stack setup`
+If you don't have ghc installed, stack will prompt you to run `stack setup`
 which will install ghc for you.
 
 ## The "curses" library


### PR DESCRIPTION
This commit ensures that the stackage snapshot used when building from
source following the instructions in INSTALL.md will be the same as the
one used in development and in binary bundles.

This is safer (because you'll end up with a set of dependencies which
have been tested together) and it also means you'll always get the
latest version according to Hackage. In comparison, the Stackage nightly
is often behind because of waiting for purescript or other libraries to
make changes to allow all packages in the nightly to build together.

See also discussion in #2278.