### PR TITLE
Add psc-package to release bundle

### DIFF
--- a/bundle/README
+++ b/bundle/README
@@ -19,6 +19,7 @@ This bundle contains the following executables:
 - psc-ide-server Provides Editor Support in the form of type information and
                  autocompletion
 - psc-ide-client Utility to query psc-ide-server
+- psc-package    Package manager for PureScript packages
 
 Copy these files anywhere on your PATH.
 

--- a/bundle/build.sh
+++ b/bundle/build.sh
@@ -26,7 +26,7 @@ fi
 mkdir -p bundle/build/purescript
 
 # Strip the binaries, and copy them to the staging directory
-for BIN in psc psci psc-docs psc-publish psc-bundle psc-ide-server psc-ide-client
+for BIN in psc psci psc-docs psc-publish psc-bundle psc-ide-server psc-ide-client psc-package
 do
   FULL_BIN="$LOCAL_INSTALL_ROOT/bin/${BIN}${BIN_EXT}"
   if [ "$OS" != "win64" ]


### PR DESCRIPTION
Add the new `psc-package` executable to the release bundle.