### PR TITLE
[psc-ide] Fixes tests on windows

### DIFF
--- a/tests/Language/PureScript/Ide/Imports/IntegrationSpec.hs
+++ b/tests/Language/PureScript/Ide/Imports/IntegrationSpec.hs
@@ -28,7 +28,7 @@ outputFileShouldBe :: [Text] -> IO ()
 outputFileShouldBe expectation = do
   outFp <- (</> "src" </> "ImportsSpecOut.tmp") <$> Integration.projectDirectory
   outRes <- readUTF8FileT outFp
-  shouldBe (T.lines outRes) expectation
+  shouldBe (T.strip <$> T.lines outRes) expectation
 
 spec :: Spec
 spec = beforeAll_ setup . describe "Adding imports" $ do


### PR DESCRIPTION
On my local windows machine \r characters were not removed by Text.lines