### PR TITLE
Update links to wiki

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -289,8 +289,8 @@ onTypesInErrorMessageM f (ErrorMessage hints simple) = ErrorMessage <$> traverse
   gTypeSearch (TSBefore env) = pure (TSBefore env)
   gTypeSearch (TSAfter result) = TSAfter <$> traverse (traverse f) result
 
-wikiUri :: ErrorMessage -> Text
-wikiUri e = "https://github.com/purescript/purescript/wiki/Error-Code-" <> errorCode e
+errorDocUri :: ErrorMessage -> Text
+errorDocUri e = "https://github.com/purescript/documentation/blob/master/errors/" <> errorCode e <> ".md"
 
 -- TODO Other possible suggestions:
 -- WildcardInferredType - source span not small enough
@@ -373,7 +373,7 @@ data PPEOptions = PPEOptions
   { ppeCodeColor :: Maybe (ANSI.ColorIntensity, ANSI.Color) -- ^ Color code with this color... or not
   , ppeFull      :: Bool -- ^ Should write a full error message?
   , ppeLevel     :: Level -- ^ Should this report an error or a warning?
-  , ppeShowWiki  :: Bool -- ^ Should show a link to error message's wiki page?
+  , ppeShowDocs  :: Bool -- ^ Should show a link to error message's doc page?
   }
 
 -- | Default options for PPEOptions
@@ -382,7 +382,7 @@ defaultPPEOptions = PPEOptions
   { ppeCodeColor = Just defaultCodeColor
   , ppeFull      = False
   , ppeLevel     = Error
-  , ppeShowWiki  = True
+  , ppeShowDocs  = True
   }
 
 
@@ -390,7 +390,7 @@ defaultPPEOptions = PPEOptions
 -- Pretty print a single error, simplifying if necessary
 --
 prettyPrintSingleError :: PPEOptions -> ErrorMessage -> Box.Box
-prettyPrintSingleError (PPEOptions codeColor full level showWiki) e = flip evalState defaultUnknownMap $ do
+prettyPrintSingleError (PPEOptions codeColor full level showDocs) e = flip evalState defaultUnknownMap $ do
   em <- onTypesInErrorMessageM replaceUnknowns (if full then e else simplifyErrorMessage e)
   um <- get
   return (prettyPrintErrorMessage um em)
@@ -405,10 +405,10 @@ prettyPrintSingleError (PPEOptions codeColor full level showWiki) e = flip evalS
       ] ++
       maybe [] (return . Box.moveDown 1) typeInformation ++
       [ Box.moveDown 1 $ paras
-          [ line $ "See " <> wikiUri e <> " for more information, "
+          [ line $ "See " <> errorDocUri e <> " for more information, "
           , line $ "or to contribute content related to this " <> levelText <> "."
           ]
-      | showWiki
+      | showDocs
       ]
     where
     typeInformation :: Maybe Box.Box

--- a/src/Language/PureScript/Errors/JSON.hs
+++ b/src/Language/PureScript/Errors/JSON.hs
@@ -52,7 +52,7 @@ toJSONError verbose level e =
   JSONError (toErrorPosition <$> sspan)
             (P.renderBox (P.prettyPrintSingleError (P.PPEOptions Nothing verbose level False) (P.stripModuleAndSpan e)))
             (P.errorCode e)
-            (P.wikiUri e)
+            (P.errorDocUri e)
             (P.spanName <$> sspan)
             (P.runModuleName <$> P.errorModule e)
             (toSuggestion e)

--- a/src/Language/PureScript/Interactive/Message.hs
+++ b/src/Language/PureScript/Interactive/Message.hs
@@ -27,8 +27,8 @@ helpMessage = "The following commands are available:\n\n    " ++
                ]
 
   extraHelp =
-    "Further information is available on the PureScript wiki:\n" ++
-    " --> https://github.com/purescript/purescript/wiki/psci"
+    "Further information is available on the PureScript documentation repository:\n" ++
+    " --> https://github.com/purescript/documentation/blob/master/PSCi.md"
 
 -- | The welcome prologue.
 prologueMessage :: String
@@ -48,7 +48,7 @@ supportModuleMessage = unlines
   , ""
   , "  psc-package install psci-support"
   , ""
-  , "For help getting started, visit http://wiki.purescript.org/PSCi"
+  , "For help getting started, visit https://github.com/purescript/documentation/blob/master/PSCi.md"
   ]
 
 -- | The quit message.


### PR DESCRIPTION
The compiler still displays links to all of these:
* https://github.com/purescript/purescript/wiki/Error-Code-*
* https://github.com/purescript/purescript/wiki/psci
* http://wiki.purescript.org/PSCi

However we are moving to use the [purescript/documentation](https://github.com/purescript/documentation) repo.

Also do you think it makes sense to tag releases on the documentation repo and have the compiler point at specific versions, instead of always pointing at master?