### PR TITLE
Speeds up parsing by reading files as Text

### DIFF
--- a/hierarchy/Main.hs
+++ b/hierarchy/Main.hs
@@ -33,7 +33,7 @@ import System.FilePath ((</>))
 import System.FilePath.Glob (glob)
 import System.Exit (exitFailure, exitSuccess)
 import System.IO (hPutStr, stderr)
-import System.IO.UTF8 (readUTF8File)
+import System.IO.UTF8 (readUTF8FileT)
 
 import qualified Language.PureScript as P
 import qualified Paths_purescript as Paths
@@ -60,7 +60,7 @@ runModuleName (P.ModuleName pns) = intercalate "_" (P.runProperName `map` pns)
 
 readInput :: [FilePath] -> IO (Either P.MultipleErrors [P.Module])
 readInput paths = do
-  content <- mapM (\path -> (path, ) <$> readUTF8File path) paths
+  content <- mapM (\path -> (path, ) <$> readUTF8FileT path) paths
   return $ map snd <$> P.parseModulesFromFiles id content
 
 compile :: HierarchyOptions -> IO ()

--- a/psc-docs/Main.hs
+++ b/psc-docs/Main.hs
@@ -7,6 +7,7 @@ import Control.Monad.Trans.Except (runExceptT)
 import Control.Arrow (first, second)
 import Control.Category ((>>>))
 import Control.Monad.Writer
+import Data.Text (Text)
 import Data.Function (on)
 import Data.List
 import Data.Maybe (fromMaybe)
@@ -20,7 +21,7 @@ import qualified Language.PureScript as P
 import qualified Paths_purescript as Paths
 import System.Exit (exitFailure)
 import System.IO (hPutStrLn, hPrint, hSetEncoding, stderr, stdout, utf8)
-import System.IO.UTF8 (readUTF8File)
+import System.IO.UTF8 (readUTF8FileT)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath (takeDirectory)
 import System.FilePath.Glob (glob)
@@ -139,8 +140,8 @@ dumpTags input renderTags = do
   ldump :: [String] -> IO ()
   ldump = mapM_ putStrLn
 
-parseFile :: FilePath -> IO (FilePath, String)
-parseFile input = (,) input <$> readUTF8File input
+parseFile :: FilePath -> IO (FilePath, Text)
+parseFile input = (,) input <$> readUTF8FileT input
 
 inputFile :: Parser FilePath
 inputFile = strArgument $

--- a/psc/Main.hs
+++ b/psc/Main.hs
@@ -15,6 +15,7 @@ import           Data.Bool (bool)
 import qualified Data.ByteString.Lazy as B
 import qualified Data.ByteString.UTF8 as BU8
 import qualified Data.Map as M
+import           Data.Text (Text)
 import           Data.Version (showVersion)
 
 import qualified Language.PureScript as P
@@ -29,7 +30,7 @@ import qualified System.Console.ANSI as ANSI
 import           System.Exit (exitSuccess, exitFailure)
 import           System.FilePath.Glob (glob)
 import           System.IO (hSetEncoding, hPutStrLn, stdout, stderr, utf8)
-import           System.IO.UTF8
+import           System.IO.UTF8 (readUTF8FileT)
 
 data PSCMakeOptions = PSCMakeOptions
   { pscmInput        :: [FilePath]
@@ -85,8 +86,8 @@ globWarningOnMisses warn = concatMapM globWithWarning
     return paths
   concatMapM f = fmap concat . mapM f
 
-readInput :: [FilePath] -> IO [(FilePath, String)]
-readInput inputFiles = forM inputFiles $ \inFile -> (inFile, ) <$> readUTF8File inFile
+readInput :: [FilePath] -> IO [(FilePath, Text)]
+readInput inputFiles = forM inputFiles $ \inFile -> (inFile, ) <$> readUTF8FileT inFile
 
 inputFile :: Parser FilePath
 inputFile = strArgument $

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -334,6 +334,7 @@ executable psc
                    mtl -any,
                    optparse-applicative >= 0.12.1,
                    parsec -any,
+                   text -any,
                    time -any,
                    transformers -any,
                    transformers-compat -any,
@@ -387,6 +388,7 @@ executable psc-docs
                    optparse-applicative >= 0.12.1,
                    process -any,
                    split -any,
+                   text -any,
                    transformers -any,
                    transformers-compat -any
     main-is: Main.hs
@@ -419,7 +421,8 @@ executable psc-hierarchy
                    mtl -any,
                    optparse-applicative >= 0.12.1,
                    parsec -any,
-                   process -any
+                   process -any,
+                   text -any
     main-is: Main.hs
     other-modules: Paths_purescript
     buildable: True

--- a/src/Language/PureScript/Docs/ParseAndBookmark.hs
+++ b/src/Language/PureScript/Docs/ParseAndBookmark.hs
@@ -9,13 +9,12 @@ import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.IO.Class (MonadIO(..))
 
 import qualified Data.Map as M
+import Data.Text (Text)
 
 import Language.PureScript.Docs.Convert (collectBookmarks)
 import Language.PureScript.Docs.Types
 import qualified Language.PureScript as P
-
-import System.IO.UTF8 (readUTF8File)
-
+import System.IO.UTF8 (readUTF8FileT)
 import Web.Bower.PackageMeta (PackageName)
 
 -- |
@@ -45,7 +44,7 @@ parseAndBookmark inputFiles depsFiles = do
 
 parseFiles ::
   (MonadError P.MultipleErrors m) =>
-  [(FileInfo, FilePath)]
+  [(FileInfo, Text)]
   -> m [(FileInfo, P.Module)]
 parseFiles =
   throwLeft . P.parseModulesFromFiles fileInfoToString
@@ -77,10 +76,10 @@ fileInfoToString :: FileInfo -> FilePath
 fileInfoToString (Local fn) = fn
 fileInfoToString (FromDep _ fn) = fn
 
-parseFile :: FilePath -> IO (FilePath, String)
-parseFile input' = (,) input' <$> readUTF8File input'
+parseFile :: FilePath -> IO (FilePath, Text)
+parseFile input' = (,) input' <$> readUTF8FileT input'
 
-parseAs :: (MonadIO m) => (FilePath -> a) -> FilePath -> m (a, String)
+parseAs :: (MonadIO m) => (FilePath -> a) -> FilePath -> m (a, Text)
 parseAs g = fmap (first g) . liftIO . parseFile
 
 getDepsModuleNames :: [InPackage (FilePath, P.Module)] -> M.Map P.ModuleName PackageName

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -21,7 +21,7 @@ import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
-import           System.IO.UTF8                  (readUTF8File)
+import           System.IO.UTF8                  (readUTF8FileT)
 
 -- | Given a filepath performs the following steps:
 --
@@ -44,7 +44,7 @@ rebuildFile
   -> m Success
 rebuildFile path = do
 
-  input <- liftIO (readUTF8File path)
+  input <- liftIO (readUTF8FileT path)
 
   m <- case snd <$> P.parseModuleFromFile identity (path, input) of
     Left parseError -> throwError

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -30,14 +30,14 @@ import qualified Language.PureScript           as P
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
-import           System.IO.UTF8                (readUTF8File)
+import           System.IO.UTF8                (readUTF8FileT)
 
 parseModule
   :: (MonadIO m)
   => FilePath
-  -> m (Either FilePath (FilePath, P.Module) )
+  -> m (Either FilePath (FilePath, P.Module))
 parseModule path = do
-  contents <- liftIO (readUTF8File path)
+  contents <- liftIO (readUTF8FileT path)
   case P.parseModuleFromFile identity (path, contents) of
     Left _ -> pure (Left path)
     Right m -> pure (Right m)

--- a/src/Language/PureScript/Interactive/Module.hs
+++ b/src/Language/PureScript/Interactive/Module.hs
@@ -6,7 +6,7 @@ import           Control.Monad
 import qualified Language.PureScript as P
 import           Language.PureScript.Interactive.Types
 import           System.FilePath (pathSeparator)
-import           System.IO.UTF8 (readUTF8File)
+import           System.IO.UTF8 (readUTF8FileT)
 
 -- * Support Module
 
@@ -25,7 +25,7 @@ supportModuleIsDefined = any ((== supportModuleName) . P.getModuleName)
 --
 loadModule :: FilePath -> IO (Either String [P.Module])
 loadModule filename = do
-  content <- readUTF8File filename
+  content <- readUTF8FileT filename
   return $ either (Left . P.prettyPrintMultipleErrors P.defaultPPEOptions) (Right . map snd) $ P.parseModulesFromFiles id [(filename, content)]
 
 -- |
@@ -34,7 +34,7 @@ loadModule filename = do
 loadAllModules :: [FilePath] -> IO (Either P.MultipleErrors [(FilePath, P.Module)])
 loadAllModules files = do
   filesAndContent <- forM files $ \filename -> do
-    content <- readUTF8File filename
+    content <- readUTF8FileT filename
     return (filename, content)
   return $ P.parseModulesFromFiles id filesAndContent
 

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -19,6 +19,7 @@ import Prelude hiding (lex)
 
 import Data.Functor (($>))
 import Data.Maybe (fromMaybe)
+import Data.Text (Text)
 
 import Control.Applicative
 import Control.Arrow ((+++))
@@ -281,7 +282,7 @@ parseModulesFromFiles
   :: forall m k
    . MonadError MultipleErrors m
   => (k -> FilePath)
-  -> [(k, String)]
+  -> [(k, Text)]
   -> m [(k, Module)]
 parseModulesFromFiles toFilePath input =
   flip parU wrapError . inParallel . flip map input $ parseModuleFromFile toFilePath
@@ -298,11 +299,11 @@ parseModulesFromFiles toFilePath input =
 -- | Parses a single module with FilePath for eventual parsing errors
 parseModuleFromFile
   :: (k -> FilePath)
-  -> (k, String)
+  -> (k, Text)
   -> Either P.ParseError (k, Module)
 parseModuleFromFile toFilePath (k, content) = do
     let filename = toFilePath k
-    ts <- lex filename content
+    ts <- lex' filename content
     m <- runTokenParser filename parseModule ts
     pure (k, m)
 

--- a/src/System/IO/UTF8.hs
+++ b/src/System/IO/UTF8.hs
@@ -4,11 +4,21 @@ import Prelude.Compat
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.UTF8 as UTF8
+import           Data.Text (Text)
+import qualified Data.Text.Encoding as TE
+
+readUTF8FileT :: FilePath -> IO Text
+readUTF8FileT inFile =
+  fmap TE.decodeUtf8 (BS.readFile inFile)
+
+writeUTF8FileT :: FilePath -> Text -> IO ()
+writeUTF8FileT inFile text =
+  BS.writeFile inFile (TE.encodeUtf8 text)
 
 readUTF8File :: FilePath -> IO String
-readUTF8File inFile = do
+readUTF8File inFile =
   fmap UTF8.toString (BS.readFile inFile)
 
 writeUTF8File :: FilePath -> String -> IO ()
-writeUTF8File inFile text = do
+writeUTF8File inFile text =
   BS.writeFile inFile (UTF8.fromString text)

--- a/tests/Language/PureScript/Ide/Imports/IntegrationSpec.hs
+++ b/tests/Language/PureScript/Ide/Imports/IntegrationSpec.hs
@@ -6,12 +6,12 @@ module Language.PureScript.Ide.Imports.IntegrationSpec where
 import           Protolude
 
 import qualified Data.Text                           as T
-import qualified Data.Text.IO                        as TIO
 import qualified Language.PureScript.Ide.Integration as Integration
 import           Test.Hspec
 
 import           System.Directory
 import           System.FilePath
+import           System.IO.UTF8                      (readUTF8FileT)
 
 setup :: IO ()
 setup = void (Integration.reset *> Integration.loadAll)
@@ -27,7 +27,7 @@ withSupportFiles test = do
 outputFileShouldBe :: [Text] -> IO ()
 outputFileShouldBe expectation = do
   outFp <- (</> "src" </> "ImportsSpecOut.tmp") <$> Integration.projectDirectory
-  outRes <- TIO.readFile outFp
+  outRes <- readUTF8FileT outFp
   shouldBe (T.lines outRes) expectation
 
 spec :: Spec


### PR DESCRIPTION
This doesn't change anything inside the parsed AST, it just changes the initial file read to use Text, so we don't need to load all the source files into memory as `String`.

The problem is I have no idea how to properly benchmark this, but consecutive runs through unix's `time` show a 5% improvement on `atom-ide-purescript`.