### PR TITLE
[WIP] :info functionality for psci

### DIFF
--- a/src/Language/PureScript/Docs/RenderedCode/Types.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Types.hs
@@ -50,6 +50,7 @@ data RenderedCodeElement
   | Ident String ContainingModule
   | Ctor String ContainingModule
   | Kind String
+  | Info String
   | Keyword String
   | Space
   deriving (Show, Eq, Ord)

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -287,16 +287,20 @@ data InfoType =
     (P.ProperName 'N.TypeName)
     [(String, Maybe P.Kind)]
 
+data InfoConstructor =
+  InfoConstructor
+    P.Type
+    -- ^ Type of constructor (as displayed in GADT form)
+    (Maybe [P.Type])
+    -- ^ Arguments to constructor (as displayed in classic form)
+
 data InfoTarget
   = IValue
       P.Type
   | IConstructor
       InfoType
       P.Type
-  | IType
-      InfoType
-      [(String, P.Type)]
-      [(Maybe P.ModuleName, P.ProperName 'N.ClassName)]
+  | IType InfoType [(String, InfoConstructor)]
   | ITypeClass
       P.TypeClassData
       [(Maybe P.ModuleName, P.ProperName 'N.TypeName)]

--- a/src/Language/PureScript/Interactive/Completion.hs
+++ b/src/Language/PureScript/Interactive/Completion.hs
@@ -125,6 +125,7 @@ directiveArg _ Help        = []
 directiveArg _ Paste       = []
 directiveArg _ Show        = map CtxFixed replQueryStrings
 directiveArg _ Type        = [CtxIdentifier]
+directiveArg _ Info        = [CtxIdentifier, CtxType]
 directiveArg _ Kind        = [CtxType]
 
 completeImport :: [String] -> String -> [CompletionContext]

--- a/src/Language/PureScript/Interactive/Directive.hs
+++ b/src/Language/PureScript/Interactive/Directive.hs
@@ -29,6 +29,7 @@ directiveStrings =
     , (Browse , ["browse"])
     , (Type   , ["type"])
     , (Kind   , ["kind"])
+    , (Info   , ["info"])
     , (Show   , ["show"])
     , (Paste  , ["paste"])
     ]

--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -9,7 +9,7 @@ import           Prelude.Compat hiding (lex)
 
 import           Data.Char (isSpace)
 import           Data.List (intercalate)
-import           Text.Parsec hiding ((<|>))
+import           Text.Parsec
 import qualified Language.PureScript as P
 import qualified Language.PureScript.Interactive.Directive as D
 import           Language.PureScript.Interactive.Types
@@ -66,6 +66,11 @@ parseDirective cmd =
     Browse  -> BrowseModule <$> parseRest P.moduleName arg
     Show    -> ShowInfo <$> parseReplQuery' (trim arg)
     Type    -> TypeOf <$> parseRest P.parseValue arg
+    Info    ->
+      InfoFor <$>
+        parseRest
+          (P.parseQualified (P.uname <|> P.identifier))
+          arg
     Kind    -> KindOf <$> parseRest P.parseType arg
 
 -- |

--- a/src/Language/PureScript/Interactive/Types.hs
+++ b/src/Language/PureScript/Interactive/Types.hs
@@ -88,6 +88,8 @@ data Command
   | Decls [P.Declaration]
   -- | Find the type of an expression
   | TypeOf P.Expr
+  -- | Find the type of an expression
+  | InfoFor (P.Qualified String)
   -- | Find the kind of an expression
   | KindOf P.Type
   -- | Shows information about the current state of the REPL
@@ -123,6 +125,7 @@ data Directive
   | Browse
   | Type
   | Kind
+  | Info
   | Show
   | Paste
   deriving (Eq, Show)


### PR DESCRIPTION
Closes #1136.

Currently the code in this branch will print type synonyms, data and newtype definitions (the former as GADTs, the latter as "classic" type definitions), summarise data definitions if you ask for info on a constructor, and print the type of functions. It will also comment each with the module it is defined in. The existing code is not production-ready as I've rewritten some pretty-printing code where some functions exist already as a helper function for the module exports printer that could be adapted and reused. Plus, my programming style is pretty pointfree-heavy which might not be considered readable (I try to structure it to be more readable than the pointful alternative but if you're not familiar with the combinators it might be rough). If we ignore this, though, I've run up against three main issues:

1. I can't figure out how to resolve names in a free-standing way (i.e. If I have a name like `map`, how do I resolve that to `Data.Functor.map`). This seems to only exist as part of the compilation code that simply mutates a module, there is no pure function to do this and the logic is complicated enough that I am worried about attempting to extract it. `:t` and `:k` get around this by just sticking the argument into a syntactically-valid place in a module, compiling it, and extracting the information after the fact. Since the argument to `:i` could be a constructor, a type, or a function, this is not really workable. I can probably get quite far by trying various syntactic positions in turn until one of them compiles, but that seems like overkill if all I want is to resolve the name.
2. I can't figure out how to resolve the classes a type implements, given an `Environment`. There's a type called `TypeClassDictionaryInScope` which seems to be related to instances, and I think I can use the `tcdInstanceTypes` field with `any (unifiesWith myType)` but I don't know what the `unifiesWith` function corresponds to. `Type` has a derived `Eq` instance so, for example, `forall a b c. a -> b -> c` and `forall a b c. c -> b -> a` would not be considered equal using `(==)` despite obviously being the same type.
3. Related to 2: I don't know how to tell if a given function is from a typeclass or not, apart from to iterate through every typeclass in the module it was imported from and check all its members for matching names. What if a module reexports a typeclass member but not the typeclass? What if the typeclass is private but not the function? Is that even allowed? Do I have to traverse the import tree to find the original definition? Would that be done for me if I solved the name resolution issue in 1?