### PR TITLE
Fix usage detection for operators

### DIFF
--- a/examples/warning/UnusedExplicitImportTypeOp.purs
+++ b/examples/warning/UnusedExplicitImportTypeOp.purs
@@ -1,0 +1,9 @@
+-- @shouldWarnWith UnusedExplicitImport
+module Main where
+
+import Prelude (Unit, unit, pure)
+import Control.Monad.Eff (Eff)
+import Lib (type (~>), natId)
+
+main :: Eff () Unit
+main = natId (pure unit)

--- a/examples/warning/UnusedExplicitImportTypeOp/Lib.purs
+++ b/examples/warning/UnusedExplicitImportTypeOp/Lib.purs
@@ -1,0 +1,8 @@
+module Lib where
+
+type Nat f g = ∀ x. f x → g x
+
+infixr 4 type Nat as ~>
+
+natId ∷ ∀ f. f ~> f
+natId x = x

--- a/examples/warning/UnusedExplicitImportValOp.purs
+++ b/examples/warning/UnusedExplicitImportValOp.purs
@@ -1,0 +1,8 @@
+-- @shouldWarnWith UnusedExplicitImport
+module Main where
+
+import Prelude (Unit, unit, pure, (+))
+import Control.Monad.Eff (Eff)
+
+main :: Eff () Unit
+main = pure unit

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -76,6 +76,7 @@ extra-source-files: examples/passing/*.purs
                   , examples/failing/OrphanInstance/*.purs
                   , examples/warning/*.purs
                   , examples/warning/*.js
+                  , examples/warning/UnusedExplicitImportTypeOp/*.purs
                   , examples/docs/bower_components/purescript-prelude/src/*.purs
                   , examples/docs/bower.json
                   , examples/docs/src/*.purs

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -107,7 +107,7 @@ data SimpleErrorMessage
   | MisleadingEmptyTypeImport ModuleName (ProperName 'TypeName)
   | ImportHidingModule ModuleName
   | UnusedImport ModuleName
-  | UnusedExplicitImport ModuleName [String] (Maybe ModuleName) [DeclarationRef]
+  | UnusedExplicitImport ModuleName [Name] (Maybe ModuleName) [DeclarationRef]
   | UnusedDctorImport ModuleName (ProperName 'TypeName) (Maybe ModuleName) [DeclarationRef]
   | UnusedDctorExplicitImport ModuleName (ProperName 'TypeName) [ProperName 'ConstructorName] (Maybe ModuleName) [DeclarationRef]
   | DuplicateSelectiveImport ModuleName

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -758,7 +758,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showWiki) e = flip evalS
 
     renderSimpleErrorMessage msg@(UnusedExplicitImport mn names _ _) =
       paras [ line $ "The import of module " ++ markCode (runModuleName mn) ++ " contains the following unused references:"
-            , indent $ paras $ map line names
+            , indent $ paras $ map (line . markCode . runName . Qualified Nothing) names
             , line "It could be replaced with:"
             , indent $ line $ markCode $ showSuggestion msg ]
 

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -243,7 +243,7 @@ lintImportDecl env mni qualifierName names declType allowImplicit =
     didWarn' <- forM (mapMaybe getTypeRef declrefs) $ \(tn, c) -> do
       let allCtors = dctorsForType mni tn
       -- If we've not already warned a type is unused, check its data constructors
-      unless' (runProperName tn `notElem` usedNames) $
+      unless' (TyName tn `notElem` usedNames) $
         case (c, dctors `intersect` allCtors) of
           (_, []) | c /= Just [] -> warn (UnusedDctorImport mni tn qualifierName allRefs)
           (Just ctors, dctors') ->
@@ -335,18 +335,18 @@ findUsedRefs env mni qn names =
 matchName
   :: (ProperName 'ConstructorName -> Maybe (ProperName 'TypeName))
   -> Name
-  -> Maybe String
-matchName _ (IdentName x) = Just $ showIdent x
-matchName _ (TyName x) = Just $ runProperName x
-matchName _ (TyClassName x) = Just $ runProperName x
-matchName lookupDc (DctorName x) = runProperName <$> lookupDc x
-matchName _ _ = Nothing
+  -> Maybe Name
+matchName lookupDc (DctorName x) = TyName <$> lookupDc x
+matchName _ ModName{} = Nothing
+matchName _ name = Just name
 
-runDeclRef :: DeclarationRef -> Maybe String
+runDeclRef :: DeclarationRef -> Maybe Name
 runDeclRef (PositionedDeclarationRef _ _ ref) = runDeclRef ref
-runDeclRef (ValueRef ident) = Just $ showIdent ident
-runDeclRef (TypeRef pn _) = Just $ runProperName pn
-runDeclRef (TypeClassRef pn) = Just $ runProperName pn
+runDeclRef (ValueRef ident) = Just $ IdentName ident
+runDeclRef (ValueOpRef op) = Just $ ValOpName op
+runDeclRef (TypeRef pn _) = Just $ TyName pn
+runDeclRef (TypeOpRef op) = Just $ TyOpName op
+runDeclRef (TypeClassRef pn) = Just $ TyClassName pn
 runDeclRef _ = Nothing
 
 checkDuplicateImports


### PR DESCRIPTION
Resolves #2269, resolves #2270.

Operators were being ignored entirely in the "unused names" calculation, so the linked issues aren't exactly surprising! It's something that slipped through the cracks when the `Ident` and `Op` namespaces were separated.