### PR TITLE
Add naive functor deriving

### DIFF
--- a/examples/passing/DerivingFunctor.purs
+++ b/examples/passing/DerivingFunctor.purs
@@ -4,7 +4,11 @@ import Prelude
 import Control.Monad.Eff.Console (log)
 import Test.Assert
 
-data M f a = M0 a (Array a) | M1 Int | M2 (f a)
+data M f a
+  = M0 a (Array a)
+  | M1 Int
+  | M2 (f a)
+  | M3 { foo :: Int, bar :: a, baz :: f a }
 
 derive instance eqM :: (Eq (f a), Eq a) => Eq (M f a)
 
@@ -16,4 +20,5 @@ main = do
   assert $ map show (M0 0 [1, 2] :: MA Int) == M0 "0" ["1", "2"]
   assert $ map show (M1 0 :: MA Int) == M1 0
   assert $ map show (M2 [0, 1] :: MA Int) == M2 ["0", "1"]
+  assert $ map show (M3 {foo: 0, bar: 1, baz: [2, 3]} :: MA Int) == M3 {foo: 0, bar: "1", baz: ["2", "3"]}
   log "Done"

--- a/examples/passing/DerivingFunctor.purs
+++ b/examples/passing/DerivingFunctor.purs
@@ -1,0 +1,19 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console (log)
+import Test.Assert
+
+data M f a = M0 a (Array a) | M1 Int | M2 (f a)
+
+derive instance eqM :: (Eq (f a), Eq a) => Eq (M f a)
+
+derive instance functorM :: Functor f => Functor (M f)
+
+type MA = M Array
+
+main = do
+  assert $ map show (M0 0 [1, 2] :: MA Int) == M0 "0" ["1", "2"]
+  assert $ map show (M1 0 :: MA Int) == M1 0
+  assert $ map show (M2 [0, 1] :: MA Int) == M2 ["0", "1"]
+  log "Done"

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -139,6 +139,9 @@ compose = "compose"
 composeFlipped :: Text
 composeFlipped = "composeFlipped"
 
+map :: Text
+map = "map"
+
 -- Functions
 
 negate :: Text


### PR DESCRIPTION
This is very basic support for deriving `Functor` in special cases: It assumes that all type constructors of kind `* -> *` applied to a type, which includes the index, implement `Functor`.  You can see examples in `example/passing/DerivingFunctor.purs`:

It doesn't look at any other argument position, thus the following is not yet supported:

```purescript
data X a = X (Either a Int)
```

Eventually I see this analysing type argument variance to work out which class (`Bifunctor`, `Profunctor`, `Contravariant`, etc) it should use when transforming.  Once we have that, we could extend it to deriving those other kinds of functor too.  Also it could probably be generalised to some kind of structural deriving thing that we can use to implement deriving `Foldable`, `Bifoldable`, `Traversable`, etc.

/cc @damncabbage for discussion :)