### PR TITLE
Instantiate types in record literals as necessary

### DIFF
--- a/examples/passing/1110.purs
+++ b/examples/passing/1110.purs
@@ -13,4 +13,14 @@ type Y = { x :: X Int }
 test :: forall m. Monad m => m Y
 test = pure { x: x }
 
+type Z t = forall x. t x -> (forall a. t a) -> t x
+
+class C t where c :: Z t
+
+instance cA :: C Array where
+  c x _ = x
+
+test2 :: forall m. Monad m => m { ccc :: Z Array }
+test2 = pure { ccc: (c :: Z Array) }
+
 main = log "Done"

--- a/examples/passing/1110.purs
+++ b/examples/passing/1110.purs
@@ -1,0 +1,16 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console (log)
+
+data X a = X
+
+x :: forall a. X a
+x = X
+	 
+type Y = { x :: X Int }
+
+test :: forall m. Monad m => m Y
+test = pure { x: x }
+
+main = log "Done"

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -319,16 +319,15 @@ infer' (Literal (ObjectLiteral ps)) = do
   -- We make a special case for Vars in record labels, since there are the
   -- only types of expressions for which 'infer' can return a polymorphic type.
   -- They need to be instantiated here.
-  let isVar :: Expr -> Bool
-      isVar Var{} = True
-      isVar (TypedValue _ e _) = isVar e
-      isVar (PositionedValue _ _ e) = isVar e
-      isVar _ = False
+  let shouldInstantiate :: Expr -> Bool
+      shouldInstantiate Var{} = True
+      shouldInstantiate (PositionedValue _ _ e) = shouldInstantiate e
+      shouldInstantiate _ = False
 
       inferProperty :: (PSString, Expr) -> m (PSString, (Expr, Type))
       inferProperty (name, val) = do
         TypedValue _ val' ty <- infer val
-        valAndType <- if isVar val
+        valAndType <- if shouldInstantiate val
                         then instantiatePolyTypeWithUnknowns val' ty
                         else pure (val', ty)
         pure (name, valAndType)


### PR DESCRIPTION
Fixes #1110 and #2312. Replaces #2367.

I'm not really very happy with this fix, but I've been stuck thinking about this for a long time now, and it's been difficult to fix this and keep Halogen compiling as-is. So this is a compromise, and I've added a note in a comment to explain the fix.