### PR TITLE
Revert http-client-0.5 change

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -119,7 +119,7 @@ library
                    fsnotify >= 0.2.1,
                    Glob >= 0.7 && < 0.8,
                    haskeline >= 0.7.0.0,
-                   http-client >= 0.4.30 && <0.6,
+                   http-client >= 0.4.30 && <0.5,
                    http-types -any,
                    language-javascript == 0.6.*,
                    lifted-base >= 0.2.3 && < 0.2.4,

--- a/src/Language/PureScript/Ide/Pursuit.hs
+++ b/src/Language/PureScript/Ide/Pursuit.hs
@@ -35,37 +35,41 @@ import qualified Pipes.Prelude                 as P
 -- TODO: remove this when the issue is fixed at Pursuit
 queryPursuit :: Text -> IO ByteString
 queryPursuit q = do
-    let qClean = T.dropWhileEnd (== '.') q
-    req' <- parseRequest "http://pursuit.purescript.org/search"
-    let req = req'
-          { queryString= "q=" <> (fromString . T.unpack) qClean
-          , requestHeaders=[(hAccept, "application/json")]
-          }
-    m <- newManager tlsManagerSettings
-    withHTTP req m $ \resp ->
-      P.fold (<>) "" identity (responseBody resp)
+  let qClean = T.dropWhileEnd (== '.') q
+  req' <- parseRequest "http://pursuit.purescript.org/search"
+  let req = req'
+        { queryString= "q=" <> (fromString . T.unpack) qClean
+        , requestHeaders=[(hAccept, "application/json")]
+        }
+  m <- newManager tlsManagerSettings
+  withHTTP req m $ \resp ->
+    P.fold (<>) "" identity (responseBody resp)
+
 
 handler :: HttpException -> IO [a]
+handler StatusCodeException{} = pure []
 handler _ = pure []
 
 searchPursuitForDeclarations :: Text -> IO [PursuitResponse]
-searchPursuitForDeclarations query = E.handle handler $ do
-    r <- queryPursuit query
-    let results' = decode (fromStrict r) :: Maybe Array
-    case results' of
-        Nothing -> pure []
-        Just results -> pure (mapMaybe (isDeclarationResponse . fromJSON) (toList results))
+searchPursuitForDeclarations query =
+    (do r <- queryPursuit query
+        let results' = decode (fromStrict r) :: Maybe Array
+        case results' of
+          Nothing -> pure []
+          Just results -> pure (mapMaybe (isDeclarationResponse . fromJSON) (toList results))) `E.catch`
+    handler
   where
     isDeclarationResponse (Success a@DeclarationResponse{}) = Just a
     isDeclarationResponse _ = Nothing
 
 findPackagesForModuleIdent :: Text -> IO [PursuitResponse]
-findPackagesForModuleIdent query = E.handle handler $ do
-    r <- queryPursuit query
-    let results' = decode (fromStrict r) :: Maybe Array
-    case results' of
+findPackagesForModuleIdent query =
+  (do r <- queryPursuit query
+      let results' = decode (fromStrict r) :: Maybe Array
+      case results' of
         Nothing -> pure []
-        Just results -> pure (mapMaybe (isModuleResponse . fromJSON) (toList results))
+        Just results -> pure (mapMaybe (isModuleResponse . fromJSON) (toList results))) `E.catch`
+  handler
   where
     isModuleResponse (Success a@ModuleResponse{}) = Just a
     isModuleResponse _ = Nothing

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,3 @@
-resolver: lts-6.13
+resolver: lts-6.10
 packages:
 - '.'
-extra-deps:
-# - aeson-1.0.0.0
-- http-client-0.5.1
-- http-client-tls-0.3.0
-- pipes-http-1.0.4
-# - semigroups-0.18.2
-# flags:
-#   semigroups:
-#     bytestring-builder: false


### PR DESCRIPTION
I think this should fix the issues with the coverage build. It looks like `wreq` has not been updated, so we can't install the coverage tool and run our tests.

We should revert this revert once `wreq` has been updated.