### PR TITLE
[psc-ide] fix 2537

### DIFF
--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -43,7 +43,7 @@ import           System.FilePath.Glob (glob)
 
 -- | Accepts a Commmand and runs it against psc-ide's State. This is the main
 -- entry point for the server.
-handleCommand :: (Ide m, MonadLogger m, MonadError PscIdeError m) =>
+handleCommand :: (Ide m, MonadLogger m, MonadError IdeError m) =>
                  Command -> m Success
 handleCommand c = case c of
   Load [] ->
@@ -131,7 +131,7 @@ listAvailableModules = do
     let cleaned = filter (`notElem` [".", ".."]) contents
     return (ModuleList (map toS cleaned))
 
-caseSplit :: (Ide m, MonadError PscIdeError m) =>
+caseSplit :: (Ide m, MonadError IdeError m) =>
   Text -> Int -> Int -> CS.WildcardAnnotations -> Text -> m Success
 caseSplit l b e csa t = do
   patterns <- CS.makePattern l b e csa <$> CS.caseSplit t
@@ -139,7 +139,7 @@ caseSplit l b e csa t = do
 
 -- | Finds all the externs.json files inside the output folder and returns the
 -- corresponding Modulenames
-findAvailableExterns :: (Ide m, MonadError PscIdeError m) => m [P.ModuleName]
+findAvailableExterns :: (Ide m, MonadError IdeError m) => m [P.ModuleName]
 findAvailableExterns = do
   oDir <- outputDirectory
   unlessM (liftIO (doesDirectoryExist oDir))
@@ -169,7 +169,7 @@ findAllSourceFiles = do
 -- inserts their ASTs into the state. Finally kicks off an async worker, which
 -- populates Stage 2 and 3 of the state.
 loadModulesAsync
-  :: (Ide m, MonadError PscIdeError m, MonadLogger m)
+  :: (Ide m, MonadError IdeError m, MonadLogger m)
   => [P.ModuleName]
   -> m Success
 loadModulesAsync moduleNames = do
@@ -185,7 +185,7 @@ loadModulesAsync moduleNames = do
   pure tr
 
 loadModulesSync
-  :: (Ide m, MonadError PscIdeError m, MonadLogger m)
+  :: (Ide m, MonadError IdeError m, MonadLogger m)
   => [P.ModuleName]
   -> m Success
 loadModulesSync moduleNames = do
@@ -194,7 +194,7 @@ loadModulesSync moduleNames = do
   pure tr
 
 loadModules
-  :: (Ide m, MonadError PscIdeError m, MonadLogger m)
+  :: (Ide m, MonadError IdeError m, MonadLogger m)
   => [P.ModuleName]
   -> m Success
 loadModules moduleNames = do

--- a/src/Language/PureScript/Ide/CaseSplit.hs
+++ b/src/Language/PureScript/Ide/CaseSplit.hs
@@ -45,7 +45,7 @@ explicitAnnotations = WildcardAnnotations True
 noAnnotations :: WildcardAnnotations
 noAnnotations = WildcardAnnotations False
 
-caseSplit :: (Ide m, MonadError PscIdeError m) =>
+caseSplit :: (Ide m, MonadError IdeError m) =>
              Text -> m [Constructor]
 caseSplit q = do
   type' <- parseType' q
@@ -55,7 +55,7 @@ caseSplit q = do
   let appliedCtors = map (second (map applyTypeVars)) ctors
   pure appliedCtors
 
-findTypeDeclaration :: (Ide m, MonadError PscIdeError m) =>
+findTypeDeclaration :: (Ide m, MonadError IdeError m) =>
                          P.ProperName 'P.TypeName -> m ExternsDeclaration
 findTypeDeclaration q = do
   efs <- getExternFiles
@@ -73,7 +73,7 @@ findTypeDeclaration' t ExternsFile{..} =
             EDType tn _ _ -> tn == t
             _ -> False) efDeclarations
 
-splitTypeConstructor :: (MonadError PscIdeError m) =>
+splitTypeConstructor :: (MonadError IdeError m) =>
                         P.Type -> m (P.ProperName 'P.TypeName, [P.Type])
 splitTypeConstructor = go []
   where
@@ -105,7 +105,7 @@ makePattern t x y wsa = makePattern' (T.take x t) (T.drop y t)
   where
     makePattern' lhs rhs = map (\ctor -> lhs <> prettyCtor wsa ctor <> rhs)
 
-addClause :: (MonadError PscIdeError m) => Text -> WildcardAnnotations -> m [Text]
+addClause :: (MonadError IdeError m) => Text -> WildcardAnnotations -> m [Text]
 addClause s wca = do
   (fName, fType) <- parseTypeDeclaration' s
   let args = splitFunctionType fType
@@ -114,7 +114,7 @@ addClause s wca = do
         " = ?" <> (T.strip . P.runIdent $ fName)
   pure [s, template]
 
-parseType' :: (MonadError PscIdeError m) =>
+parseType' :: (MonadError IdeError m) =>
               Text -> m P.Type
 parseType' s =
   case P.lex "<psc-ide>" (toS s) >>= P.runTokenParser "<psc-ide>" (P.parseType <* Parsec.eof) of
@@ -123,7 +123,7 @@ parseType' s =
       throwError (GeneralError ("Parsing the splittype failed with:"
                                 <> show err))
 
-parseTypeDeclaration' :: (MonadError PscIdeError m) => Text -> m (P.Ident, P.Type)
+parseTypeDeclaration' :: (MonadError IdeError m) => Text -> m (P.Ident, P.Type)
 parseTypeDeclaration' s =
   let x = do
         ts <- P.lex "" (toS s)

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -13,7 +13,7 @@
 -----------------------------------------------------------------------------
 
 module Language.PureScript.Ide.Error
-       ( PscIdeError(..)
+       ( IdeError(..)
        ) where
 
 import           Data.Aeson
@@ -22,7 +22,7 @@ import           Language.PureScript.Ide.Types   (ModuleIdent)
 import           Protolude
 import qualified Text.Parsec.Error               as P
 
-data PscIdeError
+data IdeError
     = GeneralError Text
     | NotFound Text
     | ModuleNotFound ModuleIdent
@@ -31,7 +31,7 @@ data PscIdeError
     | RebuildError [JSONError]
     deriving (Show, Eq)
 
-instance ToJSON PscIdeError where
+instance ToJSON IdeError where
   toJSON (RebuildError errs) = object
     [ "resultType" .= ("error" :: Text)
     , "result" .= errs
@@ -41,7 +41,7 @@ instance ToJSON PscIdeError where
     , "result" .= textError err
     ]
 
-textError :: PscIdeError -> Text
+textError :: IdeError -> Text
 textError (GeneralError msg)          = msg
 textError (NotFound ident)            = "Symbol '" <> ident <> "' not found."
 textError (ModuleNotFound ident)      = "Module '" <> ident <> "' not found."

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -28,13 +28,13 @@ import           Data.Aeson (decodeStrict)
 import qualified Data.ByteString as BS
 import qualified Data.Map as Map
 import           Data.Version (showVersion)
-import           Language.PureScript.Ide.Error (PscIdeError (..))
+import           Language.PureScript.Ide.Error (IdeError (..))
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
 
 import qualified Language.PureScript as P
 
-readExternFile :: (MonadIO m, MonadError PscIdeError m, MonadLogger m) =>
+readExternFile :: (MonadIO m, MonadError IdeError m, MonadLogger m) =>
                   FilePath -> m P.ExternsFile
 readExternFile fp = do
    parseResult <- liftIO (decodeStrict <$> BS.readFile fp)

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -39,7 +39,7 @@ import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
-import           System.IO.UTF8                     (readUTF8FileT, writeUTF8FileT)
+import           System.IO.UTF8                     (writeUTF8FileT)
 
 data Import = Import P.ModuleName P.ImportDeclarationType  (Maybe P.ModuleName)
               deriving (Eq, Show)
@@ -70,7 +70,7 @@ compImport (Import n i q) (Import n' i' q')
 parseImportsFromFile :: (MonadIO m, MonadError IdeError m) =>
                         FilePath -> m (P.ModuleName, [Text], [Import], [Text])
 parseImportsFromFile fp = do
-  file <- liftIO (readUTF8FileT fp)
+  file <- ideReadFile fp
   case sliceImportSection (T.lines file) of
     Right res -> pure res
     Left err -> throwError (GeneralError err)

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -67,7 +67,7 @@ compImport (Import n i q) (Import n' i' q')
 
 -- | Reads a file and returns the (lines before the imports, the imports, the
 -- lines after the imports)
-parseImportsFromFile :: (MonadIO m, MonadError PscIdeError m) =>
+parseImportsFromFile :: (MonadIO m, MonadError IdeError m) =>
                         FilePath -> m (P.ModuleName, [Text], [Import], [Text])
 parseImportsFromFile fp = do
   file <- liftIO (readUTF8FileT fp)
@@ -147,7 +147,7 @@ moduleParse t = first show $ do
   P.runTokenParser "<psc-ide>" P.parseModule tokens
 
 -- | Adds an implicit import like @import Prelude@ to a Sourcefile.
-addImplicitImport :: (MonadIO m, MonadError PscIdeError m)
+addImplicitImport :: (MonadIO m, MonadError IdeError m)
                      => FilePath     -- ^ The Sourcefile read from
                      -> P.ModuleName -- ^ The module to import
                      -> m [Text]
@@ -170,7 +170,7 @@ addImplicitImport' imports mn =
 -- So @addExplicitImport "/File.purs" "bind" "Prelude"@ with an already existing
 -- @import Prelude (bind)@ in the file File.purs returns @["import Prelude
 -- (bind, unit)"]@
-addExplicitImport :: (MonadIO m, MonadError PscIdeError m) =>
+addExplicitImport :: (MonadIO m, MonadError IdeError m) =>
                      FilePath -> IdeDeclaration -> P.ModuleName -> m [Text]
 addExplicitImport fp decl moduleName = do
   (mn, pre, imports, post) <- parseImportsFromFile fp
@@ -249,7 +249,7 @@ updateAtFirstOrPrepend p t d l =
 --
 -- * If more than one possible imports are found, reports the possibilities as a
 -- list of completions.
-addImportForIdentifier :: (Ide m, MonadError PscIdeError m)
+addImportForIdentifier :: (Ide m, MonadError IdeError m)
                           => FilePath -- ^ The Sourcefile to read from
                           -> Text     -- ^ The identifier to import
                           -> [Filter] -- ^ Filters to apply before searching for

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -38,7 +38,7 @@ import           System.IO.UTF8                  (readUTF8FileT)
 -- warnings, and if rebuilding fails, returns a @RebuildError@ with the
 -- generated errors.
 rebuildFile
-  :: (Ide m, MonadLogger m, MonadError PscIdeError m)
+  :: (Ide m, MonadLogger m, MonadError IdeError m)
   => FilePath
   -- ^ The file to rebuild
   -> (ReaderT IdeEnvironment (LoggingT IO) () -> m ())
@@ -80,7 +80,7 @@ rebuildFile path runOpenBuild = do
       pure (RebuildSuccess (toJSONErrors False P.Warning warnings))
 
 rebuildFileAsync
-  :: forall m. (Ide m, MonadLogger m, MonadError PscIdeError m)
+  :: forall m. (Ide m, MonadLogger m, MonadError IdeError m)
   => FilePath -> m Success
 rebuildFileAsync fp = rebuildFile fp asyncRun
   where
@@ -91,7 +91,7 @@ rebuildFileAsync fp = rebuildFile fp asyncRun
         void (liftIO (async (runLogger ll (runReaderT action env))))
 
 rebuildFileSync
-  :: forall m. (Ide m, MonadLogger m, MonadError PscIdeError m)
+  :: forall m. (Ide m, MonadLogger m, MonadError IdeError m)
   => FilePath -> m Success
 rebuildFileSync fp = rebuildFile fp syncRun
   where
@@ -158,7 +158,7 @@ shushCodegen ma MakeActionsEnv{..} =
 -- module. Throws an error if there is a cyclic dependency within the
 -- ExternsFiles
 sortExterns
-  :: (Ide m, MonadError PscIdeError m)
+  :: (Ide m, MonadError IdeError m)
   => P.Module
   -> ModuleMap P.ExternsFile
   -> m [P.ExternsFile]

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -20,7 +20,7 @@ import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Logging
 import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Types
-import           System.IO.UTF8                  (readUTF8FileT)
+import           Language.PureScript.Ide.Util
 
 -- | Given a filepath performs the following steps:
 --
@@ -46,7 +46,7 @@ rebuildFile
   -> m Success
 rebuildFile path runOpenBuild = do
 
-  input <- liftIO (readUTF8FileT path)
+  input <- ideReadFile path
 
   m <- case snd <$> P.parseModuleFromFile identity (path, input) of
     Left parseError -> throwError

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -28,14 +28,13 @@ import qualified Language.PureScript           as P
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
-import           System.IO.UTF8                (readUTF8FileT)
 
 parseModule
-  :: (MonadIO m)
+  :: (MonadIO m, MonadError IdeError m)
   => FilePath
   -> m (Either FilePath (FilePath, P.Module))
 parseModule path = do
-  contents <- liftIO (readUTF8FileT path)
+  contents <- ideReadFile path
   case P.parseModuleFromFile identity (path, contents) of
     Left _ -> pure (Left path)
     Right m -> pure (Right m)

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -47,7 +47,7 @@ getImports (P.Module _ _ _ declarations _) =
     isImport (P.PositionedDeclaration _ _ (P.ImportDeclaration a b c)) = Just (a, b, c)
     isImport _ = Nothing
 
-getImportsForFile :: (MonadIO m, MonadError PscIdeError m) =>
+getImportsForFile :: (MonadIO m, MonadError IdeError m) =>
                      FilePath -> m [ModuleImport]
 getImportsForFile fp = do
   moduleE <- parseModule fp

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -44,7 +44,6 @@ import qualified Language.PureScript                 as P
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Logging
 import           Language.PureScript.Ide.Types
-import           System.Directory                (doesFileExist)
 import           System.IO.UTF8                  (readUTF8FileT)
 
 identifierFromIdeDeclaration :: IdeDeclaration -> Text
@@ -133,9 +132,11 @@ opNameT = iso P.runOpName P.OpName
 
 ideReadFile :: (MonadIO m, MonadError IdeError m) => FilePath -> m Text
 ideReadFile fp = do
-  unlessM (liftIO (doesFileExist fp))
-    (throwError (GeneralError ("Couldn't find file at: " <> T.pack fp)))
-  liftIO (readUTF8FileT fp)
+  contents :: Either IOException Text <- liftIO (try (readUTF8FileT fp))
+  either
+    (\_ -> throwError (GeneralError ("Couldn't find file at: " <> T.pack fp)))
+    pure
+    contents
 
 prettyTypeT :: P.Type -> Text
 prettyTypeT =

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -28,6 +28,7 @@ module Language.PureScript.Ide.Util
   , properNameT
   , identT
   , opNameT
+  , ideReadFile
   , module Language.PureScript.Ide.Logging
   ) where
 
@@ -40,8 +41,11 @@ import qualified Data.Text                           as T
 import qualified Data.Text.Lazy                      as TL
 import           Data.Text.Lazy.Encoding             (decodeUtf8, encodeUtf8)
 import qualified Language.PureScript                 as P
+import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Logging
 import           Language.PureScript.Ide.Types
+import           System.Directory                (doesFileExist)
+import           System.IO.UTF8                  (readUTF8FileT)
 
 identifierFromIdeDeclaration :: IdeDeclaration -> Text
 identifierFromIdeDeclaration d = case d of
@@ -126,6 +130,12 @@ identT = iso P.runIdent P.Ident
 
 opNameT :: Iso' (P.OpName a) Text
 opNameT = iso P.runOpName P.OpName
+
+ideReadFile :: (MonadIO m, MonadError IdeError m) => FilePath -> m Text
+ideReadFile fp = do
+  unlessM (liftIO (doesFileExist fp))
+    (throwError (GeneralError ("Couldn't find file at: " <> T.pack fp)))
+  liftIO (readUTF8FileT fp)
 
 prettyTypeT :: P.Type -> Text
 prettyTypeT =

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -190,7 +190,7 @@ importShouldBe :: [Text] -> [Text] -> Expectation
 importShouldBe res importSection =
   res `shouldBe` [ "module ImportsSpec where" , ""] ++ importSection ++ [ "" , "myId x = x"]
 
-runIdeLoaded :: Command -> IO (Either PscIdeError Success)
+runIdeLoaded :: Command -> IO (Either IdeError Success)
 runIdeLoaded c = do
   ([_, result], _) <- Test.inProject $ Test.runIde [Command.LoadSync [] , c]
   pure result

--- a/tests/Language/PureScript/Ide/Test.hs
+++ b/tests/Language/PureScript/Ide/Test.hs
@@ -24,7 +24,7 @@ defConfig =
                 , confGlobs = ["src/*.purs"]
                 }
 
-runIde' :: Configuration -> IdeState -> [Command] -> IO ([Either PscIdeError Success], IdeState)
+runIde' :: Configuration -> IdeState -> [Command] -> IO ([Either IdeError Success], IdeState)
 runIde' conf s cs = do
   stateVar <- newTVarIO s
   let env' = IdeEnvironment {ideStateVar = stateVar, ideConfiguration = conf}
@@ -32,7 +32,7 @@ runIde' conf s cs = do
   newState <- readTVarIO stateVar
   pure (r, newState)
 
-runIde :: [Command] -> IO ([Either PscIdeError Success], IdeState)
+runIde :: [Command] -> IO ([Either IdeError Success], IdeState)
 runIde = runIde' defConfig emptyIdeState
 
 s3 :: IdeState -> [(Text, [IdeDeclarationAnn])] -> IdeState


### PR DESCRIPTION
Use a safer readFile that checks the files existence before reading it and utilizes psc-ide's error reporting instead of crashing.

Also renames `PscIdeError` to `IdeError` to be more consistent with naming

Edit: fixes #2537 