### PR TITLE
2323: Sort IDE-generated explicit imports

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -260,6 +260,33 @@ instance Eq DeclarationRef where
   r == (PositionedDeclarationRef _ _ r') = r == r'
   _ == _ = False
 
+-- enable sorting lists of explicitly imported refs
+instance Ord DeclarationRef where
+  compare = compDecRef
+
+compDecRef :: DeclarationRef -> DeclarationRef -> Ordering
+compDecRef (TypeRef name _) (TypeRef name' _) = compare name name'
+compDecRef (TypeOpRef name) (TypeOpRef name') = compare name name'
+compDecRef (ValueRef ident) (ValueRef ident') = compare ident ident'
+compDecRef (ValueOpRef name) (ValueOpRef name') = compare name name'
+compDecRef (TypeClassRef name) (TypeClassRef name') = compare name name'
+compDecRef (TypeInstanceRef ident) (TypeInstanceRef ident') = compare ident ident'
+compDecRef (ModuleRef name) (ModuleRef name') = compare name name'
+compDecRef (ReExportRef name _) (ReExportRef name' _) = compare name name'
+compDecRef (PositionedDeclarationRef _ _ ref) (PositionedDeclarationRef _ _ ref') = compare ref ref'
+compDecRef ref ref' = compare (orderOf ref) (orderOf ref')
+    where
+      orderOf :: DeclarationRef -> Int
+      orderOf (TypeRef _ _) = 7
+      orderOf (TypeOpRef _) = 3
+      orderOf (ValueRef _) = 8
+      orderOf (ValueOpRef _) = 4
+      orderOf (TypeClassRef _) = 5
+      orderOf (TypeInstanceRef _) = 6
+      orderOf (ModuleRef _) = 2
+      orderOf (ReExportRef _ _) = 1
+      orderOf (PositionedDeclarationRef _ _ _) = 0
+
 getTypeRef :: DeclarationRef -> Maybe (ProperName 'TypeName, Maybe [ProperName 'ConstructorName])
 getTypeRef (TypeRef name dctors) = Just (name, dctors)
 getTypeRef (PositionedDeclarationRef _ _ r) = getTypeRef r

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -228,12 +228,7 @@ addExplicitImport' decl moduleName imports =
         refs
     insertDeclIntoRefs dr refs = nubBy ((==) `on` P.prettyPrintRef) (refFromDeclaration dr : refs)
 
-    insertDtor dtor (P.TypeRef tn' dtors) =
-      case dtors of
-        Just dtors' -> P.TypeRef tn' (Just (sort (ordNub (dtor : dtors'))))
-        -- This means the import was opened. We don't add anything in this case
-        -- import Data.Maybe (Maybe(..)) -> import Data.Maybe (Maybe(Just))
-        Nothing -> P.TypeRef tn' Nothing
+    insertDtor _ (P.TypeRef tn' _) = P.TypeRef tn' Nothing
     insertDtor _ refs = refs
 
     matchType :: P.ProperName 'P.TypeName -> P.DeclarationRef -> Bool

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -216,7 +216,7 @@ addExplicitImport' decl moduleName imports =
     -- TypeDeclaration "Maybe" + Data.Maybe (maybe) -> Data.Maybe(Maybe, maybe)
     insertDeclIntoImport :: IdeDeclaration -> Import -> Import
     insertDeclIntoImport decl' (Import mn (P.Explicit refs) Nothing) =
-      Import mn (P.Explicit (sort $ insertDeclIntoRefs decl' refs)) Nothing
+      Import mn (P.Explicit (sort (insertDeclIntoRefs decl' refs))) Nothing
     insertDeclIntoImport _ is = is
 
     insertDeclIntoRefs :: IdeDeclaration -> [P.DeclarationRef] -> [P.DeclarationRef]
@@ -230,7 +230,7 @@ addExplicitImport' decl moduleName imports =
 
     insertDtor dtor (P.TypeRef tn' dtors) =
       case dtors of
-        Just dtors' -> P.TypeRef tn' (Just (sort $ ordNub (dtor : dtors')))
+        Just dtors' -> P.TypeRef tn' (Just (sort (ordNub (dtor : dtors'))))
         -- This means the import was opened. We don't add anything in this case
         -- import Data.Maybe (Maybe(..)) -> import Data.Maybe (Maybe(Just))
         Nothing -> P.TypeRef tn' Nothing

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -202,7 +202,7 @@ addExplicitImport' decl moduleName imports =
     refFromDeclaration (IdeDeclTypeClass n) =
       P.TypeClassRef n
     refFromDeclaration (IdeDeclDataConstructor dtor) =
-      P.TypeRef (dtor ^. ideDtorTypeName) (Just [dtor ^. ideDtorName])
+      P.TypeRef (dtor ^. ideDtorTypeName) Nothing
     refFromDeclaration (IdeDeclType t) =
       P.TypeRef (t ^. ideTypeName) (Just [])
     refFromDeclaration (IdeDeclValueOperator op) =

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -216,7 +216,7 @@ addExplicitImport' decl moduleName imports =
     -- TypeDeclaration "Maybe" + Data.Maybe (maybe) -> Data.Maybe(Maybe, maybe)
     insertDeclIntoImport :: IdeDeclaration -> Import -> Import
     insertDeclIntoImport decl' (Import mn (P.Explicit refs) Nothing) =
-      Import mn (P.Explicit (sort (insertDeclIntoRefs decl' refs))) Nothing
+      Import mn (P.Explicit (sortBy P.compDecRef (insertDeclIntoRefs decl' refs))) Nothing
     insertDeclIntoImport _ is = is
 
     insertDeclIntoRefs :: IdeDeclaration -> [P.DeclarationRef] -> [P.DeclarationRef]

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -216,7 +216,7 @@ addExplicitImport' decl moduleName imports =
     -- TypeDeclaration "Maybe" + Data.Maybe (maybe) -> Data.Maybe(Maybe, maybe)
     insertDeclIntoImport :: IdeDeclaration -> Import -> Import
     insertDeclIntoImport decl' (Import mn (P.Explicit refs) Nothing) =
-      Import mn (P.Explicit (insertDeclIntoRefs decl' refs)) Nothing
+      Import mn (P.Explicit (sort $ insertDeclIntoRefs decl' refs)) Nothing
     insertDeclIntoImport _ is = is
 
     insertDeclIntoRefs :: IdeDeclaration -> [P.DeclarationRef] -> [P.DeclarationRef]
@@ -230,7 +230,7 @@ addExplicitImport' decl moduleName imports =
 
     insertDtor dtor (P.TypeRef tn' dtors) =
       case dtors of
-        Just dtors' -> P.TypeRef tn' (Just (ordNub (dtor : dtors')))
+        Just dtors' -> P.TypeRef tn' (Just (sort $ ordNub (dtor : dtors')))
         -- This means the import was opened. We don't add anything in this case
         -- import Data.Maybe (Maybe(..)) -> import Data.Maybe (Maybe(Just))
         Nothing -> P.TypeRef tn' Nothing

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -308,7 +308,7 @@ findUsedRefs env mni qn names =
     typesRefs
       = map (flip TypeRef (Just [])) typesWithoutDctors
       ++ map (\(ty, ds) -> TypeRef ty (Just ds)) (M.toList typesWithDctors)
-  in classRefs ++ typeOpRefs ++ typesRefs ++ valueRefs ++ valueOpRefs
+  in sortBy compDecRef $ classRefs ++ typeOpRefs ++ typesRefs ++ valueRefs ++ valueOpRefs
 
   where
 

--- a/tests/Language/PureScript/Ide/Imports/IntegrationSpec.hs
+++ b/tests/Language/PureScript/Ide/Imports/IntegrationSpec.hs
@@ -57,10 +57,10 @@ spec = beforeAll_ setup . describe "Adding imports" $ do
     outputFileShouldBe (sourceFileSkeleton ["import ImportsSpec1 (class ATypeClass)"])
   it "adds an explicit unqualified import (dataconstructor)" $ do
     withSupportFiles (Integration.addImport "MyJust")
-    outputFileShouldBe (sourceFileSkeleton ["import ImportsSpec1 (MyMaybe(MyJust))"])
+    outputFileShouldBe (sourceFileSkeleton ["import ImportsSpec1 (MyMaybe(..))"])
   it "adds an explicit unqualified import (newtype)" $ do
     withSupportFiles (Integration.addImport "MyNewtype")
-    outputFileShouldBe (sourceFileSkeleton ["import ImportsSpec1 (MyNewtype(MyNewtype))"])
+    outputFileShouldBe (sourceFileSkeleton ["import ImportsSpec1 (MyNewtype(..))"])
   it "adds an explicit unqualified import (typeclass member function)" $ do
     withSupportFiles (Integration.addImport "typeClassFun")
     outputFileShouldBe (sourceFileSkeleton ["import ImportsSpec1 (typeClassFun)"])

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -100,7 +100,7 @@ spec = do
       shouldBe
         (addOpImport (P.OpName "<~>") (P.moduleNameFromString "Data.Array") explicitImports)
         [ "import Prelude"
-        , "import Data.Array ((<~>), tail)"
+        , "import Data.Array (tail, (<~>))"
         ]
     it "adds the type for a given DataConstructor" $
         shouldBe

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -113,7 +113,7 @@ spec = do
       shouldBe
         (addDtorImport "Just" (P.ProperName "Maybe") (P.moduleNameFromString "Data.Maybe") typeImports)
         [ "import Prelude"
-        , "import Data.Maybe (Maybe(Just))"
+        , "import Data.Maybe (Maybe(..))"
         ]
     it "doesn't add a dataconstructor to an existing type import with open dtors" $ do
       let Right (_, _, typeImports, _) = sliceImportSection (withImports ["import Data.Maybe (Maybe(..))"])
@@ -162,4 +162,4 @@ spec = do
       expectSorted
         -- the imported names don't actually have to exist!
         (map (uncurry dtorImport) [("Just", "Maybe"), ("Nothing", "Maybe"), ("SomeOtherConstructor", "SomeDataType")])
-        ["import Prelude", "import Control.Monad (Maybe(Just, Nothing), SomeDataType(SomeOtherConstructor), ap)"]
+        ["import Prelude", "import Control.Monad (Maybe(..), SomeDataType(SomeOtherConstructor), ap)"]

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -3,7 +3,6 @@
 module Language.PureScript.Ide.ImportsSpec where
 
 import           Protolude
-import           Data.List                       (nub)
 import           Data.Maybe                      (fromJust)
 
 import qualified Language.PureScript             as P
@@ -141,7 +140,7 @@ spec = do
         dtorImport name typeName = (IdeDeclDataConstructor (IdeDataConstructor (P.ProperName name) (P.ProperName typeName) wildcard))
         -- expect any list of provided identifiers, when imported, to come out as specified
         expectSorted imports expected = shouldBe
-          (nub $ map
+          (ordNub $ map
             (prettyPrintImportSection . foldl addImport baseImports)
             (permutations imports))
           [expected]


### PR DESCRIPTION
[Issue 2323](https://github.com/purescript/purescript/issues/2323) makes the IDE sort generated explicit imports instead of just prepending.