### PR TITLE
Fix GHC 8.0.2 build (and fix #2421)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -84,6 +84,7 @@ This file lists the contributors to the PureScript compiler project, and the ter
 - [@zudov](https://github.com/zudov) (Konstantin Zudov) My existing contributions and all future contributions until further notice are Copyright Konstantin Zudov, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 - [@brandonhamilton](https://github.com/brandonhamilton) (Brandon Hamilton) My existing contributions and all future contributions until further notice are Copyright Brandon Hamilton, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 - [@bbqbaron](https://github.com/bbqbaron) (Eric Loren) My existing contributions and all future contributions until further notice are Copyright Eric Loren, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
+- [@RyanGlScott](https://github.com/RyanGlScott) (Ryan Scott) My existing contributions and all future contributions until further notice are Copyright Ryan Scott, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT).
 
 ### Companies
 

--- a/src/Control/Monad/Supply/Class.hs
+++ b/src/Control/Monad/Supply/Class.hs
@@ -3,6 +3,7 @@
 --
 
 {-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Control.Monad.Supply.Class where
 
@@ -15,9 +16,9 @@ import Control.Monad.Writer
 class Monad m => MonadSupply m where
   fresh :: m Integer
   peek :: m Integer
-  default fresh :: MonadTrans t => t m Integer
+  default fresh :: (MonadTrans t, MonadSupply n, m ~ t n) => m Integer
   fresh = lift fresh
-  default peek :: MonadTrans t => t m Integer
+  default peek :: (MonadTrans t, MonadSupply n, m ~ t n) => m Integer
   peek = lift peek
 
 instance Monad m => MonadSupply (SupplyT m) where


### PR DESCRIPTION
As noted in #2421, the default type signatures for `fresh` and `peek` are bogus, and GHC 8.0.2's reworked `DefaultSignatures` typechecking now complains about them. To rectify this, I replaced them with better type signatures.

Fixes #2421.