### PR TITLE
[psc-ide] Complete record accessors

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -567,6 +567,7 @@ test-suite tests
                    TestPscIde
                    PscIdeSpec
                    Language.PureScript.Ide.Test
+                   Language.PureScript.Ide.CompletionSpec
                    Language.PureScript.Ide.FilterSpec
                    Language.PureScript.Ide.ImportsSpec
                    Language.PureScript.Ide.MatcherSpec

--- a/src/Language/PureScript.hs
+++ b/src/Language/PureScript.hs
@@ -18,6 +18,7 @@ import Language.PureScript.Environment as P
 import Language.PureScript.Errors as P hiding (indent)
 import Language.PureScript.Externs as P
 import Language.PureScript.Kinds as P
+import Language.PureScript.Label as P
 import Language.PureScript.Linter as P
 import Language.PureScript.Make as P
 import Language.PureScript.ModuleDependencies as P
@@ -25,6 +26,7 @@ import Language.PureScript.Names as P
 import Language.PureScript.Options as P
 import Language.PureScript.Parser as P
 import Language.PureScript.Pretty as P
+import Language.PureScript.PSString as P
 import Language.PureScript.Renamer as P
 import Language.PureScript.Sugar as P
 import Language.PureScript.TypeChecker as P

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -59,7 +59,7 @@ handleCommand c = case c of
   Complete filters matcher currentModule ->
     findCompletions filters matcher currentModule
   CompleteSpecial path row col ->
-    CompletionResult <$> specialCompletion path row col
+    CompletionResult <$> completeInFile path row col
   Pursuit query Package ->
     findPursuitPackages query
   Pursuit query Identifier ->

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -58,7 +58,7 @@ handleCommand c = case c of
     findType search filters currentModule
   Complete filters matcher currentModule ->
     findCompletions filters matcher currentModule
-  CompleteSpecial path row col ->
+  CompleteContextual path row col ->
     CompletionResult <$> completeInFile path row col
   Pursuit query Package ->
     findPursuitPackages query

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -59,7 +59,7 @@ handleCommand c = case c of
   Complete filters matcher currentModule ->
     findCompletions filters matcher currentModule
   CompleteSpecial path row col ->
-    MultilineTextResult <$> specialCompletion path row col
+    CompletionResult <$> specialCompletion path row col
   Pursuit query Package ->
     findPursuitPackages query
   Pursuit query Identifier ->

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -58,6 +58,8 @@ handleCommand c = case c of
     findType search filters currentModule
   Complete filters matcher currentModule ->
     findCompletions filters matcher currentModule
+  CompleteSpecial path row col ->
+    MultilineTextResult <$> specialCompletion path row col
   Pursuit query Package ->
     findPursuitPackages query
   Pursuit query Identifier ->

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -36,6 +36,11 @@ data Command
       , completeMatcher       :: Matcher IdeDeclarationAnn
       , completeCurrentModule :: Maybe P.ModuleName
       }
+    | CompleteSpecial
+      { completeSPath :: FilePath
+      , completeSRow :: Int
+      , completeSCol :: Int
+      }
     | Pursuit
       { pursuitQuery      :: PursuitQuery
       , pursuitSearchType :: PursuitSearchType
@@ -66,6 +71,7 @@ commandName c = case c of
   LoadSync{} -> "LoadSync"
   Type{} -> "Type"
   Complete{} -> "Complete"
+  CompleteSpecial{} -> "CompleteSpecial"
   Pursuit{} -> "Pursuit"
   CaseSplit{} -> "CaseSplit"
   AddClause{} -> "AddClause"
@@ -129,6 +135,12 @@ instance FromJSON Command where
           <$> params .:? "filters" .!= []
           <*> params .:? "matcher" .!= mempty
           <*> (fmap P.moduleNameFromString <$> params .:? "currentModule")
+      "completeS" -> do
+        params <- o .: "params"
+        CompleteSpecial
+          <$> params .: "path"
+          <*> params .: "row"
+          <*> params .: "column"
       "pursuit" -> do
         params <- o .: "params"
         Pursuit

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -36,10 +36,10 @@ data Command
       , completeMatcher       :: Matcher IdeDeclarationAnn
       , completeCurrentModule :: Maybe P.ModuleName
       }
-    | CompleteSpecial
-      { completeSPath :: FilePath
-      , completeSRow :: Int
-      , completeSCol :: Int
+    | CompleteContextual
+      { completeContextualPath :: FilePath
+      , completeContextualRow :: Int
+      , completeContextualCol :: Int
       }
     | Pursuit
       { pursuitQuery      :: PursuitQuery
@@ -71,7 +71,7 @@ commandName c = case c of
   LoadSync{} -> "LoadSync"
   Type{} -> "Type"
   Complete{} -> "Complete"
-  CompleteSpecial{} -> "CompleteSpecial"
+  CompleteContextual{} -> "CompleteContextual"
   Pursuit{} -> "Pursuit"
   CaseSplit{} -> "CaseSplit"
   AddClause{} -> "AddClause"
@@ -135,9 +135,9 @@ instance FromJSON Command where
           <$> params .:? "filters" .!= []
           <*> params .:? "matcher" .!= mempty
           <*> (fmap P.moduleNameFromString <$> params .:? "currentModule")
-      "completeS" -> do
+      "completeContextual" -> do
         params <- o .: "params"
-        CompleteSpecial
+        CompleteContextual
           <$> params .: "path"
           <*> params .: "row"
           <*> params .: "column"

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -1,17 +1,24 @@
+{-# LANGUAGE PackageImports #-}
 module Language.PureScript.Ide.Completion
        ( getCompletions
        , getExactMatches
+       , completeInFile
        ) where
 
 import           Protolude
 
+import Data.Char
+import "monad-logger" Control.Monad.Logger
+import qualified Data.Text as T
 import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.Matcher
 import           Language.PureScript.Ide.Types
+import           Language.PureScript.Ide.Rebuild
+import           Language.PureScript.Ide.Error
+import           Language.PureScript.Ide.Util
 import qualified Language.PureScript as P
 
 type Module = (P.ModuleName, [IdeDeclarationAnn])
-
 -- | Applies the CompletionFilters and the Matcher to the given Modules
 --   and sorts the found Completions according to the Matching Score
 getCompletions
@@ -31,3 +38,59 @@ completionsFromModules = foldMap completionFromModule
   where
     completionFromModule (moduleName, decls) =
       map (\x -> Match (moduleName, x)) decls
+
+completeInFile :: (Ide m, MonadLogger m) => FilePath -> Int -> Int -> m [Completion]
+completeInFile path row col = do
+  input <- liftIO (readUTF8FileT path)
+  completeInFile' path input row col
+
+completeInFile' :: (Ide m, MonadLogger m) => FilePath -> Text -> Int -> Int -> m [Completion]
+completeInFile' path input row col = do
+  let withHole = insertHole input
+  rebuildResult <- runExceptT (rebuildFile' path withHole)
+  case rebuildResult of
+    Left (RebuildError errs)
+      | Just holeError <- extractHole errs
+        -> do
+          pure (extractCompletions holeError)
+    _ -> pure []
+  where
+    insertHole :: Text -> Text
+    insertHole t =
+      let
+        (before, line:after) = splitAt (row - 1) (T.lines t)
+        (b, a) = T.splitAt (col - 1) line
+        (start, ident) = breakEnd (not . isSpace) b
+        withHole = start <> "(?magicUnicornHole " <> ident <> ")" <> T.tail a
+      in
+        T.unlines (before <> [withHole] <> after)
+
+    extractHole :: P.MultipleErrors -> Maybe P.Type
+    extractHole me = asum (map unicornTypeHole (P.runMultipleErrors me))
+
+    extractCompletions :: P.Type -> [Completion]
+    extractCompletions =
+      map mkCompletion
+      . map (first (P.prettyPrintStringJS . P.runLabel))
+      . fst
+      . P.rowToList
+      where
+        mkCompletion :: (Text, P.Type) -> Completion
+        mkCompletion (i, t) = Completion
+          { complModule = ""
+          , complIdentifier = T.filter (/= '"') i
+          , complType = prettyTypeT t
+          , complExpandedType = prettyTypeT t
+          , complLocation = Nothing
+          , complDocumentation = Nothing
+          }
+
+breakEnd :: (Char -> Bool) -> Text -> (Text, Text)
+breakEnd p t = (T.dropWhileEnd p t, T.takeWhileEnd p t)
+
+unicornTypeHole :: P.ErrorMessage -> Maybe P.Type
+unicornTypeHole (P.ErrorMessage _
+                 (P.HoleInferredType "magicUnicornHole"
+                  (P.TypeApp (P.TypeApp t' (P.TypeApp r t)) _) _ _))
+  | t' == P.tyFunction && r == P.tyRecord = Just t
+unicornTypeHole _ = Nothing

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -67,7 +67,7 @@ completeInFile' path input row column = do
     extractCompletions :: P.Type -> [Completion]
     extractCompletions =
       map mkCompletion
-      . map (first (P.prettyPrintStringJS . P.runLabel))
+      . map (first P.prettyPrintLabel)
       . fst
       . P.rowToList
       where

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -8,8 +8,8 @@ module Language.PureScript.Ide.Completion
 
 import           Protolude
 
-import Data.Char
-import "monad-logger" Control.Monad.Logger
+import           Data.Char
+import           "monad-logger" Control.Monad.Logger
 import qualified Data.Text as T
 import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.Matcher
@@ -45,15 +45,15 @@ completeInFile path row col = do
   input <- liftIO (readUTF8FileT path)
   completeInFile' path input row col
 
-completeInFile' :: (Ide m, MonadLogger m) => FilePath -> Text -> Int -> Int -> m [Completion]
+completeInFile'
+  :: (Ide m, MonadLogger m)
+  => FilePath -> Text -> Int -> Int -> m [Completion]
 completeInFile' path input row column = do
   let withHole = insertHole (row, column) input
   rebuildResult <- runExceptT (rebuildFile' path withHole)
   case rebuildResult of
     Left (RebuildError errs)
-      | Just holeError <- extractHole errs
-        -> do
-          pure (extractCompletions holeError)
+      | Just holeError <- extractHole errs -> pure (extractCompletions holeError)
     _ -> pure []
   where
 

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -61,7 +61,13 @@ completeInFile' path input row col = do
         (before, line:after) = splitAt (row - 1) (T.lines t)
         (b, a) = T.splitAt (col - 1) line
         (start, ident) = breakEnd (not . isSpace) b
-        withHole = start <> "(?magicUnicornHole " <> ident <> ")" <> T.tail a
+        withHole = case ident of
+          -- in this special case we are looking at syntax sugar for a record
+          -- accessor function
+          "_" ->
+            start <> "?magicUnicornHole" <> T.tail a
+          i ->
+            start <> "(?magicUnicornHole " <> i <> ")" <> T.tail a
       in
         T.unlines (before <> [withHole] <> after)
 

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -40,6 +40,10 @@ completionsFromModules = foldMap completionFromModule
     completionFromModule (moduleName, decls) =
       map (\x -> Match (moduleName, x)) decls
 
+-- | Attempts to complete a record accessor or record wildcard in the given file
+-- at the given position. Uses the typed hole machinery in combination with the
+-- Rebuild command, which makes this completion dependent on successful
+-- compilation of the module once the typed hole has been inserted.
 completeInFile :: (Ide m, MonadLogger m) => FilePath -> Int -> Int -> m [Completion]
 completeInFile path row col = do
   input <- liftIO (readUTF8FileT path)

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -17,24 +17,25 @@ module Language.PureScript.Ide.Error
        ) where
 
 import           Data.Aeson
+import qualified Language.PureScript as P
 import           Language.PureScript.Errors.JSON
 import           Language.PureScript.Ide.Types   (ModuleIdent)
 import           Protolude
-import qualified Text.Parsec.Error               as P
+import qualified Text.Parsec.Error               as Parsec
 
 data IdeError
     = GeneralError Text
     | NotFound Text
     | ModuleNotFound ModuleIdent
     | ModuleFileNotFound ModuleIdent
-    | ParseError P.ParseError Text
-    | RebuildError [JSONError]
-    deriving (Show, Eq)
+    | ParseError Parsec.ParseError Text
+    | RebuildError P.MultipleErrors
+    deriving(Show, Eq)
 
 instance ToJSON IdeError where
   toJSON (RebuildError errs) = object
     [ "resultType" .= ("error" :: Text)
-    , "result" .= errs
+    , "result" .= toJSONErrors False P.Error errs
     ]
   toJSON err = object
     [ "resultType" .= ("error" :: Text)

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -30,7 +30,7 @@ data IdeError
     | ModuleFileNotFound ModuleIdent
     | ParseError Parsec.ParseError Text
     | RebuildError P.MultipleErrors
-    deriving(Show, Eq)
+    deriving (Show)
 
 instance ToJSON IdeError where
   toJSON (RebuildError errs) = object

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -5,7 +5,7 @@ module Language.PureScript.Ide.Rebuild
   ( rebuildFileSync
   , rebuildFileAsync
   , rebuildFile
-  , specialCompletion
+  , rebuildFile'
   ) where
 
 import           Protolude
@@ -44,15 +44,16 @@ rebuildFile
   -> (ReaderT IdeEnvironment (LoggingT IO) () -> m ())
   -- ^ A runner for the second build with open exports
   -> m Success
-rebuildFile path =
-  ideReadFile path >>= rebuildFile' path
+rebuildFile path runOpenBuild =
+  ideReadFile path >>= rebuildFile' path runOpenBuild
 
 rebuildFile'
-  :: (Ide m, MonadLogger m, MonadError PscIdeError m)
+  :: (Ide m, MonadLogger m, MonadError IdeError m)
   => FilePath
+  -> (ReaderT IdeEnvironment (LoggingT IO) () -> m ())
   -> Text
   -> m Success
-rebuildFile' path input = do
+rebuildFile' path runOpenBuild input = do
 
   m <- case snd <$> P.parseModuleFromFile identity (path, input) of
     Left parseError ->

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -238,8 +238,8 @@ data Success =
   | PursuitResult [PursuitResponse]
   | ImportList [ModuleImport]
   | ModuleList [ModuleIdent]
-  | RebuildSuccess [P.JSONError]
-  deriving (Show, Eq)
+  | RebuildSuccess P.MultipleErrors
+  deriving (Show)
 
 encodeSuccess :: (ToJSON a) => a -> Value
 encodeSuccess res =
@@ -252,7 +252,8 @@ instance ToJSON Success where
   toJSON (PursuitResult resp) = encodeSuccess resp
   toJSON (ImportList decls) = encodeSuccess decls
   toJSON (ModuleList modules) = encodeSuccess modules
-  toJSON (RebuildSuccess modules) = encodeSuccess modules
+  toJSON (RebuildSuccess modules) =
+    encodeSuccess (P.toJSONErrors False P.Warning modules)
 
 newtype PursuitQuery = PursuitQuery Text
                      deriving (Show, Eq)

--- a/tests/Language/PureScript/Ide/CompletionSpec.hs
+++ b/tests/Language/PureScript/Ide/CompletionSpec.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Language.PureScript.Ide.CompletionSpec where
+
+import Protolude
+import qualified Data.Text as Text
+import Language.PureScript.Ide.Completion
+import Test.Hspec
+
+shouldInsertHole :: Text -> Text -> Expectation
+shouldInsertHole input output =
+  let
+    Just col = Text.findIndex (== '|') input
+  in
+    insertHole (1, col) (Text.filter (/= '|') input) `shouldBe` output <> "\n"
+
+spec :: Spec
+spec = describe "Inserting typed holes" $ do
+  it "inserts a typed hole for a record accessor" $ do
+    "record.|" `shouldInsertHole` "(?pscIdeHole record)"
+  it "inserts a typed hole for a record accessor and returns its prefix" $ do
+    pending
+    -- "record.pre|" `shouldInsertHole` "(?pscIdeHole record)"
+  it "inserts a typed hole for a wildcard record accessor" $ do
+    "_.|" `shouldInsertHole` "?pscIdeHole"
+


### PR DESCRIPTION
Adds a new completion command to psc-ide which accepts a file path and a cursor position to figure out possible record accessors at that position. 

A demo gif as posted on twitter:

![psc-ide-racc](https://cloud.githubusercontent.com/assets/6189397/21822512/c0a50288-d777-11e6-96a3-4101d8bd1628.gif)

Right now detecting where the typed hole should go is still very basic. The code just deletes the dot and wraps everything that's not a space character in front of it like so:

```purescript
record.

--------

(?typedHole record)
```

It then just takes the first argument to the inferred function type and if it is a record returns a list of completions for the field names. This completion command is fundamentally different from our other completions, as it treats the server less like a database and instead in a more "RPC"ish way, but there's no real way around it and it's commonplace in other language servers so it's natural that it came up for us as well.

I'd like to make figuring out where the typed hole needs to go more robust, but maybe this works for a start? We could special case parenthesized expressions to demonstrate that this works through actual type inference and not by parsing some type annotation, but I think it's already pretty fun to play with in its current state.

EDIT:

For the emacs'ers out there you can pull from this branch to try it out:
https://github.com/epost/psc-ide-emacs/pull/85