### PR TITLE
Fail early when 'bind' is brought into scope inside 'do'

### DIFF
--- a/examples/failing/BindInDo-2.purs
+++ b/examples/failing/BindInDo-2.purs
@@ -1,0 +1,9 @@
+-- @shouldFailWith CannotUseBindWithDo
+module Main where
+
+import Prelude
+
+foo = do
+  let bind = 42
+  x <- [4, 5, 6]
+  pure x

--- a/examples/failing/BindInDo.purs
+++ b/examples/failing/BindInDo.purs
@@ -1,0 +1,9 @@
+-- @shouldFailWith CannotUseBindWithDo
+module Main where
+
+import Prelude
+
+foo = do
+  bind <- [1,2,3]
+  x <- [4, 5, 6]
+  pure x

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -138,6 +138,7 @@ data SimpleErrorMessage
   | CannotGeneralizeRecursiveFunction Ident Type
   | CannotDeriveNewtypeForData (ProperName 'TypeName)
   | ExpectedWildcard (ProperName 'TypeName)
+  | CannotUseBindWithDo
   deriving (Show)
 
 -- | Error message hints, providing more detailed information about failure.

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -172,6 +172,7 @@ errorCode em = case unwrapErrorMessage em of
   CannotGeneralizeRecursiveFunction{} -> "CannotGeneralizeRecursiveFunction"
   CannotDeriveNewtypeForData{} -> "CannotDeriveNewtypeForData"
   ExpectedWildcard{} -> "ExpectedWildcard"
+  CannotUseBindWithDo{} -> "CannotUseBindWithDo"
 
 -- |
 -- A stack trace for an error
@@ -878,6 +879,10 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs) e = flip evalS
 
     renderSimpleErrorMessage (ExpectedWildcard tyName) =
       paras [ line $ "Expected a type wildcard (_) when deriving an instance for " <> markCode (runProperName tyName) <> "."
+            ]
+
+    renderSimpleErrorMessage CannotUseBindWithDo =
+      paras [ line $ "The name " <> markCode "bind" <> " cannot be brought into scope in a do notation block, since do notation uses the same name."
             ]
 
     renderHint :: ErrorMessageHint -> Box.Box -> Box.Box

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -9,7 +9,6 @@ import Prelude.Compat
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Supply.Class
 
-
 import Language.PureScript.AST
 import Language.PureScript.Crash
 import Language.PureScript.Errors
@@ -49,6 +48,8 @@ desugarDo d =
     return $ App (App bind val) (Abs (Left (Ident C.__unused)) rest')
   go [DoNotationBind _ _] = throwError . errorMessage $ InvalidDoBind
   go (DoNotationBind NullBinder val : rest) = go (DoNotationValue val : rest)
+  go (DoNotationBind b _ : _) | Ident C.bind `elem` binderNames b =
+    throwError . errorMessage $ CannotUseBindWithDo
   go (DoNotationBind (VarBinder ident) val : rest) = do
     rest' <- go rest
     return $ App (App bind val) (Abs (Left ident) rest')


### PR DESCRIPTION
Fixes #1253

This fails in the do notation desugaring pass instead.

The error message span isn't great right now, but I think we can fix that when we fix the more general problem.