### PR TITLE
Bump stack lts version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
 - export CC=gcc
 - export OS_NAME=$(./travis/convert-os-name.sh)
 script:
-- travis/build.sh
+- travis_wait 120 travis/build.sh
 before_deploy:
 - ./bundle/build.sh $OS_NAME
 deploy:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-6.10
+resolver: lts-7.9
 packages:
 - '.'


### PR DESCRIPTION
Changing this let me build on macOS Sierra - which I have been unable to do since I upgraded.