### PR TITLE
Fix a small bug in the type pretty-printer

### DIFF
--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -45,11 +45,11 @@ typeLiterals = mkPattern match
   match _ = Nothing
 
 constraintsAsBox :: [Constraint] -> Box -> Box
-constraintsAsBox [(Constraint pn tys _)] ty = text "(" <> constraintAsBox pn tys `before` (text ") => " <> ty)
-constraintsAsBox xs ty = vcat left (zipWith (\i (Constraint pn tys _) -> text (if i == 0 then "( " else ", ") <> constraintAsBox pn tys) [0 :: Int ..] xs) `before` (text ") => " <> ty)
+constraintsAsBox [con] ty = text "(" <> constraintAsBox con `before` (text ") => " <> ty)
+constraintsAsBox xs ty = vcat left (zipWith (\i con -> text (if i == 0 then "( " else ", ") <> constraintAsBox con) [0 :: Int ..] xs) `before` (text ") => " <> ty)
 
-constraintAsBox :: Qualified (ProperName a) -> [Type] -> Box
-constraintAsBox pn tys = hsep 1 left (text (runProperName (disqualify pn)) : map typeAtomAsBox tys)
+constraintAsBox :: Constraint -> Box
+constraintAsBox (Constraint pn tys _) = typeAsBox (foldl TypeApp (TypeConstructor (fmap coerceProperName pn)) tys)
 
 -- |
 -- Generate a pretty-printed string representing a Row


### PR DESCRIPTION
Another little bug I noticed while working on functional dependencies.

Previously:

```haskell
forall m.
  (MonadState { x :: Int m
              }
  ) => m Unit
```

Now:

```haskell
forall m.     
  (MonadState  
     { x :: Int
     }         
     m        
  ) => m Unit 
```