### PR TITLE
[psc-ide] resolve types/kinds for operators

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -521,5 +521,6 @@ test-suite tests
                    Language.PureScript.Ide.ReexportsSpec
                    Language.PureScript.Ide.SourceFile.IntegrationSpec
                    Language.PureScript.Ide.SourceFileSpec
+                   Language.PureScript.Ide.StateSpec
     buildable: True
     hs-source-dirs: tests

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -87,17 +87,19 @@ convertOperator :: P.ExternsFixity -> IdeDeclaration
 convertOperator P.ExternsFixity{..} =
   IdeValueOperator
     efOperator
-    (toS (P.showQualified (either P.runIdent P.runProperName) efAlias))
+    efAlias
     efPrecedence
     efAssociativity
+    Nothing
 
 convertTypeOperator :: P.ExternsTypeFixity -> IdeDeclaration
 convertTypeOperator P.ExternsTypeFixity{..} =
   IdeTypeOperator
     efTypeOperator
-    (toS (P.showQualified P.runProperName efTypeAlias))
+    efTypeAlias
     efTypePrecedence
     efTypeAssociativity
+    Nothing
 
 annotateModule
   :: (DefinitionSites P.SourceSpan, TypeAnnotations)
@@ -118,10 +120,10 @@ annotateModule (defs, types) (moduleName, decls) =
         annotateValue (runProperNameT i) (IdeDataConstructor i tn t)
       IdeTypeClass i ->
         annotateType (runProperNameT i) (IdeTypeClass i)
-      IdeValueOperator n i p a ->
-        annotateValue i (IdeValueOperator n i p a)
-      IdeTypeOperator n i p a ->
-        annotateType i (IdeTypeOperator n i p a)
+      IdeValueOperator n i p a t ->
+        annotateValue (valueOperatorAliasT i) (IdeValueOperator n i p a t)
+      IdeTypeOperator n i p a k ->
+        annotateType (typeOperatorAliasT i) (IdeTypeOperator n i p a k)
       where
         annotateFunction x = IdeDeclarationAnn (ann { annLocation = Map.lookup (Left (runIdentT x)) defs
                                                     , annTypeAnnotation = Map.lookup x types

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -203,9 +203,9 @@ addExplicitImport' decl moduleName imports =
       P.TypeRef tn (Just [n])
     refFromDeclaration (IdeType n _) =
       P.TypeRef n (Just [])
-    refFromDeclaration (IdeValueOperator op _ _ _) =
+    refFromDeclaration (IdeValueOperator op _ _ _ _) =
       P.ValueOpRef op
-    refFromDeclaration (IdeTypeOperator op _ _ _) =
+    refFromDeclaration (IdeTypeOperator op _ _ _ _) =
       P.TypeOpRef op
     refFromDeclaration d =
       P.ValueRef $ P.Ident $ T.unpack (identifierFromIdeDeclaration d)

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -91,9 +91,9 @@ resolveRef decls ref = case ref of
   P.ValueRef i ->
     findWrapped (\case IdeValue i' _ -> i' == i; _ -> False)
   P.TypeOpRef name ->
-    findWrapped (\case IdeTypeOperator n _ _ _ -> n == name; _ -> False)
+    findWrapped (\case IdeTypeOperator n _ _ _ _ -> n == name; _ -> False)
   P.ValueOpRef name ->
-    findWrapped (\case IdeValueOperator n _ _ _ -> n == name; _ -> False)
+    findWrapped (\case IdeValueOperator n _ _ _ _ -> n == name; _ -> False)
   P.TypeClassRef name ->
     findWrapped (\case IdeTypeClass n -> n == name; _ -> False)
   _ ->

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -28,6 +28,8 @@ module Language.PureScript.Ide.State
   , populateStage2
   , populateStage3
   , populateStage3STM
+  -- for tests
+  , resolveOperatorsForModule
   ) where
 
 import           Protolude
@@ -35,7 +37,8 @@ import qualified Prelude
 
 import           Control.Concurrent.STM
 import           "monad-logger" Control.Monad.Logger
-import qualified Data.Map.Lazy                     as M
+import qualified Data.Map.Lazy                     as Map
+import qualified Data.List                         as List
 import           Language.PureScript.Externs
 import           Language.PureScript.Ide.Externs
 import           Language.PureScript.Ide.Reexports
@@ -55,10 +58,10 @@ resetIdeState = do
 
 -- | Gets the loaded Modulenames
 getLoadedModulenames :: Ide m => m [P.ModuleName]
-getLoadedModulenames = M.keys <$> getExternFiles
+getLoadedModulenames = Map.keys <$> getExternFiles
 
 -- | Gets all loaded ExternFiles
-getExternFiles :: Ide m => m (M.Map P.ModuleName ExternsFile)
+getExternFiles :: Ide m => m (Map P.ModuleName ExternsFile)
 getExternFiles = s1Externs <$> getStage1
 
 -- | Insert a Module into Stage1 of the State
@@ -72,7 +75,7 @@ insertModuleSTM :: TVar IdeState -> (FilePath, P.Module) -> STM ()
 insertModuleSTM ref (fp, module') =
   modifyTVar ref $ \x ->
     x { ideStage1 = (ideStage1 x) {
-          s1Modules = M.insert
+          s1Modules = Map.insert
             (P.getModuleName module')
             (module', fp)
             (s1Modules (ideStage1 x))}}
@@ -126,17 +129,24 @@ getAllModules mmoduleName = do
   declarations <- s3Declarations <$> getStage3
   rebuild <- cachedRebuild
   case mmoduleName of
-    Nothing -> pure (M.toList declarations)
+    Nothing -> pure (Map.toList declarations)
     Just moduleName ->
       case rebuild of
         Just (cachedModulename, ef)
           | cachedModulename == moduleName -> do
               (AstData asts) <- s2AstData <$> getStage2
-              let ast = fromMaybe (M.empty, M.empty) (M.lookup moduleName asts)
-              pure . M.toList $
-                M.insert moduleName
-                (snd . annotateModule ast . fst . convertExterns $ ef) declarations
-        _ -> pure (M.toList declarations)
+              let
+                ast =
+                  fromMaybe (Map.empty, Map.empty) (Map.lookup moduleName asts)
+                cachedModule =
+                  snd . annotateModule ast . fst . convertExterns $ ef
+                tmp =
+                  Map.insert moduleName cachedModule declarations
+                resolved =
+                  Map.adjust (resolveOperatorsForModule tmp) moduleName tmp
+
+              pure (Map.toList resolved)
+        _ -> pure (Map.toList declarations)
 
 -- | Adds an ExternsFile into psc-ide's State Stage1. This does not populate the
 -- following Stages, which needs to be done after all the necessary Exterms have
@@ -151,7 +161,7 @@ insertExternsSTM :: TVar IdeState -> ExternsFile -> STM ()
 insertExternsSTM ref ef =
   modifyTVar ref $ \x ->
     x { ideStage1 = (ideStage1 x) {
-          s1Externs = M.insert (efModuleName ef) ef (s1Externs (ideStage1 x))}}
+          s1Externs = Map.insert (efModuleName ef) ef (s1Externs (ideStage1 x))}}
 
 -- | Sets rebuild cache to the given ExternsFile
 cacheRebuild :: Ide m => ExternsFile -> m ()
@@ -202,12 +212,70 @@ populateStage3STM :: TVar IdeState -> STM [ReexportResult Module]
 populateStage3STM ref = do
   externs <- s1Externs <$> getStage1STM ref
   (AstData asts) <- s2AstData <$> getStage2STM ref
-  let modules = M.map convertExterns externs
+  let modules = Map.map convertExterns externs
       nModules :: Map P.ModuleName (Module, [(P.ModuleName, P.DeclarationRef)])
-      nModules = M.mapWithKey
+      nModules = Map.mapWithKey
         (\moduleName (m, refs) ->
-           (fromMaybe m $ annotateModule <$> M.lookup moduleName asts <*> pure m, refs)) modules
+           (fromMaybe m $ annotateModule <$> Map.lookup moduleName asts <*> pure m, refs)) modules
       -- resolves reexports and discards load failures for now
-      result = resolveReexports (M.map (snd . fst) nModules) <$> M.elems nModules
-  setStage3STM ref (Stage3 (M.fromList (map reResolved result)) Nothing)
+      result = resolveReexports (map (snd . fst) nModules) <$> Map.elems nModules
+      resultP = resolveOperators (Map.fromList (reResolved <$> result))
+  setStage3STM ref (Stage3 resultP Nothing)
   pure result
+
+resolveOperators
+  :: Map P.ModuleName [IdeDeclarationAnn]
+  -> Map P.ModuleName [IdeDeclarationAnn]
+resolveOperators modules =
+  map (resolveOperatorsForModule modules) modules
+
+-- | Looks up the types and kinds for operators and assigns them to their
+-- declarations
+resolveOperatorsForModule
+  :: Map P.ModuleName [IdeDeclarationAnn]
+  -> [IdeDeclarationAnn]
+  -> [IdeDeclarationAnn]
+resolveOperatorsForModule modules = map (mapIdeDeclaration resolveOperator)
+  where
+    resolveOperator (IdeValueOperator
+                    opName
+                    i@(P.Qualified (Just moduleName)
+                        (Left ident)) precedence assoc _) =
+      let t = do
+            sourceModule <- Map.lookup moduleName modules
+            IdeValue _ tP <-
+              List.find (\case
+                            IdeValue iP _ -> iP == ident
+                            _ -> False) (discardAnn <$> sourceModule)
+            pure tP
+
+      in IdeValueOperator opName i precedence assoc t
+    resolveOperator (IdeValueOperator
+                    opName
+                    i@(P.Qualified (Just moduleName)
+                        (Right ctor)) precedence assoc _) =
+      let t = do
+            sourceModule <- Map.lookup moduleName modules
+            IdeDataConstructor _ _ tP <-
+              List.find (\case
+                            IdeDataConstructor cname _ _ -> ctor == cname
+                            _ -> False) (discardAnn <$> sourceModule)
+            pure tP
+
+      in IdeValueOperator opName i precedence assoc t
+    resolveOperator (IdeTypeOperator
+                    opName
+                    i@(P.Qualified (Just moduleName) properName) precedence assoc _)  =
+      let k = do
+            sourceModule <- Map.lookup moduleName modules
+            IdeType _ kP <-
+              List.find (\case
+                            IdeType name _ -> name == properName
+                            _ -> False) (discardAnn <$> sourceModule)
+            pure kP
+
+      in IdeTypeOperator opName i precedence assoc k
+    resolveOperator x = x
+
+mapIdeDeclaration :: (IdeDeclaration -> IdeDeclaration) -> IdeDeclarationAnn -> IdeDeclarationAnn
+mapIdeDeclaration f (IdeDeclarationAnn ann decl) = IdeDeclarationAnn ann (f decl)

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -36,8 +36,8 @@ data IdeDeclaration
   | IdeTypeSynonym (P.ProperName 'P.TypeName) P.Type
   | IdeDataConstructor (P.ProperName 'P.ConstructorName) (P.ProperName 'P.TypeName) P.Type
   | IdeTypeClass (P.ProperName 'P.ClassName)
-  | IdeValueOperator (P.OpName 'P.ValueOpName) Text P.Precedence P.Associativity
-  | IdeTypeOperator (P.OpName 'P.TypeOpName) Text P.Precedence P.Associativity
+  | IdeValueOperator (P.OpName 'P.ValueOpName) (P.Qualified (Either P.Ident (P.ProperName 'P.ConstructorName))) P.Precedence P.Associativity (Maybe P.Type)
+  | IdeTypeOperator (P.OpName 'P.TypeOpName) (P.Qualified (P.ProperName 'P.TypeName)) P.Precedence P.Associativity (Maybe P.Kind)
   deriving (Show, Eq, Ord)
 
 data IdeDeclarationAnn = IdeDeclarationAnn Annotation IdeDeclaration

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -24,6 +24,8 @@ module Language.PureScript.Ide.Util
   , decodeT
   , discardAnn
   , withEmptyAnn
+  , valueOperatorAliasT
+  , typeOperatorAliasT
   , module Language.PureScript.Ide.Conversions
   ) where
 
@@ -42,8 +44,8 @@ identifierFromIdeDeclaration d = case d of
   IdeTypeSynonym name _ -> runProperNameT name
   IdeDataConstructor name _ _ -> runProperNameT name
   IdeTypeClass name -> runProperNameT name
-  IdeValueOperator op _ _ _ -> runOpNameT op
-  IdeTypeOperator op _ _ _ -> runOpNameT op
+  IdeValueOperator op _ _ _ _ -> runOpNameT op
+  IdeTypeOperator op _ _ _ _ -> runOpNameT op
 
 discardAnn :: IdeDeclarationAnn -> IdeDeclaration
 discardAnn (IdeDeclarationAnn _ d) = d
@@ -64,10 +66,10 @@ completionFromMatch (Match (m, IdeDeclarationAnn ann decl)) =
       IdeTypeSynonym name kind -> (runProperNameT name, prettyTypeT kind)
       IdeDataConstructor name _ type' -> (runProperNameT name, prettyTypeT type')
       IdeTypeClass name -> (runProperNameT name, "class")
-      IdeValueOperator op ref precedence associativity ->
-        (runOpNameT op, showFixity precedence associativity ref op)
-      IdeTypeOperator op ref precedence associativity ->
-        (runOpNameT op, showFixity precedence associativity ref op)
+      IdeValueOperator op ref precedence associativity typeP ->
+        (runOpNameT op, maybe (showFixity precedence associativity (valueOperatorAliasT ref) op) prettyTypeT typeP) 
+      IdeTypeOperator op ref precedence associativity kind ->
+        (runOpNameT op, maybe (showFixity precedence associativity (typeOperatorAliasT ref) op) (toS . P.prettyPrintKind) kind)
             
     complModule = runModuleNameT m
 
@@ -84,6 +86,16 @@ completionFromMatch (Match (m, IdeDeclarationAnn ann decl)) =
             P.Infixr -> "infixr"
       in T.unwords [asso, show p, r, "as", runOpNameT o]
 
+valueOperatorAliasT
+  :: P.Qualified (Either P.Ident (P.ProperName 'P.ConstructorName)) -> Text
+valueOperatorAliasT i =
+  toS (P.showQualified (either P.runIdent P.runProperName) i)
+
+typeOperatorAliasT
+  :: P.Qualified (P.ProperName 'P.TypeName) -> Text
+typeOperatorAliasT i =
+  toS (P.showQualified P.runProperName i)
+  
 encodeT :: (ToJSON a) => a -> Text
 encodeT = toS . decodeUtf8 . encode
 

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -70,7 +70,7 @@ spec = do
         addValueImport i mn is =
           prettyPrintImportSection (addExplicitImport' (IdeValue (P.Ident i) wildcard) mn is)
         addOpImport op mn is =
-          prettyPrintImportSection (addExplicitImport' (IdeValueOperator op "" 2 P.Infix) mn is)
+          prettyPrintImportSection (addExplicitImport' (IdeValueOperator op (P.Qualified Nothing (Left (P.Ident ""))) 2 P.Infix Nothing) mn is)
         addDtorImport i t mn is =
           prettyPrintImportSection (addExplicitImport' (IdeDataConstructor (P.ProperName i) t wildcard) mn is)
     it "adds an implicit unqualified import" $

--- a/tests/Language/PureScript/Ide/StateSpec.hs
+++ b/tests/Language/PureScript/Ide/StateSpec.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Language.PureScript.Ide.StateSpec where
+
+import           Protolude
+import           Language.PureScript.Ide.Types
+import           Language.PureScript.Ide.State
+import qualified Language.PureScript as P
+import           Test.Hspec
+import qualified Data.Map as Map
+
+valueOperator :: Maybe P.Type -> IdeDeclarationAnn
+valueOperator =
+  d . IdeValueOperator (P.OpName "<$>") (P.Qualified (Just (mn "Test")) (Left (P.Ident "function"))) 2 P.Infix
+
+ctorOperator :: Maybe P.Type -> IdeDeclarationAnn
+ctorOperator =
+  d . IdeValueOperator (P.OpName ":") (P.Qualified (Just (mn "Test")) (Right (P.ProperName "Cons"))) 2 P.Infix
+
+typeOperator :: Maybe P.Kind -> IdeDeclarationAnn
+typeOperator =
+  d . IdeTypeOperator (P.OpName ":") (P.Qualified (Just (mn "Test")) (P.ProperName "List")) 2 P.Infix
+
+testModule :: Module
+testModule = (mn "Test", [ d (IdeValue (P.Ident "function") P.REmpty)
+                         , d (IdeDataConstructor (P.ProperName "Cons") (P.ProperName "List") (P.REmpty))
+                         , d (IdeType (P.ProperName "List") P.Star)
+                         , valueOperator Nothing
+                         , ctorOperator Nothing
+                         , typeOperator Nothing
+                         ])
+
+d :: IdeDeclaration -> IdeDeclarationAnn
+d = IdeDeclarationAnn emptyAnn
+
+mn :: Text -> P.ModuleName
+mn = P.moduleNameFromString . toS
+
+testState :: Map P.ModuleName [IdeDeclarationAnn]
+testState = Map.fromList
+  [ testModule
+  ]
+
+spec :: Spec
+spec = describe "resolving operators" $ do
+  it "resolves the type for a value operator" $
+    resolveOperatorsForModule testState (snd testModule) `shouldSatisfy` elem (valueOperator (Just P.REmpty))
+  it "resolves the type for a constructor operator" $
+    resolveOperatorsForModule testState (snd testModule) `shouldSatisfy` elem (ctorOperator (Just P.REmpty))
+  it "resolves the kind for a type operator" $
+    resolveOperatorsForModule testState (snd testModule) `shouldSatisfy` elem (typeOperator (Just P.Star))

--- a/tests/TestPscIde.hs
+++ b/tests/TestPscIde.hs
@@ -11,4 +11,5 @@ main = do
   s <- compileTestProject
   unless s $ fail "Failed to compile .purs sources"
 
+  quitServer -- shuts down any left over server (primarily happens during development)
   withServer (hspec PscIdeSpec.spec)


### PR DESCRIPTION
One point of #2222.

Things left to do:

- [x] Speed up the pass in `getAllModules`
- [x] Write tests
- [x] discuss how we want to preserve the fixity/alias information in the protocol

Where operators used the type field to pass their fixity information to the editors that field is now used for types/kinds again.

Before:
```purescript
Control.Apply.$> :: 
  infixl 4 Data.Functor.voidLeft as $>
```

Now:
````purescript
Control.Apply.$> :: 
  forall f a b. (Functor f) => f a -> b -> f b
```

The server still has that information but because of the generic completion format there is no proper way to communicate it to the clients. Maybe we should think about a sum type (with a "tag" field in the json) to return completions. I like the simplicity of the current approach and would want to preserve generic fields for `module` `type` and `identifier` on every completion to make the integration with a new editor or other tools as simple as possible. Maybe we could add a `details` field that has information specific to the type (Value, Type, Constructor, ...) of completion.

Thoughts?
/cc @nwolverson @FrigoEU @rvion @bsermons