### PR TITLE
Add command to apply minor package updates

### DIFF
--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -196,10 +196,9 @@ getVersionFromGitTag = do
   where
   trimWhitespace =
     dropWhile isSpace >>> reverse >>> dropWhile isSpace >>> reverse
-  parseMay str =
-    (str,) <$> D.parseVersion' (dropPrefix "v" str)
-  dropPrefix prefix str =
-    fromMaybe str (stripPrefix prefix str)
+  parseMay str = do
+    digits <- stripPrefix "v" str
+    (str,) <$> D.parseVersion' digits
 
 getBowerRepositoryInfo :: PackageMeta -> PrepareM (D.GithubUser, D.GithubRepo)
 getBowerRepositoryInfo = either (userError . BadRepositoryField) return . tryExtract

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -148,9 +148,8 @@ displayUserError e = case e of
             , "version."
             ])
         , spacer
-        , para "Note: tagged versions must be in one of the following forms:"
+        , para "Note: tagged versions must be in the following form:"
         , indented (para "* v{MAJOR}.{MINOR}.{PATCH} (example: \"v1.6.2\")")
-        , indented (para "* {MAJOR}.{MINOR}.{PATCH} (example: \"1.6.2\")")
         , spacer
         , para (concat
            [ "If the version you are publishing is not yet tagged, you might "

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -148,8 +148,8 @@ displayUserError e = case e of
             , "version."
             ])
         , spacer
-        , para "Note: tagged versions must be in the following form:"
-        , indented (para "* v{MAJOR}.{MINOR}.{PATCH} (example: \"v1.6.2\")")
+        , para "Note: tagged versions must be in the form"
+        , indented (para "v{MAJOR}.{MINOR}.{PATCH} (example: \"v1.6.2\")")
         , spacer
         , para (concat
            [ "If the version you are publishing is not yet tagged, you might "


### PR DESCRIPTION
This command checks for new tags on all repos and can also apply minor updates automatically. I've used it to update the package set and also find all those packages which are currently not on the latest major version.