### PR TITLE
psc-package: display full path in 'packages.json does not exist' error messsage

### DIFF
--- a/psc-package/Main.hs
+++ b/psc-package/Main.hs
@@ -119,7 +119,7 @@ readPackageSet PackageConfig{ set } = do
   let dbFile = ".psc-package" </> fromText set </> ".set" </> "packages.json"
   exists <- testfile dbFile
   unless exists $ do
-    echo "packages.json does not exist"
+    echo $ format (fp%" does not exist") dbFile
     exit (ExitFailure 1)
   mdb <- Aeson.decodeStrict . encodeUtf8 <$> readTextFile dbFile
   case mdb of


### PR DESCRIPTION
This is a very minor change to the user experience, but helpful for a check in my Makefile (and maybe some other scripts in the future). Not critical, though, so let me know if you'd rather not pull in the change.

With this change, doing a `psc-package sources` without having done an `update` first displays
```
.psc-package/psc-0.10.2/.set/packages.json does not exist
```

instead of
```
packages.json does not exist
```