### PR TITLE
Abstraction for dumping intermediate representations

### DIFF
--- a/psc/Main.hs
+++ b/psc/Main.hs
@@ -144,6 +144,16 @@ sourceMaps = switch $
      long "source-maps"
   <> help "Generate source maps"
 
+dumpParsed :: Parser Bool
+dumpParsed = switch $
+     long "dump-parsed"
+  <> help "Dump the abstract syntax tree of the compiled code at output/*/parsed.dump-parsed"
+
+dumpDesugared :: Parser Bool
+dumpDesugared = switch $
+     long "dump-desugared"
+  <> help "Dump the desugared source of the compiled code at output/*/desugared.dump-desugared"
+
 dumpCoreFn :: Parser Bool
 dumpCoreFn = switch $
      long "dump-corefn"
@@ -158,6 +168,8 @@ options = P.Options <$> noTco
                     <*> verboseErrors
                     <*> (not <$> comments)
                     <*> sourceMaps
+                    <*> dumpParsed
+                    <*> dumpDesugared
                     <*> dumpCoreFn
 
 pscMakeOptions :: Parser PSCMakeOptions

--- a/src/Language/PureScript/Options.hs
+++ b/src/Language/PureScript/Options.hs
@@ -32,6 +32,12 @@ data Options = Options {
     -- Generate soure maps
   , optionsSourceMaps :: Bool
     -- |
+    -- Dump abstract syntax tree of source
+  , optionsDumpParsed :: Bool
+    -- |
+    -- Dump desugared source
+  , optionsDumpDesugared :: Bool
+    -- |
     -- Dump CoreFn
   , optionsDumpCoreFn :: Bool
   } deriving Show
@@ -39,4 +45,4 @@ data Options = Options {
 -- |
 -- Default make options
 defaultOptions :: Options
-defaultOptions = Options False False Nothing False False False False False
+defaultOptions = Options False False Nothing False False False False False False False

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -5,6 +5,7 @@ module Language.PureScript.Pretty.Values
   ( prettyPrintValue
   , prettyPrintBinder
   , prettyPrintBinderAtom
+  , prettyPrintDeclaration
   ) where
 
 import Prelude.Compat
@@ -134,7 +135,7 @@ prettyPrintDeclaration d (BindingGroupDeclaration ds) =
   where
   toDecl (nm, t, e) = ValueDeclaration nm t [] (Right e)
 prettyPrintDeclaration d (PositionedDeclaration _ _ decl) = prettyPrintDeclaration d decl
-prettyPrintDeclaration _ _ = internalError "Invalid argument to prettyPrintDeclaration"
+prettyPrintDeclaration _ x = text ("-- " ++ show x)
 
 prettyPrintCaseAlternative :: Int -> CaseAlternative -> Box
 prettyPrintCaseAlternative d _ | d < 0 = ellipsis

--- a/src/Language/PureScript/Publish/BoxesHelpers.hs
+++ b/src/Language/PureScript/Publish/BoxesHelpers.hs
@@ -47,3 +47,6 @@ printToStderr = hPutStr stderr . Boxes.render
 
 printToStdout :: Boxes.Box -> IO ()
 printToStdout = putStr . Boxes.render
+
+renderToFile :: FilePath -> Boxes.Box -> IO ()
+renderToFile file = writeFile file . Boxes.render


### PR DESCRIPTION
While implementing https://github.com/purescript/purescript/pull/2588 I often need to view desugared source. My solutions until now were rather ad-hoc and I needed to be careful not to commit that trace messages. I hope I can convince you this is useful. 