### PR TITLE
Fix failure to parse git tag date in psc-publish

### DIFF
--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -195,8 +195,9 @@ getVersionFromGitTag = do
 getTagTime :: Text -> PrepareM UTCTime
 getTagTime tag = do
   out <- readProcess' "git" ["show", T.unpack tag, "--no-patch", "--format=%aI"] ""
-  let time = headMay (lines out) >>= D.parseTime
-  maybe (internalError (CouldntParseGitTagDate tag)) pure time
+  case mapMaybe D.parseTime (lines out) of
+    [t] -> pure t
+    _ -> internalError (CouldntParseGitTagDate tag)
 
 getBowerRepositoryInfo :: PackageMeta -> PrepareM (D.GithubUser, D.GithubRepo)
 getBowerRepositoryInfo = either (userError . BadRepositoryField) return . tryExtract


### PR DESCRIPTION
Fixes one of the problems mentioned in #2610. I've tested this with the repository that @owickstrom used to demonstrate the issue originally. I'd like to restructure the tests so that they're able to catch this sort of error but unfortunately that's going to be a bit more involved, as `psc-publish` is currently tested via the purescript library but really we should be testing it via its CLI, I think. So I'd rather just do this for now and save that for later.