### PR TITLE
Remove Stackage badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ A small strongly typed programming language with expressive types that compiles 
 
 [![Hackage](https://img.shields.io/hackage/v/purescript.svg)](http://hackage.haskell.org/package/purescript) [![Build Status](https://api.travis-ci.org/purescript/purescript.svg?branch=master)](http://travis-ci.org/purescript/purescript)
 
-[![Stackage LTS 2](http://stackage.org/package/purescript/badge/lts-2)](http://stackage.org/lts-2/package/purescript)
-[![Stackage LTS 3](http://stackage.org/package/purescript/badge/lts-3)](http://stackage.org/lts-3/package/purescript)
-[![Stackage Nightly](http://stackage.org/package/purescript/badge/nightly)](http://stackage.org/nightly/package/purescript)
-
 ## Language info
 
 - [PureScript home](http://purescript.org)


### PR DESCRIPTION
Now that we no longer are in stackage I think we should remove these. LTS 2 and 3 were horribly outdated anyway.