### PR TITLE
Update bower-json to 1.0.0.1

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -116,7 +116,7 @@ library
                    aeson-better-errors >= 0.8,
                    ansi-terminal >= 0.6.2 && < 0.7,
                    base-compat >=0.6.0,
-                   bower-json >= 0.8,
+                   bower-json >= 1.0.0.1 && < 1.1,
                    boxes >= 0.1.4 && < 0.2.0,
                    bytestring -any,
                    containers -any,

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -413,7 +413,7 @@ asReExport =
 
 asInPackage :: Parse BowerError a -> Parse BowerError (InPackage a)
 asInPackage inner =
-  build <$> key "package" (perhaps (withString parsePackageName))
+  build <$> key "package" (perhaps (withText parsePackageName))
         <*> key "item" inner
   where
   build Nothing = Local
@@ -532,7 +532,7 @@ asBookmark =
 
 asResolvedDependencies :: Parse PackageError [(PackageName, Version)]
 asResolvedDependencies =
-  eachInObjectWithKey (mapLeft ErrorInPackageMeta . parsePackageName . T.unpack) asVersion
+  eachInObjectWithKey (mapLeft ErrorInPackageMeta . parsePackageName) asVersion
   where
   mapLeft f (Left x) = Left (f x)
   mapLeft _ (Right x) = Right x
@@ -557,7 +557,7 @@ instance A.ToJSON a => A.ToJSON (Package a) where
       , "versionTag"           .= pkgVersionTag
       , "modules"              .= pkgModules
       , "bookmarks"            .= map (fmap (first P.runModuleName)) pkgBookmarks
-      , "resolvedDependencies" .= assocListToJSON (T.pack . runPackageName)
+      , "resolvedDependencies" .= assocListToJSON runPackageName
                                                   (T.pack . showVersion)
                                                   pkgResolvedDependencies
       , "github"               .= pkgGithub

--- a/src/Language/PureScript/Publish/BoxesHelpers.hs
+++ b/src/Language/PureScript/Publish/BoxesHelpers.hs
@@ -6,6 +6,8 @@ module Language.PureScript.Publish.BoxesHelpers
 
 import Prelude.Compat
 
+import Data.Text (Text)
+import qualified Data.Text as T
 import System.IO (hPutStr, stderr)
 
 import qualified Text.PrettyPrint.Boxes as Boxes
@@ -36,6 +38,9 @@ spacer = Boxes.emptyBox 1 1
 
 bulletedList :: (a -> String) -> [a] -> [Boxes.Box]
 bulletedList f = map (indented . para . ("* " ++) . f)
+
+bulletedListT :: (a -> Text) -> [a] -> [Boxes.Box]
+bulletedListT f = bulletedList (T.unpack . f)
 
 printToStderr :: Boxes.Box -> IO ()
 printToStderr = hPutStr stderr . Boxes.render

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -65,7 +65,7 @@ data UserError
 
 data RepositoryFieldError
   = RepositoryFieldMissing
-  | BadRepositoryType String
+  | BadRepositoryType Text
   | NotOnGithub
   deriving (Show)
 
@@ -213,7 +213,7 @@ displayUserError e = case e of
         , "installed:"
         ])
       ] ++
-        bulletedList runPackageName (NonEmpty.toList pkgs)
+        bulletedListT runPackageName (NonEmpty.toList pkgs)
         ++
       [ spacer
       , para (concat
@@ -263,7 +263,7 @@ displayRepositoryError err = case err of
   BadRepositoryType ty ->
     para (concat
       [ "In your bower.json file, the repository type is currently listed as "
-      , "\"" ++ ty ++ "\". Currently, only git repositories are supported. "
+      , "\"" ++ T.unpack ty ++ "\". Currently, only git repositories are supported. "
       , "Please publish your code in a git repository, and then update the "
       , "repository type in your bower.json file to \"git\"."
       ])
@@ -361,7 +361,7 @@ warnNoResolvedVersions pkgNames =
       ["The following ", packages, " did not appear to have a resolved "
       , "version:"])
     ] ++
-      bulletedList runPackageName (NonEmpty.toList pkgNames)
+      bulletedListT runPackageName (NonEmpty.toList pkgNames)
       ++
     [ spacer
     , para (concat
@@ -385,7 +385,7 @@ warnUndeclaredDependencies pkgNames =
       [ "The following Bower ", packages, " ", are, " installed, but not "
       , "declared as ", dependencies, " in your bower.json file:"
       ])
-    : bulletedList runPackageName (NonEmpty.toList pkgNames)
+    : bulletedListT runPackageName (NonEmpty.toList pkgNames)
 
 warnUnacceptableVersions :: NonEmpty (PackageName, Text) -> Box
 warnUnacceptableVersions pkgs =
@@ -403,7 +403,7 @@ warnUnacceptableVersions pkgs =
       , "not be parsed:"
       ])
     ] ++
-      bulletedList showTuple (NonEmpty.toList pkgs)
+      bulletedListT showTuple (NonEmpty.toList pkgs)
       ++
     [ spacer
     , para (concat
@@ -414,7 +414,7 @@ warnUnacceptableVersions pkgs =
       ])
     ]
   where
-  showTuple (pkgName, tag) = runPackageName pkgName ++ "#" ++ T.unpack tag
+  showTuple (pkgName, tag) = runPackageName pkgName <> "#" <> tag
 
 warnDirtyWorkingTree :: Box
 warnDirtyWorkingTree =

--- a/stack-ghc-8.0.yaml
+++ b/stack-ghc-8.0.yaml
@@ -5,3 +5,4 @@ extra-deps:
 - pipes-http-1.0.2
 - wai-websockets-3.0.0.9
 - websockets-0.9.6.2
+- bower-json-1.0.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,5 @@
 resolver: lts-6.25
 packages:
 - '.'
+extra-deps:
+- bower-json-1.0.0.1


### PR DESCRIPTION
Fixes #2528

LTS 7 still has bower-json 0.8.x, but bower-json 1.0.0.1 is in Stackage nightly now, so we will most likely be able to remove this extra-dep once we switch to LTS 8.