### PR TITLE
Relax the one-way unification check for repeated variables

### DIFF
--- a/examples/failing/1310.purs
+++ b/examples/failing/1310.purs
@@ -1,4 +1,4 @@
--- @shouldFailWith NoInstanceFound
+-- @shouldFailWith TypesDoNotUnify
 
 module Issue1310 where
 

--- a/examples/passing/UnifyInTypeInstanceLookup.purs
+++ b/examples/passing/UnifyInTypeInstanceLookup.purs
@@ -2,9 +2,6 @@ module Main where
 
 import Control.Monad.Eff.Console (log)
 
-data Z = Z
-data S n = S n
-
 data T
 data F
 
@@ -15,11 +12,11 @@ instance eqF :: EQ x y F
 test :: forall a b. (EQ a b T) => a -> b -> a
 test a _ = a
 
-spin :: forall a b. a -> b
-spin a = spin a
-
--- Expected type: 
--- forall t. (EQ t (S Z) T) => t
-test1 = test (spin 1) (S Z)
+-- Note the expected type: 
+--   Char -> Char 
+-- Not 
+--   forall t. (EQ t Char T) => t -> t
+-- as in Haskell
+test1 a = test a 'x'
 
 main = log "Done"


### PR DESCRIPTION
@garyb @kRITZCREEK 

This is the one last thing I'd like to decide before merging the fundeps branch. I think it simplifies the rules quite a bit, but at the expense of some possibly unexpected inferred types (compared to Haskell) in a few more complicated cases.

Hopefully the test changes summarize the difference, but the new rule is:

> If a type variable appears more than once in an instance head, we will commit to that instance if all occurences of that type variable will be instantiated to things which can be unified, *including unknowns*.

This rule allows things like this to work, where they wouldn't have before (in the `fundeps` branch):

```haskell
> import Prelude
> import Control.Monad.Error.Class 
> import Control.Monad.State.Class
> import Control.Monad.State
> import Control.Monad.Except

> :t get >>= throwError
forall t1 t2 t6.    
  ( Bind t1         
  , MonadState t6 t1
  , MonadError t6 t1
  ) => t1 t2        

> :t runExceptT (get >>= throwError)
forall t1 t2 t3.        
  ( Monad t2            
  , MonadState t3 t2    
  ) => t2 (Either t3 t1)

> :t runState (runExceptT (get >>= throwError))
forall t5 t7. t7 -> Tuple (Either t7 t5) t7

> :t runState (runExceptT (get >>= throwError)) 0 -- This one used to fail for a confusing reason
forall t3. Tuple (Either Int t3) Int
```

However, it means that we now might pick an instance where you might not expect us to:

```haskell
> class EQ a b
> instance eq :: EQ a a
> let test = (\x y -> x) :: forall a b. EQ a b => a -> b -> a

> :t test 'a'
Char -> Char
```

Here, Haskell would infer `EQ Char a => a -> Char`, although I'm not really sure why it infers this but allows some of the things listed above.

My rationale for allowing this is that any case where this would lead to unexpected inferred types seems to require possibly overlapping instances anyway (like `EQ` above). We warn on overlapping instances, so if you use them, you should expect odd things to happen.

I've put this in a separate branch since I'd like to discuss it in isolation before we commit to it.

It's reassuring, having gone through the literature, that the Haskell folks had to think about these issues quite hard some twenty years ago. For reference, a lot of these sorts of things are documented in "Type classes: an exploration of the design space".