### PR TITLE
Update error message of `ErrorInDataBindingGroup` to include participating identifiers

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -153,7 +153,7 @@ data ErrorMessageHint
   | ErrorInDataConstructor (ProperName 'ConstructorName)
   | ErrorInTypeConstructor (ProperName 'TypeName)
   | ErrorInBindingGroup [Ident]
-  | ErrorInDataBindingGroup
+  | ErrorInDataBindingGroup [ProperName 'TypeName]
   | ErrorInTypeSynonym (ProperName 'TypeName)
   | ErrorInValueDeclaration Ident
   | ErrorInTypeDeclaration Ident

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -968,9 +968,9 @@ prettyPrintSingleError (PPEOptions codeColor full level showWiki) e = flip evalS
       paras [ detail
             , line $ "in binding group " ++ intercalate ", " (map showIdent nms)
             ]
-    renderHint ErrorInDataBindingGroup detail =
+    renderHint (ErrorInDataBindingGroup nms) detail =
       paras [ detail
-            , line "in data binding group"
+            , line $ "in data binding group " ++ intercalate ", " (map runProperName nms)
             ]
     renderHint (ErrorInTypeSynonym name) detail =
       paras [ detail

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -207,8 +207,8 @@ typeCheckAll moduleName _ = traverse go
     return $ DataDeclaration dtype name args dctors
   go (d@(DataBindingGroupDeclaration tys)) = do
     let syns = mapMaybe toTypeSynonym tys
-    let dataDecls = mapMaybe toDataDecl tys
-    let bindingGroupNames = (syns^..traverse._1) ++ (dataDecls^..traverse._2)
+        dataDecls = mapMaybe toDataDecl tys
+        bindingGroupNames = nub ((syns^..traverse._1) ++ (dataDecls^..traverse._2))
     warnAndRethrow (addHint (ErrorInDataBindingGroup bindingGroupNames)) $ do
       (syn_ks, data_ks) <- kindsOfAll moduleName syns (map (\(_, name, args, dctors) -> (name, args, concatMap snd dctors)) dataDecls)
       for_ (zip dataDecls data_ks) $ \((dtype, name, args, dctors), ctorKind) -> do


### PR DESCRIPTION
Should help with #2431 

Given the following code:
```purescript
data Foo = MakeFoo Bar
data Bar = MakeBar (Foo Int)
```

The error message is now:
```
  Could not match kind

    * -> *

  with kind

    *

  in data binding group Bar, Foo
```