### PR TITLE
Fix #2379, add error message for unknown classes

### DIFF
--- a/examples/failing/2379.purs
+++ b/examples/failing/2379.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith UnknownClass
+module Main where
+
+import Lib
+
+test = x [1, 2, 3]

--- a/examples/failing/2379/Lib.purs
+++ b/examples/failing/2379/Lib.purs
@@ -1,0 +1,9 @@
+module Lib (class X, x) where
+
+class X a where
+  x :: a -> String
+
+class Y a
+
+instance xArray :: Y a => X (Array a) where
+  x _ = "[]"

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -23,6 +23,7 @@ extra-source-files: examples/passing/*.purs
                   , examples/passing/*.js
                   , examples/passing/2018/*.purs
                   , examples/passing/2138/*.purs
+                  , examples/passing/2379/*.purs
                   , examples/passing/ClassRefSyntax/*.purs
                   , examples/passing/DctorOperatorAlias/*.purs
                   , examples/passing/ExplicitImportReExport/*.purs

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -23,7 +23,6 @@ extra-source-files: examples/passing/*.purs
                   , examples/passing/*.js
                   , examples/passing/2018/*.purs
                   , examples/passing/2138/*.purs
-                  , examples/passing/2379/*.purs
                   , examples/passing/ClassRefSyntax/*.purs
                   , examples/passing/DctorOperatorAlias/*.purs
                   , examples/passing/ExplicitImportReExport/*.purs
@@ -57,6 +56,7 @@ extra-source-files: examples/passing/*.purs
                   , examples/failing/*.purs
                   , examples/failing/1733/*.purs
                   , examples/failing/2378/*.purs
+                  , examples/failing/2379/*.purs
                   , examples/failing/ConflictingExports/*.purs
                   , examples/failing/ConflictingImports/*.purs
                   , examples/failing/ConflictingImports2/*.purs

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -83,6 +83,7 @@ data SimpleErrorMessage
   | ConstrainedTypeUnified Type Type
   | OverlappingInstances (Qualified (ProperName 'ClassName)) [Type] [Qualified Ident]
   | NoInstanceFound Constraint
+  | UnknownClass (Qualified (ProperName 'ClassName))
   | PossiblyInfiniteInstance (Qualified (ProperName 'ClassName)) [Type]
   | CannotDerive (Qualified (ProperName 'ClassName)) [Type]
   | InvalidNewtypeInstance (Qualified (ProperName 'ClassName)) [Type]

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -601,7 +601,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showWiki) e = flip evalS
             ]
     renderSimpleErrorMessage OverlappingInstances{} = internalError "OverlappingInstances: empty instance list"
     renderSimpleErrorMessage (UnknownClass nm) =
-      paras [ line "No instance instance was found for class"
+      paras [ line "No type class instance was found for class"
             , markCodeBox $ indent $ line (showQualified runProperName nm)
             , line "because the class was not in scope. Perhaps it was not exported."
             ]

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -118,6 +118,7 @@ errorCode em = case unwrapErrorMessage em of
   ConstrainedTypeUnified{} -> "ConstrainedTypeUnified"
   OverlappingInstances{} -> "OverlappingInstances"
   NoInstanceFound{} -> "NoInstanceFound"
+  UnknownClass{} -> "UnknownClass"
   PossiblyInfiniteInstance{} -> "PossiblyInfiniteInstance"
   CannotDerive{} -> "CannotDerive"
   InvalidNewtypeInstance{} -> "InvalidNewtypeInstance"
@@ -599,6 +600,11 @@ prettyPrintSingleError (PPEOptions codeColor full level showWiki) e = flip evalS
             , line "They may be disallowed completely in a future version of the compiler."
             ]
     renderSimpleErrorMessage OverlappingInstances{} = internalError "OverlappingInstances: empty instance list"
+    renderSimpleErrorMessage (UnknownClass nm) =
+      paras [ line "No instance instance was found for class"
+            , markCodeBox $ indent $ line (showQualified runProperName nm)
+            , line "because the class was not in scope. Perhaps it was not exported."
+            ]
     renderSimpleErrorMessage (NoInstanceFound (Constraint C.Fail [ ty ] _)) | Just box <- toTypelevelString ty =
       paras [ line "A custom type error occurred while solving type class constraints:"
             , indent box


### PR DESCRIPTION
This seemed preferable to throwing on the declaration of the instance itself, since we might want classes and instances which are internal to a module.