### PR TITLE
Allow symbols in data contructors

### DIFF
--- a/examples/passing/DctorName.purs
+++ b/examples/passing/DctorName.purs
@@ -1,11 +1,24 @@
 module Main where
 
+import Prelude
 import Control.Monad.Eff.Console (log)
 
 newtype Bar' = Bar' Int
 
 data Foo' = Foo' Bar'
 
-data Baz'' = Baz''
+data Baz'' = Baz'' | Baz'
+
+f :: Foo' -> Boolean
+f a = case a of Foo' b -> true
+
+g :: Baz'' -> Int
+g Baz'' = 0
+g Baz' = 1
+ 
+h :: Bar' -> Int
+h (Bar' x)
+ | x <= 10 = x * 2 
+ | otherwise = 10
 
 main = log "Done"

--- a/examples/passing/DctorName.purs
+++ b/examples/passing/DctorName.purs
@@ -9,16 +9,25 @@ data Foo' = Foo' Bar'
 
 data Baz'' = Baz'' | Baz'
 
-f :: Foo' -> Boolean
-f a = case a of Foo' b -> true
+f ∷ Foo' → Boolean
+f a = case a of Foo' b → true
 
-g :: Baz'' -> Int
+f' ∷ Boolean
+f' = f $ Foo' $ Bar' 0
+
+g ∷ Baz'' → Int
 g Baz'' = 0
 g Baz' = 1
- 
-h :: Bar' -> Int
+
+g' ∷ Int
+g' = g Baz''
+
+h ∷ Bar' → Int
 h (Bar' x)
  | x <= 10 = x * 2 
  | otherwise = 10
+
+h' ∷ Int
+h' = h $ Bar' 4
 
 main = log "Done"

--- a/examples/passing/DctorName.purs
+++ b/examples/passing/DctorName.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Control.Monad.Eff.Console (log)
+
+newtype Bar' = Bar' Int
+
+data Foo' = Foo' Bar'
+
+data Baz'' = Baz''
+
+main = log "Done"

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -244,23 +244,23 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
     ret <- valueToJs val
     return $ JSApp Nothing (JSFunction Nothing Nothing [] (JSBlock Nothing (ds' ++ [JSReturn Nothing ret]))) []
   valueToJs' (Constructor (_, _, _, Just IsNewtype) _ (ProperName ctor) _) =
-    return $ JSVariableIntroduction Nothing (identToJs . Ident $ ctor) (Just $
+    return $ JSVariableIntroduction Nothing (properToJs ctor) (Just $
                 JSObjectLiteral Nothing [("create",
                   JSFunction Nothing Nothing ["value"]
                     (JSBlock Nothing [JSReturn Nothing $ JSVar Nothing "value"]))])
   valueToJs' (Constructor _ _ (ProperName ctor) []) =
-    return $ iife (identToJs . Ident $ ctor) [ JSFunction Nothing (Just (identToJs . Ident $ ctor)) [] (JSBlock Nothing [])
-           , JSAssignment Nothing (JSAccessor Nothing "value" (JSVar Nothing (identToJs . Ident $ ctor)))
-                (JSUnary Nothing JSNew $ JSApp Nothing (JSVar Nothing (identToJs . Ident $ ctor)) []) ]
+    return $ iife (properToJs ctor) [ JSFunction Nothing (Just (properToJs ctor)) [] (JSBlock Nothing [])
+           , JSAssignment Nothing (JSAccessor Nothing "value" (JSVar Nothing (properToJs ctor)))
+                (JSUnary Nothing JSNew $ JSApp Nothing (JSVar Nothing (properToJs ctor)) []) ]
   valueToJs' (Constructor _ _ (ProperName ctor) fields) =
     let constructor =
           let body = [ JSAssignment Nothing (JSAccessor Nothing (identToJs f) (JSVar Nothing "this")) (var f) | f <- fields ]
-          in JSFunction Nothing (Just (identToJs . Ident $ ctor)) (identToJs `map` fields) (JSBlock Nothing body)
+          in JSFunction Nothing (Just (properToJs ctor)) (identToJs `map` fields) (JSBlock Nothing body)
         createFn =
-          let body = JSUnary Nothing JSNew $ JSApp Nothing (JSVar Nothing (identToJs . Ident $ ctor)) (var `map` fields)
+          let body = JSUnary Nothing JSNew $ JSApp Nothing (JSVar Nothing (properToJs ctor)) (var `map` fields)
           in foldr (\f inner -> JSFunction Nothing Nothing [identToJs f] (JSBlock Nothing [JSReturn Nothing inner])) body fields
-    in return $ iife (identToJs . Ident $ ctor) [ constructor
-                          , JSAssignment Nothing (JSAccessor Nothing "create" (JSVar Nothing (identToJs . Ident $ ctor))) createFn
+    in return $ iife (properToJs ctor) [ constructor
+                          , JSAssignment Nothing (JSAccessor Nothing "create" (JSVar Nothing (properToJs ctor))) createFn
                           ]
 
   iife :: String -> [JS] -> JS

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -244,23 +244,23 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
     ret <- valueToJs val
     return $ JSApp Nothing (JSFunction Nothing Nothing [] (JSBlock Nothing (ds' ++ [JSReturn Nothing ret]))) []
   valueToJs' (Constructor (_, _, _, Just IsNewtype) _ (ProperName ctor) _) =
-    return $ JSVariableIntroduction Nothing ctor (Just $
+    return $ JSVariableIntroduction Nothing (identToJs . Ident $ ctor) (Just $
                 JSObjectLiteral Nothing [("create",
                   JSFunction Nothing Nothing ["value"]
                     (JSBlock Nothing [JSReturn Nothing $ JSVar Nothing "value"]))])
   valueToJs' (Constructor _ _ (ProperName ctor) []) =
-    return $ iife ctor [ JSFunction Nothing (Just ctor) [] (JSBlock Nothing [])
-           , JSAssignment Nothing (JSAccessor Nothing "value" (JSVar Nothing ctor))
-                (JSUnary Nothing JSNew $ JSApp Nothing (JSVar Nothing ctor) []) ]
+    return $ iife (identToJs . Ident $ ctor) [ JSFunction Nothing (Just (identToJs . Ident $ ctor)) [] (JSBlock Nothing [])
+           , JSAssignment Nothing (JSAccessor Nothing "value" (JSVar Nothing (identToJs . Ident $ ctor)))
+                (JSUnary Nothing JSNew $ JSApp Nothing (JSVar Nothing (identToJs . Ident $ ctor)) []) ]
   valueToJs' (Constructor _ _ (ProperName ctor) fields) =
     let constructor =
           let body = [ JSAssignment Nothing (JSAccessor Nothing (identToJs f) (JSVar Nothing "this")) (var f) | f <- fields ]
-          in JSFunction Nothing (Just ctor) (identToJs `map` fields) (JSBlock Nothing body)
+          in JSFunction Nothing (Just (identToJs . Ident $ ctor)) (identToJs `map` fields) (JSBlock Nothing body)
         createFn =
-          let body = JSUnary Nothing JSNew $ JSApp Nothing (JSVar Nothing ctor) (var `map` fields)
+          let body = JSUnary Nothing JSNew $ JSApp Nothing (JSVar Nothing (identToJs . Ident $ ctor)) (var `map` fields)
           in foldr (\f inner -> JSFunction Nothing Nothing [identToJs f] (JSBlock Nothing [JSReturn Nothing inner])) body fields
-    in return $ iife ctor [ constructor
-                          , JSAssignment Nothing (JSAccessor Nothing "create" (JSVar Nothing ctor)) createFn
+    in return $ iife (identToJs . Ident $ ctor) [ constructor
+                          , JSAssignment Nothing (JSAccessor Nothing "create" (JSVar Nothing (identToJs . Ident $ ctor))) createFn
                           ]
 
   iife :: String -> [JS] -> JS

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -16,11 +16,6 @@ moduleNameToJs (ModuleName pns) =
   let name = intercalate "_" (runProperName `map` pns)
   in if nameIsJsBuiltIn name then "$$" ++ name else name
 
-properToJs :: String -> String
-properToJs name
-  | nameIsJsReserved name || nameIsJsBuiltIn name = "$$" ++ name
-  | otherwise = concatMap identCharToString name
-
 -- |
 -- Convert an Ident into a valid Javascript identifier:
 --
@@ -31,10 +26,13 @@ properToJs name
 --  * Symbols are prefixed with '$' followed by a symbol name or their ordinal value.
 --
 identToJs :: Ident -> String
-identToJs (Ident name)
+identToJs (Ident name) = properToJs name
+identToJs (GenIdent _ _) = internalError "GenIdent in identToJs"
+
+properToJs :: String -> String
+properToJs name
   | nameIsJsReserved name || nameIsJsBuiltIn name = "$$" ++ name
   | otherwise = concatMap identCharToString name
-identToJs (GenIdent _ _) = internalError "GenIdent in identToJs"
 
 -- |
 -- Test if a string is a valid JS identifier without escaping.

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -16,6 +16,11 @@ moduleNameToJs (ModuleName pns) =
   let name = intercalate "_" (runProperName `map` pns)
   in if nameIsJsBuiltIn name then "$$" ++ name else name
 
+properToJs :: String -> String
+properToJs name
+  | nameIsJsReserved name || nameIsJsBuiltIn name = "$$" ++ name
+  | otherwise = concatMap identCharToString name
+
 -- |
 -- Convert an Ident into a valid Javascript identifier:
 --

--- a/src/Language/PureScript/Parser/Common.hs
+++ b/src/Language/PureScript/Parser/Common.hs
@@ -29,6 +29,12 @@ typeName :: TokenParser (ProperName 'TypeName)
 typeName = ProperName <$> tyname
 
 -- |
+-- Parse a proper name for a data constructor.
+--
+dataConstructorName :: TokenParser (ProperName 'ConstructorName)
+dataConstructorName = ProperName <$> dconsname
+
+-- |
 -- Parse a module name
 --
 moduleName :: TokenParser ModuleName

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -360,7 +360,7 @@ parseVar :: TokenParser Expr
 parseVar = Var <$> C.parseQualified C.parseIdent
 
 parseConstructor :: TokenParser Expr
-parseConstructor = Constructor <$> C.parseQualified C.properName
+parseConstructor = Constructor <$> C.parseQualified C.dataConstructorName
 
 parseCase :: TokenParser Expr
 parseCase = Case <$> P.between (reserved "case") (C.indented *> reserved "of") (commaSep1 parseValue)
@@ -494,10 +494,10 @@ parseNumberLiteral = LiteralBinder . NumericLiteral <$> (sign <*> number)
          <|> return id
 
 parseNullaryConstructorBinder :: TokenParser Binder
-parseNullaryConstructorBinder = ConstructorBinder <$> C.parseQualified C.properName <*> pure []
+parseNullaryConstructorBinder = ConstructorBinder <$> C.parseQualified C.dataConstructorName <*> pure []
 
 parseConstructorBinder :: TokenParser Binder
-parseConstructorBinder = ConstructorBinder <$> C.parseQualified C.properName <*> many (C.indented *> parseBinderNoParens)
+parseConstructorBinder = ConstructorBinder <$> C.parseQualified C.dataConstructorName <*> many (C.indented *> parseBinderNoParens)
 
 parseObjectBinder:: TokenParser Binder
 parseObjectBinder = LiteralBinder <$> parseObjectLiteral (C.indented *> parseIdentifierAndBinder)

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -71,7 +71,7 @@ parseDataDeclaration = do
   tyArgs <- many (indented *> kindedIdent)
   ctors <- P.option [] $ do
     indented *> equals
-    P.sepBy1 ((,) <$> properName <*> P.many (indented *> noWildcards parseTypeAtom)) pipe
+    P.sepBy1 ((,) <$> dataConstructorName <*> P.many (indented *> noWildcards parseTypeAtom)) pipe
   return $ DataDeclaration dtype name tyArgs ctors
 
 parseTypeDeclaration :: TokenParser Declaration

--- a/src/Language/PureScript/Parser/Lexer.hs
+++ b/src/Language/PureScript/Parser/Lexer.hs
@@ -43,6 +43,7 @@ module Language.PureScript.Parser.Lexer
   , lname'
   , qualifier
   , tyname
+  , dconsname
   , uname
   , uname'
   , mname
@@ -448,6 +449,12 @@ uname' s = token go P.<?> "proper name"
 
 tyname :: TokenParser String
 tyname = token go P.<?> "type name"
+  where
+  go (UName s) = Just s
+  go _ = Nothing
+
+dconsname :: TokenParser String
+dconsname = token go P.<?> "data constructor name"
   where
   go (UName s) = Just s
   go _ = Nothing


### PR DESCRIPTION
I would like to attempt to contribute a solution to resolve #2208 

As I am new to the Purescript compiler, I am not sure if there is anything that I have overlooked here or if there is perhaps a better way to achieve this.

In essence, the changes I have made are:

- Modify the Lexer to accept the same range of tokens for data constructors as those for type constructors.
- Modify the Codegen to pass data constructor strings through the logic for generating appropriate javascript names from identifiers.
- Added an example to use as a test case.
