### PR TITLE
display error hint. Fixes #2250

### DIFF
--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -336,8 +336,8 @@ parseIdentifierAndValue =
     return (name, b)
   <|> (do name <- C.indented *> stringLiteral; b <- rest name; return (name, b))
   where
-  rest name = C.indented *> (colon <|> P.lookAhead equals *> fail (updateSyntaxError name)) *> C.indented *> parseValue
-  updateSyntaxError name = "\nYou are using record update syntax {" ++ name ++ " = ...} inside a record literal.\nDid you mean to write {" ++ name ++ " : ...} instead?"
+  rest name = C.indented *> (colon <|> P.try (P.lookAhead equals) *> fail (updateSyntaxError name)) *> C.indented *> parseValue
+  updateSyntaxError name = "\n  You are using record update syntax {" ++ name ++ " = ...} inside a record literal.\n  Did you mean to write {" ++ name ++ " : ...} instead?"
 
 parseAbs :: TokenParser Expr
 parseAbs = do

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -332,11 +332,12 @@ parseIdentifierAndValue :: TokenParser (String, Expr)
 parseIdentifierAndValue =
   do
     name <- C.indented *> lname
-    b <- P.option (Var $ Qualified Nothing (Ident name)) rest
+    b <- P.option (Var $ Qualified Nothing (Ident name)) (rest name)
     return (name, b)
-  <|> (,) <$> (C.indented *> stringLiteral) <*> rest
+  <|> (do name <- C.indented *> stringLiteral; b <- rest name; return (name, b))
   where
-  rest = C.indented *> colon *> C.indented *> parseValue
+  rest name = C.indented *> (colon <|> P.lookAhead equals *> fail (updateSyntaxError name)) *> C.indented *> parseValue
+  updateSyntaxError name = "\nYou are using record update syntax {" ++ name ++ " = ...} inside a record literal.\nDid you mean to write {" ++ name ++ " : ...} instead?"
 
 parseAbs :: TokenParser Expr
 parseAbs = do

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -336,7 +336,8 @@ parseIdentifierAndValue =
     return (name, b)
   <|> (do name <- C.indented *> stringLiteral; b <- rest name; return (name, b))
   where
-  rest name = C.indented *> (colon <|> P.try (P.lookAhead equals) *> fail (updateSyntaxError name)) *> C.indented *> parseValue
+  rest name = C.indented *> separator name *> C.indented *> parseValue
+  separator name = colon <|> P.try (P.lookAhead equals) *> fail (updateSyntaxError name) P.<?> ":"
   updateSyntaxError name = "\n  You are using record update syntax {" ++ name ++ " = ...} inside a record literal.\n  Did you mean to write {" ++ name ++ " : ...} instead?"
 
 parseAbs :: TokenParser Expr


### PR DESCRIPTION
Got here through https://www.codetriage.com/. I'll try to help reduce the number of issues a bit.

```purescript
r' = {foo = "bar"}
```

Now produces the following error:

```
Error found:
at /home/creek/Documents/purs/temp/src/Main.purs line 7, column 11 - line 7, column 11

  Unable to parse module:
  unexpected =
  expecting :, , or }

  You are using record update syntax {foo = ...} inside a record literal.
  Did you mean to write {foo : ...} instead?


See https://github.com/purescript/purescript/wiki/Error-Code-ErrorParsingModule for more information,
or to contribute content related to this error.
```

> A remaining issue is that `r' = {foo ? "bar"}` now produces the following expecting error:

> ```
  Unable to parse module:
  unexpected ?
  expecting :, =, , or }
```

> The `=` sign shouldn't appear in there, but maybe someone knows how I can avoid that from appearing? I'm already using the `lookAhead` combinator but that doesn't seem to cut it.

Fixed that by using `<?>`