### PR TITLE
Keep synonym information for pretty-printing

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -1265,6 +1265,7 @@ renderBox = unlines
   whiteSpace = all isSpace
 
 toTypelevelString :: Type -> Maybe Box.Box
+toTypelevelString (ExpandedSynonym _ ty) = toTypelevelString ty
 toTypelevelString (TypeLevelString s) = Just $ Box.text $ T.unpack $ prettyPrintString s
 toTypelevelString (TypeApp (TypeConstructor f) x)
   | f == primName "TypeString" = Just $ typeAsBox x

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -96,6 +96,7 @@ kinded = mkPattern match
 insertPlaceholders :: Type -> Type
 insertPlaceholders = everywhereOnTypesTopDown convertForAlls . everywhereOnTypes convert
   where
+  convert (ExpandedSynonym ty _) = ty
   convert (TypeApp (TypeApp f arg) ret) | f == tyFunction = PrettyPrintFunction arg ret
   convert (TypeApp o r) | o == tyRecord = PrettyPrintObject r
   convert other = other

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -369,14 +369,16 @@ matches deps TypeClassDictionaryInScope{..} tys = do
     -- and return a substitution from type variables to types which makes the type heads unify.
     --
     typeHeadsAreEqual :: Type -> Type -> (Bool, Matching [Type])
-    typeHeadsAreEqual (KindedType t1 _)    t2                              = typeHeadsAreEqual t1 t2
-    typeHeadsAreEqual t1                   (KindedType t2 _)               = typeHeadsAreEqual t1 t2
-    typeHeadsAreEqual (TUnknown u1)        (TUnknown u2)        | u1 == u2 = (True, M.empty)
-    typeHeadsAreEqual (Skolem _ s1 _ _)    (Skolem _ s2 _ _)    | s1 == s2 = (True, M.empty)
-    typeHeadsAreEqual t                    (TypeVar v)                     = (True, M.singleton v [t])
-    typeHeadsAreEqual (TypeConstructor c1) (TypeConstructor c2) | c1 == c2 = (True, M.empty)
-    typeHeadsAreEqual (TypeLevelString s1) (TypeLevelString s2) | s1 == s2 = (True, M.empty)
-    typeHeadsAreEqual (TypeApp h1 t1)      (TypeApp h2 t2)                 =
+    typeHeadsAreEqual (ExpandedSynonym _ ty1) ty2                             = typeHeadsAreEqual ty1 ty2
+    typeHeadsAreEqual ty1                     (ExpandedSynonym _ ty2)         = typeHeadsAreEqual ty1 ty2
+    typeHeadsAreEqual (KindedType t1 _)       t2                              = typeHeadsAreEqual t1 t2
+    typeHeadsAreEqual t1                      (KindedType t2 _)               = typeHeadsAreEqual t1 t2
+    typeHeadsAreEqual (TUnknown u1)           (TUnknown u2)        | u1 == u2 = (True, M.empty)
+    typeHeadsAreEqual (Skolem _ s1 _ _)       (Skolem _ s2 _ _)    | s1 == s2 = (True, M.empty)
+    typeHeadsAreEqual t                       (TypeVar v)                     = (True, M.singleton v [t])
+    typeHeadsAreEqual (TypeConstructor c1)    (TypeConstructor c2) | c1 == c2 = (True, M.empty)
+    typeHeadsAreEqual (TypeLevelString s1)    (TypeLevelString s2) | s1 == s2 = (True, M.empty)
+    typeHeadsAreEqual (TypeApp h1 t1)         (TypeApp h2 t2)                 =
       both (typeHeadsAreEqual h1 h2) (typeHeadsAreEqual t1 t2)
     typeHeadsAreEqual REmpty REmpty = (True, M.empty)
     typeHeadsAreEqual r1@RCons{} r2@RCons{} =

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -215,6 +215,7 @@ infer' (KindedType ty k) = do
   (k', args) <- infer ty
   unifyKinds k k'
   return (k', args)
+infer' (ExpandedSynonym before _) = infer' before
 infer' other = (, []) <$> go other
   where
   go :: Type -> m Kind
@@ -263,4 +264,5 @@ infer' other = (, []) <$> go other
     k <- go ty
     unifyKinds k kindType
     return kindType
+  go (ExpandedSynonym before _) = go before
   go ty = internalError $ "Invalid argument to infer: " ++ show ty

--- a/src/Language/PureScript/TypeChecker/Subsumption.hs
+++ b/src/Language/PureScript/TypeChecker/Subsumption.hs
@@ -75,6 +75,10 @@ subsumes'
   -> Type
   -> Type
   -> m (Coercion mode)
+subsumes' mode (ExpandedSynonym _ ty1) ty2 =
+  subsumes' mode ty1 ty2
+subsumes' mode ty1 (ExpandedSynonym _ ty2) = 
+  subsumes' mode ty1 ty2
 subsumes' mode (ForAll ident ty1 _) ty2 = do
   replaced <- replaceVarWithUnknown ident ty1
   subsumes' mode replaced ty2

--- a/src/Language/PureScript/TypeChecker/Synonyms.hs
+++ b/src/Language/PureScript/TypeChecker/Synonyms.hs
@@ -30,7 +30,7 @@ replaceAllTypeSynonyms'
   :: SynonymMap
   -> Type
   -> Either MultipleErrors Type
-replaceAllTypeSynonyms' syns = everywhereOnTypesTopDownM try
+replaceAllTypeSynonyms' syns = traverseWithoutLooping try
   where
   try :: Type -> Either MultipleErrors Type
   try t = fromMaybe t <$> go 0 [] t
@@ -40,12 +40,32 @@ replaceAllTypeSynonyms' syns = everywhereOnTypesTopDownM try
     | Just (synArgs, body) <- M.lookup ctor syns
     , c == length synArgs
     = let repl = replaceAllTypeVars (zip (map fst synArgs) args) body
-      in Just <$> try repl
+      in Just . ExpandedSynonym (foldl TypeApp (TypeConstructor ctor) args) <$> try repl
     | Just (synArgs, _) <- M.lookup ctor syns
     , length synArgs > c
     = throwError . errorMessage $ PartiallyAppliedSynonym ctor
   go c args (TypeApp f arg) = go (c + 1) (arg : args) f
   go _ _ _ = return Nothing
+
+  -- This is a variant on 'everywhereOnTypesTopDownM', but which does not recur into
+  -- the left hand side of 'ExpandedSynonym', to avoid an infinite loop.
+  --
+  -- TODO: improve this later
+  traverseWithoutLooping :: Monad m => (Type -> m Type) -> Type -> m Type
+  traverseWithoutLooping f = go <=< f
+    where
+    go (TypeApp t1 t2) = TypeApp <$> (f t1 >>= go) <*> (f t2 >>= go)
+    go (ForAll arg ty sco) = ForAll arg <$> (f ty >>= go) <*> pure sco
+    go (ConstrainedType cs ty) = ConstrainedType <$> mapM (overConstraintArgs (mapM (go <=< f))) cs <*> (f ty >>= go)
+    go (RCons name ty rest) = RCons name <$> (f ty >>= go) <*> (f rest >>= go)
+    go (KindedType ty k) = KindedType <$> (f ty >>= go) <*> pure k
+    go (PrettyPrintFunction t1 t2) = PrettyPrintFunction <$> (f t1 >>= go) <*> (f t2 >>= go)
+    go (PrettyPrintObject t) = PrettyPrintObject <$> (f t >>= go)
+    go (PrettyPrintForAll args t) = PrettyPrintForAll args <$> (f t >>= go)
+    go (BinaryNoParensType t1 t2 t3) = BinaryNoParensType <$> (f t1 >>= go) <*> (f t2 >>= go) <*> (f t3 >>= go)
+    go (ParensInType t) = ParensInType <$> (f t >>= go)
+    go (ExpandedSynonym t1 t2) = ExpandedSynonym t1 <$> (f t2 >>= go)
+    go other = f other
 
 -- | Replace fully applied type synonyms
 replaceAllTypeSynonyms :: (e ~ MultipleErrors, MonadState CheckState m, MonadError e m) => Type -> m Type

--- a/src/Language/PureScript/TypeChecker/Synonyms.hs
+++ b/src/Language/PureScript/TypeChecker/Synonyms.hs
@@ -47,25 +47,25 @@ replaceAllTypeSynonyms' syns = traverseWithoutLooping try
   go c args (TypeApp f arg) = go (c + 1) (arg : args) f
   go _ _ _ = return Nothing
 
-  -- This is a variant on 'everywhereOnTypesTopDownM', but which does not recur into
-  -- the left hand side of 'ExpandedSynonym', to avoid an infinite loop.
-  --
-  -- TODO: improve this later
-  traverseWithoutLooping :: Monad m => (Type -> m Type) -> Type -> m Type
-  traverseWithoutLooping f = go <=< f
-    where
-    go (TypeApp t1 t2) = TypeApp <$> (f t1 >>= go) <*> (f t2 >>= go)
-    go (ForAll arg ty sco) = ForAll arg <$> (f ty >>= go) <*> pure sco
-    go (ConstrainedType cs ty) = ConstrainedType <$> mapM (overConstraintArgs (mapM (go <=< f))) cs <*> (f ty >>= go)
-    go (RCons name ty rest) = RCons name <$> (f ty >>= go) <*> (f rest >>= go)
-    go (KindedType ty k) = KindedType <$> (f ty >>= go) <*> pure k
-    go (PrettyPrintFunction t1 t2) = PrettyPrintFunction <$> (f t1 >>= go) <*> (f t2 >>= go)
-    go (PrettyPrintObject t) = PrettyPrintObject <$> (f t >>= go)
-    go (PrettyPrintForAll args t) = PrettyPrintForAll args <$> (f t >>= go)
-    go (BinaryNoParensType t1 t2 t3) = BinaryNoParensType <$> (f t1 >>= go) <*> (f t2 >>= go) <*> (f t3 >>= go)
-    go (ParensInType t) = ParensInType <$> (f t >>= go)
-    go (ExpandedSynonym t1 t2) = ExpandedSynonym t1 <$> (f t2 >>= go)
-    go other = f other
+-- This is a variant on 'everywhereOnTypesTopDownM', but which does not recur into
+-- the left hand side of 'ExpandedSynonym', to avoid an infinite loop.
+--
+-- TODO: improve this later
+traverseWithoutLooping :: Monad m => (Type -> m Type) -> Type -> m Type
+traverseWithoutLooping f = go <=< f
+  where
+  go (TypeApp t1 t2) = TypeApp <$> (f t1 >>= go) <*> (f t2 >>= go)
+  go (ForAll arg ty sco) = ForAll arg <$> (f ty >>= go) <*> pure sco
+  go (ConstrainedType cs ty) = ConstrainedType <$> mapM (overConstraintArgs (mapM (go <=< f))) cs <*> (f ty >>= go)
+  go (RCons name ty rest) = RCons name <$> (f ty >>= go) <*> (f rest >>= go)
+  go (KindedType ty k) = KindedType <$> (f ty >>= go) <*> pure k
+  go (PrettyPrintFunction t1 t2) = PrettyPrintFunction <$> (f t1 >>= go) <*> (f t2 >>= go)
+  go (PrettyPrintObject t) = PrettyPrintObject <$> (f t >>= go)
+  go (PrettyPrintForAll args t) = PrettyPrintForAll args <$> (f t >>= go)
+  go (BinaryNoParensType t1 t2 t3) = BinaryNoParensType <$> (f t1 >>= go) <*> (f t2 >>= go) <*> (f t3 >>= go)
+  go (ParensInType t) = ParensInType <$> (f t >>= go)
+  go (ExpandedSynonym t1 t2) = ExpandedSynonym t1 <$> (f t2 >>= go)
+  go other = f other
 
 -- | Replace fully applied type synonyms
 replaceAllTypeSynonyms :: (e ~ MultipleErrors, MonadState CheckState m, MonadError e m) => Type -> m Type

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -569,6 +569,7 @@ check'
   => Expr
   -> Type
   -> m Expr
+check' val (ExpandedSynonym _ ty) = check' val ty
 check' val (ForAll ident ty _) = do
   scope <- newSkolemScope
   sko <- newSkolemConstant
@@ -765,6 +766,8 @@ checkFunctionApplication'
   -> Type
   -> Expr
   -> m (Type, Expr)
+checkFunctionApplication' fn (ExpandedSynonym _ ty) arg = do
+  checkFunctionApplication' fn ty arg
 checkFunctionApplication' fn (TypeApp (TypeApp tyFunction' argTy) retTy) arg = do
   unifyTypes tyFunction' tyFunction
   arg' <- check arg argTy

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -84,6 +84,10 @@ unifyTypes t1 t2 = do
   sub <- gets checkSubstitution
   withErrorMessageHint (ErrorUnifyingTypes t1 t2) $ unifyTypes' (substituteType sub t1) (substituteType sub t2)
   where
+  unifyTypes' (ExpandedSynonym before ty1) ty2 =
+    withErrorMessageHint (ErrorUnifyingTypes before ty2) $ unifyTypes' ty1 ty2
+  unifyTypes' ty1 (ExpandedSynonym before ty2) =
+    withErrorMessageHint (ErrorUnifyingTypes ty1 before) $ unifyTypes' ty1 ty2
   unifyTypes' (TUnknown u1) (TUnknown u2) | u1 == u2 = return ()
   unifyTypes' (TUnknown u) t = solveType u t
   unifyTypes' t (TUnknown u) = solveType u t


### PR DESCRIPTION
For #1821. I hope to finish this tomorrow, but it'll need quite a bit of testing.

I'm not sure this is the best approach yet, but it does improve things slightly.

For example, [this error](http://try.purescript.org/?gist=824542b782c78ccd5580066fb61516b9&backend=core) doesn't mention the synonym `X` anywhere, but now it at least shows up, even if not in the best place:

```text
  Could not match type
          
    String
          
  with type
       
    Int
       

while checking that type String
  is at least as general as type Int
while checking that expression ""
  has type X
in value declaration foo
```