### PR TITLE
[psc-ide] Speeds up rebuilding by x2

### DIFF
--- a/src/Language/PureScript/Ide/Logging.hs
+++ b/src/Language/PureScript/Ide/Logging.hs
@@ -4,6 +4,7 @@ module Language.PureScript.Ide.Logging
        ( runLogger
        , logPerf
        , displayTimeSpec
+       , labelTimespec
        ) where
 
 import           Protolude
@@ -23,6 +24,9 @@ runLogger logLevel' =
                                          LogNone -> False
                                          LogDebug -> not (logLevel == LevelOther "perf")
                                          LogPerf -> logLevel == LevelOther "perf")
+
+labelTimespec :: Text -> TimeSpec -> Text
+labelTimespec label duration = label <> ": " <> displayTimeSpec duration
 
 logPerf :: (MonadIO m, MonadLogger m) => (TimeSpec -> Text) -> m t -> m t
 logPerf format f = do


### PR DESCRIPTION
This puts the second rebuild, which is used to make private members of modules
available during completion on a separate thread and thus halves the time spent
rebuilding.