### PR TITLE
Fix #2331, substutute types in newtype class deriving

### DIFF
--- a/examples/passing/DeriveNewtype.purs
+++ b/examples/passing/DeriveNewtype.purs
@@ -14,4 +14,14 @@ t = wrap "hello"
 a :: String
 a = unwrap t
 
+newtype First a = First a
+
+derive instance newtypeFirst :: Newtype (First b) _
+
+f :: First Int
+f = wrap 1
+
+i :: Int
+i = unwrap f
+
 main = log "Done"

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -55,10 +55,10 @@ deriveInstance mn ds (TypeInstanceDeclaration nm deps className tys@[ty] Derived
   = TypeInstanceDeclaration nm deps className tys . ExplicitInstance <$> deriveOrd mn ds tyCon
 deriveInstance mn ds (TypeInstanceDeclaration nm deps className [wrappedTy, unwrappedTy] DerivedInstance)
   | className == Qualified (Just dataNewtype) (ProperName "Newtype")
-  , Just (Qualified mn' tyCon, _) <- unwrapTypeConstructor wrappedTy
+  , Just (Qualified mn' tyCon, args) <- unwrapTypeConstructor wrappedTy
   , mn == fromMaybe mn mn'
   = do
-    (inst, actualUnwrappedTy) <- deriveNewtype mn ds tyCon unwrappedTy
+    (inst, actualUnwrappedTy) <- deriveNewtype mn ds tyCon args unwrappedTy
     return $ TypeInstanceDeclaration nm deps className [wrappedTy, actualUnwrappedTy] (ExplicitInstance inst)
 deriveInstance _ _ (TypeInstanceDeclaration _ _ className tys DerivedInstance)
   = throwError . errorMessage $ CannotDerive className tys
@@ -427,40 +427,41 @@ deriveNewtype
   => ModuleName
   -> [Declaration]
   -> ProperName 'TypeName
+  -> [Type]
   -> Type
   -> m ([Declaration], Type)
-deriveNewtype mn ds tyConNm unwrappedTy = do
-  checkIsWildcard unwrappedTy
-  go =<< findTypeDecl tyConNm ds
+deriveNewtype mn ds tyConNm tyConArgs unwrappedTy = do
+    checkIsWildcard unwrappedTy
+    go =<< findTypeDecl tyConNm ds
   where
+    go :: Declaration -> m ([Declaration], Type)
+    go (DataDeclaration Data name _ _) =
+      throwError . errorMessage $ CannotDeriveNewtypeForData name
+    go (DataDeclaration Newtype name args dctors) = do
+      checkNewtype name dctors
+      wrappedIdent <- freshIdent "n"
+      unwrappedIdent <- freshIdent "a"
+      let (ctorName, [ty]) = head dctors
+          inst =
+            [ ValueDeclaration (Ident "wrap") Public [] $ Right $
+                Constructor (Qualified (Just mn) ctorName)
+            , ValueDeclaration (Ident "unwrap") Public [] $ Right $
+                lamCase wrappedIdent
+                  [ CaseAlternative
+                      [ConstructorBinder (Qualified (Just mn) ctorName) [VarBinder unwrappedIdent]]
+                      (Right (Var (Qualified Nothing unwrappedIdent)))
+                  ]
+            ]
+          subst = zipWith ((,) . fst) args tyConArgs
+      return (inst, replaceAllTypeVars subst ty)
+    go (PositionedDeclaration _ _ d) = go d
+    go _ = internalError "deriveNewtype go: expected DataDeclaration"
 
-  go :: Declaration -> m ([Declaration], Type)
-  go (DataDeclaration Data name _ _) =
-    throwError . errorMessage $ CannotDeriveNewtypeForData name
-  go (DataDeclaration Newtype name _ dctors) = do
-    checkNewtype name dctors
-    let (ctorName, [ty]) = head dctors
-    wrappedIdent <- freshIdent "n"
-    unwrappedIdent <- freshIdent "a"
-    let inst =
-          [ ValueDeclaration (Ident "wrap") Public [] $ Right $
-              Constructor (Qualified (Just mn) ctorName)
-          , ValueDeclaration (Ident "unwrap") Public [] $ Right $
-              lamCase wrappedIdent
-                [ CaseAlternative
-                    [ConstructorBinder (Qualified (Just mn) ctorName) [VarBinder unwrappedIdent]]
-                    (Right (Var (Qualified Nothing unwrappedIdent)))
-                ]
-          ]
-    return (inst, ty)
-  go (PositionedDeclaration _ _ d) = go d
-  go _ = internalError "deriveNewtype go: expected DataDeclaration"
-
-  checkIsWildcard :: Type -> m ()
-  checkIsWildcard (TypeWildcard _) =
-    return ()
-  checkIsWildcard _ =
-    throwError . errorMessage $ NonWildcardNewtypeInstance tyConNm
+    checkIsWildcard :: Type -> m ()
+    checkIsWildcard (TypeWildcard _) =
+      return ()
+    checkIsWildcard _ =
+      throwError . errorMessage $ NonWildcardNewtypeInstance tyConNm
 
 findTypeDecl
   :: (MonadError MultipleErrors m)


### PR DESCRIPTION
Sorry that the indentation makes this hard to read. The only real change is in the line with

```haskell
replaceAllTypeVars subst ty
```