### PR TITLE
Add git tag time to psc-publish JSON

### DIFF
--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -73,6 +73,7 @@ data RepositoryFieldError
 -- | An error that probably indicates a bug in this module.
 data InternalError
   = JSONError JSONSource (ParseError BowerError)
+  | CouldntParseGitTagDate Text
   deriving (Show)
 
 data JSONSource
@@ -288,6 +289,9 @@ displayInternalError e = case e of
   JSONError src r ->
     [ "Error in JSON " ++ displayJSONSource src ++ ":"
     , T.unpack (Bower.displayError r)
+    ]
+  CouldntParseGitTagDate tag ->
+    [ "Unable to parse the date for a git tag: " ++ T.unpack tag
     ]
 
 displayJSONSource :: JSONSource -> String

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -9,14 +9,16 @@ import Prelude ()
 import Prelude.Compat
 
 import Control.Arrow (first)
+import Control.Monad.IO.Class (liftIO)
 
-import Data.Version (Version(..))
-import Data.Monoid
-import Data.Maybe (fromMaybe)
-import Data.List ((\\))
 import Data.Foldable
+import Data.List ((\\))
+import Data.Maybe (fromMaybe)
+import Data.Monoid
 import Data.Text (Text)
 import qualified Data.Text as T
+import Data.Time.Clock (getCurrentTime)
+import Data.Version (Version(..))
 import System.Exit
 
 import qualified Language.PureScript as P
@@ -32,6 +34,7 @@ import TestUtils
 publishOpts :: Publish.PublishOptions
 publishOpts = Publish.defaultPublishOptions
   { Publish.publishGetVersion = return testVersion
+  , Publish.publishGetTagTime = const (liftIO getCurrentTime)
   , Publish.publishWorkingTreeDirty = return ()
   }
   where testVersion = ("v999.0.0", Version [999,0,0] [])

--- a/tests/TestPscPublish.hs
+++ b/tests/TestPscPublish.hs
@@ -4,8 +4,10 @@
 
 module TestPscPublish where
 
+import Control.Monad.IO.Class (liftIO)
 import System.Exit (exitFailure)
 import Data.ByteString.Lazy (ByteString)
+import Data.Time.Clock (getCurrentTime)
 import qualified Data.Aeson as A
 import Data.Version
 
@@ -38,6 +40,7 @@ roundTrip pkg =
 testRunOptions :: PublishOptions
 testRunOptions = defaultPublishOptions
   { publishGetVersion = return testVersion
+  , publishGetTagTime = const (liftIO getCurrentTime)
   , publishWorkingTreeDirty = return ()
   }
   where testVersion = ("v999.0.0", Version [999,0,0] [])


### PR DESCRIPTION
This is done in a backwards-compatible way by making the time in the
Package type a Maybe UTCTime. Later we can change this to just a
UTCTime.

Prerequisite for addressing https://github.com/purescript/pursuit/issues/216