### PR TITLE
Fix scope traversal for do-notation bind.

### DIFF
--- a/examples/warning/2383.purs
+++ b/examples/warning/2383.purs
@@ -1,0 +1,12 @@
+-- | This specifically shouldn't warn about `x` being shadowed in `main`
+-- | See https://github.com/purescript/purescript/issues/2383
+module Main where
+
+import Prelude
+
+import Control.Monad.Eff (Eff)
+
+main :: Eff () Unit
+main = do
+  x <- let x = pure unit in x
+  pure unit

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -551,7 +551,7 @@ everythingWithScope f g h i j = (f'', g'', h'', i'', \s -> snd . j'' s)
   j' s (DoNotationValue v) = (s, g'' s v)
   j' s (DoNotationBind b v) =
     let s' = S.union (S.fromList (binderNames b)) s
-    in (s', h'' s b <> g'' s' v)
+    in (s', h'' s b <> g'' s v)
   j' s (DoNotationLet ds) =
     let s' = S.union s (S.fromList (mapMaybe getDeclIdent ds))
     in (s', foldMap (f'' s') ds)


### PR DESCRIPTION
Added a warning test which lists no `@shouldWarnWith` pragmas to check that the shadowing warning isn't raised.  Is this an acceptable use of the test system?

Unfortunately I can't verify that the test passes as I haven't been able to build at all due to: https://github.com/commercialhaskell/stack/issues/2577
