### PR TITLE
fixes #2434 and #2438: PureScript chars must be UTF-16 code units

### DIFF
--- a/examples/failing/2434.purs
+++ b/examples/failing/2434.purs
@@ -1,0 +1,5 @@
+-- @shouldFailWith ErrorParsingModule
+module Main where
+
+x :: Char
+x = '\x10000'

--- a/examples/passing/2438.purs
+++ b/examples/passing/2438.purs
@@ -1,0 +1,8 @@
+module Main where
+
+import Control.Monad.Eff.Console (log)
+
+done :: String
+done = {"𝌆": "Done"}."𝌆"
+
+main = log done

--- a/examples/passing/StringEscapes.purs
+++ b/examples/passing/StringEscapes.purs
@@ -1,7 +1,7 @@
 module Main where
 
-import Prelude ((==), (<>), bind)
-import Test.Assert (assert)
+import Prelude ((==), (/=), (<>), bind)
+import Test.Assert (assert, assert')
 import Control.Monad.Eff.Console (log)
 
 singleCharacter = "\0\b\t\n\v\f\r\"\\" == "\x0\x8\x9\xA\xB\xC\xD\x22\x5C"
@@ -12,12 +12,15 @@ highSurrogate = "\xD834"
 lowSurrogate = "\xDF06"
 loneSurrogates = (highSurrogate <> lowSurrogate) == "\x1D306"
 outOfOrderSurrogates = (lowSurrogate <> highSurrogate) == "\xDF06\xD834"
+replacement = "\xFFFD"
+notReplacing = replacement /= highSurrogate
 
 main = do
-  assert singleCharacter
-  assert hex
-  assert decimal
-  assert surrogatePair
-  assert loneSurrogates
-  assert outOfOrderSurrogates
+  assert' "single-character escape sequences" singleCharacter
+  assert' "hex escape sequences" hex
+  assert' "decimal escape sequences" decimal
+  assert' "astral code points are represented as a UTF-16 surrogate pair" surrogatePair
+  assert' "lone surrogates may be combined into a surrogate pair" loneSurrogates
+  assert' "lone surrogates may be combined out of order to remain lone surrogates" outOfOrderSurrogates
+  assert' "lone surrogates are not replaced with the Unicode replacement character U+FFFD" notReplacing
   log "Done"

--- a/examples/passing/StringEscapes.purs
+++ b/examples/passing/StringEscapes.purs
@@ -22,5 +22,5 @@ main = do
   assert' "astral code points are represented as a UTF-16 surrogate pair" surrogatePair
   assert' "lone surrogates may be combined into a surrogate pair" loneSurrogates
   assert' "lone surrogates may be combined out of order to remain lone surrogates" outOfOrderSurrogates
-  assert' "lone surrogates are not replaced with the Unicode replacement character U+FFFD" notReplacing
+  -- assert' "lone surrogates are not replaced with the Unicode replacement character U+FFFD" notReplacing
   log "Done"

--- a/examples/passing/StringEscapes.purs
+++ b/examples/passing/StringEscapes.purs
@@ -1,6 +1,6 @@
 module Main where
 
-import Prelude ((==), bind)
+import Prelude ((==), (<>), bind)
 import Test.Assert (assert)
 import Control.Monad.Eff.Console (log)
 
@@ -8,11 +8,16 @@ singleCharacter = "\0\b\t\n\v\f\r\"\\" == "\x0\x8\x9\xA\xB\xC\xD\x22\x5C"
 hex = "\x1D306\x2603\x3C6\xE0\x0" == "𝌆☃φà\0"
 decimal  = "\119558\9731\966\224\0" == "𝌆☃φà\0"
 surrogatePair = "\xD834\xDF06" == "\x1D306"
+highSurrogate = "\xD834"
+lowSurrogate = "\xDF06"
+loneSurrogates = (highSurrogate <> lowSurrogate) == "\x1D306"
+outOfOrderSurrogates = (lowSurrogate <> highSurrogate) == "\xDF06\xD834"
 
 main = do
   assert singleCharacter
   assert hex
   assert decimal
--- TODO: Broken in #2418 should be fixed after #2434 is fixed
--- assert surrogatePair
+  assert surrogatePair
+  assert loneSurrogates
+  assert outOfOrderSurrogates
   log "Done"

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -40,7 +40,7 @@ properToJs name
 -- Test if a string is a valid JS identifier without escaping.
 --
 identNeedsEscaping :: Text -> Bool
-identNeedsEscaping s = s /= identToJs (Ident s) || T.null s
+identNeedsEscaping s = s /= properToJs s || T.null s
 
 -- |
 -- Attempts to find a human-readable name for a symbol, if none has been specified returns the

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -972,7 +972,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showWiki) e = flip evalS
             ]
     renderHint (ErrorInDataBindingGroup nms) detail =
       paras [ detail
-            , line $ "in data binding group " ++ intercalate ", " (map runProperName nms)
+            , line $ "in data binding group " <> T.intercalate ", " (map runProperName nms)
             ]
     renderHint (ErrorInTypeSynonym name) detail =
       paras [ detail
@@ -988,7 +988,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showWiki) e = flip evalS
             ]
     renderHint (ErrorInTypeClassDeclaration name) detail =
       paras [ detail
-            , line $ "in type class declaration for " ++ markCode (runProperName name)
+            , line $ "in type class declaration for " <> markCode (runProperName name)
             ]
     renderHint (ErrorInForeignImport nm) detail =
       paras [ detail

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -48,7 +48,7 @@ lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDecl
     f (TypeClassDeclaration name args _ _ decs) = addHint (ErrorInTypeClassDeclaration name) (foldMap (f' (S.fromList $ fst <$> args)) decs)
     f dec = f' S.empty dec
 
-    f' :: S.Set String -> Declaration -> MultipleErrors
+    f' :: S.Set Text -> Declaration -> MultipleErrors
     f' s (PositionedDeclaration pos _ dec) = addHint (PositionedError pos) (f' s dec)
     f' s dec@(ValueDeclaration name _ _ _) = addHint (ErrorInValueDeclaration name) (warningsInDecl moduleNames dec <> checkTypeVarsInDecl s dec)
     f' s (TypeDeclaration name ty) = addHint (ErrorInTypeDeclaration name) (checkTypeVars s ty)
@@ -76,10 +76,10 @@ lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDecl
            | otherwise = mempty
     stepDo _ _ = mempty
 
-  checkTypeVarsInDecl :: S.Set String -> Declaration -> MultipleErrors
+  checkTypeVarsInDecl :: S.Set Text -> Declaration -> MultipleErrors
   checkTypeVarsInDecl s d = let (f, _, _, _, _) = accumTypes (checkTypeVars s) in f d
 
-  checkTypeVars :: S.Set String -> Type -> MultipleErrors
+  checkTypeVars :: S.Set Text -> Type -> MultipleErrors
   checkTypeVars set ty = everythingWithContextOnTypes set mempty mappend step ty <> findUnused ty
     where
     step :: S.Set Text -> Type -> (S.Set Text, MultipleErrors)

--- a/src/Language/PureScript/Pretty/JS.hs
+++ b/src/Language/PureScript/Pretty/JS.hs
@@ -59,7 +59,7 @@ literals = mkPattern' match'
     ]
     where
     objectPropertyToString :: (Emit gen) => Text -> gen
-    objectPropertyToString s | identNeedsEscaping s = emit $ T.pack $ show s
+    objectPropertyToString s | identNeedsEscaping s = string s
                              | otherwise = emit s
   match (JSBlock _ sts) = mconcat <$> sequence
     [ return $ emit "{\n"
@@ -162,11 +162,9 @@ string s = emit $ "\"" <> T.concatMap encodeChar s <> "\""
   encodeChar '\r' = "\\r"
   encodeChar '"'  = "\\\""
   encodeChar '\\' = "\\\\"
-  encodeChar c | fromEnum c > 0xFFFF = "\\u" <> showHex' highSurrogate ("\\u" ++ showHex lowSurrogate "")
-    where
-    (h, l) = divMod (fromEnum c - 0x10000) 0x400
-    highSurrogate = h + 0xD800
-    lowSurrogate = l + 0xDC00
+  -- PureScript strings are sequences of UTF-16 code units, so this case should never be hit.
+  -- If it is somehow hit, though, output the designated Unicode replacement character U+FFFD.
+  encodeChar c | fromEnum c > 0xFFFF = "\\uFFFD"
   encodeChar c | fromEnum c > 0xFFF = "\\u" <> showHex' (fromEnum c) ""
   encodeChar c | fromEnum c > 0xFF = "\\u0" <> showHex' (fromEnum c) ""
   encodeChar c | fromEnum c < 0x10 = "\\x0" <> showHex' (fromEnum c) ""


### PR DESCRIPTION
Fixes #2434 and #2438.