### PR TITLE
Add package information to re-exports

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -511,6 +511,7 @@ test-suite tests
                    aeson -any,
                    aeson-better-errors -any,
                    base-compat -any,
+                   bower-json -any,
                    boxes -any,
                    bytestring -any,
                    containers -any,

--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -33,7 +33,7 @@ renderModulesAsMarkdown ::
   [P.Module] ->
   m Text
 renderModulesAsMarkdown =
-  fmap (runDocs . modulesAsMarkdown) . Convert.convertModules
+  fmap (runDocs . modulesAsMarkdown) . Convert.convertModules Local
 
 modulesAsMarkdown :: [Module] -> Docs
 modulesAsMarkdown = mapM_ moduleAsMarkdown
@@ -45,7 +45,8 @@ moduleAsMarkdown Module{..} = do
   for_ modComments tell'
   mapM_ (declAsMarkdown modName) modDeclarations
   spacer
-  for_ modReExports $ \(mn, decls) -> do
+  for_ modReExports $ \(mn', decls) -> do
+    let mn = ignorePackage mn'
     headerLevel 3 $ "Re-exported from " <> P.runModuleName mn <> ":"
     spacer
     mapM_ (declAsMarkdown mn) decls

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -15,6 +15,7 @@ import Control.Monad
 import Control.Monad.Error.Class (MonadError)
 import Control.Monad.State (runStateT)
 import Control.Monad.Writer.Strict (runWriterT)
+import Data.List (find)
 import qualified Data.Map as Map
 import Data.Text (Text)
 
@@ -42,8 +43,17 @@ convertModulesInPackage modules =
     map P.getModuleName (takeLocals modules)
   go =
     map ignorePackage
-     >>> convertModules
+     >>> convertModules withPackage
      >>> fmap (filter ((`elem` localNames) . modName))
+
+  withPackage :: P.ModuleName -> InPackage P.ModuleName
+  withPackage mn =
+    case find ((== mn) . P.getModuleName . ignorePackage) modules of
+      Just m ->
+        fmap P.getModuleName m
+      Nothing ->
+        P.internalError $ "withPackage: missing module:" ++
+          show (P.runModuleName mn)
 
 -- |
 -- Convert a group of modules to the intermediate format, designed for
@@ -61,12 +71,13 @@ convertModulesInPackage modules =
 --
 convertModules ::
   (MonadError P.MultipleErrors m) =>
+  (P.ModuleName -> InPackage P.ModuleName) ->
   [P.Module] ->
   m [Module]
-convertModules =
+convertModules withPackage =
   P.sortModules
     >>> fmap (fst >>> map importPrim)
-    >=> convertSorted
+    >=> convertSorted withPackage
 
 importPrim :: P.Module -> P.Module
 importPrim = P.addDefaultImport (P.ModuleName [P.ProperName C.prim])
@@ -76,16 +87,17 @@ importPrim = P.addDefaultImport (P.ModuleName [P.ProperName C.prim])
 --
 convertSorted ::
   (MonadError P.MultipleErrors m) =>
+  (P.ModuleName -> InPackage P.ModuleName) ->
   [P.Module] ->
   m [Module]
-convertSorted modules = do
+convertSorted withPackage modules = do
   (env, convertedModules) <- second (map convertSingleModule) <$> partiallyDesugar modules
 
   modulesWithTypes <- typeCheckIfNecessary modules convertedModules
   let moduleMap = Map.fromList (map (modName &&& id) modulesWithTypes)
 
   let traversalOrder = map P.getModuleName modules
-  pure (Map.elems (updateReExports env traversalOrder moduleMap))
+  pure (Map.elems (updateReExports env traversalOrder withPackage moduleMap))
 
 -- |
 -- If any exported value declarations have either wildcard type signatures, or

--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -4,7 +4,7 @@ module Language.PureScript.Docs.Convert.ReExports
 
 import Prelude.Compat
 
-import Control.Arrow ((&&&), second)
+import Control.Arrow ((&&&), first, second)
 import Control.Monad
 import Control.Monad.Reader.Class (MonadReader, ask)
 import Control.Monad.State.Class (MonadState, gets, modify)
@@ -35,9 +35,10 @@ import qualified Language.PureScript as P
 updateReExports ::
   P.Env ->
   [P.ModuleName] ->
+  (P.ModuleName -> InPackage P.ModuleName) ->
   Map P.ModuleName Module ->
   Map P.ModuleName Module
-updateReExports env order = execState action
+updateReExports env order withPackage = execState action
   where
   action =
     void (traverse go order)
@@ -45,7 +46,7 @@ updateReExports env order = execState action
   go mn = do
     mdl <- lookup' mn
     reExports <- getReExports env mn
-    let mdl' = mdl { modReExports = reExports }
+    let mdl' = mdl { modReExports = map (first withPackage) reExports }
     modify (Map.insert mn mdl')
 
   lookup' mn = do


### PR DESCRIPTION
This gets us most of the way towards fixing the following issue:

  https://github.com/purescript/pursuit/issues/209

This change preserves backwards-compatibility in the parser by
pretending that all re-exports come from local modules (i.e. in the same
package) in JSON produced by older compilers. This is obviously not
ideal but it's most likely going to be temporary and it's better than
any alternatives I can think of.