### PR TITLE
Solving IsSymbol instances

### DIFF
--- a/examples/passing/SolvingIsSymbol.purs
+++ b/examples/passing/SolvingIsSymbol.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Prelude
+import Data.Symbol
+import Control.Monad.Eff
+import Control.Monad.Eff.Console
+
+main = do
+  let lit = reflectSymbol (SProxy :: SProxy "literal")
+  when (lit == "literal") (log "Done")

--- a/examples/passing/SolvingIsSymbol.purs
+++ b/examples/passing/SolvingIsSymbol.purs
@@ -1,10 +1,13 @@
 module Main where
 
 import Prelude
-import Data.Symbol
 import Control.Monad.Eff
 import Control.Monad.Eff.Console
 
+-- Here we import as alias of reflectSymbol without importing Data.Symbol. However,
+-- Data.Symbol should be implicitly imported as we have an instance of IsSymbol solved.
+import SolvingIsSymbol.Lib (literalSymbol, libReflectSymbol)
+
 main = do
-  let lit = reflectSymbol (SProxy :: SProxy "literal")
+  let lit = libReflectSymbol literalSymbol
   when (lit == "literal") (log "Done")

--- a/examples/passing/SolvingIsSymbol/Lib.purs
+++ b/examples/passing/SolvingIsSymbol/Lib.purs
@@ -1,0 +1,10 @@
+module SolvingIsSymbol.Lib where
+
+import Data.Symbol
+
+literalSymbol :: SProxy "literal"
+literalSymbol = SProxy
+
+libReflectSymbol :: forall s. IsSymbol s => SProxy s -> String
+libReflectSymbol = reflectSymbol
+

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -50,6 +50,7 @@ extra-source-files: examples/passing/*.purs
                   , examples/passing/ResolvableScopeConflict2/*.purs
                   , examples/passing/ResolvableScopeConflict3/*.purs
                   , examples/passing/ShadowedModuleName/*.purs
+                  , examples/passing/SolvingIsSymbol/*.purs
                   , examples/passing/TransitiveImport/*.purs
                   , examples/passing/TypeOperators/*.purs
                   , examples/passing/TypeWithoutParens/*.purs

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -607,7 +607,7 @@ data Expr
   -- instance type, and the type class dictionaries in scope.
   --
   | TypeClassDictionary Constraint
-                        (M.Map (Maybe ModuleName) (M.Map (Qualified (ProperName 'ClassName)) (M.Map (Qualified Ident) TypeClassDictionaryInScope)))
+                        (M.Map (Maybe ModuleName) (M.Map (Qualified (ProperName 'ClassName)) (M.Map (Qualified Ident) NamedDict)))
                         [ErrorMessageHint]
   -- |
   -- A typeclass dictionary accessor, the implementation is left unspecified until CoreFn desugaring.

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -314,6 +314,11 @@ fromSpine = "fromSpine"
 toSignature :: String
 toSignature = "toSignature"
 
+-- IsSymbol class
+
+pattern IsSymbol :: Qualified (ProperName 'ClassName)
+pattern IsSymbol = Qualified (Just (ModuleName [ProperName "Data", ProperName "Symbol"])) (ProperName "IsSymbol")
+
 -- Main module
 
 main :: String

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -212,6 +212,10 @@ findQualModules decls =
   fqValues :: A.Expr -> [ModuleName]
   fqValues (A.Var q) = getQual' q
   fqValues (A.Constructor q) = getQual' q
+  -- IsSymbol instances for literal symbols are automatically solved and the type
+  -- class dictionaries are built inline instead of having a named instance defined
+  -- and imported.  We therefore need to import the IsSymbol constructor from
+  -- Data.Symbol if it hasn't already been imported.
   fqValues (A.TypeClassDictionaryConstructorApp C.IsSymbol _) = getQual' C.IsSymbol
   fqValues _ = []
 

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -13,6 +13,7 @@ import Language.PureScript.AST.Literals
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.AST.Traversals
 import Language.PureScript.Comments
+import qualified Language.PureScript.Constants as C
 import Language.PureScript.CoreFn.Ann
 import Language.PureScript.CoreFn.Binders
 import Language.PureScript.CoreFn.Expr
@@ -110,7 +111,9 @@ moduleToCoreFn env (A.Module _ coms mn decls (Just exps)) =
     exprToCoreFn ss com (Just ty) v
   exprToCoreFn ss com ty (A.Let ds v) =
     Let (ss, com, ty, Nothing) (concatMap (declToCoreFn ss []) ds) (exprToCoreFn ss [] Nothing v)
-  exprToCoreFn ss com _  (A.TypeClassDictionaryConstructorApp name (A.TypedValue _ (A.Literal (A.ObjectLiteral vs)) _)) =
+  exprToCoreFn ss com ty (A.TypeClassDictionaryConstructorApp name (A.TypedValue _ lit@(A.Literal (A.ObjectLiteral _)) _)) =
+    exprToCoreFn ss com ty (A.TypeClassDictionaryConstructorApp name lit)
+  exprToCoreFn ss com _ (A.TypeClassDictionaryConstructorApp name (A.Literal (A.ObjectLiteral vs))) =
     let args = map (exprToCoreFn ss [] Nothing . snd) $ sortBy (compare `on` fst) vs
         ctor = Var (ss, [], Nothing, Just IsTypeClassConstructor) (fmap properToIdent name)
     in foldl (App (ss, com, Nothing, Nothing)) ctor args
@@ -209,6 +212,7 @@ findQualModules decls =
   fqValues :: A.Expr -> [ModuleName]
   fqValues (A.Var q) = getQual' q
   fqValues (A.Constructor q) = getQual' q
+  fqValues (A.TypeClassDictionaryConstructorApp C.IsSymbol _) = getQual' C.IsSymbol
   fqValues _ = []
 
   fqBinders :: A.Binder -> [ModuleName]

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -29,7 +29,7 @@ data Environment = Environment
   -- constructor name, argument types and return type.
   , typeSynonyms :: M.Map (Qualified (ProperName 'TypeName)) ([(String, Maybe Kind)], Type)
   -- ^ Type synonyms currently in scope
-  , typeClassDictionaries :: M.Map (Maybe ModuleName) (M.Map (Qualified (ProperName 'ClassName)) (M.Map (Qualified Ident) TypeClassDictionaryInScope))
+  , typeClassDictionaries :: M.Map (Maybe ModuleName) (M.Map (Qualified (ProperName 'ClassName)) (M.Map (Qualified Ident) NamedDict))
   -- ^ Available type class dictionaries
   , typeClasses :: M.Map (Qualified (ProperName 'ClassName)) TypeClassData
   -- ^ Type classes

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -145,7 +145,7 @@ applyExternsFileToEnvironment ExternsFile{..} = flip (foldl' applyDecl) efDeclar
   applyDecl env (EDClass pn args members cs deps) = env { typeClasses = M.insert (qual pn) (TypeClassData args members cs deps) (typeClasses env) }
   applyDecl env (EDInstance className ident tys cs) = env { typeClassDictionaries = updateMap (updateMap (M.insert (qual ident) dict) className) (Just efModuleName) (typeClassDictionaries env) }
     where
-    dict :: TypeClassDictionaryInScope
+    dict :: NamedDict
     dict = TypeClassDictionaryInScope (qual ident) [] className tys cs
 
     updateMap :: (Ord k, Monoid a) => (a -> a) -> k -> M.Map k a -> M.Map k a

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -134,7 +134,7 @@ addTypeClass moduleName pn args implies dependencies ds =
 addTypeClassDictionaries
   :: (MonadState CheckState m)
   => Maybe ModuleName
-  -> M.Map (Qualified (ProperName 'ClassName)) (M.Map (Qualified Ident) TypeClassDictionaryInScope)
+  -> M.Map (Qualified (ProperName 'ClassName)) (M.Map (Qualified Ident) NamedDict)
   -> m ()
 addTypeClassDictionaries mn entries =
   modify $ \st -> st { checkEnv = (checkEnv st) { typeClassDictionaries = insertState st } }
@@ -282,7 +282,7 @@ typeCheckAll moduleName _ = traverse go
     checkOrphanInstance dictName className tys
     _ <- traverseTypeInstanceBody checkInstanceMembers body
     let dict = TypeClassDictionaryInScope (Qualified (Just moduleName) dictName) [] className tys (Just deps)
-    addTypeClassDictionaries (Just moduleName) . M.singleton className $ M.singleton (tcdName dict) dict
+    addTypeClassDictionaries (Just moduleName) . M.singleton className $ M.singleton (tcdValue dict) dict
     return d
   go (PositionedDeclaration pos com d) =
     warnAndRethrowWithPosition pos $ PositionedDeclaration pos com <$> go d

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -111,7 +111,8 @@ isSymbolDictionary sym =
   let inst = ObjectLiteral
                [ ("reflectSymbol", Abs (Left (Ident C.__unused)) (Literal (StringLiteral sym)))
                ]
-  in TypeClassDictionaryInScope (Left (Literal inst)) [] C.IsSymbol [TypeLevelString sym] Nothing
+      dict = TypeClassDictionaryConstructorApp C.IsSymbol (Literal inst) 
+  in TypeClassDictionaryInScope (Left dict) [] C.IsSymbol [TypeLevelString sym] Nothing
 
 -- | Check that the current set of type class dictionaries entail the specified type class goal, and, if so,
 -- return a type class dictionary reference.

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -133,12 +133,12 @@ warnAndRethrowWithPositionTC pos = rethrowWithPositionTC pos . warnWithPosition 
 -- | Temporarily make a collection of type class dictionaries available
 withTypeClassDictionaries
   :: MonadState CheckState m
-  => [TypeClassDictionaryInScope]
+  => [NamedDict]
   -> m a
   -> m a
 withTypeClassDictionaries entries action = do
   orig <- get
-  let mentries = M.fromListWith (M.unionWith M.union) [ (mn, M.singleton className (M.singleton (tcdName entry) entry)) | entry@TypeClassDictionaryInScope{ tcdName = Qualified mn _, tcdClassName = className }  <- entries ]
+  let mentries = M.fromListWith (M.unionWith M.union) [ (mn, M.singleton className (M.singleton (tcdValue entry) entry)) | entry@TypeClassDictionaryInScope{ tcdValue = Qualified mn _, tcdClassName = className }  <- entries ]
   modify $ \st -> st { checkEnv = (checkEnv st) { typeClassDictionaries = M.unionWith (M.unionWith M.union) (typeClassDictionaries . checkEnv $ st) mentries } }
   a <- action
   modify $ \st -> st { checkEnv = (checkEnv st) { typeClassDictionaries = typeClassDictionaries . checkEnv $ orig } }
@@ -147,14 +147,14 @@ withTypeClassDictionaries entries action = do
 -- | Get the currently available map of type class dictionaries
 getTypeClassDictionaries
   :: (MonadState CheckState m)
-  => m (M.Map (Maybe ModuleName) (M.Map (Qualified (ProperName 'ClassName)) (M.Map (Qualified Ident) TypeClassDictionaryInScope)))
+  => m (M.Map (Maybe ModuleName) (M.Map (Qualified (ProperName 'ClassName)) (M.Map (Qualified Ident) NamedDict)))
 getTypeClassDictionaries = typeClassDictionaries . checkEnv <$> get
 
 -- | Lookup type class dictionaries in a module.
 lookupTypeClassDictionaries
   :: (MonadState CheckState m)
   => Maybe ModuleName
-  -> m (M.Map (Qualified (ProperName 'ClassName)) (M.Map (Qualified Ident) TypeClassDictionaryInScope))
+  -> m (M.Map (Qualified (ProperName 'ClassName)) (M.Map (Qualified Ident) NamedDict))
 lookupTypeClassDictionaries mn = fromMaybe M.empty . M.lookup mn . typeClassDictionaries . checkEnv <$> get
 
 -- | Temporarily bind a collection of names to local variables

--- a/src/Language/PureScript/TypeClassDictionaries.hs
+++ b/src/Language/PureScript/TypeClassDictionaries.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveFoldable    #-}
+{-# LANGUAGE DeriveTraversable #-}
 module Language.PureScript.TypeClassDictionaries where
 
 import Prelude.Compat
@@ -8,10 +10,10 @@ import Language.PureScript.Types
 -- |
 -- Data representing a type class dictionary which is in scope
 --
-data TypeClassDictionaryInScope
+data TypeClassDictionaryInScope v
   = TypeClassDictionaryInScope {
-    -- | The identifier with which the dictionary can be accessed at runtime
-      tcdName :: Qualified Ident
+    -- | The value with which the dictionary can be accessed at runtime
+      tcdValue :: v
     -- | How to obtain this instance via superclass relationships
     , tcdPath :: [(Qualified (ProperName 'ClassName), Integer)]
     -- | The name of the type class to which this type class instance applies
@@ -21,4 +23,7 @@ data TypeClassDictionaryInScope
     -- | Type class dependencies which must be satisfied to construct this dictionary
     , tcdDependencies :: Maybe [Constraint]
     }
-    deriving (Show)
+    deriving (Show, Functor, Foldable, Traversable)
+
+type NamedDict = TypeClassDictionaryInScope (Qualified Ident)
+

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -104,6 +104,7 @@ supportModules =
   , "Data.Ring"
   , "Data.Semigroup"
   , "Data.Semiring"
+  , "Data.Symbol"
   , "Data.Show"
   , "Data.Unit"
   , "Data.Void"
@@ -112,6 +113,7 @@ supportModules =
   , "Prelude"
   , "Test.Assert"
   , "Test.Main"
+  , "Unsafe.Coerce"
   ]
 
 pushd :: forall a. FilePath -> IO a -> IO a

--- a/tests/support/bower.json
+++ b/tests/support/bower.json
@@ -9,6 +9,8 @@
     "purescript-st": "1.0.0-rc.1",
     "purescript-partial": "1.1.2",
     "purescript-newtype": "0.1.0",
-    "purescript-generics-rep": "2.0.0"
+    "purescript-generics-rep": "2.0.0",
+    "purescript-symbols": "^1.0.1",
+    "purescript-unsafe-coerce": "^1.0.0"
   }
 }


### PR DESCRIPTION
Opening this PR for discussion: there are some TODOs and other things.

Currently many of the `example` tests fail since I updated `tests/support/bower.json` to specify the current latest versions of libraries.  They fail with `The foreign module implementation for module Unsafe.Coerce is missing.`.  I added `purescript-unsafe-coerce` as a dependency, but it didn't help.  So I'm not sure why that fails.

However my `SolvingIsSymbol` test does pass 👍 