### PR TITLE
Derive instances when data types use type synonyms

### DIFF
--- a/examples/passing/DeriveNewtype.purs
+++ b/examples/passing/DeriveNewtype.purs
@@ -4,7 +4,9 @@ import Control.Monad.Eff.Console (log)
 
 import Data.Newtype
 
-newtype Test = Test String
+type MyString = String
+
+newtype Test = Test MyString
 
 derive instance newtypeTest :: Newtype Test _
 

--- a/examples/passing/DeriveWithNestedSynonyms.purs
+++ b/examples/passing/DeriveWithNestedSynonyms.purs
@@ -1,0 +1,29 @@
+module Main where
+	
+import Prelude
+import Control.Monad.Eff.Console (log)
+
+type L = {}
+data X = X L
+derive instance eqX :: Eq X
+
+type M = {}
+data Y = Y {foo :: M}
+derive instance eqY :: Eq Y
+
+type N = {}
+data Z = Z N
+derive instance eqZ :: Eq Z
+
+type Foo = String
+
+type Bar = { foo :: Foo }
+
+type Baz = { baz :: Bar }
+
+newtype T = T Baz
+
+derive instance eqT :: Eq T
+derive instance ordT :: Ord T
+
+main = log "Done"

--- a/examples/passing/Deriving.purs
+++ b/examples/passing/Deriving.purs
@@ -10,7 +10,9 @@ derive instance eqV :: Eq V
 
 derive instance ordV :: Ord V
 
-data X = X Int | Y String
+type MyString = String
+
+data X = X Int | Y MyString
 
 derive instance eqX :: Eq X
 

--- a/examples/passing/GenericsRep.purs
+++ b/examples/passing/GenericsRep.purs
@@ -27,7 +27,9 @@ derive instance genericZ :: Generic Z _
 instance eqZ :: Eq Z where
   eq x y = genericEq x y
 
-newtype W = W { x :: Int, y :: String }
+type MyString = String
+
+newtype W = W { x :: Int, y :: MyString }
 
 derive instance genericW :: Generic W _
 

--- a/examples/passing/NewtypeInstance.purs
+++ b/examples/passing/NewtypeInstance.purs
@@ -4,7 +4,9 @@ import Prelude
 import Control.Monad.Eff
 import Control.Monad.Eff.Console
 
-newtype X = X String
+type MyString = String 
+
+newtype X = X MyString
 
 derive newtype instance showX :: Show X
 

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -62,6 +62,6 @@ desugar externs =
     >=> desugarImports externs
     >=> rebracket externs
     >=> traverse checkFixityExports
-    >=> traverse deriveInstances
+    >=> traverse (deriveInstances externs)
     >=> desugarTypeClasses externs
     >=> traverse createBindingGroupsModule

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -23,10 +23,8 @@ import           Language.PureScript.Kinds
 import           Language.PureScript.Names
 import           Language.PureScript.Types
 import           Language.PureScript.TypeChecker (checkNewtype)
-import           Language.PureScript.TypeChecker.Synonyms (replaceAllTypeSynonyms')
+import           Language.PureScript.TypeChecker.Synonyms (SynonymMap, replaceAllTypeSynonymsM)
 import qualified Language.PureScript.Constants as C
-
-type SynonymMap = M.Map (Qualified (ProperName 'TypeName)) ([(Text, Maybe Kind)], Type)
 
 -- | Elaborates deriving instance declarations by code generation.
 deriveInstances
@@ -38,6 +36,8 @@ deriveInstances
 deriveInstances externs (Module ss coms mn ds exts) =
     Module ss coms mn <$> mapM (deriveInstance mn synonyms ds) ds <*> pure exts
   where
+    -- We need to collect type synonym information, since synonyms will not be
+    -- removed until later, during type checking.
     synonyms :: SynonymMap
     synonyms =
         M.fromList $ (externs >>= \ExternsFile{..} -> mapMaybe (fromExternsDecl efModuleName) efDeclarations)
@@ -51,13 +51,6 @@ deriveInstances externs (Module ss coms mn ds exts) =
         fromLocalDecl (PositionedDeclaration _ _ d) = fromLocalDecl d
         fromLocalDecl _ = Nothing
 
-replaceAllTypeSynonymsM
-  :: MonadError MultipleErrors m
-  => SynonymMap
-  -> Type
-  -> m Type
-replaceAllTypeSynonymsM syns = either throwError pure . replaceAllTypeSynonyms' syns
-
 -- | Takes a declaration, and if the declaration is a deriving TypeInstanceDeclaration,
 -- elaborates that into an instance declaration via code generation.
 deriveInstance
@@ -67,19 +60,19 @@ deriveInstance
   -> [Declaration]
   -> Declaration
   -> m Declaration
-deriveInstance mn _ ds (TypeInstanceDeclaration nm deps className tys@[ty] DerivedInstance)
+deriveInstance mn syns ds (TypeInstanceDeclaration nm deps className tys@[ty] DerivedInstance)
   | className == Qualified (Just dataGeneric) (ProperName C.generic)
   , Just (Qualified mn' tyCon, args) <- unwrapTypeConstructor ty
   , mn == fromMaybe mn mn'
-  = TypeInstanceDeclaration nm deps className tys . ExplicitInstance <$> deriveGeneric mn ds tyCon args
+  = TypeInstanceDeclaration nm deps className tys . ExplicitInstance <$> deriveGeneric mn syns ds tyCon args
   | className == Qualified (Just dataEq) (ProperName "Eq")
   , Just (Qualified mn' tyCon, _) <- unwrapTypeConstructor ty
   , mn == fromMaybe mn mn'
-  = TypeInstanceDeclaration nm deps className tys . ExplicitInstance <$> deriveEq mn ds tyCon
+  = TypeInstanceDeclaration nm deps className tys . ExplicitInstance <$> deriveEq mn syns ds tyCon
   | className == Qualified (Just dataOrd) (ProperName "Ord")
   , Just (Qualified mn' tyCon, _) <- unwrapTypeConstructor ty
   , mn == fromMaybe mn mn'
-  = TypeInstanceDeclaration nm deps className tys . ExplicitInstance <$> deriveOrd mn ds tyCon
+  = TypeInstanceDeclaration nm deps className tys . ExplicitInstance <$> deriveOrd mn syns ds tyCon
 deriveInstance mn syns ds (TypeInstanceDeclaration nm deps className [wrappedTy, unwrappedTy] DerivedInstance)
   | className == Qualified (Just dataNewtype) (ProperName "Newtype")
   , Just (Qualified mn' tyCon, args) <- unwrapTypeConstructor wrappedTy
@@ -176,11 +169,12 @@ dataNewtype = ModuleName [ ProperName "Data", ProperName "Newtype" ]
 deriveGeneric
   :: forall m. (MonadError MultipleErrors m, MonadSupply m)
   => ModuleName
+  -> SynonymMap
   -> [Declaration]
   -> ProperName 'TypeName
   -> [Type]
   -> m [Declaration]
-deriveGeneric mn ds tyConNm dargs = do
+deriveGeneric mn syns ds tyConNm dargs = do
   tyCon <- findTypeDecl tyConNm ds
   toSpine <- mkSpineFunction tyCon
   fromSpine <- mkFromSpineFunction tyCon
@@ -204,12 +198,12 @@ deriveGeneric mn ds tyConNm dargs = do
       mkCtorClause :: (ProperName 'ConstructorName, [Type]) -> m CaseAlternative
       mkCtorClause (ctorName, tys) = do
         idents <- replicateM (length tys) freshIdent'
+        tys' <- mapM (replaceAllTypeSynonymsM syns) tys
+        let caseResult idents =
+              App (prodConstructor (Literal . StringLiteral . showQualified runProperName $ Qualified (Just mn) ctorName))
+                . Literal . ArrayLiteral
+                $ zipWith toSpineFun (map (Var . Qualified Nothing) idents) tys'
         return $ CaseAlternative [ConstructorBinder (Qualified (Just mn) ctorName) (map VarBinder idents)] (Right (caseResult idents))
-        where
-        caseResult idents =
-          App (prodConstructor (Literal . StringLiteral . showQualified runProperName $ Qualified (Just mn) ctorName))
-            . Literal . ArrayLiteral
-            $ zipWith toSpineFun (map (Var . Qualified Nothing) idents) tys
 
       toSpineFun :: Expr -> Type -> Expr
       toSpineFun i r | Just rec <- objectType r =
@@ -526,10 +520,11 @@ checkIsWildcard tyConNm _ =
 deriveEq ::
   forall m. (MonadError MultipleErrors m, MonadSupply m)
   => ModuleName
+  -> SynonymMap
   -> [Declaration]
   -> ProperName 'TypeName
   -> m [Declaration]
-deriveEq mn ds tyConNm = do
+deriveEq mn syns ds tyConNm = do
   tyCon <- findTypeDecl tyConNm ds
   eqFun <- mkEqFunction tyCon
   return [ ValueDeclaration (Ident C.eq) Public [] (Right eqFun) ]
@@ -559,7 +554,8 @@ deriveEq mn ds tyConNm = do
     mkCtorClause (ctorName, tys) = do
       identsL <- replicateM (length tys) (freshIdent "l")
       identsR <- replicateM (length tys) (freshIdent "r")
-      let tests = zipWith3 toEqTest (map (Var . Qualified Nothing) identsL) (map (Var . Qualified Nothing) identsR) tys
+      tys' <- mapM (replaceAllTypeSynonymsM syns) tys
+      let tests = zipWith3 toEqTest (map (Var . Qualified Nothing) identsL) (map (Var . Qualified Nothing) identsR) tys'
       return $ CaseAlternative [caseBinder identsL, caseBinder identsR] (Right (conjAll tests))
       where
       caseBinder idents = ConstructorBinder (Qualified (Just mn) ctorName) (map VarBinder idents)
@@ -578,10 +574,11 @@ deriveEq mn ds tyConNm = do
 deriveOrd ::
   forall m. (MonadError MultipleErrors m, MonadSupply m)
   => ModuleName
+  -> SynonymMap
   -> [Declaration]
   -> ProperName 'TypeName
   -> m [Declaration]
-deriveOrd mn ds tyConNm = do
+deriveOrd mn syns ds tyConNm = do
   tyCon <- findTypeDecl tyConNm ds
   compareFun <- mkCompareFunction tyCon
   return [ ValueDeclaration (Ident C.compare) Public [] (Right compareFun) ]
@@ -622,7 +619,8 @@ deriveOrd mn ds tyConNm = do
     mkCtorClauses ((ctorName, tys), isLast) = do
       identsL <- replicateM (length tys) (freshIdent "l")
       identsR <- replicateM (length tys) (freshIdent "r")
-      let tests = zipWith3 toOrdering (map (Var . Qualified Nothing) identsL) (map (Var . Qualified Nothing) identsR) tys
+      tys' <- mapM (replaceAllTypeSynonymsM syns) tys
+      let tests = zipWith3 toOrdering (map (Var . Qualified Nothing) identsL) (map (Var . Qualified Nothing) identsR) tys'
           extras | not isLast = [ CaseAlternative [ ConstructorBinder (Qualified (Just mn) ctorName) (replicate (length tys) NullBinder)
                                                   , NullBinder
                                                   ]

--- a/src/Language/PureScript/TypeChecker/Synonyms.hs
+++ b/src/Language/PureScript/TypeChecker/Synonyms.hs
@@ -5,43 +5,47 @@
 --
 module Language.PureScript.TypeChecker.Synonyms
   ( replaceAllTypeSynonyms
+  , replaceAllTypeSynonyms'
   ) where
 
-import Prelude.Compat
+import           Prelude.Compat
 
-import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.State
-
-import Data.Maybe (fromMaybe)
+import           Control.Monad.Error.Class (MonadError(..))
+import           Control.Monad.State
+import           Data.Maybe (fromMaybe)
 import qualified Data.Map as M
+import           Data.Text (Text)
+import           Language.PureScript.Environment
+import           Language.PureScript.Errors
+import           Language.PureScript.Kinds
+import           Language.PureScript.Names
+import           Language.PureScript.TypeChecker.Monad
+import           Language.PureScript.Types
 
-import Language.PureScript.Environment
-import Language.PureScript.Errors
-import Language.PureScript.TypeChecker.Monad
-import Language.PureScript.Types
-
--- |
--- Replace fully applied type synonyms.
---
-replaceAllTypeSynonyms' :: Environment -> Type -> Either MultipleErrors Type
-replaceAllTypeSynonyms' env = everywhereOnTypesTopDownM try
+-- | Replace fully applied type synonyms
+replaceAllTypeSynonyms'
+  :: M.Map (Qualified (ProperName 'TypeName)) ([(Text, Maybe Kind)], Type)
+  -> Type
+  -> Either MultipleErrors Type
+replaceAllTypeSynonyms' syns = everywhereOnTypesTopDownM try
   where
   try :: Type -> Either MultipleErrors Type
   try t = fromMaybe t <$> go 0 [] t
 
   go :: Int -> [Type] -> Type -> Either MultipleErrors (Maybe Type)
   go c args (TypeConstructor ctor)
-    | Just (synArgs, body) <- M.lookup ctor (typeSynonyms env)
+    | Just (synArgs, body) <- M.lookup ctor syns
     , c == length synArgs
     = let repl = replaceAllTypeVars (zip (map fst synArgs) args) body
       in Just <$> try repl
-    | Just (synArgs, _) <- M.lookup ctor (typeSynonyms env)
+    | Just (synArgs, _) <- M.lookup ctor syns
     , length synArgs > c
     = throwError . errorMessage $ PartiallyAppliedSynonym ctor
   go c args (TypeApp f arg) = go (c + 1) (arg : args) f
   go _ _ _ = return Nothing
 
+-- | Replace fully applied type synonyms
 replaceAllTypeSynonyms :: (e ~ MultipleErrors, MonadState CheckState m, MonadError e m) => Type -> m Type
 replaceAllTypeSynonyms d = do
   env <- getEnv
-  either throwError return $ replaceAllTypeSynonyms' env d
+  either throwError return $ replaceAllTypeSynonyms' (typeSynonyms env) d


### PR DESCRIPTION
Fixes #2481 
Fixes #2416
Fixes #1443

I would have liked to fix this by moving deriving into the type checker, but then we'd have to rearrange a whole bunch of stuff, so instead this just uses the externs to build a map of type synonym data, and then reuses the existing `replaceAllTypeSynonyms'` function to eliminate any synonyms in the instance head.