### PR TITLE
'kind' is no longer a reserved word

### DIFF
--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -110,7 +110,7 @@ parseValueDeclaration = do
 
 parseExternDeclaration :: TokenParser Declaration
 parseExternDeclaration = reserved "foreign" *> indented *> reserved "import" *> indented *> parseExternAlt where
-  parseExternAlt = parseExternData <|> parseExternKind <|> parseExternTerm
+  parseExternAlt = parseExternData <|> P.try parseExternKind <|> parseExternTerm
 
   parseExternData = ExternDataDeclaration <$> (reserved "data" *> indented *> typeName)
                                           <*> (indented *> doubleColon *> parseKind)
@@ -167,11 +167,11 @@ parseImportDeclaration' = do
 parseDeclarationRef :: TokenParser DeclarationRef
 parseDeclarationRef =
   withSourceSpan PositionedDeclarationRef
-    $ (ValueRef <$> parseIdent)
+    $ (KindRef <$> P.try (reserved "kind" *> kindName))
+    <|> (ValueRef <$> parseIdent)
     <|> (ValueOpRef <$> parens parseOperator)
     <|> parseTypeRef
     <|> (TypeClassRef <$> (reserved "class" *> properName))
-    <|> (KindRef <$> (reserved "kind" *> kindName))
     <|> (ModuleRef <$> (indented *> reserved "module" *> moduleName))
     <|> (TypeOpRef <$> (indented *> reserved "type" *> parens parseOperator))
   where

--- a/src/Language/PureScript/Parser/Lexer.hs
+++ b/src/Language/PureScript/Parser/Lexer.hs
@@ -556,7 +556,6 @@ reservedPsNames :: [Text]
 reservedPsNames = [ "data"
                   , "newtype"
                   , "type"
-                  , "kind"
                   , "foreign"
                   , "import"
                   , "infixl"


### PR DESCRIPTION
This removes `kind` from the reserved word list, so that we can continue to use the word `kind` as an `Ident` (e.g. in Halogen and `purescript-dom`).

Before 0.11, we should decide whether we want to make `kind` a reserved word or not.

After this is merged, I'll make a 0.10.4 release. I will probably mark the user-defined kinds feature as experimental in the release notes for now.

cc @LiamGoodacre