### PR TITLE
Add upper bound on turtle, fixes #2472

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -427,7 +427,7 @@ executable psc-package
                    optparse-applicative -any,
                    system-filepath -any,
                    text -any,
-                   turtle -any
+                   turtle <1.3
     main-is: Main.hs
     other-modules: Paths_purescript
     buildable: True


### PR DESCRIPTION
I think it would also be good to amend the cabal file in the same way in 0.10.3 via Hackage, as the docs build failed for the same reason so docs are missing for 0.10.3: https://hackage.haskell.org/package/purescript/maintain