### PR TITLE
Only require repeated types to be equal on the solved set

### DIFF
--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -280,9 +280,9 @@ matches deps TypeClassDictionaryInScope{..} tys = do
     -- Now, use any functional dependencies to infer any remaining types
     guard $ covers matched
     -- Verify that any repeated type variables are unifiable
-    let inferredSet = foldMap (S.fromList . fdDetermined) deps
-        tagged = zipWith (\(_, ts) i -> fmap (fmap (S.member i inferredSet, )) ts) matched [0..]
-    verifySubstitution (M.unionsWith (++) tagged)
+    let determinedSet = foldMap (S.fromList . fdDetermined) deps
+        solved = map snd . filter ((`S.notMember` determinedSet) . fst) $ zipWith (\(_, ts) i -> (i, ts)) matched [0..]
+    verifySubstitution (M.unionsWith (++) solved)
   where
     -- | Find the closure of a set of functional dependencies.
     covers :: [(Bool, subst)] -> Bool
@@ -345,46 +345,42 @@ matches deps TypeClassDictionaryInScope{..} tys = do
     both (b1, m1) (b2, m2) = (b1 && b2, M.unionWith (++) m1 m2)
 
     -- Ensure that a substitution is valid
-    verifySubstitution :: Matching [(Bool, Type)] -> Maybe (Matching [Type])
+    verifySubstitution :: Matching [Type] -> Maybe (Matching [Type])
     verifySubstitution = traverse meet where
-      meet ts | pairwiseAll unifiesWith ts = Just (fmap snd ts)
+      meet ts | pairwiseAll typesAreEqual ts = Just ts
               | otherwise = Nothing
 
       -- Note that unknowns are only allowed to unify if they came from a type
       -- which was _not_ solved, i.e. one which was inferred by a functional
       -- dependency.
-      unifiesWith :: (Bool, Type) -> (Bool, Type) -> Bool
-      unifiesWith (solved1, ty1) (solved2, ty2) = unifiesWith' ty1 ty2 where
-        unifiesWith' (TUnknown u1)        (TUnknown u2)        | u1 == u2 = True
-        unifiesWith' (TUnknown _)         _                    | solved1 = True
-        unifiesWith' _                    (TUnknown _)         | solved2 = True
-        unifiesWith' (Skolem _ s1 _ _)    (Skolem _ s2 _ _)    = s1 == s2
-        unifiesWith' (TypeVar v1)         (TypeVar v2)         = v1 == v2
-        unifiesWith' (TypeLevelString s1) (TypeLevelString s2) = s1 == s2
-        unifiesWith' (TypeConstructor c1) (TypeConstructor c2) = c1 == c2
-        unifiesWith' (TypeApp h1 t1)      (TypeApp h2 t2)      = unifiesWith' h1 h2 && unifiesWith' t1 t2
-        unifiesWith' REmpty               REmpty               = True
-        unifiesWith' r1                   r2                   | isRCons r1 || isRCons r2 =
-            let (s1, r1') = rowToList r1
-                (s2, r2') = rowToList r2
+      typesAreEqual :: Type -> Type -> Bool
+      typesAreEqual (TUnknown u1)        (TUnknown u2)        | u1 == u2 = True
+      typesAreEqual (Skolem _ s1 _ _)    (Skolem _ s2 _ _)    = s1 == s2
+      typesAreEqual (TypeVar v1)         (TypeVar v2)         = v1 == v2
+      typesAreEqual (TypeLevelString s1) (TypeLevelString s2) = s1 == s2
+      typesAreEqual (TypeConstructor c1) (TypeConstructor c2) = c1 == c2
+      typesAreEqual (TypeApp h1 t1)      (TypeApp h2 t2)      = typesAreEqual h1 h2 && typesAreEqual t1 t2
+      typesAreEqual REmpty               REmpty               = True
+      typesAreEqual r1                   r2                   | isRCons r1 || isRCons r2 =
+          let (s1, r1') = rowToList r1
+              (s2, r2') = rowToList r2
 
-                int = [ (t1, t2) | (name, t1) <- s1, (name', t2) <- s2, name == name' ]
-                sd1 = [ (name, t1) | (name, t1) <- s1, name `notElem` map fst s2 ]
-                sd2 = [ (name, t2) | (name, t2) <- s2, name `notElem` map fst s1 ]
-            in all (uncurry unifiesWith') int && go sd1 r1' sd2 r2'
-          where
-            go :: [(String, Type)] -> Type -> [(String, Type)] -> Type -> Bool
-            go _  (TUnknown _)      _  _                 | solved1 = True
-            go _  _                 _  (TUnknown _)      | solved2 = True
-            go [] (Skolem _ s1 _ _) [] (Skolem _ s2 _ _) = s1 == s2
-            go [] REmpty            [] REmpty            = True
-            go [] (TypeVar v1)      [] (TypeVar v2)      = v1 == v2
-            go _  _                 _  _                 = False
-        unifiesWith' _ _ = False
+              int = [ (t1, t2) | (name, t1) <- s1, (name', t2) <- s2, name == name' ]
+              sd1 = [ (name, t1) | (name, t1) <- s1, name `notElem` map fst s2 ]
+              sd2 = [ (name, t2) | (name, t2) <- s2, name `notElem` map fst s1 ]
+          in all (uncurry typesAreEqual) int && go sd1 r1' sd2 r2'
+        where
+          go :: [(String, Type)] -> Type -> [(String, Type)] -> Type -> Bool
+          go [] (TUnknown u1)     [] (TUnknown u2)     | u1 == u2 = True
+          go [] (Skolem _ s1 _ _) [] (Skolem _ s2 _ _) = s1 == s2
+          go [] REmpty            [] REmpty            = True
+          go [] (TypeVar v1)      [] (TypeVar v2)      = v1 == v2
+          go _  _                 _  _                 = False
+      typesAreEqual _ _ = False
 
-        isRCons :: Type -> Bool
-        isRCons RCons{}    = True
-        isRCons _          = False
+      isRCons :: Type -> Bool
+      isRCons RCons{}    = True
+      isRCons _          = False
 
 -- | Add a dictionary for the constraint to the scope, and dictionaries
 -- for all implied superclass instances.


### PR DESCRIPTION
After giving this more thought, I'd like to present this as an alternative to my other open PR.

This relaxes the unification check for repeated type variables in a different way:

> We now require repeated types to be *equal*, not just unify, but only on the set of types not determined by some functional dependency.

The rationale is that anything solved by a functional dependency will be forced to unify after the instance is chosen anyway, so it not being equal on the nose should not stop us from choosing the instance. 

This seems to match GHC more closely in my tests, although I'll admit, I haven't tested it thoroughly yet.

I suggest we try to put both approaches through their paces and see which works out best, before merging into the `fundeps` branch. That said, after thinking about this quite a bit, I think this is the better approach.