### PR TITLE
Warn for shadowed type class variables

### DIFF
--- a/examples/warning/2140.purs
+++ b/examples/warning/2140.purs
@@ -1,0 +1,5 @@
+-- @shouldWarnWith ShadowedTypeVar
+module Main where
+
+class Test a where
+  f :: (forall a. a -> a) -> a -> a

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -157,6 +157,7 @@ data ErrorMessageHint
   | ErrorInTypeSynonym (ProperName 'TypeName)
   | ErrorInValueDeclaration Ident
   | ErrorInTypeDeclaration Ident
+  | ErrorInTypeClassDeclaration (ProperName 'ClassName)
   | ErrorInForeignImport Ident
   | ErrorSolvingConstraint Constraint
   | PositionedError SourceSpan

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -984,6 +984,10 @@ prettyPrintSingleError (PPEOptions codeColor full level showWiki) e = flip evalS
       paras [ detail
             , line $ "in type declaration for " ++ markCode (showIdent n)
             ]
+    renderHint (ErrorInTypeClassDeclaration name) detail =
+      paras [ detail
+            , line $ "in type class declaration for " ++ markCode (runProperName name)
+            ]
     renderHint (ErrorInForeignImport nm) detail =
       paras [ detail
             , line $ "in foreign import " ++ markCode (showIdent nm)

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -44,10 +44,14 @@ lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDecl
 
     f :: Declaration -> MultipleErrors
     f (PositionedDeclaration pos _ dec) = addHint (PositionedError pos) (f dec)
-    f dec@(ValueDeclaration name _ _ _) = addHint (ErrorInValueDeclaration name) (warningsInDecl moduleNames dec <> checkTypeVarsInDecl dec)
-    f (TypeDeclaration name ty) = addHint (ErrorInTypeDeclaration name) (checkTypeVars ty)
-    f (TypeClassDeclaration name args _ _ decs) = addHint (ErrorInTypeClassDeclaration name) (foldMap (checkTypeVarsInDecl' (S.fromList $ fst <$> args)) decs)
-    f dec = warningsInDecl moduleNames dec <> checkTypeVarsInDecl dec
+    f (TypeClassDeclaration name args _ _ decs) = addHint (ErrorInTypeClassDeclaration name) (foldMap (f' (S.fromList $ fst <$> args)) decs)
+    f dec = f' S.empty dec
+
+    f' :: S.Set String -> Declaration -> MultipleErrors
+    f' s (PositionedDeclaration pos _ dec) = addHint (PositionedError pos) (f' s dec)
+    f' s dec@(ValueDeclaration name _ _ _) = addHint (ErrorInValueDeclaration name) (warningsInDecl moduleNames dec <> checkTypeVarsInDecl s dec)
+    f' s (TypeDeclaration name ty) = addHint (ErrorInTypeDeclaration name) (checkTypeVars s ty)
+    f' s dec = warningsInDecl moduleNames dec <> checkTypeVarsInDecl s dec
 
     stepE :: S.Set Ident -> Expr -> MultipleErrors
     stepE s (Abs (Left name) _) | name `S.member` s = errorMessage (ShadowedName name)
@@ -71,17 +75,11 @@ lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDecl
            | otherwise = mempty
     stepDo _ _ = mempty
 
-  checkTypeVarsInDecl :: Declaration -> MultipleErrors
-  checkTypeVarsInDecl = checkTypeVarsInDecl' S.empty
+  checkTypeVarsInDecl :: S.Set String -> Declaration -> MultipleErrors
+  checkTypeVarsInDecl s d = let (f, _, _, _, _) = accumTypes (checkTypeVars s) in f d
 
-  checkTypeVars :: Type -> MultipleErrors
-  checkTypeVars = checkTypeVars' S.empty
-
-  checkTypeVarsInDecl' :: S.Set String -> Declaration -> MultipleErrors
-  checkTypeVarsInDecl' s d = let (f, _, _, _, _) = accumTypes (checkTypeVars' s) in f d
-
-  checkTypeVars' :: S.Set String -> Type -> MultipleErrors
-  checkTypeVars' set ty = everythingWithContextOnTypes set mempty mappend step ty <> findUnused ty
+  checkTypeVars :: S.Set String -> Type -> MultipleErrors
+  checkTypeVars set ty = everythingWithContextOnTypes set mempty mappend step ty <> findUnused ty
     where
     step :: S.Set String -> Type -> (S.Set String, MultipleErrors)
     step s (ForAll tv _ _) = bindVar s tv


### PR DESCRIPTION
Should fix #2140 

The error seems less than ideal:

```
psc: No input files.
➜  purescript git:(2140-fix) stack exec psc -- examples/warning/2140.purs                   
Compiling Main
Warning found:
in module Main
at /home/joneshf/programming/purescript/examples/warning/2140.purs line 4, column 1 - line 5, column 35

  Type variable a was shadowed.

in type class declaration for Test

See https://github.com/purescript/purescript/wiki/Error-Code-ShadowedTypeVar for more information,
or to contribute content related to this warning.
```

Should we add which type definition is shadowing? If so, how do we nest that properly? Or is this a fine message?