### PR TITLE
Error hints in psc-ide

### DIFF
--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -29,7 +29,7 @@ data PscIdeError
     | ModuleNotFound ModuleIdent
     | ModuleFileNotFound ModuleIdent
     | ParseError P.ParseError Text
-    | RebuildError [(JSONError, Maybe Text)]
+    | RebuildError [(JSONError, Maybe Value)]
 
 instance ToJSON PscIdeError where
   toJSON (RebuildError errs) = object
@@ -41,8 +41,10 @@ instance ToJSON PscIdeError where
     , "result" .= textError err
     ]
 
-addHint :: (ToJSON a, ToJSON b) => (a, b) -> Value
-addHint (err, d) = addKey ("psc-ide-hint", toJSON d) (toJSON err )
+addHint :: (ToJSON a) => (a, Maybe Value) -> Value
+addHint (err, v) = case v of
+  Just v' -> addKey ("psc-ide-hint", v') (toJSON err)
+  Nothing -> toJSON err
 
 addKey :: (Text, Value) -> Value -> Value
 addKey (k, v) (Object hashMap) = Object (HM.insert k v hashMap)

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -17,6 +17,7 @@ module Language.PureScript.Ide.Error
        ) where
 
 import           Data.Aeson
+import qualified Data.HashMap.Strict as HM
 import           Language.PureScript.Errors.JSON
 import           Language.PureScript.Ide.Types   (ModuleIdent)
 import           Protolude
@@ -28,17 +29,24 @@ data PscIdeError
     | ModuleNotFound ModuleIdent
     | ModuleFileNotFound ModuleIdent
     | ParseError P.ParseError Text
-    | RebuildError [JSONError]
+    | RebuildError [(JSONError, Maybe Text)]
 
 instance ToJSON PscIdeError where
   toJSON (RebuildError errs) = object
     [ "resultType" .= ("error" :: Text)
-    , "result" .= errs
+    , "result" .= map addHint errs
     ]
   toJSON err = object
     [ "resultType" .= ("error" :: Text)
     , "result" .= textError err
     ]
+
+addHint :: (ToJSON a, ToJSON b) => (a, b) -> Value
+addHint (err, d) = addKey ("psc-ide-hint", toJSON d) (toJSON err )
+
+addKey :: (Text, Value) -> Value -> Value
+addKey (k, v) (Object hashMap) = Object (HM.insert k v hashMap)
+addKey _ _ = panic "Not an object"
 
 textError :: PscIdeError -> Text
 textError (GeneralError msg)          = msg

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -24,6 +24,7 @@ module Language.PureScript.Ide.State
   , insertModule
   , insertExternsSTM
   , getAllModules
+  , getStage1
   , populateStage2
   , populateStage3
   , populateStage3STM

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,3 @@
-resolver: lts-7.9
+resolver: lts-6.25
 packages:
 - '.'
-extra-deps:
-- pipes-http-1.0.2
-- wai-websockets-3.0.0.9
-- websockets-0.9.6.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,7 @@
-resolver: lts-6.25
+resolver: lts-7.9
 packages:
 - '.'
+extra-deps:
+- pipes-http-1.0.2
+- wai-websockets-3.0.0.9
+- websockets-0.9.6.2


### PR DESCRIPTION
This makes psc-ide add hints to specific errors.

1. `ModuleNotFound`: If the module was parsed as a source file but doesn't show up in the output/ directory it's likely the project needs to be fully rebuilt.

2. `MissingFFIModule`: Point out where to create the FFI file

3. `HoleInferredType`: JSON describing the result of type directed search for the typed hole 

I then pretty print these hints and tack them onto the json errors at a `"psc-ide-hint"` field, which I consider a horrible hack 🤕 I'd prefer to pass the json errors on unmodified and instead add more structure to the error reporting. Just thought I'd put the code out there so we could brainstorm about a few more errors that `psc-ide` could add hints to.