### PR TITLE
Use writeUTF8File in psc-bundle

### DIFF
--- a/psc-bundle/Main.hs
+++ b/psc-bundle/Main.hs
@@ -20,7 +20,7 @@ import System.FilePath (takeDirectory)
 import System.FilePath.Glob (glob)
 import System.Exit (exitFailure)
 import System.IO (stderr, stdout, hPutStrLn, hSetEncoding, utf8)
-import System.IO.UTF8 (readUTF8File)
+import System.IO.UTF8 (readUTF8File, writeUTF8File)
 import System.Directory (createDirectoryIfMissing)
 
 import Language.PureScript.Bundle
@@ -110,7 +110,7 @@ main = do
       case optionsOutputFile opts of
         Just outputFile -> do
           createDirectoryIfMissing True (takeDirectory outputFile)
-          writeFile outputFile js
+          writeUTF8File outputFile js
         Nothing -> putStrLn js
   where
   infoModList = Opts.fullDesc <> headerInfo <> footerInfo


### PR DESCRIPTION
I am hoping that this change will fix an error I saw when running psc-bundle for Pulp in the windows CI:

```
psc-bundle: pulp.js: commitBuffer: invalid argument (invalid character)
```

Unfortunately I can't test this effectively since I'm not on windows. We might also need to do something about the `putStrLn` on the next line but I'm not sure what that might be.

I believe the above error was triggered by non-ascii characters in comments in the `purescript-now` package, e.g.: https://github.com/purescript-contrib/purescript-now/blob/dcdd05d630ee4ca8973665999c05ac627712fb19/src/Control/Monad/Eff/Now.purs#L24