### PR TITLE
Require dependencies to exist during sorting phase

### DIFF
--- a/examples/failing/ImportModule.purs
+++ b/examples/failing/ImportModule.purs
@@ -1,4 +1,4 @@
--- @shouldFailWith UnknownName
+-- @shouldFailWith ModuleNotFound
 module Main where
 
 import M1

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -44,7 +44,8 @@ data TypeSearch
 
 -- | A type of error messages
 data SimpleErrorMessage
-  = ErrorParsingFFIModule FilePath (Maybe Bundle.ErrorMessage)
+  = ModuleNotFound ModuleName 
+  | ErrorParsingFFIModule FilePath (Maybe Bundle.ErrorMessage)
   | ErrorParsingModule P.ParseError
   | MissingFFIModule ModuleName
   | MultipleFFIModules ModuleName [FilePath]

--- a/src/Language/PureScript/ModuleDependencies.hs
+++ b/src/Language/PureScript/ModuleDependencies.hs
@@ -4,17 +4,18 @@ module Language.PureScript.ModuleDependencies
   , ModuleGraph
   ) where
 
-import Prelude.Compat
+import           Prelude.Compat
 
-import Control.Monad (forM_, when)
-import Control.Monad.Error.Class (MonadError(..))
-import Data.Graph
-import Data.List (nub)
-import Data.Maybe (fromMaybe)
-import Language.PureScript.AST
-import Language.PureScript.Crash
-import Language.PureScript.Errors
-import Language.PureScript.Names
+import           Control.Monad (forM_, when)
+import           Control.Monad.Error.Class (MonadError(..))
+import           Data.Graph
+import           Data.List (nub)
+import           Data.Maybe (fromMaybe)
+import           Language.PureScript.AST
+import qualified Language.PureScript.Constants as C
+import           Language.PureScript.Crash
+import           Language.PureScript.Errors
+import           Language.PureScript.Names
 
 -- | A list of modules with their transitive dependencies
 type ModuleGraph = [(ModuleName, [ModuleName])]
@@ -43,7 +44,7 @@ sortModules ms = do
     toGraphNode mns m@(Module _ _ mn ds _) = do
       let deps = nub (concatMap usedModules ds)
       forM_ deps $ \dep ->
-        when (dep `notElem` mns) $
+        when (dep /= C.Prim && notElem dep mns) $
           throwError . addHint (ErrorInModule mn) . errorMessage $ ModuleNotFound dep
       pure (m, getModuleName m, deps)
 

--- a/src/Language/PureScript/ModuleDependencies.hs
+++ b/src/Language/PureScript/ModuleDependencies.hs
@@ -1,6 +1,4 @@
--- |
--- Provides the ability to sort modules based on module dependencies
---
+-- | Provides the ability to sort modules based on module dependencies
 module Language.PureScript.ModuleDependencies
   ( sortModules
   , ModuleGraph
@@ -8,17 +6,15 @@ module Language.PureScript.ModuleDependencies
 
 import Prelude.Compat
 
+import Control.Monad (forM_, when)
 import Control.Monad.Error.Class (MonadError(..))
-
 import Data.Graph
 import Data.List (nub)
 import Data.Maybe (fromMaybe)
-
 import Language.PureScript.AST
 import Language.PureScript.Crash
 import Language.PureScript.Errors
 import Language.PureScript.Names
-import Language.PureScript.Types
 
 -- | A list of modules with their transitive dependencies
 type ModuleGraph = [(ModuleName, [ModuleName])]
@@ -26,74 +22,44 @@ type ModuleGraph = [(ModuleName, [ModuleName])]
 -- | Sort a collection of modules based on module dependencies.
 --
 -- Reports an error if the module graph contains a cycle.
---
-sortModules :: (MonadError MultipleErrors m) => [Module] -> m ([Module], ModuleGraph)
+sortModules
+  :: forall m
+   . MonadError MultipleErrors m
+  => [Module]
+  -> m ([Module], ModuleGraph)
 sortModules ms = do
-  let verts = map goModule ms
-  ms' <- mapM toModule $ stronglyConnComp verts
-  let (graph, fromVertex, toVertex) = graphFromEdges verts
-      moduleGraph = do (_, mn, _) <- verts
-                       let v       = fromMaybe (internalError "sortModules: vertex not found") (toVertex mn)
-                           deps    = reachable graph v
-                           toKey i = case fromVertex i of (_, key, _) -> key
-                       return (mn, filter (/= mn) (map toKey deps))
-  return (ms', moduleGraph)
+    let mns = map getModuleName ms
+    verts <- mapM (toGraphNode mns) ms
+    ms' <- mapM toModule $ stronglyConnComp verts
+    let (graph, fromVertex, toVertex) = graphFromEdges verts
+        moduleGraph = do (_, mn, _) <- verts
+                         let v       = fromMaybe (internalError "sortModules: vertex not found") (toVertex mn)
+                             deps    = reachable graph v
+                             toKey i = case fromVertex i of (_, key, _) -> key
+                         return (mn, filter (/= mn) (map toKey deps))
+    return (ms', moduleGraph)
   where
-  goModule :: Module -> (Module, ModuleName, [ModuleName])
-  goModule m@(Module _ _ _ ds _) =
-    let ams = concatMap extractQualAs ds
-    in (m, getModuleName m, nub (concatMap (usedModules ams) ds))
+    toGraphNode :: [ModuleName] -> Module -> m (Module, ModuleName, [ModuleName])
+    toGraphNode mns m@(Module _ _ mn ds _) = do
+      let deps = nub (concatMap usedModules ds)
+      forM_ deps $ \dep ->
+        when (dep `notElem` mns) $
+          throwError . addHint (ErrorInModule mn) . errorMessage $ ModuleNotFound dep
+      pure (m, getModuleName m, deps)
 
-  -- Extract module names that have been brought into scope by an `as` import.
-  extractQualAs :: Declaration -> [ModuleName]
-  extractQualAs (PositionedDeclaration _ _ d) = extractQualAs d
-  extractQualAs (ImportDeclaration _ _ (Just am)) = [am]
-  extractQualAs _ = []
-
--- |
--- Calculate a list of used modules based on explicit imports and qualified
--- names. `ams` is a list of `ModuleNames` that refer to names brought into
--- scope by importing with `as` - this ensures that when building the list we
--- don't inadvertantly assume a dependency on an actual module, if there is a
--- module that has the same name as the qualified import.
---
-usedModules :: [ModuleName] -> Declaration -> [ModuleName]
-usedModules ams d =
-  let (f, _, _, _, _) = everythingOnValues (++) forDecls forValues (const []) (const []) (const [])
-      (g, _, _, _, _) = accumTypes (everythingOnTypes (++) forTypes)
-  in nub (f d ++ g d)
-  where
+-- | Calculate a list of used modules based on explicit imports and qualified names.
+usedModules :: Declaration -> [ModuleName]
+usedModules d = nub (f d) where
+  f :: Declaration -> [ModuleName]
+  (f, _, _, _, _) = everythingOnValues (++) forDecls (const []) (const []) (const []) (const [])
 
   forDecls :: Declaration -> [ModuleName]
-  forDecls (ImportDeclaration mn _ _) =
-    -- Regardless of whether an imported module is qualified we still need to
-    -- take into account its import to build an accurate list of dependencies.
-    [mn]
-  forDecls (FixityDeclaration fd)
-    | Just mn <- extractQualFixity fd, mn `notElem` ams = [mn]
-  forDecls (TypeInstanceDeclaration _ _ (Qualified (Just mn) _) _ _)
-    | mn `notElem` ams = [mn]
+  -- Regardless of whether an imported module is qualified we still need to
+  -- take into account its import to build an accurate list of dependencies.
+  forDecls (ImportDeclaration mn _ _) = [mn]
   forDecls _ = []
 
-  forValues :: Expr -> [ModuleName]
-  forValues (Var (Qualified (Just mn) _))
-    | mn `notElem` ams = [mn]
-  forValues (Constructor (Qualified (Just mn) _))
-    | mn `notElem` ams = [mn]
-  forValues _ = []
-
-  forTypes :: Type -> [ModuleName]
-  forTypes (TypeConstructor (Qualified (Just mn) _))
-    | mn `notElem` ams = [mn]
-  forTypes _ = []
-
-  extractQualFixity :: Either ValueFixity TypeFixity -> Maybe ModuleName
-  extractQualFixity (Left (ValueFixity _ (Qualified mn _) _)) = mn
-  extractQualFixity (Right (TypeFixity _ (Qualified mn _) _)) = mn
-
--- |
--- Convert a strongly connected component of the module graph to a module
---
+-- | Convert a strongly connected component of the module graph to a module
 toModule :: (MonadError MultipleErrors m) => SCC Module -> m Module
 toModule (AcyclicSCC m) = return m
 toModule (CyclicSCC [m]) = return m

--- a/tests/Language/PureScript/Ide/Integration.hs
+++ b/tests/Language/PureScript/Ide/Integration.hs
@@ -243,7 +243,7 @@ unwrapResult = withObject "result" $ \o -> do
   case rt of
     "error" -> do
       res <- o .: "result"
-      pure (Left res)
+      withArray "errors" (fmap (Left . fold) . traverse (withObject "error" (.: "message"))) res
     "success" -> do
       res <- o .: "result"
       pure (Right res)


### PR DESCRIPTION
Fixes #1921

I did some tidying up again as I went through here. Sorry for all the commit noise.

The main changes are:

- Adding the `ModuleNotFound` error, and throwing it during module sorting.
- Simplifying the module sorting logic, since we only need to look at imports now, I think.

It turns out the problem was that if a dependency were deleted, it was never getting passed into `Make` in the first place, so the "should rebuild" test was always returning `False`, since `Make` thought the other module had no dependencies.

Since `sortModules` is the first thing to happen, it makes sense to me that we should check for missing imports there.