### PR TITLE
Add value source positions

### DIFF
--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -392,7 +392,7 @@ parseLet = do
   return $ Let ds result
 
 parseValueAtom :: TokenParser Expr
-parseValueAtom = P.choice
+parseValueAtom = withSourceSpan PositionedValue $ P.choice
                  [ parseAnonymousArgument
                  , Literal <$> parseNumericLiteral
                  , Literal <$> parseCharLiteral
@@ -418,7 +418,7 @@ parseValueAtom = P.choice
 parseInfixExpr :: TokenParser Expr
 parseInfixExpr
   = P.between tick tick parseValue
-  <|> Op <$> parseQualified parseOperator
+  <|> withSourceSpan PositionedValue (Op <$> parseQualified parseOperator)
 
 parseHole :: TokenParser Expr
 parseHole = Hole <$> holeLit

--- a/src/Language/PureScript/Sugar/Operators/Expr.hs
+++ b/src/Language/PureScript/Sugar/Operators/Expr.hs
@@ -20,7 +20,9 @@ matchExprOperators = matchOperators isBinOp extractOp fromOp reapply modOpTable
   isBinOp _ = False
 
   extractOp :: Expr -> Maybe (Expr, Expr, Expr)
-  extractOp (BinaryNoParens op l r) = Just (op, l, r)
+  extractOp (BinaryNoParens op l r)
+    | PositionedValue _ _ op' <- op = Just (op', l, r)
+    | otherwise = Just (op, l, r)
   extractOp _ = Nothing
 
   fromOp :: Expr -> Maybe (Qualified (OpName 'ValueOpName))


### PR DESCRIPTION
Addresses a few errors with overgenerous source spans listed in https://github.com/purescript/purescript/issues/1801 - specifically `UnknownName` for data constructors, identifiers and operators.

(I previously tried to add this for value atoms for source maps, at which point it broke something, though tests at least seem to pass now). 