### PR TITLE
Add 'available' command to psc-package

### DIFF
--- a/psc-package/Main.hs
+++ b/psc-package/Main.hs
@@ -188,6 +188,15 @@ listDependencies = do
   trans <- getTransitiveDeps db depends
   traverse_ (echo . fst) trans
 
+listPackages :: IO ()
+listPackages = do
+  pkg <- readPackageFile
+  db <- readPackageSet pkg
+  traverse_ echo (fmt <$> Map.assocs db)
+  where
+  fmt :: (Text, PackageInfo) -> Text
+  fmt (name, PackageInfo{ version }) = name <> " (" <> version <> ")"
+
 getSourcePaths :: PackageConfig -> PackageSet -> [Text] -> IO [Turtle.FilePath]
 getSourcePaths PackageConfig{..} db pkgNames = do
   trans <- getTransitiveDeps db pkgNames
@@ -252,6 +261,9 @@ main = do
         , Opts.command "sources"
             (Opts.info (pure listSourcePaths)
             (Opts.progDesc "List all (active) source paths for dependencies"))
+        , Opts.command "available"
+            (Opts.info (pure listPackages)
+            (Opts.progDesc "List all packages available in the package set"))
         ]
       where
         pkg = Opts.strArgument $


### PR DESCRIPTION
I found myself wanting this command when working on a package set. If you'd rather not have it, then feel free to just decline the PR. 

Output looks like this:
```
assert (v1.0.0p11)
bifunctors (v2.0.0)
console (v1.0.0p11)
control (v2.0.0)
prelude (v2.1.0p11)
st (v1.0.0p11)
tuples (v2.0.0)
```