### PR TITLE
Fix parsing for named binders

### DIFF
--- a/examples/passing/ParseNamedBinder.purs
+++ b/examples/passing/ParseNamedBinder.purs
@@ -1,0 +1,9 @@
+module Main where
+
+import Control.Monad.Eff.Console (log)
+
+data X = X
+
+f a@X X = a
+
+main = log "Done"

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -1,6 +1,4 @@
--- |
--- Parsers for module definitions and declarations
---
+-- | Parsers for module definitions and declarations
 module Language.PureScript.Parser.Declarations
   ( parseDeclaration
   , parseModule
@@ -15,52 +13,28 @@ module Language.PureScript.Parser.Declarations
   , toPositionedError
   ) where
 
-import Prelude hiding (lex)
+import           Prelude hiding (lex)
 
-import Data.Functor (($>))
-import Data.Maybe (fromMaybe)
-import Data.Text (Text)
-
-import Control.Applicative
-import Control.Arrow ((+++))
-import Control.Monad.Error.Class (MonadError(..))
-import Control.Parallel.Strategies (withStrategy, parList, rseq)
-
-import Language.PureScript.AST
-import Language.PureScript.Comments
-import Language.PureScript.Environment
-import Language.PureScript.Errors
-import Language.PureScript.Kinds
-import Language.PureScript.Names
-import Language.PureScript.Types
-import Language.PureScript.PSString (PSString, mkString)
-import Language.PureScript.Parser.Common
-import Language.PureScript.Parser.Kinds
-import Language.PureScript.Parser.Lexer
-import Language.PureScript.Parser.Types
-
-import qualified Language.PureScript.Parser.Common as C
+import           Control.Applicative
+import           Control.Arrow ((+++))
+import           Control.Monad.Error.Class (MonadError(..))
+import           Control.Parallel.Strategies (withStrategy, parList, rseq)
+import           Data.Functor (($>))
+import           Data.Maybe (fromMaybe)
+import           Data.Text (Text)
+import           Language.PureScript.AST
+import           Language.PureScript.Environment
+import           Language.PureScript.Errors
+import           Language.PureScript.Kinds
+import           Language.PureScript.Names
+import           Language.PureScript.Parser.Common
+import           Language.PureScript.Parser.Kinds
+import           Language.PureScript.Parser.Lexer
+import           Language.PureScript.Parser.Types
+import           Language.PureScript.PSString (PSString, mkString)
+import           Language.PureScript.Types
 import qualified Text.Parsec as P
 import qualified Text.Parsec.Expr as P
-
--- |
--- Read source position information
---
-withSourceSpan
-  :: (SourceSpan -> [Comment] -> a -> a)
-  -> P.Parsec [PositionedToken] u a
-  -> P.Parsec [PositionedToken] u a
-withSourceSpan f p = do
-  start <- P.getPosition
-  comments <- C.readComments
-  x <- p
-  end <- P.getPosition
-  input <- P.getInput
-  let end' = case input of
-        pt:_ -> ptPrevEndPos pt
-        _ -> Nothing
-  let sp = SourceSpan (P.sourceName start) (C.toSourcePos start) (C.toSourcePos $ fromMaybe end end')
-  return $ f sp comments x
 
 kindedIdent :: TokenParser (Text, Maybe Kind)
 kindedIdent = (, Nothing) <$> identifier
@@ -91,7 +65,7 @@ parseValueDeclaration :: TokenParser Declaration
 parseValueDeclaration = do
   name <- parseIdent
   binders <- P.many parseBinderNoParens
-  value <- Left <$> (C.indented *>
+  value <- Left <$> (indented *>
                        P.many1 ((,) <$> parseGuard
                                     <*> (indented *> equals *> parseValueWithWhereClause)
                                ))
@@ -100,13 +74,13 @@ parseValueDeclaration = do
   where
   parseValueWithWhereClause :: TokenParser Expr
   parseValueWithWhereClause = do
-    C.indented
+    indented
     value <- parseValue
     whereClause <- P.optionMaybe $ do
-      C.indented
+      indented
       reserved "where"
-      C.indented
-      C.mark $ P.many1 (C.same *> parseLocalDeclaration)
+      indented
+      mark $ P.many1 (same *> parseLocalDeclaration)
     return $ maybe value (`Let` value) whereClause
 
 parseExternDeclaration :: TokenParser Declaration
@@ -237,9 +211,7 @@ parseDerivingInstanceDeclaration = do
 positioned :: TokenParser Declaration -> TokenParser Declaration
 positioned = withSourceSpan PositionedDeclaration
 
--- |
--- Parse a single declaration
---
+-- | Parse a single declaration
 parseDeclaration :: TokenParser Declaration
 parseDeclaration = positioned (P.choice
                    [ parseDataDeclaration
@@ -259,12 +231,10 @@ parseLocalDeclaration = positioned (P.choice
                    , parseValueDeclaration
                    ] P.<?> "local declaration")
 
--- |
--- Parse a module header and a collection of declarations
---
+-- | Parse a module header and a collection of declarations
 parseModule :: TokenParser Module
 parseModule = do
-  comments <- C.readComments
+  comments <- readComments
   start <- P.getPosition
   reserved "module"
   indented
@@ -280,7 +250,7 @@ parseModule = do
     return (imports ++ decls)
   _ <- P.eof
   end <- P.getPosition
-  let ss = SourceSpan (P.sourceName start) (C.toSourcePos start) (C.toSourcePos end)
+  let ss = SourceSpan (P.sourceName start) (toSourcePos start) (toSourcePos end)
   return $ Module ss comments name decls exports
 
 -- | Parse a collection of modules in parallel
@@ -301,7 +271,6 @@ parseModulesFromFiles toFilePath input =
   inParallel :: [Either P.ParseError (k, a)] -> [Either P.ParseError (k, a)]
   inParallel = withStrategy (parList rseq)
 
-
 -- | Parses a single module with FilePath for eventual parsing errors
 parseModuleFromFile
   :: (k -> FilePath)
@@ -313,12 +282,12 @@ parseModuleFromFile toFilePath (k, content) = do
     m <- runTokenParser filename parseModule ts
     pure (k, m)
 
--- | Converts a @ParseError@ into a @PositionedError@
+-- | Converts a 'ParseError' into a 'PositionedError'
 toPositionedError :: P.ParseError -> ErrorMessage
 toPositionedError perr = ErrorMessage [ PositionedError (SourceSpan name start end) ] (ErrorParsingModule perr)
   where
   name   = (P.sourceName  . P.errorPos) perr
-  start  = (C.toSourcePos . P.errorPos) perr
+  start  = (toSourcePos . P.errorPos) perr
   end    = start
 
 booleanLiteral :: TokenParser Bool
@@ -345,18 +314,18 @@ parseObjectLiteral p = ObjectLiteral <$> braces (commaSep p)
 parseIdentifierAndValue :: TokenParser (PSString, Expr)
 parseIdentifierAndValue =
   do
-    name <- C.indented *> lname
+    name <- indented *> lname
     b <- P.option (Var $ Qualified Nothing (Ident name)) rest
     return (mkString name, b)
-  <|> (,) <$> (C.indented *> stringLiteral) <*> rest
+  <|> (,) <$> (indented *> stringLiteral) <*> rest
   where
-  rest = C.indented *> colon *> C.indented *> parseValue
+  rest = indented *> colon *> indented *> parseValue
 
 parseAbs :: TokenParser Expr
 parseAbs = do
   symbol' "\\"
-  args <- P.many1 (C.indented *> (Abs <$> (Left <$> C.parseIdent <|> Right <$> parseBinderNoParens)))
-  C.indented *> rarrow
+  args <- P.many1 (indented *> (Abs <$> (Left <$> parseIdent <|> Right <$> parseBinderNoParens)))
+  indented *> rarrow
   value <- parseValue
   return $ toFunction args value
   where
@@ -364,18 +333,18 @@ parseAbs = do
   toFunction args value = foldr ($) value args
 
 parseVar :: TokenParser Expr
-parseVar = Var <$> C.parseQualified C.parseIdent
+parseVar = Var <$> parseQualified parseIdent
 
 parseConstructor :: TokenParser Expr
-parseConstructor = Constructor <$> C.parseQualified C.dataConstructorName
+parseConstructor = Constructor <$> parseQualified dataConstructorName
 
 parseCase :: TokenParser Expr
-parseCase = Case <$> P.between (reserved "case") (C.indented *> reserved "of") (commaSep1 parseValue)
-                 <*> (C.indented *> C.mark (P.many1 (C.same *> C.mark parseCaseAlternative)))
+parseCase = Case <$> P.between (reserved "case") (indented *> reserved "of") (commaSep1 parseValue)
+                 <*> (indented *> mark (P.many1 (same *> mark parseCaseAlternative)))
 
 parseCaseAlternative :: TokenParser CaseAlternative
 parseCaseAlternative = CaseAlternative <$> commaSep1 parseBinder
-                                       <*> (Left <$> (C.indented *>
+                                       <*> (Left <$> (indented *>
                                                         P.many1 ((,) <$> parseGuard
                                                                      <*> (indented *> rarrow *> parseValue)
                                                                 ))
@@ -383,16 +352,16 @@ parseCaseAlternative = CaseAlternative <$> commaSep1 parseBinder
                                        P.<?> "case alternative"
 
 parseIfThenElse :: TokenParser Expr
-parseIfThenElse = IfThenElse <$> (P.try (reserved "if") *> C.indented *> parseValue)
-                             <*> (C.indented *> reserved "then" *> C.indented *> parseValue)
-                             <*> (C.indented *> reserved "else" *> C.indented *> parseValue)
+parseIfThenElse = IfThenElse <$> (P.try (reserved "if") *> indented *> parseValue)
+                             <*> (indented *> reserved "then" *> indented *> parseValue)
+                             <*> (indented *> reserved "else" *> indented *> parseValue)
 
 parseLet :: TokenParser Expr
 parseLet = do
   reserved "let"
-  C.indented
-  ds <- C.mark $ P.many1 (C.same *> parseLocalDeclaration)
-  C.indented
+  indented
+  ds <- mark $ P.many1 (same *> parseLocalDeclaration)
+  indented
   reserved "in"
   result <- parseValue
   return $ Let ds result
@@ -418,9 +387,7 @@ parseValueAtom = withSourceSpan PositionedValue $ P.choice
                  , parseHole
                  ]
 
--- |
--- Parse an expression in backticks or an operator
---
+-- | Parse an expression in backticks or an operator
 parseInfixExpr :: TokenParser Expr
 parseInfixExpr
   = P.between tick tick parseValue
@@ -432,25 +399,25 @@ parseHole = Hole <$> holeLit
 parsePropertyUpdate :: TokenParser (PSString, Expr)
 parsePropertyUpdate = do
   name <- parseLabel
-  _ <- C.indented *> equals
-  value <- C.indented *> parseValue
+  _ <- indented *> equals
+  value <- indented *> parseValue
   return (name, value)
 
 parseAccessor :: Expr -> TokenParser Expr
 parseAccessor (Constructor _) = P.unexpected "constructor"
-parseAccessor obj = P.try $ Accessor <$> (C.indented *> dot *> C.indented *> parseLabel) <*> pure obj
+parseAccessor obj = P.try $ Accessor <$> (indented *> dot *> indented *> parseLabel) <*> pure obj
 
 parseDo :: TokenParser Expr
 parseDo = do
   reserved "do"
-  C.indented
-  Do <$> C.mark (P.many1 (C.same *> C.mark parseDoNotationElement))
+  indented
+  Do <$> mark (P.many1 (same *> mark parseDoNotationElement))
 
 parseDoNotationLet :: TokenParser DoNotationElement
-parseDoNotationLet = DoNotationLet <$> (reserved "let" *> C.indented *> C.mark (P.many1 (C.same *> parseLocalDeclaration)))
+parseDoNotationLet = DoNotationLet <$> (reserved "let" *> indented *> mark (P.many1 (same *> parseLocalDeclaration)))
 
 parseDoNotationBind :: TokenParser DoNotationElement
-parseDoNotationBind = DoNotationBind <$> P.try (parseBinder <* C.indented <* larrow) <*> parseValue
+parseDoNotationBind = DoNotationBind <$> P.try (parseBinder <* indented <* larrow) <*> parseValue
 
 parseDoNotationElement :: TokenParser DoNotationElement
 parseDoNotationElement = P.choice
@@ -461,33 +428,31 @@ parseDoNotationElement = P.choice
 
 -- | Expressions including indexers and record updates
 indexersAndAccessors :: TokenParser Expr
-indexersAndAccessors = C.buildPostfixParser postfixTable parseValueAtom
+indexersAndAccessors = buildPostfixParser postfixTable parseValueAtom
   where
   postfixTable = [ parseAccessor
                  , P.try . parseUpdaterBody
                  ]
 
--- |
--- Parse a value
---
+-- | Parse an expression
 parseValue :: TokenParser Expr
 parseValue = withSourceSpan PositionedValue
   (P.buildExpressionParser operators
-    . C.buildPostfixParser postfixTable
+    . buildPostfixParser postfixTable
     $ indexersAndAccessors) P.<?> "expression"
   where
-  postfixTable = [ \v -> P.try (flip App <$> (C.indented *> indexersAndAccessors)) <*> pure v
-                 , \v -> flip (TypedValue True) <$> (C.indented *> doubleColon *> parsePolyType) <*> pure v
+  postfixTable = [ \v -> P.try (flip App <$> (indented *> indexersAndAccessors)) <*> pure v
+                 , \v -> flip (TypedValue True) <$> (indented *> doubleColon *> parsePolyType) <*> pure v
                  ]
-  operators = [ [ P.Prefix (C.indented *> symbol' "-" *> return UnaryMinus)
+  operators = [ [ P.Prefix (indented *> symbol' "-" *> return UnaryMinus)
                 ]
-              , [ P.Infix (P.try (C.indented *> parseInfixExpr P.<?> "infix expression") >>= \ident ->
+              , [ P.Infix (P.try (indented *> parseInfixExpr P.<?> "infix expression") >>= \ident ->
                     return (BinaryNoParens ident)) P.AssocRight
                 ]
               ]
 
 parseUpdaterBody :: Expr -> TokenParser Expr
-parseUpdaterBody v = ObjectUpdate v <$> (C.indented *> braces (commaSep1 (C.indented *> parsePropertyUpdate)))
+parseUpdaterBody v = ObjectUpdate v <$> (indented *> braces (commaSep1 (indented *> parsePropertyUpdate)))
 
 parseAnonymousArgument :: TokenParser Expr
 parseAnonymousArgument = underscore *> pure AnonymousArgument
@@ -501,21 +466,21 @@ parseNumberLiteral = LiteralBinder . NumericLiteral <$> (sign <*> number)
          <|> return id
 
 parseNullaryConstructorBinder :: TokenParser Binder
-parseNullaryConstructorBinder = ConstructorBinder <$> C.parseQualified C.dataConstructorName <*> pure []
+parseNullaryConstructorBinder = ConstructorBinder <$> parseQualified dataConstructorName <*> pure []
 
 parseConstructorBinder :: TokenParser Binder
-parseConstructorBinder = ConstructorBinder <$> C.parseQualified C.dataConstructorName <*> many (C.indented *> parseBinderNoParens)
+parseConstructorBinder = ConstructorBinder <$> parseQualified dataConstructorName <*> many (indented *> parseBinderNoParens)
 
 parseObjectBinder:: TokenParser Binder
-parseObjectBinder = LiteralBinder <$> parseObjectLiteral (C.indented *> parseIdentifierAndBinder)
+parseObjectBinder = LiteralBinder <$> parseObjectLiteral (indented *> parseIdentifierAndBinder)
 
 parseArrayBinder :: TokenParser Binder
-parseArrayBinder = LiteralBinder <$> parseArrayLiteral (C.indented *> parseBinder)
+parseArrayBinder = LiteralBinder <$> parseArrayLiteral (indented *> parseBinder)
 
 parseVarOrNamedBinder :: TokenParser Binder
 parseVarOrNamedBinder = do
-  name <- C.parseIdent
-  let parseNamedBinder = NamedBinder name <$> (at *> C.indented *> parseBinderAtom)
+  name <- parseIdent
+  let parseNamedBinder = NamedBinder name <$> (at *> indented *> parseBinderNoParens)
   parseNamedBinder <|> return (VarBinder name)
 
 parseNullBinder :: TokenParser Binder
@@ -528,11 +493,9 @@ parseIdentifierAndBinder =
        return (mkString name, b)
     <|> (,) <$> stringLiteral <*> rest
   where
-    rest = C.indented *> colon *> C.indented *> parseBinder
+    rest = indented *> colon *> indented *> parseBinder
 
--- |
--- Parse a binder
---
+-- | Parse a binder
 parseBinder :: TokenParser Binder
 parseBinder =
   withSourceSpan
@@ -543,7 +506,7 @@ parseBinder =
     )
   where
   operators =
-    [ [ P.Infix (P.try (C.indented *> parseOpBinder P.<?> "binder operator") >>= \op ->
+    [ [ P.Infix (P.try (indented *> parseOpBinder P.<?> "binder operator") >>= \op ->
           return (BinaryNoParensBinder op)) P.AssocRight
       ]
     ]
@@ -569,9 +532,7 @@ parseBinderAtom = P.choice
   , ParensInBinder <$> parens parseBinder
   ] P.<?> "binder"
 
--- |
--- Parse a binder as it would appear in a top level declaration
---
+-- | Parse a binder as it would appear in a top level declaration
 parseBinderNoParens :: TokenParser Binder
 parseBinderNoParens = P.choice
                       [ parseNullBinder
@@ -586,8 +547,6 @@ parseBinderNoParens = P.choice
                       , ParensInBinder <$> parens parseBinder
                       ] P.<?> "binder"
 
--- |
--- Parse a guard
---
+-- | Parse a guard
 parseGuard :: TokenParser Guard
-parseGuard = pipe *> C.indented *> parseValue
+parseGuard = pipe *> indented *> parseValue


### PR DESCRIPTION
I spotted this today. You can see that the example I added actually parses incorrectly, if you run it in Try PureScript.

The only change here is in `parseVarOrNamedBinder`, which now uses `parseBinderNoParens`, but I'm trying to go through and tidy things up a little bit as I make fixes.