### PR TITLE
Add modules for rendering HTML documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -48,6 +48,7 @@ PureScript uses the following Haskell library packages. Their license files foll
   bytestring-builder
   case-insensitive
   cereal
+  cheapskate
   clock
   cmdargs
   comonad
@@ -58,7 +59,13 @@ PureScript uses the following Haskell library packages. Their license files foll
   contravariant
   cookie
   cryptonite
+  css-text
+  data-default
   data-default-class
+  data-default-instances-base
+  data-default-instances-containers
+  data-default-instances-dlist
+  data-default-instances-old-locale
   data-ordlist
   deepseq
   directory
@@ -142,6 +149,7 @@ PureScript uses the following Haskell library packages. Their license files foll
   system-fileio
   system-filepath
   tagged
+  tagsoup
   template-haskell
   temporary
   terminfo
@@ -152,6 +160,7 @@ PureScript uses the following Haskell library packages. Their license files foll
   transformers-base
   transformers-compat
   turtle
+  uniplate
   unix
   unix-compat
   unix-time
@@ -172,6 +181,7 @@ PureScript uses the following Haskell library packages. Their license files foll
   x509-store
   x509-system
   x509-validation
+  xss-sanitize
   zlib
 
 Glob LICENSE file:
@@ -1311,6 +1321,39 @@ cereal LICENSE file:
   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 
+cheapskate LICENSE file:
+
+  Copyright (c) 2013, John MacFarlane
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+
+      * Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials provided
+        with the distribution.
+
+      * Neither the name of John MacFarlane nor the names of other
+        contributors may be used to endorse or promote products derived
+        from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 clock LICENSE file:
 
   Copyright (c) 2009-2012, Cetin Sert
@@ -1606,7 +1649,180 @@ cryptonite LICENSE file:
   OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
   SUCH DAMAGE.
 
+css-text LICENSE file:
+
+  The following license covers this documentation, and the source code, except
+  where otherwise indicated.
+
+  Copyright 2010, Michael Snoyman. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS "AS IS" AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+  EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+  OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+data-default LICENSE file:
+
+  Copyright (c) 2013 Lukas Mai
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * Neither the name of the author nor the names of his contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 data-default-class LICENSE file:
+
+  Copyright (c) 2013 Lukas Mai
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * Neither the name of the author nor the names of his contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY LUKAS MAI AND CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+data-default-instances-base LICENSE file:
+
+  Copyright (c) 2013 Lukas Mai
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * Neither the name of the author nor the names of his contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+data-default-instances-containers LICENSE file:
+
+  Copyright (c) 2013 Lukas Mai
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * Neither the name of the author nor the names of his contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY LUKAS MAI AND CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+data-default-instances-dlist LICENSE file:
+
+  Copyright (c) 2013 Lukas Mai
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * Neither the name of the author nor the names of his contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY LUKAS MAI AND CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+data-default-instances-old-locale LICENSE file:
 
   Copyright (c) 2013 Lukas Mai
 
@@ -4366,6 +4582,39 @@ tagged LICENSE file:
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+tagsoup LICENSE file:
+
+  Copyright Neil Mitchell 2006-2016.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+
+      * Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials provided
+        with the distribution.
+
+      * Neither the name of Neil Mitchell nor the names of other
+        contributors may be used to endorse or promote products derived
+        from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 template-haskell LICENSE file:
 
 
@@ -4648,6 +4897,39 @@ turtle LICENSE file:
   ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+uniplate LICENSE file:
+
+  Copyright Neil Mitchell 2006-2013.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+
+      * Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials provided
+        with the distribution.
+
+      * Neither the name of Neil Mitchell nor the names of other
+        contributors may be used to endorse or promote products derived
+        from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 unix LICENSE file:
 
@@ -5237,6 +5519,34 @@ x509-validation LICENSE file:
   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
   OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
   SUCH DAMAGE.
+
+xss-sanitize LICENSE file:
+
+  The following license covers this documentation, and the source code, except
+  where otherwise indicated.
+
+  Copyright 2010, Greg Weber. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS "AS IS" AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+  EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+  OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 zlib LICENSE file:
 

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -117,9 +117,11 @@ library
                    aeson-better-errors >= 0.8,
                    ansi-terminal >= 0.6.2 && < 0.7,
                    base-compat >=0.6.0,
+                   blaze-html >= 0.8.1 && < 0.9,
                    bower-json >= 1.0.0.1 && < 1.1,
                    boxes >= 0.1.4 && < 0.2.0,
                    bytestring -any,
+                   cheapskate >= 0.1 && < 0.2,
                    containers -any,
                    clock -any,
                    data-ordlist >= 0.4.7.0,
@@ -270,6 +272,7 @@ library
                      Language.PureScript.Docs.RenderedCode.RenderType
                      Language.PureScript.Docs.RenderedCode.RenderKind
                      Language.PureScript.Docs.AsMarkdown
+                     Language.PureScript.Docs.AsHtml
                      Language.PureScript.Docs.ParseInPackage
                      Language.PureScript.Docs.Utils.MonoidExtras
 

--- a/src/Language/PureScript/Docs/AsHtml.hs
+++ b/src/Language/PureScript/Docs/AsHtml.hs
@@ -1,0 +1,299 @@
+
+-- | Functions for rendering generated documentation from PureScript code as
+-- HTML.
+
+module Language.PureScript.Docs.AsHtml (
+  HtmlOutput(..),
+  HtmlOutputModule(..),
+  HtmlRenderContext(..),
+  nullRenderContext,
+  declNamespace,
+  packageAsHtml,
+  moduleAsHtml,
+  makeFragment,
+  renderMarkdown
+) where
+
+import Prelude
+import Control.Arrow (second)
+import Control.Category ((>>>))
+import Control.Monad (unless)
+import Data.Char (isUpper)
+import Data.Monoid ((<>))
+import Data.Foldable (for_)
+import Data.String (fromString)
+
+import Data.Text (Text)
+import qualified Data.Text as T
+
+import Text.Blaze.Html5 as H hiding (map)
+import qualified Text.Blaze.Html5.Attributes as A
+import qualified Cheapskate
+
+import qualified Language.PureScript as P
+
+import Language.PureScript.Docs.Types
+import Language.PureScript.Docs.RenderedCode hiding (sp)
+import qualified Language.PureScript.Docs.Render as Render
+
+declNamespace :: Declaration -> Namespace
+declNamespace = declInfoNamespace . declInfo
+
+data HtmlOutput a = HtmlOutput
+  { htmlIndex     :: [(Maybe Char, a)]
+  , htmlModules   :: [(P.ModuleName, HtmlOutputModule a)]
+  }
+  deriving (Show, Functor)
+
+data HtmlOutputModule a = HtmlOutputModule
+  { htmlOutputModuleLocals    :: a
+  , htmlOutputModuleReExports :: [(InPackage P.ModuleName, a)]
+  }
+  deriving (Show, Functor)
+
+data HtmlRenderContext = HtmlRenderContext
+  { currentModuleName :: P.ModuleName
+  , buildDocLink :: Namespace -> Text -> ContainingModule -> Maybe DocLink
+  , renderDocLink :: DocLink -> Text
+  , renderSourceLink :: P.SourceSpan -> Text
+  }
+
+-- |
+-- An HtmlRenderContext for when you don't want to render any links.
+nullRenderContext :: P.ModuleName -> HtmlRenderContext
+nullRenderContext mn = HtmlRenderContext
+  { currentModuleName = mn
+  , buildDocLink = const (const (const Nothing))
+  , renderDocLink = const ""
+  , renderSourceLink = const ""
+  }
+
+packageAsHtml :: (P.ModuleName -> HtmlRenderContext) -> Package a -> HtmlOutput Html
+packageAsHtml getHtmlCtx Package{..} =
+  HtmlOutput indexFile modules
+  where
+  indexFile = []
+  modules = map (\m -> moduleAsHtml (getHtmlCtx (modName m)) m) pkgModules
+
+moduleAsHtml :: HtmlRenderContext -> Module -> (P.ModuleName, HtmlOutputModule Html)
+moduleAsHtml r Module{..} = (modName, HtmlOutputModule modHtml reexports)
+  where
+  renderDecl = declAsHtml r
+  modHtml = do
+    for_ modComments renderMarkdown
+    for_ modDeclarations renderDecl
+  reexports =
+    map (second (foldMap renderDecl)) modReExports
+
+-- renderIndex :: LinksContext -> [(Maybe Char, Html)]
+-- renderIndex LinksContext{..} = go ctxBookmarks
+--   where
+--   go = takeLocals
+--      >>> groupIndex getIndex renderEntry
+--      >>> map (second (ul . mconcat))
+-- 
+--   getIndex (_, title_) = do
+--     c <- textHeadMay title_
+--     guard (toUpper c `elem` ['A'..'Z'])
+--     pure c
+-- 
+--   textHeadMay t =
+--     case T.length t of
+--       0 -> Nothing
+--       _ -> Just (T.index t 0)
+-- 
+--   renderEntry (mn, title_) =
+--     li $ do
+--       let url = T.pack (filePathFor mn `relativeTo` "index") <> "#" <> title_
+--       code $
+--         a ! A.href (v url) $ text title_
+--       sp
+--       text ("(" <> P.runModuleName mn <> ")")
+-- 
+--   groupIndex :: Ord i => (a -> Maybe i) -> (a -> b) -> [a] -> [(Maybe i, [b])]
+--   groupIndex f g =
+--     map (second DList.toList) . M.toList . foldr go' M.empty . sortBy (comparing f)
+--     where
+--     go' x = insertOrAppend (f x) (g x)
+--     insertOrAppend idx val m =
+--       let cur = M.findWithDefault DList.empty idx m
+--           new = DList.snoc cur val
+--       in  M.insert idx new m
+
+declAsHtml :: HtmlRenderContext -> Declaration -> Html
+declAsHtml r d@Declaration{..} = do
+  let declFragment = makeFragment (declInfoNamespace declInfo) declTitle
+  H.div ! A.class_ "decl" ! A.id (v (T.drop 1 declFragment)) $ do
+    h3 ! A.class_ "decl__title clearfix" $ do
+      a ! A.class_ "decl__anchor" ! A.href (v declFragment) $ "#"
+      text declTitle
+      for_ declSourceSpan (linkToSource r)
+
+    H.div ! A.class_ "decl__body" $ do
+      case declInfo of
+        AliasDeclaration fixity alias_ ->
+          renderAlias fixity alias_
+        _ ->
+          pre ! A.class_ "decl__signature" $ code $
+            codeAsHtml r (Render.renderDeclaration d)
+
+      for_ declComments renderMarkdown
+
+      let (instances, dctors, members) = partitionChildren declChildren
+
+      unless (null dctors) $ do
+        h4 "Constructors"
+        renderChildren r dctors
+
+      unless (null members) $ do
+        h4 "Members"
+        renderChildren r members
+
+      unless (null instances) $ do
+        h4 "Instances"
+        renderChildren r instances
+  where
+    linkToSource :: HtmlRenderContext -> P.SourceSpan -> Html
+    linkToSource ctx srcspan =
+      H.span ! A.class_ "decl__source" $
+        a ! A.href (v (renderSourceLink ctx srcspan)) $ text "Source"
+
+renderChildren :: HtmlRenderContext -> [ChildDeclaration] -> Html
+renderChildren _ [] = return ()
+renderChildren r xs = ul $ mapM_ go xs
+  where
+  go decl = item decl . code . codeAsHtml r . Render.renderChildDeclaration $ decl
+  item decl = let fragment = makeFragment (childDeclInfoNamespace (cdeclInfo decl)) (cdeclTitle decl)
+              in  li ! A.id (v (T.drop 1 fragment))
+
+codeAsHtml :: HtmlRenderContext -> RenderedCode -> Html
+codeAsHtml r = outputWith elemAsHtml
+  where
+  elemAsHtml e = case e of
+    Syntax x ->
+      withClass "syntax" (text x)
+    Keyword x ->
+      withClass "keyword" (text x)
+    Space ->
+      text " "
+    Symbol ns name link_ ->
+      case link_ of
+        Link mn ->
+          let
+            class_ = if startsWithUpper name then "ctor" else "ident"
+          in
+            linkToDecl ns name mn (withClass class_ (text name))
+        NoLink ->
+          text name
+
+  linkToDecl = linkToDeclaration r
+
+  startsWithUpper :: Text -> Bool
+  startsWithUpper str =
+    if T.null str
+      then False
+      else isUpper (T.index str 0)
+
+renderLink :: HtmlRenderContext -> DocLink -> Html -> Html
+renderLink r link_@DocLink{..} =
+  a ! A.href (v (renderDocLink r link_ <> fragmentFor link_))
+    ! A.title (v fullyQualifiedName)
+  where
+  fullyQualifiedName = case linkLocation of
+    SameModule                -> fq (currentModuleName r) linkTitle
+    LocalModule _ modName     -> fq modName linkTitle
+    DepsModule _ _ _ modName  -> fq modName linkTitle
+    BuiltinModule modName     -> fq modName linkTitle
+
+  fq mn str = P.runModuleName mn <> "." <> str
+
+makeFragment :: Namespace -> Text -> Text
+makeFragment ns = (prefix <>) . escape
+  where
+  prefix = case ns of
+    TypeLevel -> "#t:"
+    ValueLevel -> "#v:"
+    KindLevel -> "#k:"
+
+  -- TODO
+  escape = id
+
+fragmentFor :: DocLink -> Text
+fragmentFor l = makeFragment (linkNamespace l) (linkTitle l)
+
+linkToDeclaration ::
+  HtmlRenderContext ->
+  Namespace ->
+  Text ->
+  ContainingModule ->
+  Html ->
+  Html
+linkToDeclaration r ns target containMn =
+  maybe id (renderLink r) (buildDocLink r ns target containMn)
+
+renderAlias :: P.Fixity -> FixityAlias -> Html
+renderAlias (P.Fixity associativity precedence) alias_ =
+  p $ do
+    -- TODO: Render a link
+    toHtml $ "Operator alias for " <> P.showQualified showAliasName alias_ <> " "
+    em $
+      text ("(" <> associativityStr <> " / precedence " <> T.pack (show precedence) <> ")")
+  where
+  showAliasName (Left valueAlias) = P.runProperName valueAlias
+  showAliasName (Right typeAlias) = case typeAlias of
+    (Left identifier)  -> P.runIdent identifier
+    (Right properName) -> P.runProperName properName
+  associativityStr = case associativity of
+    P.Infixl -> "left-associative"
+    P.Infixr -> "right-associative"
+    P.Infix  -> "non-associative"
+
+-- | Render Markdown to HTML. Safe for untrusted input. Relative links are
+-- | removed.
+renderMarkdown :: Text -> H.Html
+renderMarkdown =
+  H.toMarkup . removeRelativeLinks . Cheapskate.markdown opts
+  where
+  opts = Cheapskate.def { Cheapskate.allowRawHtml = False }
+
+removeRelativeLinks :: Cheapskate.Doc -> Cheapskate.Doc
+removeRelativeLinks = Cheapskate.walk go
+  where
+  go :: Cheapskate.Inlines -> Cheapskate.Inlines
+  go = (>>= stripRelatives)
+
+  stripRelatives :: Cheapskate.Inline -> Cheapskate.Inlines
+  stripRelatives (Cheapskate.Link contents_ href _)
+    | isRelativeURI href = contents_
+  stripRelatives other = pure other
+
+  -- Tests for a ':' character in the first segment of a URI.
+  --
+  -- See Section 4.2 of RFC 3986:
+  -- https://tools.ietf.org/html/rfc3986#section-4.2
+  --
+  -- >>> isRelativeURI "http://example.com/" == False
+  -- >>> isRelativeURI "mailto:me@example.com" == False
+  -- >>> isRelativeURI "foo/bar" == True
+  -- >>> isRelativeURI "/bar" == True
+  -- >>> isRelativeURI "./bar" == True
+  isRelativeURI :: Text -> Bool
+  isRelativeURI =
+    T.takeWhile (/= '/') >>> T.all (/= ':')
+
+v :: Text -> AttributeValue
+v = toValue
+
+withClass :: String -> Html -> Html
+withClass className content = H.span ! A.class_ (fromString className) $ content
+
+partitionChildren ::
+  [ChildDeclaration] ->
+  ([ChildDeclaration], [ChildDeclaration], [ChildDeclaration])
+partitionChildren = foldl go ([], [], [])
+  where
+  go (instances, dctors, members) rcd =
+    case cdeclInfo rcd of
+      ChildInstance _ _      -> (rcd : instances, dctors, members)
+      ChildDataConstructor _ -> (instances, rcd : dctors, members)
+      ChildTypeClassMember _ -> (instances, dctors, rcd : members)

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -5,7 +5,7 @@ module Language.PureScript.Docs.Types
   where
 
 import Protolude hiding (to, from)
-import Prelude (String, unlines)
+import Prelude (String, unlines, lookup)
 
 import Control.Arrow ((***))
 
@@ -352,6 +352,89 @@ takeLocals = mapMaybe takeLocal
 ignorePackage :: InPackage a -> a
 ignorePackage (Local x) = x
 ignorePackage (FromDep _ x) = x
+
+----------------------------------------------------
+-- Types for links between declarations
+
+data LinksContext = LinksContext
+  { ctxGithub               :: (GithubUser, GithubRepo)
+  , ctxModuleMap            :: Map P.ModuleName PackageName
+  , ctxResolvedDependencies :: [(PackageName, Version)]
+  , ctxPackageName          :: PackageName
+  , ctxVersion              :: Version
+  , ctxVersionTag           :: Text
+  }
+  deriving (Show, Eq, Ord)
+
+data DocLink = DocLink
+  { linkLocation  :: LinkLocation
+  , linkTitle     :: Text
+  , linkNamespace :: Namespace
+  }
+  deriving (Show, Eq, Ord)
+
+data LinkLocation
+  -- | A link to a declaration in the same module.
+  = SameModule
+
+  -- | A link to a declaration in a different module, but still in the current
+  -- package; we need to store the current module and the other declaration's
+  -- module.
+  | LocalModule P.ModuleName P.ModuleName
+
+  -- | A link to a declaration in a different package. We store: current module
+  -- name, name of the other package, version of the other package, and name of
+  -- the module in the other package that the declaration is in.
+  | DepsModule P.ModuleName PackageName Version P.ModuleName
+
+  -- | A link to a declaration that is built in to the compiler, e.g. the Prim
+  -- module. In this case we only need to store the module that the builtin
+  -- comes from (at the time of writing, this will only ever be "Prim").
+  | BuiltinModule P.ModuleName
+  deriving (Show, Eq, Ord)
+
+-- | Given a links context, a thing to link to (either a value or a type), and
+-- its containing module, attempt to create a DocLink.
+getLink :: LinksContext -> P.ModuleName -> Namespace -> Text -> ContainingModule -> Maybe DocLink
+getLink LinksContext{..} curMn namespace target containingMod = do
+  location <- getLinkLocation
+  return DocLink
+    { linkLocation = location
+    , linkTitle = target
+    , linkNamespace = namespace
+    }
+
+  where
+  getLinkLocation = normalLinkLocation <|> builtinLinkLocation
+
+  normalLinkLocation = do
+    case containingMod of
+      ThisModule ->
+        return SameModule
+      OtherModule destMn ->
+        case Map.lookup destMn ctxModuleMap of
+          Nothing ->
+            return $ LocalModule curMn destMn
+          Just pkgName -> do
+            pkgVersion <- lookup pkgName ctxResolvedDependencies
+            return $ DepsModule curMn pkgName pkgVersion destMn
+
+  builtinLinkLocation = do
+    let primMn = P.moduleNameFromString "Prim"
+    guard $ containingMod == OtherModule primMn
+    -- TODO: ensure the declaration exists in the builtin module too
+    return $ BuiltinModule primMn
+
+getLinksContext :: Package a -> LinksContext
+getLinksContext Package{..} =
+  LinksContext
+    { ctxGithub               = pkgGithub
+    , ctxModuleMap            = pkgModuleMap
+    , ctxResolvedDependencies = pkgResolvedDependencies
+    , ctxPackageName          = bowerName pkgMeta
+    , ctxVersion              = pkgVersion
+    , ctxVersionTag           = pkgVersionTag
+    }
 
 ----------------------
 -- Parsing


### PR DESCRIPTION
Refs #2520. This code is more or less copied from Pursuit, although I
managed to drop the `hxt` dependency by instead using Cheapskate's
provided functions for walking a rendered Markdown document.

This is just a starting point towards generating HTML documentation from
a given package set. Next, I plan to make psc-docs capable of producing
HTML documentation as well as Markdown.