### PR TITLE
Fix function application judgment

### DIFF
--- a/examples/failing/DoNotSuggestComposition2.purs
+++ b/examples/failing/DoNotSuggestComposition2.purs
@@ -1,4 +1,4 @@
--- @shouldFailWith CannotApplyFunction
+-- @shouldFailWith TypesDoNotUnify
 -- TODO: Check that this does not produce a "function composition is (<<<)"
 -- suggestion.
 

--- a/examples/failing/OperatorSections.purs
+++ b/examples/failing/OperatorSections.purs
@@ -1,8 +1,7 @@
--- @shouldFailWith CannotApplyFunction
+-- @shouldFailWith TypesDoNotUnify
 module Main where
 
 import Prelude
 
 main = do
   (true `not` _)
-

--- a/examples/passing/1807.purs
+++ b/examples/passing/1807.purs
@@ -1,0 +1,14 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console (log)
+
+fn = _.b.c.d
+a = {b:{c:{d:2}}}
+
+d :: Int
+d = fn a + a.b.c.d
+
+main = if fn a + a.b.c.d == 4
+  then log "Done"
+  else log "Fail"

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -90,7 +90,6 @@ data SimpleErrorMessage
   | ExprDoesNotHaveType Expr Type
   | PropertyIsMissing String
   | AdditionalProperty String
-  | CannotApplyFunction Type Expr
   | TypeSynonymInstance
   | OrphanInstance Ident (Qualified (ProperName 'ClassName)) [Type]
   | InvalidNewtype (ProperName 'TypeName)

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -133,7 +133,6 @@ errorCode em = case unwrapErrorMessage em of
   ExprDoesNotHaveType{} -> "ExprDoesNotHaveType"
   PropertyIsMissing{} -> "PropertyIsMissing"
   AdditionalProperty{} -> "AdditionalProperty"
-  CannotApplyFunction{} -> "CannotApplyFunction"
   TypeSynonymInstance -> "TypeSynonymInstance"
   OrphanInstance{} -> "OrphanInstance"
   InvalidNewtype{} -> "InvalidNewtype"
@@ -257,7 +256,6 @@ onTypesInErrorMessageM f (ErrorMessage hints simple) = ErrorMessage <$> traverse
   gSimple (TypesDoNotUnify t1 t2) = TypesDoNotUnify <$> f t1 <*> f t2
   gSimple (ConstrainedTypeUnified t1 t2) = ConstrainedTypeUnified <$> f t1 <*> f t2
   gSimple (ExprDoesNotHaveType e t) = ExprDoesNotHaveType e <$> f t
-  gSimple (CannotApplyFunction t e) = CannotApplyFunction <$> f t <*> pure e
   gSimple (InvalidInstanceHead t) = InvalidInstanceHead <$> f t
   gSimple (NoInstanceFound con) = NoInstanceFound <$> overConstraintArgs (traverse f) con
   gSimple (OverlappingInstances cl ts insts) = OverlappingInstances cl <$> traverse f ts <*> pure insts
@@ -691,12 +689,6 @@ prettyPrintSingleError (PPEOptions codeColor full level showWiki) e = flip evalS
       line $ "Type of expression lacks required label " ++ markCode prop ++ "."
     renderSimpleErrorMessage (AdditionalProperty prop) =
       line $ "Type of expression contains additional label " ++ markCode prop ++ "."
-    renderSimpleErrorMessage (CannotApplyFunction fn arg) =
-      paras [ line "A function of type"
-            , markCodeBox $ indent $ typeAsBox fn
-            , line "can not be applied to the argument"
-            , markCodeBox $ indent $ prettyPrintValue valueDepth arg
-            ]
     renderSimpleErrorMessage TypeSynonymInstance =
       line "Type class instances for type synonyms are disallowed."
     renderSimpleErrorMessage (OrphanInstance nm cnm ts) =
@@ -1036,10 +1028,6 @@ prettyPrintSingleError (PPEOptions codeColor full level showWiki) e = flip evalS
 
     -- | See https://github.com/purescript/purescript/issues/1802
     stripRedudantHints :: SimpleErrorMessage -> [ErrorMessageHint] -> [ErrorMessageHint]
-    stripRedudantHints CannotApplyFunction{} = stripFirst isApplicationHint
-      where
-      isApplicationHint ErrorInApplication{} = True
-      isApplicationHint _ = False
     stripRedudantHints ExprDoesNotHaveType{} = stripFirst isCheckHint
       where
       isCheckHint ErrorCheckingType{} = True

--- a/src/Language/PureScript/Sugar/ObjectWildcards.hs
+++ b/src/Language/PureScript/Sugar/ObjectWildcards.hs
@@ -1,5 +1,6 @@
 module Language.PureScript.Sugar.ObjectWildcards
   ( desugarObjectConstructors
+  , desugarDecl
   ) where
 
 import Prelude.Compat
@@ -21,13 +22,12 @@ desugarObjectConstructors
   => Module
   -> m Module
 desugarObjectConstructors (Module ss coms mn ds exts) = Module ss coms mn <$> mapM desugarDecl ds <*> pure exts
-  where
 
-  desugarDecl :: Declaration -> m Declaration
-  desugarDecl (PositionedDeclaration pos com d) = rethrowWithPosition pos $ PositionedDeclaration pos com <$> desugarDecl d
-  desugarDecl other = f other
-    where
-    (f, _, _) = everywhereOnValuesTopDownM return desugarExpr return
+desugarDecl :: forall m. (MonadSupply m, MonadError MultipleErrors m) => Declaration -> m Declaration
+desugarDecl (PositionedDeclaration pos com d) = rethrowWithPosition pos $ PositionedDeclaration pos com <$> desugarDecl d
+desugarDecl other = fn other
+  where
+  (fn, _, _) = everywhereOnValuesTopDownM return desugarExpr return
 
   desugarExpr :: Expr -> m Expr
   desugarExpr AnonymousArgument = throwError . errorMessage $ IncorrectAnonymousArgument
@@ -45,9 +45,10 @@ desugarObjectConstructors (Module ss coms mn ds exts) = Module ss coms mn <$> ma
     obj <- freshIdent'
     Abs (Left obj) <$> wrapLambda (ObjectUpdate (argToExpr obj)) ps
   desugarExpr (ObjectUpdate obj ps) = wrapLambda (ObjectUpdate obj) ps
-  desugarExpr (Accessor prop u) | isAnonymousArgument u = do
-    arg <- freshIdent'
-    return $ Abs (Left arg) (Accessor prop (argToExpr arg))
+  desugarExpr (Accessor prop u)
+    | Just props <- peelAnonAccessorChain u = do
+      arg <- freshIdent'
+      return $ Abs (Left arg) $ foldr Accessor (argToExpr arg) (prop:props)
   desugarExpr (Case args cas) | any isAnonymousArgument args = do
     argIdents <- forM args freshIfAnon
     let args' = zipWith (`maybe` argToExpr) args argIdents
@@ -72,6 +73,12 @@ desugarObjectConstructors (Module ss coms mn ds exts) = Module ss coms mn <$> ma
   stripPositionInfo :: Expr -> Expr
   stripPositionInfo (PositionedValue _ _ e) = stripPositionInfo e
   stripPositionInfo e = e
+
+  peelAnonAccessorChain :: Expr -> Maybe [String]
+  peelAnonAccessorChain (Accessor p e) = (p :) <$> peelAnonAccessorChain e
+  peelAnonAccessorChain (PositionedValue _ _ e) = peelAnonAccessorChain e
+  peelAnonAccessorChain AnonymousArgument = Just []
+  peelAnonAccessorChain _ = Nothing
 
   isAnonymousArgument :: Expr -> Bool
   isAnonymousArgument AnonymousArgument = True

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -292,7 +292,7 @@ infer' (Abs (Left arg) ret) = do
 infer' (Abs (Right _) _) = internalError "Binder was not desugared"
 infer' (App f arg) = do
   f'@(TypedValue _ _ ft) <- infer f
-  (ret, app) <- checkFunctionApplication f' ft arg Nothing
+  (ret, app) <- checkFunctionApplication f' ft arg
   return $ TypedValue True app ret
 infer' (Var var) = do
   checkVisibility var
@@ -567,8 +567,11 @@ check' (Abs (Left arg) ret) ty@(TypeApp (TypeApp t argTy) retTy) = do
 check' (Abs (Right _) _) _ = internalError "Binder was not desugared"
 check' (App f arg) ret = do
   f'@(TypedValue _ _ ft) <- infer f
-  (_, app) <- checkFunctionApplication f' ft arg (Just ret)
-  return $ TypedValue True app ret
+  (retTy, app) <- checkFunctionApplication f' ft arg
+  v' <- subsumes (Just app) retTy ret
+  case v' of
+    Nothing -> internalError "check: unable to check the subsumes relation."
+    Just app' -> return $ TypedValue True app' ret
 check' v@(Var var) ty = do
   checkVisibility var
   repl <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< lookupVariable $ var
@@ -692,7 +695,19 @@ checkProperties expr ps row lax = let (ts, r') = rowToList row in go ps ts r' wh
         return $ (p, v') : ps''
   go _ _ _ = throwError . errorMessage $ ExprDoesNotHaveType expr (TypeApp tyRecord row)
 
--- | Check the type of a function application, rethrowing errors to provide a better error message
+-- | Check the type of a function application, rethrowing errors to provide a better error message.
+--
+-- This judgment takes three inputs:
+--
+-- * The expression of the function we are applying
+-- * The type of that function
+-- * The expression we are applying it to
+--
+-- and synthesizes two outputs:
+--
+-- * The return type
+-- * The elaborated expression for the function application (since we might need to
+--   insert type class dictionaries, etc.)
 checkFunctionApplication
   :: (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
   => Expr
@@ -701,13 +716,11 @@ checkFunctionApplication
   -- ^ The type of the function
   -> Expr
   -- ^ The argument expression
-  -> Maybe Type
-  -- ^ The result type we are expecting
   -> m (Type, Expr)
   -- ^ The result type, and the elaborated term
-checkFunctionApplication fn fnTy arg ret = withErrorMessageHint (ErrorInApplication fn fnTy arg) $ do
+checkFunctionApplication fn fnTy arg = withErrorMessageHint (ErrorInApplication fn fnTy arg) $ do
   subst <- gets checkSubstitution
-  checkFunctionApplication' fn (substituteType subst fnTy) arg (substituteType subst <$> ret)
+  checkFunctionApplication' fn (substituteType subst fnTy) arg
 
 -- | Check the type of a function application
 checkFunctionApplication'
@@ -715,36 +728,31 @@ checkFunctionApplication'
   => Expr
   -> Type
   -> Expr
-  -> Maybe Type
   -> m (Type, Expr)
-checkFunctionApplication' fn (TypeApp (TypeApp tyFunction' argTy) retTy) arg ret = do
+checkFunctionApplication' fn (TypeApp (TypeApp tyFunction' argTy) retTy) arg = do
   unifyTypes tyFunction' tyFunction
   arg' <- check arg argTy
-  case ret of
-    Nothing -> return (retTy, App fn arg')
-    Just ret' -> do
-      Just app' <- subsumes (Just (App fn arg')) retTy ret'
-      return (retTy, app')
-checkFunctionApplication' fn (ForAll ident ty _) arg ret = do
+  return (retTy, App fn arg')
+checkFunctionApplication' fn (ForAll ident ty _) arg = do
   replaced <- replaceVarWithUnknown ident ty
-  checkFunctionApplication fn replaced arg ret
-checkFunctionApplication' fn (KindedType ty _) arg ret =
-  checkFunctionApplication fn ty arg ret
-checkFunctionApplication' fn (ConstrainedType constraints fnTy) arg ret = do
+  checkFunctionApplication fn replaced arg
+checkFunctionApplication' fn (KindedType ty _) arg =
+  checkFunctionApplication fn ty arg
+checkFunctionApplication' fn (ConstrainedType constraints fnTy) arg = do
   dicts <- getTypeClassDictionaries
   hints <- gets checkHints
-  checkFunctionApplication' (foldl App fn (map (\cs -> TypeClassDictionary cs dicts hints) constraints)) fnTy arg ret
-checkFunctionApplication' fn fnTy dict@TypeClassDictionary{} _ =
+  checkFunctionApplication' (foldl App fn (map (\cs -> TypeClassDictionary cs dicts hints) constraints)) fnTy arg
+checkFunctionApplication' fn fnTy dict@TypeClassDictionary{} =
   return (fnTy, App fn dict)
-checkFunctionApplication' fn u arg ret = do
+checkFunctionApplication' fn u arg = do
   arg' <- do
     TypedValue _ arg' t <- infer arg
     (arg'', t') <- instantiatePolyTypeWithUnknowns arg' t
     return $ TypedValue True arg'' t'
   let ty = (\(TypedValue _ _ t) -> t) arg'
-  ret' <- maybe freshType return ret
-  unifyTypes u (function ty ret')
-  return (ret', App fn arg')
+  ret <- freshType
+  unifyTypes u (function ty ret)
+  return (ret, App fn arg')
 
 -- |
 -- Ensure a set of property names and value does not contain duplicate labels

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -693,25 +693,30 @@ checkProperties expr ps row lax = let (ts, r') = rowToList row in go ps ts r' wh
   go _ _ _ = throwError . errorMessage $ ExprDoesNotHaveType expr (TypeApp tyRecord row)
 
 -- | Check the type of a function application, rethrowing errors to provide a better error message
-checkFunctionApplication ::
-  (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) =>
-  Expr ->
-  Type ->
-  Expr ->
-  Maybe Type ->
-  m (Type, Expr)
+checkFunctionApplication
+  :: (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
+  => Expr
+  -- ^ The function expression
+  -> Type
+  -- ^ The type of the function
+  -> Expr
+  -- ^ The argument expression
+  -> Maybe Type
+  -- ^ The result type we are expecting
+  -> m (Type, Expr)
+  -- ^ The result type, and the elaborated term
 checkFunctionApplication fn fnTy arg ret = withErrorMessageHint (ErrorInApplication fn fnTy arg) $ do
   subst <- gets checkSubstitution
   checkFunctionApplication' fn (substituteType subst fnTy) arg (substituteType subst <$> ret)
 
 -- | Check the type of a function application
-checkFunctionApplication' ::
-  (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) =>
-  Expr ->
-  Type ->
-  Expr ->
-  Maybe Type ->
-  m (Type, Expr)
+checkFunctionApplication'
+  :: (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
+  => Expr
+  -> Type
+  -> Expr
+  -> Maybe Type
+  -> m (Type, Expr)
 checkFunctionApplication' fn (TypeApp (TypeApp tyFunction' argTy) retTy) arg ret = do
   unifyTypes tyFunction' tyFunction
   arg' <- check arg argTy


### PR DESCRIPTION
I came across this while testing my `fundeps` branch. This would fail previously:

```
$ pulp psci
> import Control.Monad.Reader.Class
> ask 0
```

Now it correctly returns `0`.