### PR TITLE
Remove extra-deps from stack-ghc-8.0.yaml

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -113,7 +113,7 @@ source-repository head
 
 library
     build-depends: base >=4.8 && <5,
-                   aeson >= 0.8 && < 1.0,
+                   aeson >= 0.8 && < 1.1,
                    aeson-better-errors >= 0.8,
                    ansi-terminal >= 0.6.2 && < 0.7,
                    base-compat >=0.6.0,
@@ -133,7 +133,7 @@ library
                    fsnotify >= 0.2.1,
                    Glob >= 0.7 && < 0.8,
                    haskeline >= 0.7.0.0,
-                   http-client >= 0.4.30 && <0.5,
+                   http-client >= 0.4.30 && < 0.6.0,
                    http-types -any,
                    language-javascript >= 0.6.0.9 && < 0.7,
                    lens == 4.*,
@@ -144,7 +144,7 @@ library
                    parallel >= 3.2 && < 3.3,
                    parsec >=3.1.10,
                    pattern-arrows >= 0.0.2 && < 0.1,
-                   pipes >= 4.0.0 && < 4.3.0,
+                   pipes >= 4.0.0 && < 4.4.0,
                    pipes-http -any,
                    process >= 1.2.0 && < 1.5,
                    protolude >= 0.1.6,
@@ -341,7 +341,7 @@ library
 
 executable purs
     build-depends: base >=4 && <5,
-                   aeson >= 0.8 && < 1.0,
+                   aeson >= 0.8 && < 1.1,
                    ansi-terminal >= 0.6.2 && < 0.7,
                    ansi-wl-pprint -any,
                    base-compat >=0.6.0,
@@ -373,7 +373,7 @@ executable purs
                    wai == 3.*,
                    wai-websockets == 3.*,
                    warp == 3.*,
-                   websockets >= 0.9 && <0.10
+                   websockets >= 0.9 && <0.11
     main-is: Main.hs
     buildable: True
     hs-source-dirs: app

--- a/src/Language/PureScript/Ide/Pursuit.hs
+++ b/src/Language/PureScript/Ide/Pursuit.hs
@@ -45,7 +45,6 @@ queryPursuit q = do
 
 
 handler :: HttpException -> IO [a]
-handler StatusCodeException{} = pure []
 handler _ = pure []
 
 searchPursuitForDeclarations :: Text -> IO [PursuitResponse]

--- a/stack-ghc-8.0.yaml
+++ b/stack-ghc-8.0.yaml
@@ -2,12 +2,4 @@ resolver: nightly-2017-01-31
 packages:
 - '.'
 extra-deps:
-- aeson-0.11.3.0
-- bower-json-1.0.0.1
-- http-client-0.4.31.2
-- http-client-tls-0.2.4.1
-- optparse-applicative-0.13.0.0
-- pipes-4.1.9
-- pipes-http-1.0.2
-- wai-websockets-3.0.0.9
-- websockets-0.9.6.2
+- pipes-http-1.0.5


### PR DESCRIPTION
To use the packages in the resolver, version constraints in the cabal file is loosened. Also Pursuit.hs is modified to support the higher version of http-client, without behaviour change.

I've built and tested with both `stack.yaml` and `stack-ghc-8.0.yaml`, and there was no problem.