### PR TITLE
Address travis timeout issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,11 @@ cache:
   directories:
   - $HOME/.local/bin
   - $HOME/.stack
+  # Maximum amount of time in seconds spent attempting to upload a new cache
+  # before aborting. Since our cache can get rather large, increasing this
+  # value helps avoid situations where caches fail to be stored. The default
+  # value is 180 (at the time of writing).
+  timeout: 1000
 install:
 - | # Install stack.
   if test ! -f "$HOME/.local/bin/stack"

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,6 @@ install:
   else
     export TIMEOUT=timeout
   fi
-# Setup & install dependencies or abort
-- $TIMEOUT 40m stack --no-terminal -j1 --install-ghc build --only-dependencies --test --haddock
 script:
 - travis/build.sh
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,21 @@ install:
   fi
 - npm install -g bower # for psc-docs / psc-publish tests
 - export OS_NAME=$(./travis/convert-os-name.sh)
+# Install 'timeout'
+- |
+  if [ "$TRAVIS_OS_NAME" == "osx" ]
+  then
+    if ! which gtimeout >/dev/null
+    then
+      brew update
+      brew install coreutils
+    fi
+    export TIMEOUT=gtimeout
+  else
+    export TIMEOUT=timeout
+  fi
 # Setup & install dependencies or abort
-- timeout 40m stack --no-terminal -j1 --install-ghc build --only-dependencies --test --haddock
+- $TIMEOUT 40m stack --no-terminal -j1 --install-ghc build --only-dependencies --test --haddock
 script:
 - travis/build.sh
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
 - npm install -g bower # for psc-docs / psc-publish tests
 - export OS_NAME=$(./travis/convert-os-name.sh)
 # Setup & install dependencies or abort
-- timeout 40m stack --no-terminal -j1 --install-ghc build --only-dependencies
+- timeout 40m stack --no-terminal -j1 --install-ghc build --only-dependencies --test --haddock
 script:
 - travis/build.sh
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,49 +3,38 @@ dist: trusty # because of perf issues
 sudo: required
 matrix:
   include:
-    # The 'compiler' key is a hack to get Travis to use different caches for
-    # each job in a build, in order to avoid the separate jobs stomping on each
-    # other's caches. See https://github.com/travis-ci/travis-ci/issues/4393
-    #
     # We use trusty boxes because they seem to be a bit faster.
-    - compiler: cc-linux-lts-normal
-      os: linux
+    - os: linux
       dist: trusty
       sudo: required
       env: BUILD_TYPE=normal DEPLOY=true
 
-    # - compiler: cc-linux-nightly-normal
-    #   os: linux
+    # - os: linux
     #   dist: trusty
     #   sudo: required
     #   env: BUILD_TYPE=normal STACKAGE_NIGHTLY=true
     #   allow_failures: true
 
-    - compiler: cc-linux-ghc8.0-normal
-      os: linux
+    - os: linux
       dist: trusty
       sudo: required
       env: BUILD_TYPE=normal STACK_YAML=stack-ghc-8.0.yaml
 
-    - compiler: cc-linux-lts-sdist
-      os: linux
+    - os: linux
       dist: trusty
       sudo: required
       env: BUILD_TYPE=sdist COVERAGE=true
 
-    - compiler: cc-linux-lts-haddock
-      os: linux
+    - os: linux
       dist: trusty
       sudo: required
       env: BUILD_TYPE=haddock
 
-    # - compiler: cc-osx-lts-normal
-    #   os: osx
-    #   env: BUILD_TYPE=normal DEPLOY=true
-    
-    # - compiler: cc-osx-lts-sdist
-    #   os: osx
-    #   env: BUILD_TYPE=sdist
+    - os: osx
+      env: BUILD_TYPE=normal DEPLOY=true
+
+    - os: osx
+      env: BUILD_TYPE=sdist
 addons:
   apt:
     packages:
@@ -66,9 +55,9 @@ install:
     mv stack "$HOME/.local/bin/"
   fi
 - npm install -g bower # for psc-docs / psc-publish tests
-# Fix the CC environment variable, because Travis changes it
-- export CC=gcc
 - export OS_NAME=$(./travis/convert-os-name.sh)
+# Setup & install dependencies or abort
+- timeout 40m stack --no-terminal -j1 --install-ghc build --only-dependencies
 script:
 - travis/build.sh
 before_deploy:

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -12,7 +12,8 @@ case "$ret" in
   0) # continue
     ;;
   124)
-    echo "Timed out while installing dependencies; try restarting the build."
+    echo "Timed out while installing dependencies."
+    echo "Try pushing a new commit to build again."
     exit 1
     ;;
   *)

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -3,6 +3,24 @@ set -e
 
 STACK="stack --no-terminal --jobs=1"
 
+# Setup & install dependencies or abort
+ret=0
+$TIMEOUT 40m $STACK --install-ghc build \
+  --only-dependencies --test --haddock \
+  || ret=$?
+case "$ret" in
+  0) # continue
+    ;;
+  124)
+    echo "Timed out while installing dependencies; try restarting the build."
+    exit 1
+    ;;
+  *)
+    echo "Failed to install dependencies."
+    exit 1
+    ;;
+esac
+
 # Set up configuration
 STACK_EXTRA_FLAGS=""
 if [ -z "$TRAVIS_TAG" ]

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -2,7 +2,6 @@
 set -e
 
 STACK="stack --no-terminal --jobs=1"
-$STACK setup
 
 # Set up configuration
 STACK_EXTRA_FLAGS=""


### PR DESCRIPTION
These commits amend the CI scripts so that if a build does time out, the next one can continue where the previous left off. For more info see https://gist.github.com/hdgarrood/29fa8ebcd5b5acd679cf429fd0a93e3e

This enables us to enable OSX builds again (which I have done).