### PR TITLE
Fix psc-publish --dry-run

### DIFF
--- a/psc-publish/Main.hs
+++ b/psc-publish/Main.hs
@@ -2,10 +2,12 @@
 
 module Main where
 
+import Control.Monad.IO.Class (liftIO)
 import Data.Version (Version(..), showVersion)
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy.Char8 as BL
 import Data.Monoid ((<>))
+import Data.Time.Clock (getCurrentTime)
 
 import Options.Applicative (Parser, ParseError (..))
 import qualified Options.Applicative as Opts
@@ -25,6 +27,7 @@ dryRunOptions :: PublishOptions
 dryRunOptions = defaultPublishOptions
   { publishGetVersion = return dummyVersion
   , publishWorkingTreeDirty = warn DirtyWorkingTree_Warn
+  , publishGetTagTime = const (liftIO getCurrentTime)
   }
   where dummyVersion = ("0.0.0", Version [0,0,0] [])
 

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -424,7 +424,9 @@ executable psc-publish
                    purescript -any,
                    aeson >= 0.8 && < 1.0,
                    bytestring -any,
-                   optparse-applicative -any
+                   optparse-applicative -any,
+                   time -any,
+                   transformers -any
     main-is: Main.hs
     other-modules: Paths_purescript
     buildable: True

--- a/tests/TestPscPublish.hs
+++ b/tests/TestPscPublish.hs
@@ -61,13 +61,4 @@ testPackage dir = pushd dir $ do
         print other
         exitFailure
   where
-    preparePackageError e@(UserError BowerJSONNotFound) = do
-      Publish.printErrorToStdout e
-      putStrLn ""
-      putStrLn "=========================================="
-      putStrLn "Did you forget to update the submodules?"
-      putStrLn "$ git submodule sync; git submodule update"
-      putStrLn "=========================================="
-      putStrLn ""
-      exitFailure
     preparePackageError e = Publish.printErrorToStdout e >> exitFailure


### PR DESCRIPTION
This fixes one of the two problems mentioned in #2610, that psc-publish
--dry-run is broken.

I also removed a misleading error message from the psc-publish tests (we
no longer use git submodules for retrieving purescript libraries for
running tests with).