### PR TITLE
Replace type wildcards earlier

### DIFF
--- a/examples/failing/2534.purs
+++ b/examples/failing/2534.purs
@@ -1,4 +1,4 @@
--- @shouldFailWith TypesDoNotUnify
+-- @shouldFailWith InfiniteType
 module Main where
 
 foo :: Array Int -> Int

--- a/examples/failing/2534.purs
+++ b/examples/failing/2534.purs
@@ -1,0 +1,8 @@
+-- @shouldFailWith TypesDoNotUnify
+module Main where
+
+foo :: Array Int -> Int
+foo xs = go xs where
+  go :: Array _ -> Int
+  go [] = 0
+  go xs = go [xs]

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -229,6 +229,7 @@ infer' other = (, []) <$> go other
     unifyKinds k k'
     return k'
   go TypeWildcard{} = freshKind
+  go TUnknown{} = freshKind
   go (TypeLevelString _) = return kindSymbol
   go (TypeVar v) = do
     Just moduleName <- checkCurrentModule <$> get

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -239,11 +239,11 @@ typeForBindingGroupElement (ident, val) dict untypedDict = do
   return (ident, (TypedValue True val' ty, ty))
 
 -- | Check the kind of a type, failing if it is not of kind *.
-checkTypeKind ::
-  (MonadError MultipleErrors m) =>
-  Type ->
-  Kind ->
-  m ()
+checkTypeKind
+  :: MonadError MultipleErrors m
+  => Type
+  -> Kind
+  -> m ()
 checkTypeKind ty kind = guardWith (errorMessage (ExpectedType ty kind)) $ kind == kindType
 
 -- | Remove any ForAlls and ConstrainedType constructors in a type by introducing new unknowns
@@ -251,11 +251,11 @@ checkTypeKind ty kind = guardWith (errorMessage (ExpectedType ty kind)) $ kind =
 --
 -- This is necessary during type checking to avoid unifying a polymorphic type with a
 -- unification variable.
-instantiatePolyTypeWithUnknowns ::
-  (MonadState CheckState m, MonadError MultipleErrors m) =>
-  Expr ->
-  Type ->
-  m (Expr, Type)
+instantiatePolyTypeWithUnknowns
+  :: (MonadState CheckState m, MonadError MultipleErrors m)
+  => Expr
+  -> Type
+  -> m (Expr, Type)
 instantiatePolyTypeWithUnknowns val (ForAll ident ty _) = do
   ty' <- replaceVarWithUnknown ident ty
   instantiatePolyTypeWithUnknowns val ty'
@@ -266,17 +266,17 @@ instantiatePolyTypeWithUnknowns val (ConstrainedType constraints ty) = do
 instantiatePolyTypeWithUnknowns val ty = return (val, ty)
 
 -- | Infer a type for a value, rethrowing any error to provide a more useful error message
-infer ::
-  (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) =>
-  Expr ->
-  m Expr
+infer
+  :: (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
+  => Expr
+  -> m Expr
 infer val = withErrorMessageHint (ErrorInferringType val) $ infer' val
 
 -- | Infer a type for a value
-infer' ::
-  (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m) =>
-  Expr ->
-  m Expr
+infer'
+  :: (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
+  => Expr
+  -> m Expr
 infer' v@(Literal (NumericLiteral (Left _))) = return $ TypedValue True v tyInt
 infer' v@(Literal (NumericLiteral (Right _))) = return $ TypedValue True v tyNumber
 infer' v@(Literal (StringLiteral _)) = return $ TypedValue True v tyString


### PR DESCRIPTION
Fixes #2534

This looks like a bigger change than it is. The key is to move the call to `replaceTypeWildcards` from `checkTypedBindingGroupElement` into `typeDictionaryForBindingGroup`. This function is called earlier and returns the map from function names in a binding group to their types. This forces the necessary unification to happen on the expanded type instead of the original type, which includes the wildcard.

I also did a bit of tidying to make the formatting in this module more consistent.