### PR TITLE
Fix windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ version: '{build}'
 environment:
   # Keep the path as short as possible, just in case.
   STACK_ROOT: c:\s
+  STACK_VER: 1.2.0
   RELEASE_USER: purescript
   RELEASE_REPO: purescript
 cache:
@@ -15,7 +16,9 @@ install:
 - ps: |
     New-Item -ItemType Directory -Force -Path C:\tools
     $env:Path += ";C:\tools"
-    (New-Object Net.WebClient).DownloadFile('https://www.stackage.org/stack/windows-x86_64', 'c:\tools\stack.zip')
+    $stackRelease = "stack-$env:STACK_VER-windows-x86_64"
+    $downloadUrl = "https://github.com/commercialhaskell/stack/releases/download/v$env:STACK_VER/$stackRelease.zip"
+    (New-Object Net.WebClient).DownloadFile($downloadUrl, 'c:\tools\stack.zip')
     pushd c:\tools
     7z x c:\tools\stack.zip stack.exe
     popd


### PR DESCRIPTION
The stack windows binary archive seems to have changed from a .zip to a
.tar.gz, which is confusing 7zip - it seems 7zip uses the file name to
guess what kind of archive it is.