### PR TITLE
[psc-ide] Parse type annotations from source files

### DIFF
--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -17,9 +17,9 @@
 {-# LANGUAGE FlexibleContexts  #-}
 
 module Language.PureScript.Ide.Externs
-  ( readExternFile,
-    convertExterns,
-    annotateLocations
+  ( readExternFile
+  , convertExterns
+  , annotateModule
   ) where
 
 import           Protolude
@@ -99,14 +99,17 @@ convertTypeOperator P.ExternsTypeFixity{..} =
     efTypePrecedence
     efTypeAssociativity
 
-annotateLocations :: Map (Either Text Text) P.SourceSpan -> Module -> Module
-annotateLocations ast (moduleName, decls) =
+annotateModule
+  :: (DefinitionSites P.SourceSpan, TypeAnnotations)
+  -> Module
+  -> Module
+annotateModule (defs, types) (moduleName, decls) =
   (moduleName, map convertDeclaration decls)
   where
     convertDeclaration :: IdeDeclarationAnn -> IdeDeclarationAnn
     convertDeclaration (IdeDeclarationAnn ann d) = case d of
       IdeValue i t ->
-        annotateValue (runIdentT i) (IdeValue i t)
+        annotateFunction i (IdeValue i t)
       IdeType i k ->
         annotateType (runProperNameT i) (IdeType i k)
       IdeTypeSynonym i t ->
@@ -120,5 +123,8 @@ annotateLocations ast (moduleName, decls) =
       IdeTypeOperator n i p a ->
         annotateType i (IdeTypeOperator n i p a)
       where
-        annotateValue x = IdeDeclarationAnn (ann {annLocation = Map.lookup (Left x) ast})
-        annotateType x = IdeDeclarationAnn (ann {annLocation = Map.lookup (Right x) ast})
+        annotateFunction x = IdeDeclarationAnn (ann { annLocation = Map.lookup (Left (runIdentT x)) defs
+                                                    , annTypeAnnotation = Map.lookup x types
+                                                    })
+        annotateValue x = IdeDeclarationAnn (ann {annLocation = Map.lookup (Left x) defs})
+        annotateType x = IdeDeclarationAnn (ann {annLocation = Map.lookup (Right x) defs})

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -18,6 +18,7 @@ module Language.PureScript.Ide.SourceFile
   ( parseModule
   , getImportsForFile
   , extractSpans
+  , extractTypeAnnotations
   ) where
 
 import           Protolude
@@ -63,6 +64,16 @@ getImportsForFile fp = do
         unwrapImportType (P.Explicit decls) = P.Explicit (map unwrapPositionedRef decls)
         unwrapImportType (P.Hiding decls)   = P.Hiding (map unwrapPositionedRef decls)
         unwrapImportType P.Implicit         = P.Implicit
+
+-- | Extracts type annotations for functions from a given Module
+extractTypeAnnotations
+  :: [P.Declaration]
+  -> [(P.Ident, P.Type)]
+extractTypeAnnotations = mapMaybe extract
+  where
+    extract d = case unwrapPositioned d of
+      P.TypeDeclaration ident ty -> Just (ident, ty)
+      _ -> Nothing
 
 -- | Given a surrounding Sourcespan and a Declaration from the PS AST, extracts
 -- definition sites inside that Declaration.

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -47,15 +47,19 @@ data Annotation
   = Annotation
   { annLocation     :: Maybe P.SourceSpan
   , annExportedFrom :: Maybe P.ModuleName
+  , annTypeAnnotation :: Maybe P.Type
   } deriving (Show, Eq, Ord)
 
 emptyAnn :: Annotation
-emptyAnn = Annotation Nothing Nothing
+emptyAnn = Annotation Nothing Nothing Nothing
 
 type Module = (P.ModuleName, [IdeDeclarationAnn])
 
-newtype AstData a =
-  AstData (Map P.ModuleName (Map (Either Text Text) a))
+type DefinitionSites a = Map (Either Text Text) a
+type TypeAnnotations = Map P.Ident P.Type
+newtype AstData a = AstData (Map P.ModuleName (DefinitionSites a, TypeAnnotations))
+  -- ^ SourceSpans for the definition sites of Values and Types aswell as type
+  -- annotations found in a module
   deriving (Show, Eq, Ord, Functor, Foldable)
 
 data Configuration =

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -76,7 +76,7 @@ completionFromMatch' (Match (m', d)) = case d of
 
 infoFromMatch :: Match IdeDeclarationAnn -> Info
 infoFromMatch (Match (m, IdeDeclarationAnn ann d)) =
-  Info (a, b, c, annLocation ann)
+  Info (a, b, maybe c prettyTypeT (annTypeAnnotation ann), annLocation ann)
   where
     (a, b, c) = completionFromMatch' (Match (m, d))
 


### PR DESCRIPTION
Then use these parsed type annotations to give back the non-expanded
types for functions that contain type synonyms in their annotation.

Fixes #2302 

I didn't add any tests for this yet but it's kind of trivial so I'm willing to accept that for now. The extra information about type annotations is only available on the `type` command and not the `complete` command yet, just like with definitions sites. This can definitely be changed but I'll leave that for another PR.