### PR TITLE
Revert binder syntax

### DIFF
--- a/examples/passing/ParseNamedBinder.purs
+++ b/examples/passing/ParseNamedBinder.purs
@@ -1,9 +1,0 @@
-module Main where
-
-import Control.Monad.Eff.Console (log)
-
-data X = X
-
-f a@X X = a
-
-main = log "Done"

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -497,7 +497,7 @@ parseArrayBinder = LiteralBinder <$> parseArrayLiteral (indented *> parseBinder)
 parseVarOrNamedBinder :: TokenParser Binder
 parseVarOrNamedBinder = do
   name <- parseIdent
-  let parseNamedBinder = NamedBinder name <$> (at *> indented *> parseBinderNoParens)
+  let parseNamedBinder = NamedBinder name <$> (at *> indented *> parseBinderAtom)
   parseNamedBinder <|> return (VarBinder name)
 
 parseNullBinder :: TokenParser Binder


### PR DESCRIPTION
This reverts (the key part of) #2559, since it's a breaking change and I shouldn't really have merged it to begin with. I think we should add it back before 0.11.