### PR TITLE
Support nested record update

### DIFF
--- a/examples/passing/NestedRecordUpdate.purs
+++ b/examples/passing/NestedRecordUpdate.purs
@@ -1,0 +1,23 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console
+
+type T = { foo :: Int, bar :: { baz :: Int, qux :: Int } }
+
+init :: T
+init = { foo: 1, bar: { baz: 2, qux: 3 } }
+
+updated :: T
+updated = init { foo = 10, bar.baz = 20, bar.qux = 30 }
+
+expected :: T
+expected = { foo: 10, bar: { baz: 20, qux: 30 } }
+
+check l r =
+  l.foo == r.foo &&
+  l.bar.baz == r.bar.baz &&
+  l.bar.qux == r.bar.qux
+
+main = do
+  when (check updated expected) $ log "Done"

--- a/examples/passing/NestedRecordUpdateWildcards.purs
+++ b/examples/passing/NestedRecordUpdateWildcards.purs
@@ -1,0 +1,20 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console
+
+update = _ { foo = _, bar.baz = _, bar.qux = _ }
+
+init = { foo: 1, bar: { baz: 2, qux: 3 } }
+
+after = update init 10 20 30
+
+expected = { foo: 10, bar: { baz: 20, qux: 30 } }
+
+check l r =
+  l.foo == r.foo &&
+  l.bar.baz == r.bar.baz &&
+  l.bar.qux == r.bar.qux
+
+main = do
+  when (check after expected) $ log "Done"

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -12,6 +12,7 @@ import Control.Monad.Identity
 import Data.Aeson.TH
 import qualified Data.Map as M
 import Data.Text (Text)
+import Data.List.NonEmpty (NonEmpty(..))
 
 import Language.PureScript.AST.Binders
 import Language.PureScript.AST.Literals
@@ -581,6 +582,11 @@ data Expr
   -- Partial record update
   --
   | ObjectUpdate Expr [(PSString, Expr)]
+  -- |
+  -- Object updates with nested support: `x { foo.bar = e }`
+  -- Replaced during desugaring into a `Let` and nested `ObjectUpdate`s
+  --
+  | ObjectUpdateNested Expr [(NonEmpty PSString, Expr)]
   -- |
   -- Function introduction
   --

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -12,6 +12,7 @@ import Prelude.Compat
 import Control.Arrow (second)
 
 import qualified Data.Monoid as Monoid ((<>))
+import Data.List.NonEmpty (NonEmpty(..))
 
 import qualified Data.Text as T
 import Data.Text (Text)
@@ -47,6 +48,12 @@ prettyPrintObject d = list '{' '}' prettyPrintObjectProperty
   prettyPrintObjectProperty :: (PSString, Maybe Expr) -> Box
   prettyPrintObjectProperty (key, value) = textT (prettyPrintObjectKey key Monoid.<> ": ") <> maybe (text "_") (prettyPrintValue (d - 1)) value
 
+prettyPrintObjectUpdate :: forall k. (k -> Box) -> Int -> Expr -> [(k, Expr)] -> Box
+prettyPrintObjectUpdate printKey d o ps =
+  prettyPrintValueAtom (d - 1) o `beforeWithSpace` list '{' '}' printEntry ps
+  where
+    printEntry (key, val) = printKey key <> text " = " <> prettyPrintValue (d - 1) val
+
 -- | Pretty-print an expression
 prettyPrintValue :: Int -> Expr -> Box
 prettyPrintValue d _ | d < 0 = text "..."
@@ -56,7 +63,10 @@ prettyPrintValue d (IfThenElse cond th el) =
                             , text "else " <> prettyPrintValueAtom (d - 1) el
                             ])
 prettyPrintValue d (Accessor prop val) = prettyPrintValueAtom (d - 1) val `before` textT ("." Monoid.<> prettyPrintObjectKey prop)
-prettyPrintValue d (ObjectUpdate o ps) = prettyPrintValueAtom (d - 1) o `beforeWithSpace` list '{' '}' (\(key, val) -> textT (prettyPrintObjectKey key Monoid.<> " = ") <> prettyPrintValue (d - 1) val) ps
+prettyPrintValue d (ObjectUpdate o ps) = prettyPrintObjectUpdate (textT . prettyPrintObjectKey) d o ps
+prettyPrintValue d (ObjectUpdateNested o ps) = prettyPrintObjectUpdate printPath d o ps where
+  printPath (hd :| tl) = foldl combine (textT (prettyPrintObjectKey hd)) tl
+  combine acc key = acc <> textT ("." Monoid.<> prettyPrintObjectKey key)
 prettyPrintValue d (App val arg) = prettyPrintValueAtom (d - 1) val `beforeWithSpace` prettyPrintValueAtom (d - 1) arg
 prettyPrintValue d (Abs (Left arg) val) = text ('\\' : T.unpack (showIdent arg) ++ " -> ") // moveRight 2 (prettyPrintValue (d - 1) val)
 prettyPrintValue d (Abs (Right arg) val) = text ('\\' : T.unpack (prettyPrintBinder arg) ++ " -> ") // moveRight 2 (prettyPrintValue (d - 1) val)

--- a/src/Language/PureScript/Sugar/ObjectWildcards.hs
+++ b/src/Language/PureScript/Sugar/ObjectWildcards.hs
@@ -30,8 +30,8 @@ import           Language.PureScript.PSString (PSString)
 -- We represent the updates as the `PathTree`:
 --
 --  M.fromList [ ("foo", Leaf 3)
---             , ("bar", Branch M.fromList [ ("baz", Leaf 1)
---                                         , ("qux", Leaf 2) ]) ]
+--             , ("bar", Branch (M.fromList [ ("baz", Leaf 1)
+--                                          , ("qux", Leaf 2) ]) ])
 --
 -- Which we then convert to an expression representing the following:
 --
@@ -39,6 +39,9 @@ import           Language.PureScript.PSString (PSString)
 --   in x' { foo = 0
 --         , bar = x'.bar { baz = 1
 --                        , qux = 2 } }
+--
+-- The `let` here is required to prevent re-evaluating the object expression `x`.
+-- However we don't generate this when using an anonymous argument for the object.
 --
 type PathTree = Map PSString PathNode
 data PathNode = Leaf Expr | Branch PathTree


### PR DESCRIPTION
This adds sugar for nested record updates:

```purescript
x { foo.bar = 3, foo.baz = 2 }
```

Also allows wildcards:

```purescript
_ { foo.bar = _ }
```