### PR TITLE
[psc-ide] Collect type class instances

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -539,6 +539,7 @@ test-suite tests
                    hspec -any,
                    hspec-discover -any,
                    HUnit -any,
+                   lens -any,
                    mtl -any,
                    optparse-applicative -any,
                    parsec -any,

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -8,6 +8,9 @@ import           Protolude
 import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.Matcher
 import           Language.PureScript.Ide.Types
+import qualified Language.PureScript as P
+
+type Module = (P.ModuleName, [IdeDeclarationAnn])
 
 -- | Applies the CompletionFilters and the Matcher to the given Modules
 --   and sorts the found Completions according to the Matching Score

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -96,7 +96,7 @@ convertDecl P.EDDataConstructor{..} = Just $ IdeDeclDataConstructor $
 convertDecl P.EDValue{..} = Just $ IdeDeclValue $
   IdeValue edValueName edValueType
 convertDecl P.EDClass{..} = Just $ IdeDeclTypeClass $
-  IdeTypeClass edClassName Nothing
+  IdeTypeClass edClassName []
 convertDecl P.EDKind{..} = Just (IdeDeclKind edKindName)
 convertDecl P.EDInstance{} = Nothing
 

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -54,9 +54,9 @@ readExternFile fp = do
      where
        version = toS (showVersion P.version)
 
-convertExterns :: P.ExternsFile -> (Module, [(P.ModuleName, P.DeclarationRef)])
+convertExterns :: P.ExternsFile -> ([IdeDeclarationAnn], [(P.ModuleName, P.DeclarationRef)])
 convertExterns ef =
-  ((P.efModuleName ef, decls), exportDecls)
+  (decls, exportDecls)
   where
     decls = map
       (IdeDeclarationAnn emptyAnn)
@@ -120,10 +120,10 @@ convertTypeOperator P.ExternsTypeFixity{..} =
 
 annotateModule
   :: (DefinitionSites P.SourceSpan, TypeAnnotations)
-  -> Module
-  -> Module
-annotateModule (defs, types) (moduleName, decls) =
-  (moduleName, map convertDeclaration decls)
+  -> [IdeDeclarationAnn]
+  -> [IdeDeclarationAnn]
+annotateModule (defs, types) decls =
+  map convertDeclaration decls
   where
     convertDeclaration :: IdeDeclarationAnn -> IdeDeclarationAnn
     convertDeclaration (IdeDeclarationAnn ann d) = case d of

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -71,8 +71,10 @@ convertExterns ef =
 
 removeTypeDeclarationsForClass :: IdeDeclaration -> Endo [IdeDeclaration]
 removeTypeDeclarationsForClass (IdeDeclTypeClass n) = Endo (filter notDuplicate)
-  where notDuplicate (IdeDeclType t) = n ^. properNameT /= t ^. ideTypeName . properNameT
-        notDuplicate (IdeDeclTypeSynonym s) = n ^. properNameT /= s ^. ideSynonymName . properNameT
+  where notDuplicate (IdeDeclType t) =
+          n ^. ideTCName . properNameT /= t ^. ideTypeName . properNameT
+        notDuplicate (IdeDeclTypeSynonym s) =
+          n ^. ideTCName . properNameT /= s ^. ideSynonymName . properNameT
         notDuplicate _ = True
 removeTypeDeclarationsForClass _ = mempty
 
@@ -93,7 +95,8 @@ convertDecl P.EDDataConstructor{..} = Just $ IdeDeclDataConstructor $
   IdeDataConstructor edDataCtorName edDataCtorTypeCtor edDataCtorType
 convertDecl P.EDValue{..} = Just $ IdeDeclValue $
   IdeValue edValueName edValueType
-convertDecl P.EDClass{..} = Just (IdeDeclTypeClass edClassName)
+convertDecl P.EDClass{..} = Just $ IdeDeclTypeClass $
+  IdeTypeClass edClassName Nothing
 convertDecl P.EDKind{..} = Just (IdeDeclKind edKindName)
 convertDecl P.EDInstance{} = Nothing
 
@@ -132,8 +135,8 @@ annotateModule (defs, types) (moduleName, decls) =
         annotateType (s ^. ideSynonymName . properNameT) (IdeDeclTypeSynonym s)
       IdeDeclDataConstructor dtor ->
         annotateValue (dtor ^. ideDtorName . properNameT) (IdeDeclDataConstructor dtor)
-      IdeDeclTypeClass i ->
-        annotateType (i ^. properNameT) (IdeDeclTypeClass i)
+      IdeDeclTypeClass tc ->
+        annotateType (tc ^. ideTCName . properNameT) (IdeDeclTypeClass tc)
       IdeDeclValueOperator op ->
         annotateValue (op ^. ideValueOpAlias & valueOperatorAliasT) (IdeDeclValueOperator op)
       IdeDeclTypeOperator op ->

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -32,6 +32,8 @@ import           Language.PureScript.Ide.Util
 
 newtype Filter = Filter (Endo [Module]) deriving(Monoid)
 
+type Module = (P.ModuleName, [IdeDeclarationAnn])
+
 mkFilter :: ([Module] -> [Module]) -> Filter
 mkFilter = Filter . Endo
 

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -197,8 +197,8 @@ addExplicitImport' decl moduleName imports =
     then imports
     else updateAtFirstOrPrepend matches (insertDeclIntoImport decl) freshImport imports
   where
-    refFromDeclaration (IdeDeclTypeClass n) =
-      P.TypeClassRef n
+    refFromDeclaration (IdeDeclTypeClass tc) =
+      P.TypeClassRef (tc ^. ideTCName)
     refFromDeclaration (IdeDeclDataConstructor dtor) =
       P.TypeRef (dtor ^. ideDtorTypeName) Nothing
     refFromDeclaration (IdeDeclType t) =

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -99,8 +99,8 @@ rebuildModuleOpen makeEnv externs m = do
 data MakeActionsEnv =
   MakeActionsEnv
   { maeOutputDirectory :: FilePath
-  , maeFilePathMap     :: Map P.ModuleName (Either P.RebuildPolicy FilePath)
-  , maeForeignPathMap  :: Map P.ModuleName FilePath
+  , maeFilePathMap     :: ModuleMap (Either P.RebuildPolicy FilePath)
+  , maeForeignPathMap  :: ModuleMap FilePath
   , maePrefixComment   :: Bool
   }
 
@@ -130,7 +130,7 @@ shushCodegen ma MakeActionsEnv{..} =
 sortExterns
   :: (Ide m, MonadError PscIdeError m)
   => P.Module
-  -> Map P.ModuleName P.ExternsFile
+  -> ModuleMap P.ExternsFile
   -> m [P.ExternsFile]
 sortExterns m ex = do
   sorted' <- runExceptT

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -57,7 +57,7 @@ reexportHasFailures = not . null . reFailed
 -- | Resolves Reexports for a given Module, by looking up the reexported values
 -- from the passed in Map
 resolveReexports
-  :: Map P.ModuleName [IdeDeclarationAnn]
+  :: ModuleMap [IdeDeclarationAnn]
   -- ^ Modules to search for the reexported declarations
   -> (Module, [(P.ModuleName, P.DeclarationRef)])
   -- ^ The module to resolve reexports for, aswell as the references to resolve

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -30,6 +30,7 @@ module Language.PureScript.Ide.State
   , populateStage3STM
   -- for tests
   , resolveOperatorsForModule
+  , resolveInstances
   ) where
 
 import           Protolude
@@ -206,7 +207,8 @@ populateStage3STM ref = do
   externs <- s1Externs <$> getStage1STM ref
   (AstData asts) <- s2AstData <$> getStage2STM ref
   let (modules, reexportRefs) = (map fst &&& map snd) (Map.map convertExterns externs)
-      results = resolveLocations asts modules
+      results =
+        resolveLocations asts modules
         & resolveInstances externs
         & resolveOperators
         & resolveReexports reexportRefs

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -203,7 +203,7 @@ populateStage3STM ref = do
   externs <- s1Externs <$> getStage1STM ref
   (AstData asts) <- s2AstData <$> getStage2STM ref
   let modules = Map.map convertExterns externs
-      nModules :: Map P.ModuleName (Module, [(P.ModuleName, P.DeclarationRef)])
+      nModules :: ModuleMap (Module, [(P.ModuleName, P.DeclarationRef)])
       nModules = Map.mapWithKey
         (\moduleName (m, refs) ->
            (fromMaybe m $ annotateModule <$> Map.lookup moduleName asts <*> pure m, refs)) modules
@@ -215,9 +215,9 @@ populateStage3STM ref = do
   pure result
 
 resolveInstances
-  :: Map P.ModuleName P.ExternsFile
-  -> Map P.ModuleName [IdeDeclarationAnn]
-  -> Map P.ModuleName [IdeDeclarationAnn]
+  :: ModuleMap P.ExternsFile
+  -> ModuleMap [IdeDeclarationAnn]
+  -> ModuleMap [IdeDeclarationAnn]
 resolveInstances externs declarations =
   Map.foldrWithKey
     (\mn ef acc -> foldr (go mn) acc (efDeclarations ef))
@@ -252,15 +252,15 @@ resolveInstances externs declarations =
     go _ _ acc' = acc'
 
 resolveOperators
-  :: Map P.ModuleName [IdeDeclarationAnn]
-  -> Map P.ModuleName [IdeDeclarationAnn]
+  :: ModuleMap [IdeDeclarationAnn]
+  -> ModuleMap [IdeDeclarationAnn]
 resolveOperators modules =
   map (resolveOperatorsForModule modules) modules
 
 -- | Looks up the types and kinds for operators and assigns them to their
 -- declarations
 resolveOperatorsForModule
-  :: Map P.ModuleName [IdeDeclarationAnn]
+  :: ModuleMap [IdeDeclarationAnn]
   -> [IdeDeclarationAnn]
   -> [IdeDeclarationAnn]
 resolveOperatorsForModule modules = map ((over idaDeclaration) resolveOperator)

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -116,8 +116,6 @@ makeLenses ''IdeDeclarationAnn
 emptyAnn :: Annotation
 emptyAnn = Annotation Nothing Nothing Nothing
 
-type Module = (P.ModuleName, [IdeDeclarationAnn])
-
 type DefinitionSites a = Map IdeDeclNamespace a
 type TypeAnnotations = Map P.Ident P.Type
 newtype AstData a = AstData (ModuleMap (DefinitionSites a, TypeAnnotations))

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -67,10 +67,10 @@ data IdeTypeClass = IdeTypeClass
   } deriving (Show, Eq, Ord)
 
 data IdeInstance = IdeInstance
-  { _ideInstanceModule          :: P.ModuleName
-  , _ideInstanceName            :: P.Ident
-  , _ideInstanceTypes           :: [P.Type]
-  , _ideInstanceConstraints     :: Maybe [P.Constraint]
+  { _ideInstanceModule      :: P.ModuleName
+  , _ideInstanceName        :: P.Ident
+  , _ideInstanceTypes       :: [P.Type]
+  , _ideInstanceConstraints :: Maybe [P.Constraint]
   } deriving (Show, Eq, Ord)
 
 data IdeValueOperator = IdeValueOperator

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -33,7 +33,7 @@ data IdeDeclaration
   | IdeDeclType IdeType
   | IdeDeclTypeSynonym IdeSynonym
   | IdeDeclDataConstructor IdeDataConstructor
-  | IdeDeclTypeClass (P.ProperName 'P.ClassName)
+  | IdeDeclTypeClass IdeTypeClass
   | IdeDeclValueOperator IdeValueOperator
   | IdeDeclTypeOperator IdeTypeOperator
   | IdeDeclKind (P.ProperName 'P.KindName)
@@ -60,6 +60,18 @@ data IdeDataConstructor = IdeDataConstructor
   , _ideDtorType     :: P.Type
   } deriving (Show, Eq, Ord)
 
+data IdeTypeClass = IdeTypeClass
+  { _ideTCName :: P.ProperName 'P.ClassName
+  , _ideTCInstances :: Maybe [IdeInstance]
+  } deriving (Show, Eq, Ord)
+
+data IdeInstance = IdeInstance
+  { _ideInstanceModule          :: P.ModuleName
+  , _ideInstanceName            :: P.Ident
+  , _ideInstanceTypes           :: [P.Type]
+  , _ideInstanceConstraints     :: Maybe [P.Constraint]
+  } deriving (Show, Eq, Ord)
+
 data IdeValueOperator = IdeValueOperator
   { _ideValueOpName          :: P.OpName 'P.ValueOpName
   , _ideValueOpAlias         :: P.Qualified (Either P.Ident (P.ProperName 'P.ConstructorName))
@@ -81,6 +93,8 @@ makeLenses ''IdeValue
 makeLenses ''IdeType
 makeLenses ''IdeSynonym
 makeLenses ''IdeDataConstructor
+makeLenses ''IdeTypeClass
+makeLenses ''IdeInstance
 makeLenses ''IdeValueOperator
 makeLenses ''IdeTypeOperator
 

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -27,6 +27,7 @@ import qualified Language.PureScript                 as P
 import qualified Language.PureScript.Errors.JSON     as P
 
 type ModuleIdent = Text
+type ModuleMap a = Map P.ModuleName a
 
 data IdeDeclaration
   = IdeDeclValue IdeValue
@@ -62,7 +63,7 @@ data IdeDataConstructor = IdeDataConstructor
 
 data IdeTypeClass = IdeTypeClass
   { _ideTCName :: P.ProperName 'P.ClassName
-  , _ideTCInstances :: Maybe [IdeInstance]
+  , _ideTCInstances :: [IdeInstance]
   } deriving (Show, Eq, Ord)
 
 data IdeInstance = IdeInstance
@@ -119,7 +120,7 @@ type Module = (P.ModuleName, [IdeDeclarationAnn])
 
 type DefinitionSites a = Map IdeDeclNamespace a
 type TypeAnnotations = Map P.Ident P.Type
-newtype AstData a = AstData (Map P.ModuleName (DefinitionSites a, TypeAnnotations))
+newtype AstData a = AstData (ModuleMap (DefinitionSites a, TypeAnnotations))
   -- ^ SourceSpans for the definition sites of Values and Types aswell as type
   -- annotations found in a module
   deriving (Show, Eq, Ord, Functor, Foldable)
@@ -161,8 +162,8 @@ emptyStage3 :: Stage3
 emptyStage3 = Stage3 M.empty Nothing
 
 data Stage1 = Stage1
-  { s1Externs :: M.Map P.ModuleName P.ExternsFile
-  , s1Modules :: M.Map P.ModuleName (P.Module, FilePath)
+  { s1Externs :: ModuleMap P.ExternsFile
+  , s1Modules :: ModuleMap (P.Module, FilePath)
   }
 
 data Stage2 = Stage2
@@ -170,7 +171,7 @@ data Stage2 = Stage2
   }
 
 data Stage3 = Stage3
-  { s3Declarations  :: M.Map P.ModuleName [IdeDeclarationAnn]
+  { s3Declarations  :: ModuleMap [IdeDeclarationAnn]
   , s3CachedRebuild :: Maybe (P.ModuleName, P.ExternsFile)
   }
 

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -71,7 +71,7 @@ completionFromMatch (Match (m, IdeDeclarationAnn ann decl)) =
       IdeDeclType t -> (t ^. ideTypeName . properNameT, t ^. ideTypeKind & P.prettyPrintKind & toS )
       IdeDeclTypeSynonym s -> (s ^. ideSynonymName . properNameT, s ^. ideSynonymType & prettyTypeT)
       IdeDeclDataConstructor d -> (d ^. ideDtorName . properNameT, d ^. ideDtorType & prettyTypeT)
-      IdeDeclTypeClass d -> (d ^. ideTCName . properNameT, "class")
+      IdeDeclTypeClass d -> (d ^. ideTCName . properNameT, show (d ^. ideTCInstances & map (^. ideInstanceName)))
       IdeDeclValueOperator (IdeValueOperator op ref precedence associativity typeP) ->
         (P.runOpName op, maybe (showFixity precedence associativity (valueOperatorAliasT ref) op) prettyTypeT typeP)
       IdeDeclTypeOperator (IdeTypeOperator op ref precedence associativity kind) ->

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -37,6 +37,7 @@ import           Protolude                           hiding (decodeUtf8,
 import           Control.Lens                        ((^.), (^?), Iso', iso, Getting, (<&>))
 import           Data.Aeson
 import qualified Data.Text                           as T
+import qualified Data.Text.Lazy                      as TL
 import           Data.Text.Lazy.Encoding             (decodeUtf8, encodeUtf8)
 import qualified Language.PureScript                 as P
 import           Language.PureScript.Ide.Logging
@@ -68,14 +69,14 @@ completionFromMatch (Match (m, IdeDeclarationAnn ann decl)) =
   where
     (complIdentifier, complExpandedType) = case decl of
       IdeDeclValue v -> (v ^. ideValueIdent . identT, v ^. ideValueType & prettyTypeT)
-      IdeDeclType t -> (t ^. ideTypeName . properNameT, t ^. ideTypeKind & P.prettyPrintKind & toS )
+      IdeDeclType t -> (t ^. ideTypeName . properNameT, t ^. ideTypeKind & P.prettyPrintKind)
       IdeDeclTypeSynonym s -> (s ^. ideSynonymName . properNameT, s ^. ideSynonymType & prettyTypeT)
       IdeDeclDataConstructor d -> (d ^. ideDtorName . properNameT, d ^. ideDtorType & prettyTypeT)
-      IdeDeclTypeClass d -> (d ^. ideTCName . properNameT, show (d ^. ideTCInstances & map (^. ideInstanceName)))
+      IdeDeclTypeClass d -> (d ^. ideTCName . properNameT, "type class")
       IdeDeclValueOperator (IdeValueOperator op ref precedence associativity typeP) ->
         (P.runOpName op, maybe (showFixity precedence associativity (valueOperatorAliasT ref) op) prettyTypeT typeP)
       IdeDeclTypeOperator (IdeTypeOperator op ref precedence associativity kind) ->
-        (P.runOpName op, maybe (showFixity precedence associativity (typeOperatorAliasT ref) op) (toS . P.prettyPrintKind) kind)
+        (P.runOpName op, maybe (showFixity precedence associativity (typeOperatorAliasT ref) op) P.prettyPrintKind kind)
       IdeDeclKind k -> (P.runProperName k, "kind")
 
     complModule = P.runModuleName m
@@ -104,10 +105,10 @@ typeOperatorAliasT i =
   P.showQualified P.runProperName i
 
 encodeT :: (ToJSON a) => a -> Text
-encodeT = toS . decodeUtf8 . encode
+encodeT = TL.toStrict . decodeUtf8 . encode
 
 decodeT :: (FromJSON a) => Text -> Maybe a
-decodeT = decode . encodeUtf8 . toS
+decodeT = decode . encodeUtf8 . TL.fromStrict
 
 unwrapPositioned :: P.Declaration -> P.Declaration
 unwrapPositioned (P.PositionedDeclaration _ _ x) = unwrapPositioned x

--- a/tests/Language/PureScript/Ide/FilterSpec.hs
+++ b/tests/Language/PureScript/Ide/FilterSpec.hs
@@ -8,6 +8,8 @@ import           Language.PureScript.Ide.Types
 import qualified Language.PureScript as P
 import           Test.Hspec
 
+type Module = (P.ModuleName, [IdeDeclarationAnn])
+
 value :: Text -> IdeDeclarationAnn
 value s = IdeDeclarationAnn emptyAnn (IdeDeclValue (IdeValue (P.Ident (toS s)) P.REmpty))
 

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -144,7 +144,7 @@ spec = do
         addImport imports import' = addExplicitImport' import' moduleName imports
         valueImport ident = (IdeDeclValue (IdeValue (P.Ident ident) wildcard))
         typeImport name = (IdeDeclType (IdeType (P.ProperName name) P.kindType))
-        classImport name = (IdeDeclTypeClass (P.ProperName name))
+        classImport name = (IdeDeclTypeClass (IdeTypeClass (P.ProperName name) Nothing))
         dtorImport name typeName = (IdeDeclDataConstructor (IdeDataConstructor (P.ProperName name) (P.ProperName typeName) wildcard))
         -- expect any list of provided identifiers, when imported, to come out as specified
         expectSorted imports expected = shouldBe

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -144,7 +144,7 @@ spec = do
         addImport imports import' = addExplicitImport' import' moduleName imports
         valueImport ident = (IdeDeclValue (IdeValue (P.Ident ident) wildcard))
         typeImport name = (IdeDeclType (IdeType (P.ProperName name) P.kindType))
-        classImport name = (IdeDeclTypeClass (IdeTypeClass (P.ProperName name) Nothing))
+        classImport name = (IdeDeclTypeClass (IdeTypeClass (P.ProperName name) []))
         dtorImport name typeName = (IdeDeclDataConstructor (IdeDataConstructor (P.ProperName name) (P.ProperName typeName) wildcard))
         -- expect any list of provided identifiers, when imported, to come out as specified
         expectSorted imports expected = shouldBe

--- a/tests/Language/PureScript/Ide/ReexportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ReexportsSpec.hs
@@ -19,7 +19,7 @@ d = IdeDeclarationAnn emptyAnn
 valueA, typeA, classA, dtorA1, dtorA2 :: IdeDeclarationAnn
 valueA = d (IdeDeclValue (IdeValue (P.Ident "valueA") P.REmpty))
 typeA = d (IdeDeclType (IdeType(P.ProperName "TypeA") P.kindType))
-classA = d (IdeDeclTypeClass (IdeTypeClass (P.ProperName "ClassA") Nothing))
+classA = d (IdeDeclTypeClass (IdeTypeClass (P.ProperName "ClassA") []))
 dtorA1 = d (IdeDeclDataConstructor (IdeDataConstructor (P.ProperName "DtorA1") (P.ProperName "TypeA") P.REmpty))
 dtorA2 = d (IdeDeclDataConstructor (IdeDataConstructor (P.ProperName "DtorA2") (P.ProperName "TypeA") P.REmpty))
 

--- a/tests/Language/PureScript/Ide/ReexportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ReexportsSpec.hs
@@ -19,7 +19,7 @@ d = IdeDeclarationAnn emptyAnn
 valueA, typeA, classA, dtorA1, dtorA2 :: IdeDeclarationAnn
 valueA = d (IdeDeclValue (IdeValue (P.Ident "valueA") P.REmpty))
 typeA = d (IdeDeclType (IdeType(P.ProperName "TypeA") P.kindType))
-classA = d (IdeDeclTypeClass (P.ProperName "ClassA"))
+classA = d (IdeDeclTypeClass (IdeTypeClass (P.ProperName "ClassA") Nothing))
 dtorA1 = d (IdeDeclDataConstructor (IdeDataConstructor (P.ProperName "DtorA1") (P.ProperName "TypeA") P.REmpty))
 dtorA2 = d (IdeDeclDataConstructor (IdeDataConstructor (P.ProperName "DtorA2") (P.ProperName "TypeA") P.REmpty))
 

--- a/tests/Language/PureScript/Ide/ReexportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ReexportsSpec.hs
@@ -23,7 +23,7 @@ classA = d (IdeDeclTypeClass (IdeTypeClass (P.ProperName "ClassA") Nothing))
 dtorA1 = d (IdeDeclDataConstructor (IdeDataConstructor (P.ProperName "DtorA1") (P.ProperName "TypeA") P.REmpty))
 dtorA2 = d (IdeDeclDataConstructor (IdeDataConstructor (P.ProperName "DtorA2") (P.ProperName "TypeA") P.REmpty))
 
-env :: Map P.ModuleName [IdeDeclarationAnn]
+env :: ModuleMap [IdeDeclarationAnn]
 env = Map.fromList
   [ (m "A", [valueA, typeA, classA, dtorA1, dtorA2])
   ]

--- a/tests/Language/PureScript/Ide/ReexportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ReexportsSpec.hs
@@ -10,6 +10,8 @@ import           Language.PureScript.Ide.Types
 import qualified Language.PureScript as P
 import           Test.Hspec
 
+type Module = (P.ModuleName, [IdeDeclarationAnn])
+
 m :: Text -> P.ModuleName
 m = P.moduleNameFromString
 
@@ -30,21 +32,21 @@ env = Map.fromList
 
 type Refs = [(P.ModuleName, P.DeclarationRef)]
 
-succTestCases :: [(Text, Module, Refs, Module)]
+succTestCases :: [(Text, [IdeDeclarationAnn], Refs, [IdeDeclarationAnn])]
 succTestCases =
-  [ ("resolves a value reexport", (m "C", []), [(m "A", P.ValueRef (P.Ident "valueA"))], (m "C", [valueA]))
+  [ ("resolves a value reexport", [], [(m "A", P.ValueRef (P.Ident "valueA"))], [valueA])
   , ("resolves a type reexport with explicit data constructors"
-    , (m "C", []), [(m "A", P.TypeRef (P.ProperName "TypeA") (Just [P.ProperName "DtorA1"]))], (m "C", [typeA, dtorA1]))
+    , [], [(m "A", P.TypeRef (P.ProperName "TypeA") (Just [P.ProperName "DtorA1"]))], [typeA, dtorA1])
   , ("resolves a type reexport with implicit data constructors"
-    , (m "C", []), [(m "A", P.TypeRef (P.ProperName "TypeA") Nothing)], (m "C", [typeA, dtorA1, dtorA2]))
-  , ("resolves a class reexport", (m "C", []), [(m "A", P.TypeClassRef (P.ProperName "ClassA"))], (m "C", [classA]))
+    , [], [(m "A", P.TypeRef (P.ProperName "TypeA") Nothing)], [typeA, dtorA1, dtorA2])
+  , ("resolves a class reexport", [], [(m "A", P.TypeClassRef (P.ProperName "ClassA"))], [classA])
   ]
 
-failTestCases :: [(Text, Module, Refs)]
+failTestCases :: [(Text, [IdeDeclarationAnn], Refs)]
 failTestCases =
-  [ ("fails to resolve a non existing value", (m "C", []), [(m "A", P.ValueRef (P.Ident "valueB"))])
-  , ("fails to resolve a non existing type reexport" , (m "C", []), [(m "A", P.TypeRef (P.ProperName "TypeB") Nothing)])
-  , ("fails to resolve a non existing class reexport", (m "C", []), [(m "A", P.TypeClassRef (P.ProperName "ClassB"))])
+  [ ("fails to resolve a non existing value", [], [(m "A", P.ValueRef (P.Ident "valueB"))])
+  , ("fails to resolve a non existing type reexport" , [], [(m "A", P.TypeRef (P.ProperName "TypeB") Nothing)])
+  , ("fails to resolve a non existing class reexport", [], [(m "A", P.TypeClassRef (P.ProperName "ClassB"))])
   ]
 
 spec :: Spec
@@ -52,12 +54,12 @@ spec = do
   describe "Successful Reexports" $
     for_ succTestCases $ \(desc, initial, refs, result) ->
       it (toS desc) $ do
-        let reResult = resolveReexports env (initial, refs)
+        let reResult = resolveReexports' env initial refs
         reResolved reResult `shouldBe` result
         reResult `shouldSatisfy` not . reexportHasFailures
   describe "Failed Reexports" $
     for_ failTestCases $ \(desc, initial, refs) ->
       it (toS desc) $ do
-        let reResult = resolveReexports env (initial, refs)
+        let reResult = resolveReexports'  env initial refs
         reFailed reResult `shouldBe` refs
         reResult `shouldSatisfy` reexportHasFailures

--- a/tests/Language/PureScript/Ide/StateSpec.hs
+++ b/tests/Language/PureScript/Ide/StateSpec.hs
@@ -36,10 +36,8 @@ d = IdeDeclarationAnn emptyAnn
 mn :: Text -> P.ModuleName
 mn = P.moduleNameFromString . toS
 
-testState :: Map P.ModuleName [IdeDeclarationAnn]
-testState = Map.fromList
-  [ testModule
-  ]
+testState :: ModuleMap [IdeDeclarationAnn]
+testState = Map.fromList [testModule]
 
 spec :: Spec
 spec = describe "resolving operators" $ do

--- a/tests/Language/PureScript/Ide/StateSpec.hs
+++ b/tests/Language/PureScript/Ide/StateSpec.hs
@@ -3,6 +3,7 @@
 module Language.PureScript.Ide.StateSpec where
 
 import           Protolude
+import           Control.Lens hiding ((&))
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.State
 import qualified Language.PureScript as P
@@ -34,16 +35,57 @@ d :: IdeDeclaration -> IdeDeclarationAnn
 d = IdeDeclarationAnn emptyAnn
 
 mn :: Text -> P.ModuleName
-mn = P.moduleNameFromString . toS
+mn = P.moduleNameFromString
 
 testState :: ModuleMap [IdeDeclarationAnn]
 testState = Map.fromList [testModule]
 
+-- The accessor fields for these data types are not exposed unfortunately
+ef :: P.ExternsFile
+ef = P.ExternsFile
+  -- { efVersion =
+    mempty
+  -- , efModuleName =
+    (mn "InstanceModule")
+  -- , efExports =
+    mempty
+  -- , efImports =
+    mempty
+  -- , efFixities =
+    mempty
+  -- , efTypeFixities =
+    mempty
+  --, efDeclarations =
+    [ P.EDInstance
+      -- { edInstanceClassName =
+      (P.Qualified (Just (mn "ClassModule")) (P.ProperName "MyClass"))
+      -- , edInstanceName =
+      (P.Ident "myClassInstance")
+      -- , edInstanceTypes =
+      mempty
+      -- , edInstanceConstraints =
+      mempty
+ --     }
+    ]
+ -- }
+
+moduleMap :: ModuleMap [IdeDeclarationAnn]
+moduleMap = Map.singleton (mn "ClassModule") [d (IdeDeclTypeClass (IdeTypeClass (P.ProperName "MyClass") []))]
+
+ideInstance :: IdeInstance
+ideInstance = IdeInstance (mn "InstanceModule") (P.Ident "myClassInstance") mempty mempty
+
 spec :: Spec
-spec = describe "resolving operators" $ do
-  it "resolves the type for a value operator" $
-    resolveOperatorsForModule testState (snd testModule) `shouldSatisfy` elem (valueOperator (Just P.REmpty))
-  it "resolves the type for a constructor operator" $
-    resolveOperatorsForModule testState (snd testModule) `shouldSatisfy` elem (ctorOperator (Just P.REmpty))
-  it "resolves the kind for a type operator" $
-    resolveOperatorsForModule testState (snd testModule) `shouldSatisfy` elem (typeOperator (Just P.kindType))
+spec = do
+  describe "resolving operators" $ do
+    it "resolves the type for a value operator" $
+      resolveOperatorsForModule testState (snd testModule) `shouldSatisfy` elem (valueOperator (Just P.REmpty))
+    it "resolves the type for a constructor operator" $
+      resolveOperatorsForModule testState (snd testModule) `shouldSatisfy` elem (ctorOperator (Just P.REmpty))
+    it "resolves the kind for a type operator" $
+      resolveOperatorsForModule testState (snd testModule) `shouldSatisfy` elem (typeOperator (Just P.kindType))
+  describe "resolving instances for type classes" $ do
+    it "resolves an instance for an existing type class" $ do
+      resolveInstances (Map.singleton (mn "InstanceModule") ef) moduleMap
+        `shouldSatisfy`
+        elemOf (ix (mn "ClassModule") . ix 0 . idaDeclaration . _IdeDeclTypeClass . ideTCInstances . folded) ideInstance

--- a/tests/Language/PureScript/Ide/StateSpec.hs
+++ b/tests/Language/PureScript/Ide/StateSpec.hs
@@ -21,7 +21,7 @@ typeOperator :: Maybe P.Kind -> IdeDeclarationAnn
 typeOperator =
   d . IdeDeclTypeOperator . IdeTypeOperator (P.OpName ":") (P.Qualified (Just (mn "Test")) (P.ProperName "List")) 2 P.Infix
 
-testModule :: Module
+testModule :: (P.ModuleName, [IdeDeclarationAnn])
 testModule = (mn "Test", [ d (IdeDeclValue (IdeValue (P.Ident "function") P.REmpty))
                          , d (IdeDeclDataConstructor (IdeDataConstructor (P.ProperName "Cons") (P.ProperName "List") (P.REmpty)))
                          , d (IdeDeclType (IdeType (P.ProperName "List") P.kindType))


### PR DESCRIPTION
The main addition of this PR is to collect all instances from the ExternsFiles and add them to their respective type class declaration inside Stage3. While I was at it I cleaned up the different resolving steps for Stage3 into a more uniform pipeline of functions.

There is currently no way to access the gathered information through psc-ide's commands, but I'd like to think about how to expose the information without bastardizing the stringly typed completion format we have right now.

Fixes #2350 