### PR TITLE
Use HTTPS to query Pursuit

### DIFF
--- a/src/Language/PureScript/Ide/Pursuit.hs
+++ b/src/Language/PureScript/Ide/Pursuit.hs
@@ -36,7 +36,7 @@ import qualified Pipes.Prelude                 as P
 queryPursuit :: Text -> IO ByteString
 queryPursuit q = do
   let qClean = T.dropWhileEnd (== '.') q
-  req' <- parseRequest "http://pursuit.purescript.org/search"
+  req' <- parseRequest "https://pursuit.purescript.org/search"
   let req = req'
         { queryString= "q=" <> (fromString . T.unpack) qClean
         , requestHeaders=[(hAccept, "application/json")]


### PR DESCRIPTION
Fixes #2074

I tested with `tcpdump port 443` and could see the HTTPS traffic going to the Linode box when querying Pursuit inside Atom.