### PR TITLE
Disallow polymorphic types in binders, prevent internalError

### DIFF
--- a/examples/docs/src/ExplicitTypeSignatures.purs
+++ b/examples/docs/src/ExplicitTypeSignatures.purs
@@ -14,5 +14,3 @@ anInt = 0
 
 -- This should infer a type.
 aNumber = 1.0
-
-foreign import nestedForAll :: forall c. (forall a b. c)

--- a/examples/failing/2445.purs
+++ b/examples/failing/2445.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module Main where
+
+data X a = X
+
+eg = \(X :: (forall a. X a)) -> X

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -127,6 +127,8 @@ rowFromList ((name, t):ts, r) = RCons name t (rowFromList (ts, r))
 --
 isMonoType :: Type -> Bool
 isMonoType ForAll{} = False
+isMonoType (ParensInType t) = isMonoType t
+isMonoType (KindedType t _) = isMonoType t
 isMonoType _        = True
 
 -- |

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -336,7 +336,6 @@ testCases =
       [ ValueShouldHaveTypeSignature (n "ExplicitTypeSignatures") "explicit" (ShowFn (hasTypeVar "something"))
       , ValueShouldHaveTypeSignature (n "ExplicitTypeSignatures") "anInt"    (ShowFn (P.tyInt ==))
       , ValueShouldHaveTypeSignature (n "ExplicitTypeSignatures") "aNumber"  (ShowFn (P.tyNumber ==))
-      , ValueShouldHaveTypeSignature (n "ExplicitTypeSignatures") "nestedForAll" (renderedType "forall c. (forall a b. c)")
       ])
 
   , ("ConstrainedArgument",


### PR DESCRIPTION
@LiamGoodacre Could you please review? This "fixes" #2445, although I'm deferring a proper fix until after I dust off the skolem escape check code and fix a few issues there.

_Edit_: I think we should open a separate issue to deal with polymorphic types in typed binders more generally.