### PR TITLE
Fix object key quoting

### DIFF
--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -148,7 +148,7 @@ prettyPrintMany f xs = do
 
 objectKeyRequiresQuoting :: Text -> Bool
 objectKeyRequiresQuoting s =
-  s `elem` reservedPsNames || isUnquotedKey s
+  s `elem` reservedPsNames || not (isUnquotedKey s)
 
 -- | Place a box before another, vertically when the first box takes up multiple lines.
 before :: Box -> Box -> Box


### PR DESCRIPTION
At the moment, names which require quoting are not quoted and names which do not require quoting are quoted. For example, `{ "💡" :: Int }` will come out as `{ 💡 :: Int }` in error messages, even though the parser will reject the latter, but `{ foo :: Int }` comes out as `{ "foo" :: Int }`.