### PR TITLE
[psc-ide] Polling option for psc-ide-server

### DIFF
--- a/psc-ide-server/README.md
+++ b/psc-ide-server/README.md
@@ -23,6 +23,8 @@ It supports the following options:
   project directory. Defaults to `output/`, relative to either the current
   directory or the directory specified by `-d`.
 - `--debug`: Enables some logging meant for debugging
+- `--polling`: Uses polling instead of file system events to watch the externs
+  files. This flag is reversed on Windows and polling is the default.
 - `--no-watch`: Disables the filewatcher
 - `--version`: Output psc-ide version
 

--- a/src/Language/PureScript/Ide/Watcher.hs
+++ b/src/Language/PureScript/Ide/Watcher.hs
@@ -40,10 +40,13 @@ reloadFile ref ev = do
 
 -- | Installs filewatchers for the given directory and reloads ExternsFiles when
 -- they change on disc
-watcher :: TVar IdeState -> FilePath -> IO ()
-watcher stateVar fp =
-  withManagerConf (defaultConfig { confDebounce = NoDebounce }) $ \mgr -> do
-    _ <- watchTree mgr fp
-      (\ev -> takeFileName (eventPath ev) == "externs.json")
-      (reloadFile stateVar)
-    forever (threadDelay 100000)
+watcher :: Bool -> TVar IdeState -> FilePath -> IO ()
+watcher polling stateVar fp =
+  withManagerConf
+    (defaultConfig { confDebounce = NoDebounce
+                   , confUsePolling = polling
+                   }) $ \mgr -> do
+      _ <- watchTree mgr fp
+        (\ev -> takeFileName (eventPath ev) == "externs.json")
+        (reloadFile stateVar)
+      forever (threadDelay 100000)


### PR DESCRIPTION
This is investigative work for #2209. It forces the use of polling for the filewatcher.

@garyb or @natefaubion could you give this branch a try? Right now this branch ignores the `--force-polling` flags and always polls, but if it works out I'll add the option and we can add a toggle to the editor plugins.