### PR TITLE
Fix #2370, allow rows in instance contexts

### DIFF
--- a/examples/passing/RowsInInstanceContext.purs
+++ b/examples/passing/RowsInInstanceContext.purs
@@ -1,0 +1,25 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, log)
+import Data.Newtype (class Newtype, unwrap)
+
+class TypeEquals a b | a -> b, b -> a where
+  coerce :: a -> b
+  coerceBack :: b -> a
+
+instance refl :: TypeEquals a a where
+  coerce = id
+  coerceBack = id
+
+newtype RecordNewtype = RecordNewtype { x :: String }
+
+instance newtypeRecordNewtype ::
+  TypeEquals inner { x :: String }
+    => Newtype RecordNewtype inner where
+  wrap = RecordNewtype <<< coerce
+  unwrap (RecordNewtype rec) = coerceBack rec
+
+main :: Eff (console :: CONSOLE) Unit
+main = log (unwrap (RecordNewtype { x: "Done" })).x

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -11,7 +11,7 @@ module Language.PureScript.TypeChecker
 
 import Prelude.Compat
 
-import Control.Monad (when, unless, void, forM, forM_)
+import Control.Monad (when, unless, void, forM)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Class (MonadState(..), modify)
 import Control.Monad.Supply.Class (MonadSupply)
@@ -279,7 +279,6 @@ typeCheckAll moduleName _ = traverse go
     return d
   go (d@(TypeInstanceDeclaration dictName deps className tys body)) = rethrow (addHint (ErrorInInstance className tys)) $ do
     traverse_ (checkTypeClassInstance moduleName) tys
-    forM_ deps $ traverse_ (checkTypeClassInstance moduleName) . constraintArgs
     checkOrphanInstance dictName className tys
     _ <- traverseTypeInstanceBody checkInstanceMembers body
     let dict = TypeClassDictionaryInScope (Qualified (Just moduleName) dictName) [] className tys (Just deps)


### PR DESCRIPTION
If this looks okay, then I'll open an issue to derive `Newtype` instances like this whenever a record appears under a newtype.