### PR TITLE
Fix version bounds on language-javascript

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -124,7 +124,7 @@ library
                    haskeline >= 0.7.0.0,
                    http-client >= 0.4.30 && <0.5,
                    http-types -any,
-                   language-javascript == 0.6.*,
+                   language-javascript >= 0.6.0.9 && < 0.7,
                    lens == 4.*,
                    lifted-base >= 0.2.3 && < 0.2.4,
                    monad-control >= 1.0.0.0 && < 1.1,


### PR DESCRIPTION
The JSAnnotSpace constructor was introduced in 0.6.0.9 and therefore
this should be the lower bound (since we match on this constructor explicitly).