### PR TITLE
[psc-ide] Unify Completion Commands

### DIFF
--- a/psc-ide-server/PROTOCOL.md
+++ b/psc-ide-server/PROTOCOL.md
@@ -51,27 +51,7 @@ definition position, if it can be found in the passed source files.
 ```
 
 **Result:**
-The possible types are returned in the same format as completions + eventual position information
-```json
-[
-  {
-  "module": "Data.Array",
-  "identifier": "filter",
-  "type": "forall a. (a -> Boolean) -> Array a -> Array a"
-  },
-  {
-  "module": "Data.Array",
-  "identifier": "filter",
-  "type": "forall a. (a -> Boolean) -> Array a -> Array a",
-  "definedAt":
-    {
-    "name": "/path/to/file",
-    "start": [1, 3],
-    "end": [3, 1]
-    }
-  }
-]
-```
+The possible types are returned in the same format as completions
 
 ### Complete
 The `complete` command looks up possible completions/corrections.
@@ -104,12 +84,23 @@ The `complete` command looks up possible completions/corrections.
 
 The following format is returned as the Result:
 
+Both the `definedAt` aswell as the `documentation` field might be `null` if they
+couldn't be extracted from a source file.
+
 ```json
 [
   {
   "module": "Data.Array",
   "identifier": "filter",
-  "type": "forall a. (a -> Boolean) -> Array a -> Array a"
+  "type": "forall a. (a -> Boolean) -> Array a -> Array a",
+  "expandedType": "forall a. (a -> Boolean) -> Array a -> Array a",
+  "definedAt":
+    {
+    "name": "/path/to/file",
+    "start": [1, 3],
+    "end": [3, 1]
+    },
+  "documentation": "A filtering function"
   }
 ]
 ```

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -34,7 +34,7 @@ data Command
       }
     | Complete
       { completeFilters       :: [Filter]
-      , completeMatcher       :: Matcher IdeDeclaration
+      , completeMatcher       :: Matcher IdeDeclarationAnn
       , completeCurrentModule :: Maybe P.ModuleName
       }
     | Pursuit

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -9,24 +9,23 @@ import           Protolude
 import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.Matcher
 import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util
 
 -- | Applies the CompletionFilters and the Matcher to the given Modules
 --   and sorts the found Completions according to the Matching Score
 getCompletions
   :: [Filter]
-  -> Matcher IdeDeclaration
+  -> Matcher IdeDeclarationAnn
   -> [Module]
-  -> [Match IdeDeclaration]
+  -> [Match IdeDeclarationAnn]
 getCompletions filters matcher modules =
-  runMatcher matcher (completionsFromModules discardAnn (applyFilters filters modules))
+  runMatcher matcher (completionsFromModules (applyFilters filters modules))
 
 getExactMatches :: Text -> [Filter] -> [Module] -> [Match IdeDeclarationAnn]
 getExactMatches search filters modules =
-  completionsFromModules identity (applyFilters (equalityFilter search : filters) modules)
+  completionsFromModules (applyFilters (equalityFilter search : filters) modules)
 
-completionsFromModules :: (IdeDeclarationAnn -> a) -> [Module] -> [Match a]
-completionsFromModules f = foldMap completionFromModule
+completionsFromModules :: [Module] -> [Match IdeDeclarationAnn]
+completionsFromModules = foldMap completionFromModule
   where
     completionFromModule (moduleName, decls) =
-      map (\x -> Match (moduleName, f x)) decls
+      map (\x -> Match (moduleName, x)) decls

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -17,12 +17,15 @@
 module Language.PureScript.Ide.SourceFile
   ( parseModule
   , getImportsForFile
+  , extractAstInformation
+  -- for tests
   , extractSpans
   , extractTypeAnnotations
   ) where
 
 import           Protolude
 
+import qualified Data.Map as Map
 import qualified Language.PureScript                  as P
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Util
@@ -64,6 +67,15 @@ getImportsForFile fp = do
         unwrapImportType (P.Explicit decls) = P.Explicit (map unwrapPositionedRef decls)
         unwrapImportType (P.Hiding decls)   = P.Hiding (map unwrapPositionedRef decls)
         unwrapImportType P.Implicit         = P.Implicit
+
+-- | Extracts AST information from a parsed module
+extractAstInformation
+  :: P.Module
+  -> (DefinitionSites P.SourceSpan, TypeAnnotations)
+extractAstInformation (P.Module ss _ _ decls _) =
+  let definitions = Map.fromList (concatMap (extractSpans ss) decls)
+      typeAnnotations = Map.fromList (extractTypeAnnotations decls)
+  in (definitions, typeAnnotations)
 
 -- | Extracts type annotations for functions from a given Module
 extractTypeAnnotations

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -180,10 +180,7 @@ populateStage2 = do
 populateStage2STM :: TVar IdeState -> STM ()
 populateStage2STM ref = do
   modules <- s1Modules <$> getStage1STM ref
-  let astData = map (\(P.Module ss _ _ decls _, _) ->
-                       let definitions = M.fromList (concatMap (extractSpans ss) decls)
-                           typeAnnotations = M.fromList (extractTypeAnnotations decls)
-                       in (definitions, typeAnnotations)) modules
+  let astData = map (extractAstInformation . fst) modules
   setStage2STM ref (Stage2 (AstData astData))
 
 -- | Resolves reexports and populates Stage3 with data to be used in queries.

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -20,10 +20,10 @@ module Language.PureScript.Ide.Util
   , unwrapPositioned
   , unwrapPositionedRef
   , completionFromMatch
-  , infoFromMatch
   , encodeT
   , decodeT
   , discardAnn
+  , withEmptyAnn
   , module Language.PureScript.Ide.Conversions
   ) where
 
@@ -48,37 +48,41 @@ identifierFromIdeDeclaration d = case d of
 discardAnn :: IdeDeclarationAnn -> IdeDeclaration
 discardAnn (IdeDeclarationAnn _ d) = d
 
+withEmptyAnn :: IdeDeclaration -> IdeDeclarationAnn
+withEmptyAnn = IdeDeclarationAnn emptyAnn
+
 unwrapMatch :: Match a -> a
 unwrapMatch (Match (_, ed)) = ed
 
-completionFromMatch :: Match IdeDeclaration -> Completion
-completionFromMatch = Completion . completionFromMatch'
-
-completionFromMatch' :: Match IdeDeclaration -> (Text, Text, Text)
-completionFromMatch' (Match (m', d)) = case d of
-  IdeValue name type' -> (m, runIdentT name, prettyTypeT type')
-  IdeType name kind -> (m, runProperNameT name, toS (P.prettyPrintKind kind))
-  IdeTypeSynonym name kind -> (m, runProperNameT name, prettyTypeT kind)
-  IdeDataConstructor name _ type' -> (m, runProperNameT name, prettyTypeT type')
-  IdeTypeClass name -> (m, runProperNameT name, "class")
-  IdeValueOperator op ref precedence associativity ->
-    (m, runOpNameT op, showFixity precedence associativity ref op)
-  IdeTypeOperator op ref precedence associativity ->
-    (m, runOpNameT op, showFixity precedence associativity ref op)
+completionFromMatch :: Match IdeDeclarationAnn -> Completion
+completionFromMatch (Match (m, IdeDeclarationAnn ann decl)) =
+  Completion {..}
   where
-    m = runModuleNameT m'
+    (complIdentifier, complExpandedType) = case decl of
+      IdeValue name type' -> (runIdentT name, prettyTypeT type')
+      IdeType name kind -> (runProperNameT name, toS (P.prettyPrintKind kind))
+      IdeTypeSynonym name kind -> (runProperNameT name, prettyTypeT kind)
+      IdeDataConstructor name _ type' -> (runProperNameT name, prettyTypeT type')
+      IdeTypeClass name -> (runProperNameT name, "class")
+      IdeValueOperator op ref precedence associativity ->
+        (runOpNameT op, showFixity precedence associativity ref op)
+      IdeTypeOperator op ref precedence associativity ->
+        (runOpNameT op, showFixity precedence associativity ref op)
+            
+    complModule = runModuleNameT m
+
+    complType = maybe complExpandedType prettyTypeT (annTypeAnnotation ann)
+    
+    complLocation = annLocation ann
+
+    complDocumentation = Nothing
+    
     showFixity p a r o =
       let asso = case a of
             P.Infix -> "infix"
             P.Infixl -> "infixl"
             P.Infixr -> "infixr"
       in T.unwords [asso, show p, r, "as", runOpNameT o]
-
-infoFromMatch :: Match IdeDeclarationAnn -> Info
-infoFromMatch (Match (m, IdeDeclarationAnn ann d)) =
-  Info (a, b, maybe c prettyTypeT (annTypeAnnotation ann), annLocation ann)
-  where
-    (a, b, c) = completionFromMatch' (Match (m, d))
 
 encodeT :: (ToJSON a) => a -> Text
 encodeT = toS . decodeUtf8 . encode
@@ -87,9 +91,9 @@ decodeT :: (FromJSON a) => Text -> Maybe a
 decodeT = decode . encodeUtf8 . toS
 
 unwrapPositioned :: P.Declaration -> P.Declaration
-unwrapPositioned (P.PositionedDeclaration _ _ x) = x
+unwrapPositioned (P.PositionedDeclaration _ _ x) = unwrapPositioned x
 unwrapPositioned x = x
 
 unwrapPositionedRef :: P.DeclarationRef -> P.DeclarationRef
-unwrapPositionedRef (P.PositionedDeclarationRef _ _ x) = x
+unwrapPositionedRef (P.PositionedDeclarationRef _ _ x) = unwrapPositionedRef x
 unwrapPositionedRef x = x

--- a/tests/Language/PureScript/Ide/Integration.hs
+++ b/tests/Language/PureScript/Ide/Integration.hs
@@ -37,13 +37,11 @@ module Language.PureScript.Ide.Integration
        , getFlexCompletions
        , getFlexCompletionsInModule
        , getType
-       , getInfo
        , rebuildModule
        , reset
          -- checking results
        , resultIsSuccess
        , parseCompletions
-       , parseInfo
        , parseTextResult
        ) where
 
@@ -158,17 +156,14 @@ loadModules = sendCommand . load
 loadAll :: IO Text
 loadAll = sendCommand (load [])
 
-getFlexCompletions :: Text -> IO [(Text, Text, Text)]
+getFlexCompletions :: Text -> IO [(Text, Text, Text, Maybe P.SourceSpan)]
 getFlexCompletions q = parseCompletions <$> sendCommand (completion [] (Just (flexMatcher q)) Nothing)
 
-getFlexCompletionsInModule :: Text -> Text -> IO [(Text, Text, Text)]
+getFlexCompletionsInModule :: Text -> Text -> IO [(Text, Text, Text, Maybe P.SourceSpan)]
 getFlexCompletionsInModule q m = parseCompletions <$> sendCommand (completion [] (Just (flexMatcher q)) (Just m))
 
-getType :: Text -> IO [(Text, Text, Text)]
+getType :: Text -> IO [(Text, Text, Text, Maybe P.SourceSpan)]
 getType q = parseCompletions <$> sendCommand (typeC q [])
-
-getInfo :: Text -> IO [P.SourceSpan]
-getInfo q = parseInfo <$> sendCommand (typeC q [])
 
 addImport :: Text -> FilePath -> FilePath -> IO Text
 addImport identifier fp outfp = sendCommand (addImportC identifier fp outfp)
@@ -254,17 +249,14 @@ withResult p v = do
     Left err -> pure (Left err)
     Right res -> Right <$> p res
 
-completionParser :: Value -> Parser [(Text, Text, Text)]
+completionParser :: Value -> Parser [(Text, Text, Text, Maybe P.SourceSpan)]
 completionParser = withArray "res" $ \cs ->
   mapM (withObject "completion" $ \o -> do
            ident <- o .: "identifier"
            module' <- o .: "module"
            ty <- o .: "type"
-           pure (module', ident, ty)) (V.toList cs)
-
-infoParser :: Value -> Parser [P.SourceSpan]
-infoParser = withArray "res" $ \cs ->
-  mapM (withObject "info" $ \o -> o .: "definedAt") (V.toList cs)
+           ss <- o .: "definedAt"
+           pure (module', ident, ty, ss)) (V.toList cs)
 
 valueFromText :: Text -> Value
 valueFromText = fromJust . decode . toS
@@ -272,13 +264,9 @@ valueFromText = fromJust . decode . toS
 resultIsSuccess :: Text -> Bool
 resultIsSuccess = isRight . join . first toS . parseEither unwrapResult . valueFromText
 
-parseCompletions :: Text -> [(Text, Text, Text)]
+parseCompletions :: Text -> [(Text, Text, Text, Maybe P.SourceSpan)]
 parseCompletions s =
   fromJust $ join (rightToMaybe <$> parseMaybe (withResult completionParser) (valueFromText s))
-
-parseInfo :: Text -> [P.SourceSpan]
-parseInfo s =
-  fromJust $ join (rightToMaybe <$> parseMaybe (withResult infoParser) (valueFromText s))
 
 parseTextResult :: Text -> Text
 parseTextResult s =

--- a/tests/Language/PureScript/Ide/MatcherSpec.hs
+++ b/tests/Language/PureScript/Ide/MatcherSpec.hs
@@ -9,20 +9,21 @@ import qualified Language.PureScript                 as P
 import           Language.PureScript.Ide.Integration
 import           Language.PureScript.Ide.Matcher
 import           Language.PureScript.Ide.Types
+import           Language.PureScript.Ide.Util
 import           Test.Hspec
 
-value :: Text -> IdeDeclaration
-value s = IdeValue (P.Ident (toS s)) P.REmpty
+value :: Text -> IdeDeclarationAnn
+value s = withEmptyAnn (IdeValue (P.Ident (toS s)) P.REmpty)
 
-firstResult, secondResult, fiult :: Match IdeDeclaration
+firstResult, secondResult, fiult :: Match IdeDeclarationAnn
 firstResult = Match (P.moduleNameFromString "Match", value "firstResult")
 secondResult = Match (P.moduleNameFromString "Match", value "secondResult")
 fiult = Match (P.moduleNameFromString "Match", value "fiult")
 
-completions :: [Match IdeDeclaration]
+completions :: [Match IdeDeclarationAnn]
 completions = [firstResult, secondResult, fiult]
 
-runFlex :: Text -> [Match IdeDeclaration]
+runFlex :: Text -> [Match IdeDeclarationAnn]
 runFlex s = runMatcher (flexMatcher s) completions
 
 setup :: IO ()
@@ -43,5 +44,6 @@ spec = do
         cs <- getFlexCompletions ""
         cs `shouldBe` []
       it "matches on equality" $ do
-        cs <- getFlexCompletions "const"
-        cs `shouldBe` [("MatcherSpec", "const", "forall a b. a -> b -> a")]
+        -- ignore any position information
+        (m, i, t, _) : _ <- getFlexCompletions "const"
+        (m, i, t) `shouldBe` ("MatcherSpec", "const", "forall a b. a -> b -> a")

--- a/tests/Language/PureScript/Ide/SourceFile/IntegrationSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFile/IntegrationSpec.hs
@@ -31,6 +31,11 @@ spec = beforeAll_ setup $
 
 testCase :: Text -> (Int, Int) -> IO ()
 testCase s (x, y) = do
-  P.SourceSpan f (P.SourcePos l c) _ : _ <- Integration.getInfo s
+  P.SourceSpan f (P.SourcePos l c) _ <- getLocation s
   toS f `shouldSatisfy` T.isSuffixOf "SourceFileSpec.purs"
   (l, c) `shouldBe` (x, y)
+
+getLocation :: Text -> IO P.SourceSpan
+getLocation s = do
+  (_, _, _, Just location) : _ <- Integration.getType s
+  pure location

--- a/tests/Language/PureScript/Ide/SourceFileSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFileSpec.hs
@@ -13,7 +13,8 @@ span0 = P.SourceSpan "ModuleLevel" (P.SourcePos 0 0) (P.SourcePos 1 1)
 span1 = P.SourceSpan "" (P.SourcePos 1 1) (P.SourcePos 2 2)
 span2 = P.SourceSpan "" (P.SourcePos 2 2) (P.SourcePos 3 3)
 
-value1, synonym1, class1, class2, data1, data2, foreign1, foreign2, member1 :: P.Declaration
+typeAnnotation1, value1, synonym1, class1, class2, data1, data2, foreign1, foreign2, member1 :: P.Declaration
+typeAnnotation1 = P.TypeDeclaration (P.Ident "value1") P.REmpty
 value1 = P.ValueDeclaration (P.Ident "value1") P.Public [] (Left [])
 synonym1 = P.TypeSynonymDeclaration (P.ProperName "Synonym1") [] P.REmpty
 class1 = P.TypeClassDeclaration (P.ProperName "Class1") [] [] []
@@ -26,7 +27,7 @@ foreign2 = P.ExternDataDeclaration (P.ProperName "Foreign2") P.Star
 member1 = P.TypeDeclaration (P.Ident "member1") P.REmpty
 
 spec :: Spec
-spec =
+spec = do
   describe "Extracting Spans" $ do
     it "extracts a span for a value declaration" $
       extractSpans span0 (P.PositionedDeclaration span1 [] value1) `shouldBe` [(Left "value1", span1)]
@@ -44,3 +45,6 @@ spec =
       extractSpans span0 (P.PositionedDeclaration span1 [] foreign1) `shouldBe` [(Left "foreign1", span1)]
     it "extracts a span for a data foreign declaration" $
       extractSpans span0 (P.PositionedDeclaration span1 [] foreign2) `shouldBe` [(Right "Foreign2", span1)]
+  describe "Type annotations" $ do
+    it "extracts a type annotation" $
+      extractTypeAnnotations [typeAnnotation1] `shouldBe` [(P.Ident "value1", P.REmpty)]


### PR DESCRIPTION
Follow up on #2303 and #2302.

This PR merges the two different response types for the `type` and `completion` command. We now provide all the AST information for both of these.

The format for the returned completions has thus changed from:

```json
{ "module" : "Text"
, "identifier" : "Text"
, "type" : "Text"
}
```

to:
```json
{ "module" : "Text"
, "identifier" : "Text"
, "type" : "Text"
, "expandedType" : "Text"
, "definedAt" : "Maybe SourceSpan"
, "documentation" : "Maybe Text"
}
```

The `type` field now contains the annotated type, if we found it by parsing the sourcefiles. If we didn't find any annotation it still contains the type with fully expanded type synonyms. This should provide a better default for the editors and if they still want to show the expanded types that is now available via the `expandedType` field. 

The `documentation` field is always Nothing for now, but I intend to fill out that information soon, so I thought I'll change the API just once instead of twice.

Because all the old fields remain we shouldn't break any editor plugins, give better type information for the end users and allow for more features on the editor side through the new fields.

TODO:

- [x] Document the new API
- [x] Write a few tests
- [x] Squash commits