### PR TITLE
Store more information in RenderedCode / refactoring

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -123,6 +123,7 @@ library
                    containers -any,
                    clock -any,
                    data-ordlist >= 0.4.7.0,
+                   deepseq -any,
                    directory >= 1.2,
                    dlist -any,
                    edit-distance -any,
@@ -266,7 +267,8 @@ library
                      Language.PureScript.Docs.Types
                      Language.PureScript.Docs.RenderedCode
                      Language.PureScript.Docs.RenderedCode.Types
-                     Language.PureScript.Docs.RenderedCode.Render
+                     Language.PureScript.Docs.RenderedCode.RenderType
+                     Language.PureScript.Docs.RenderedCode.RenderKind
                      Language.PureScript.Docs.AsMarkdown
                      Language.PureScript.Docs.ParseInPackage
                      Language.PureScript.Docs.Utils.MonoidExtras

--- a/src/Language/PureScript/Docs.hs
+++ b/src/Language/PureScript/Docs.hs
@@ -10,6 +10,5 @@ import Language.PureScript.Docs.Convert as Docs
 import Language.PureScript.Docs.Prim as Docs
 import Language.PureScript.Docs.ParseInPackage as Docs
 import Language.PureScript.Docs.Render as Docs
-import Language.PureScript.Docs.RenderedCode.Render as Docs
-import Language.PureScript.Docs.RenderedCode.Types as Docs
+import Language.PureScript.Docs.RenderedCode as Docs
 import Language.PureScript.Docs.Types as Docs

--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -77,12 +77,10 @@ declAsMarkdown mn decl@Declaration{..} = do
 codeToString :: RenderedCode -> Text
 codeToString = outputWith elemAsMarkdown
   where
-  elemAsMarkdown (Syntax x)  = x
-  elemAsMarkdown (Ident x _) = x
-  elemAsMarkdown (Ctor x _)  = x
-  elemAsMarkdown (Kind x)    = x
-  elemAsMarkdown (Keyword x) = x
-  elemAsMarkdown Space       = " "
+  elemAsMarkdown (Syntax x)     = x
+  elemAsMarkdown (Keyword x)    = x
+  elemAsMarkdown Space          = " "
+  elemAsMarkdown (Symbol _ x _) = x
 
 -- fixityAsMarkdown :: P.Fixity -> Docs
 -- fixityAsMarkdown (P.Fixity associativity precedence) =

--- a/src/Language/PureScript/Docs/RenderedCode.hs
+++ b/src/Language/PureScript/Docs/RenderedCode.hs
@@ -5,4 +5,5 @@
 module Language.PureScript.Docs.RenderedCode (module RenderedCode) where
 
 import Language.PureScript.Docs.RenderedCode.Types as RenderedCode
-import Language.PureScript.Docs.RenderedCode.Render as RenderedCode
+import Language.PureScript.Docs.RenderedCode.RenderType as RenderedCode
+import Language.PureScript.Docs.RenderedCode.RenderKind as RenderedCode

--- a/src/Language/PureScript/Docs/RenderedCode/RenderKind.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/RenderKind.hs
@@ -1,0 +1,57 @@
+-- | Functions for producing RenderedCode values from PureScript Kind values.
+--
+module Language.PureScript.Docs.RenderedCode.RenderKind
+  ( renderKind
+  ) where
+
+-- TODO: This is pretty much copied from Language.PureScript.Pretty.Kinds.
+-- Ideally we would unify the two.
+
+import Prelude.Compat
+
+import Control.Arrow (ArrowPlus(..))
+import Control.PatternArrows as PA
+
+import Data.Monoid ((<>))
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+
+import Language.PureScript.Crash
+import Language.PureScript.Kinds
+
+import Language.PureScript.Docs.RenderedCode.Types
+
+typeLiterals :: Pattern () Kind RenderedCode
+typeLiterals = mkPattern match
+  where
+  match (KUnknown u) =
+    Just $ typeVar $ T.cons 'k' (T.pack (show u))
+  match (NamedKind n) =
+    Just $ kind n
+  match _ = Nothing
+
+matchRow :: Pattern () Kind ((), Kind)
+matchRow = mkPattern match
+  where
+  match (Row k) = Just ((), k)
+  match _ = Nothing
+
+funKind :: Pattern () Kind (Kind, Kind)
+funKind = mkPattern match
+  where
+  match (FunKind arg ret) = Just (arg, ret)
+  match _ = Nothing
+
+-- | Generate RenderedCode value representing a Kind
+renderKind :: Kind -> RenderedCode
+renderKind
+  = fromMaybe (internalError "Incomplete pattern")
+  . PA.pattern matchKind ()
+  where
+  matchKind :: Pattern () Kind RenderedCode
+  matchKind = buildPrettyPrinter operators (typeLiterals <+> fmap parens matchKind)
+
+  operators :: OperatorTable () Kind RenderedCode
+  operators =
+    OperatorTable [ [ Wrap matchRow $ \_ k -> syntax "#" <> sp <> k]
+                  , [ AssocR funKind $ \arg ret -> arg <> sp <> syntax "->" <> sp <> ret ] ]

--- a/src/Language/PureScript/Docs/RenderedCode/Types.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 -- | Data types and functions for representing a simplified form of PureScript
 -- code, intended for use in e.g. HTML documentation.
@@ -11,15 +12,16 @@ module Language.PureScript.Docs.RenderedCode.Types
  , containingModuleToMaybe
  , maybeToContainingModule
  , fromContainingModule
+ , fromQualified
+ , Namespace(..)
+ , Link(..)
+ , FixityAlias
  , RenderedCode
  , asRenderedCode
  , outputWith
  , sp
+ , parens
  , syntax
- , ident
- , ident'
- , ctor
- , kind
  , keyword
  , keywordForall
  , keywordData
@@ -30,17 +32,165 @@ module Language.PureScript.Docs.RenderedCode.Types
  , keywordWhere
  , keywordFixity
  , keywordKind
+ , keywordAs
+ , ident
+ , dataCtor
+ , typeCtor
+ , typeOp
+ , typeVar
+ , kind
+ , alias
+ , aliasName
  ) where
 
 import Prelude.Compat
+import GHC.Generics (Generic)
 
+import Control.DeepSeq (NFData)
 import Control.Monad.Error.Class (MonadError(..))
 
+import Data.Monoid ((<>))
 import Data.Aeson.BetterErrors
 import qualified Data.Aeson as A
 import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy as BS
+import qualified Data.Text.Encoding as TE
 
-import qualified Language.PureScript as P
+import Language.PureScript.Names
+import Language.PureScript.AST (Associativity(..))
+import Language.PureScript.Crash (internalError)
+
+-- | Given a list of actions, attempt them all, returning the first success.
+-- If all the actions fail, 'tryAll' returns the first argument.
+tryAll :: MonadError e m => m a -> [m a] -> m a
+tryAll = foldr $ \x y -> catchError x (const y)
+
+firstEq :: Text -> Parse Text a -> Parse Text a
+firstEq str p = nth 0 (withText (eq str)) *> p
+  where
+  eq s s' = if s == s' then Right () else Left ""
+
+-- |
+-- Try the given parsers in sequence. If all fail, fail with the given message,
+-- and include the JSON in the error.
+--
+tryParse :: Text -> [Parse Text a] -> Parse Text a
+tryParse msg =
+  tryAll (withValue (Left . (fullMsg <>) . showJSON))
+
+  where
+  fullMsg = "Invalid " <> msg <> ": "
+
+  showJSON :: A.Value -> Text
+  showJSON = TE.decodeUtf8 . BS.toStrict . A.encode
+
+-- |
+-- This type is isomorphic to 'Maybe' 'ModuleName'. It makes code a bit
+-- easier to read, as the meaning is more explicit.
+--
+data ContainingModule
+  = ThisModule
+  | OtherModule ModuleName
+  deriving (Show, Eq, Ord)
+
+instance A.ToJSON ContainingModule where
+  toJSON = A.toJSON . go
+    where
+    go = \case
+      ThisModule -> ["ThisModule"]
+      OtherModule mn -> ["OtherModule", runModuleName mn]
+
+instance A.FromJSON ContainingModule where
+  parseJSON = toAesonParser id asContainingModule
+
+asContainingModule :: Parse Text ContainingModule
+asContainingModule =
+  tryParse "containing module" $
+    current ++ backwardsCompat
+  where
+  current =
+    [ firstEq "ThisModule" (pure ThisModule)
+    , firstEq "OtherModule" (OtherModule <$> nth 1 asModuleName)
+    ]
+
+  -- For JSON produced by compilers up to 0.10.5.
+  backwardsCompat =
+    [ maybeToContainingModule <$> perhaps asModuleName
+    ]
+
+  asModuleName = moduleNameFromString <$> asText
+
+-- |
+-- Convert a 'Maybe' 'ModuleName' to a 'ContainingModule', using the obvious
+-- isomorphism.
+--
+maybeToContainingModule :: Maybe ModuleName -> ContainingModule
+maybeToContainingModule Nothing = ThisModule
+maybeToContainingModule (Just mn) = OtherModule mn
+
+-- |
+-- Convert a 'ContainingModule' to a 'Maybe' 'ModuleName', using the obvious
+-- isomorphism.
+--
+containingModuleToMaybe :: ContainingModule -> Maybe ModuleName
+containingModuleToMaybe ThisModule = Nothing
+containingModuleToMaybe (OtherModule mn) = Just mn
+
+-- |
+-- A version of 'fromMaybe' for 'ContainingModule' values.
+--
+fromContainingModule :: ModuleName -> ContainingModule -> ModuleName
+fromContainingModule def ThisModule = def
+fromContainingModule _ (OtherModule mn) = mn
+
+fromQualified :: Qualified a -> (ContainingModule, a)
+fromQualified (Qualified mn x) =
+  (maybeToContainingModule mn, x)
+
+data Link
+  = NoLink
+  | Link ContainingModule
+  deriving (Show, Eq, Ord)
+
+instance A.ToJSON Link where
+  toJSON = \case
+    NoLink -> A.toJSON ["NoLink" :: Text]
+    Link mn -> A.toJSON ["Link", A.toJSON mn]
+
+asLink :: Parse Text Link
+asLink =
+  tryParse "link"
+    [ firstEq "NoLink" (pure NoLink)
+    , firstEq "Link" (Link <$> nth 1 asContainingModule)
+    ]
+
+instance A.FromJSON Link where
+  parseJSON = toAesonParser id asLink
+
+data Namespace
+  = ValueLevel
+  | TypeLevel
+  | KindLevel
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData Namespace
+
+instance A.ToJSON Namespace where
+  toJSON = A.toJSON . show
+
+asNamespace :: Parse Text Namespace
+asNamespace =
+  tryParse "namespace"
+    [ withText $ \case
+        "ValueLevel" -> Right ValueLevel
+        "TypeLevel" -> Right TypeLevel
+        "KindLevel" -> Right KindLevel
+        _ -> Left ""
+    ]
+
+instance A.FromJSON Namespace where
+  parseJSON = toAesonParser id asNamespace
 
 -- |
 -- A single element in a rendered code fragment. The intention is to support
@@ -48,86 +198,49 @@ import qualified Language.PureScript as P
 --
 data RenderedCodeElement
   = Syntax Text
-  | Ident Text ContainingModule
-  | Ctor Text ContainingModule
-  | Kind Text
   | Keyword Text
   | Space
+  -- | Any symbol which you might or might not want to link to, in any
+  -- namespace (value, type, or kind). Note that this is not related to the
+  -- kind called Symbol for type-level strings.
+  | Symbol Namespace Text Link
   deriving (Show, Eq, Ord)
 
 instance A.ToJSON RenderedCodeElement where
   toJSON (Syntax str) =
     A.toJSON ["syntax", str]
-  toJSON (Ident str mn) =
-    A.toJSON ["ident", A.toJSON str, A.toJSON mn]
-  toJSON (Ctor str mn) =
-    A.toJSON ["ctor", A.toJSON str, A.toJSON mn ]
-  toJSON (Kind str) =
-    A.toJSON ["kind", str]
   toJSON (Keyword str) =
     A.toJSON ["keyword", str]
   toJSON Space =
     A.toJSON ["space" :: Text]
+  toJSON (Symbol ns str link) =
+    A.toJSON ["symbol", A.toJSON ns, A.toJSON str, A.toJSON link]
 
 asRenderedCodeElement :: Parse Text RenderedCodeElement
 asRenderedCodeElement =
-  a Syntax "syntax" <|>
-  asIdent <|>
-  asCtor <|>
-  a Kind "kind" <|>
-  a Keyword "keyword" <|>
-  asSpace <|>
-  unableToParse
+  tryParse "RenderedCodeElement" $
+    [ a Syntax "syntax"
+    , a Keyword "keyword"
+    , asSpace
+    , asSymbol
+    ] ++ backwardsCompat
   where
-  p <|> q = catchError p (const q)
+  a ctor' ctorStr = firstEq ctorStr (ctor' <$> nth 1 asText)
+  asSymbol = firstEq "symbol" (Symbol <$> nth 1 asNamespace <*> nth 2 asText <*> nth 3 asLink)
+  asSpace = firstEq "space" (pure Space)
 
-  a ctor' ctorStr = ctor' <$> (nth 0 (withText (eq ctorStr)) *> nth 1 asText)
-  asIdent = nth 0 (withText (eq "ident")) *> (Ident <$> nth 1 asText <*> nth 2 asContainingModule)
-  asCtor = nth 0 (withText (eq "ctor")) *> (Ctor <$> nth 1 asText <*> nth 2 asContainingModule)
-  asSpace = nth 0 (withText (eq "space")) *> pure Space
+  -- These will make some mistakes e.g. treating data constructors as types,
+  -- because the old code did not save information which is necessary to
+  -- distinguish these cases. This is the best we can do.
+  backwardsCompat =
+    [ oldAsIdent
+    , oldAsCtor
+    , oldAsKind
+    ]
 
-  eq s s' = if s == s' then Right () else Left ""
-
-  unableToParse = withText Left
-
--- |
--- This type is isomorphic to 'Maybe' 'P.ModuleName'. It makes code a bit easier
--- to read, as the meaning is more explicit.
---
-data ContainingModule
-  = ThisModule
-  | OtherModule P.ModuleName
-  deriving (Show, Eq, Ord)
-
-instance A.ToJSON ContainingModule where
-  toJSON mn = A.toJSON (P.runModuleName <$> containingModuleToMaybe mn)
-
-asContainingModule :: Parse e ContainingModule
-asContainingModule =
-  maybeToContainingModule <$> perhaps (P.moduleNameFromString <$> asText)
-
--- |
--- Convert a 'Maybe' 'P.ModuleName' to a 'ContainingModule', using the obvious
--- isomorphism.
---
-maybeToContainingModule :: Maybe P.ModuleName -> ContainingModule
-maybeToContainingModule Nothing = ThisModule
-maybeToContainingModule (Just mn) = OtherModule mn
-
--- |
--- Convert a 'ContainingModule' to a 'Maybe' 'P.ModuleName', using the obvious
--- isomorphism.
---
-containingModuleToMaybe :: ContainingModule -> Maybe P.ModuleName
-containingModuleToMaybe ThisModule = Nothing
-containingModuleToMaybe (OtherModule mn) = Just mn
-
--- |
--- A version of 'fromMaybe' for 'ContainingModule' values.
---
-fromContainingModule :: P.ModuleName -> ContainingModule -> P.ModuleName
-fromContainingModule def ThisModule = def
-fromContainingModule _ (OtherModule mn) = mn
+  oldAsIdent = firstEq "ident" (Symbol ValueLevel <$> nth 1 asText <*> nth 2 (Link <$> asContainingModule))
+  oldAsCtor = firstEq "ctor" (Symbol TypeLevel <$> nth 1 asText <*> nth 2 (Link <$> asContainingModule))
+  oldAsKind = firstEq "kind" (Symbol KindLevel <$> nth 1 asText <*> pure (Link ThisModule))
 
 -- |
 -- A type representing a highly simplified version of PureScript code, intended
@@ -158,20 +271,16 @@ outputWith f = foldMap f . unRC
 sp :: RenderedCode
 sp = RC [Space]
 
+-- |
+-- Wrap a RenderedCode value in parens.
+parens :: RenderedCode -> RenderedCode
+parens x = syntax "(" <> x <> syntax ")"
+
+-- possible TODO: instead of this function, export RenderedCode values for
+-- each syntax element, eg syntaxArr (== syntax "->"), syntaxLBrace,
+-- syntaxRBrace, etc.
 syntax :: Text -> RenderedCode
 syntax x = RC [Syntax x]
-
-ident :: Text -> RenderedCode
-ident x = RC [Ident x ThisModule]
-
-ident' :: Text -> ContainingModule -> RenderedCode
-ident' x m = RC [Ident x m]
-
-ctor :: Text -> ContainingModule -> RenderedCode
-ctor x m = RC [Ctor x m]
-
-kind :: Text -> RenderedCode
-kind x = RC [Kind x]
 
 keyword :: Text -> RenderedCode
 keyword kw = RC [Keyword kw]
@@ -197,10 +306,78 @@ keywordInstance = keyword "instance"
 keywordWhere :: RenderedCode
 keywordWhere = keyword "where"
 
-keywordFixity :: P.Associativity -> RenderedCode
-keywordFixity P.Infixl = keyword "infixl"
-keywordFixity P.Infixr = keyword "infixr"
-keywordFixity P.Infix = keyword "infix"
+keywordFixity :: Associativity -> RenderedCode
+keywordFixity Infixl = keyword "infixl"
+keywordFixity Infixr = keyword "infixr"
+keywordFixity Infix = keyword "infix"
 
 keywordKind :: RenderedCode
 keywordKind = keyword "kind"
+
+keywordAs :: RenderedCode
+keywordAs = keyword "as"
+
+ident :: Qualified Ident -> RenderedCode
+ident (fromQualified -> (mn, name)) =
+  RC [Symbol ValueLevel (runIdent name) (Link mn)]
+
+dataCtor :: Qualified (ProperName 'ConstructorName) -> RenderedCode
+dataCtor (fromQualified -> (mn, name)) =
+  RC [Symbol ValueLevel (runProperName name) (Link mn)]
+
+typeCtor :: Qualified (ProperName 'TypeName) -> RenderedCode
+typeCtor (fromQualified -> (mn, name)) =
+  RC [Symbol TypeLevel (runProperName name) (Link mn)]
+
+typeOp :: Qualified (OpName 'TypeOpName) -> RenderedCode
+typeOp (fromQualified -> (mn, name)) =
+  RC [Symbol TypeLevel (runOpName name) (Link mn)]
+
+typeVar :: Text -> RenderedCode
+typeVar x = RC [Symbol TypeLevel x NoLink]
+
+kind :: Qualified (ProperName 'KindName) -> RenderedCode
+kind (fromQualified -> (mn, name)) =
+  RC [Symbol KindLevel (runProperName name) (Link mn)]
+
+type FixityAlias = Qualified (Either (ProperName 'TypeName) (Either Ident (ProperName 'ConstructorName)))
+
+alias :: FixityAlias -> RenderedCode
+alias for =
+  prefix <> RC [Symbol ns name (Link mn)]
+  where
+  (ns, name, mn) = unpackFixityAlias for
+  prefix = case ns of
+    TypeLevel ->
+      keywordType <> sp
+    _ ->
+      mempty
+
+aliasName :: FixityAlias -> Text -> RenderedCode
+aliasName for name' =
+  let
+    (ns, _, _) = unpackFixityAlias for
+    unParen = T.tail . T.init
+    name = unParen name'
+  in
+    case ns of
+      ValueLevel ->
+        ident (Qualified Nothing (Ident name))
+      TypeLevel ->
+        typeCtor (Qualified Nothing (ProperName name))
+      KindLevel ->
+        internalError "Kind aliases are not supported"
+
+-- | Converts a FixityAlias into a different representation which is more
+-- useful to other functions in this module.
+unpackFixityAlias :: FixityAlias -> (Namespace, Text, ContainingModule)
+unpackFixityAlias (fromQualified -> (mn, x)) =
+  case x of
+    -- We add some seemingly superfluous type signatures here just to be extra
+    -- sure we are not mixing up our namespaces.
+    Left (n :: ProperName 'TypeName) ->
+      (TypeLevel, runProperName n, mn)
+    Right (Left n) ->
+      (ValueLevel, runIdent n, mn)
+    Right (Right (n :: ProperName 'ConstructorName)) ->
+      (ValueLevel, runProperName n, mn)


### PR DESCRIPTION
* Changes the RenderedCodeElement type to preserve more information for
  creating links in RenderedCode values. In particular, the namespace of
  a symbol is now stored.
* Refactor Docs.RenderedCode.Types so that the functions for creating
  RenderedCode values are easier to use and more type-safe.
* Include information about the module that kinds are contained in in
  the RenderedCode renderer.
* Split Docs.RenderedCode.Render into two modules:
  Docs.RenderedCode.RenderType and Docs.RenderedCode.RenderKind.

The JSON format has changed but in a backwards-compatible way. So once
this is released and Pursuit is updated with these changes, old
compilers will not be able to upload to Pursuit, but Pursuit will still
understand JSON produced by old compilers.

This gets us most of the way towards fixing https://github.com/purescript/pursuit/issues/271 and https://github.com/purescript/pursuit/issues/119.