### PR TITLE
Capitalise *script into *Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![PureScript](logo.png)](http://purescript.org)
 
-A small strongly typed programming language with expressive types that compiles to Javascript, written in and inspired by Haskell.
+A small strongly typed programming language with expressive types that compiles to JavaScript, written in and inspired by Haskell.
 
 [![Hackage](https://img.shields.io/hackage/v/purescript.svg)](http://hackage.haskell.org/package/purescript) [![Build Status](https://api.travis-ci.org/purescript/purescript.svg?branch=master)](http://travis-ci.org/purescript/purescript)
 

--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -250,7 +250,7 @@ browserBackend serverPort = Backend setup evaluate reload shutdown
 
     createBundle :: BrowserState -> IO ()
     createBundle state = do
-      putStrLn "Bundling Javascript..."
+      putStrLn "Bundling JavaScript..."
       ejs <- bundle
       case ejs of
         Left err -> do

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -8,7 +8,7 @@ copyright: (c) 2013-16 Phil Freeman, (c) 2014-16 Gary Burgess
 maintainer: Phil Freeman <paf31@cantab.net>
 stability: experimental
 synopsis: PureScript Programming Language Compiler
-description: A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to Javascript.
+description: A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
 category: Language
 Homepage: http://www.purescript.org/
 author: Phil Freeman <paf31@cantab.net>,

--- a/src/Language/PureScript/Bundle.hs
+++ b/src/Language/PureScript/Bundle.hs
@@ -3,7 +3,7 @@
 --
 -- This module takes as input the individual generated modules from 'Language.PureScript.Make' and
 -- performs dead code elimination, filters empty modules,
--- and generates the final Javascript bundle.
+-- and generates the final JavaScript bundle.
 module Language.PureScript.Bundle
   ( bundle
   , bundleSM
@@ -249,7 +249,7 @@ trailingCommaList :: JSCommaTrailingList a -> [a]
 trailingCommaList (JSCTLComma l _) = commaList l
 trailingCommaList (JSCTLNone l) = commaList l
 
--- | Attempt to create a Module from a Javascript AST.
+-- | Attempt to create a Module from a JavaScript AST.
 --
 -- Each type of module element is matched using pattern guards, and everything else is bundled into the
 -- Other constructor.
@@ -671,7 +671,7 @@ codeGen optionsMainModule optionsNamespace ms outFileOpt = (fmap sourceMapping o
 
 -- | The bundling function.
 -- This function performs dead code elimination, filters empty modules
--- and generates and prints the final Javascript bundle.
+-- and generates and prints the final JavaScript bundle.
 bundleSM :: (MonadError ErrorMessage m)
        => [(ModuleIdentifier, Maybe FilePath, String)] -- ^ The input modules.  Each module should be javascript rendered from 'Language.PureScript.Make' or @psc@.
        -> [ModuleIdentifier] -- ^ Entry points.  These module identifiers are used as the roots for dead-code elimination
@@ -700,7 +700,7 @@ bundleSM inputStrs entryPoints mainModule namespace outFilename = do
 
 -- | The bundling function.
 -- This function performs dead code elimination, filters empty modules
--- and generates and prints the final Javascript bundle.
+-- and generates and prints the final JavaScript bundle.
 bundle :: (MonadError ErrorMessage m)
        => [(ModuleIdentifier, String)] -- ^ The input modules.  Each module should be javascript rendered from 'Language.PureScript.Make' or @psc@.
        -> [ModuleIdentifier] -- ^ Entry points.  These module identifiers are used as the roots for dead-code elimination

--- a/src/Language/PureScript/CodeGen.hs
+++ b/src/Language/PureScript/CodeGen.hs
@@ -1,7 +1,7 @@
 -- |
 -- A collection of modules related to code generation:
 --
---  [@Language.PureScript.CodeGen.JS@] Code generator for Javascript
+--  [@Language.PureScript.CodeGen.JS@] Code generator for JavaScript
 --
 module Language.PureScript.CodeGen (module C) where
 

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -1,5 +1,5 @@
 -- |
--- This module generates code in the simplified Javascript intermediate representation from Purescript code
+-- This module generates code in the simplified JavaScript intermediate representation from PureScript code
 --
 module Language.PureScript.CodeGen.JS
   ( module AST
@@ -42,7 +42,7 @@ import qualified Language.PureScript.Constants as C
 import System.FilePath.Posix ((</>))
 
 -- |
--- Generate code in the simplified Javascript intermediate representation for all declarations in a
+-- Generate code in the simplified JavaScript intermediate representation for all declarations in a
 -- module.
 --
 moduleToJs
@@ -104,7 +104,7 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
          else newName
 
   -- |
-  -- Generates Javascript code for a module import, binding the required module
+  -- Generates JavaScript code for a module import, binding the required module
   -- to the alternative
   --
   importToJs :: M.Map ModuleName (Ann, ModuleName) -> ModuleName -> m JS
@@ -135,14 +135,14 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
     renameQual q = q
 
   -- |
-  -- Generate code in the simplified Javascript intermediate representation for a declaration
+  -- Generate code in the simplified JavaScript intermediate representation for a declaration
   --
   bindToJs :: Bind Ann -> m [JS]
   bindToJs (NonRec ann ident val) = return <$> nonRecToJS ann ident val
   bindToJs (Rec vals) = forM vals (uncurry . uncurry $ nonRecToJS)
 
   -- |
-  -- Generate code in the simplified Javascript intermediate representation for a single non-recursive
+  -- Generate code in the simplified JavaScript intermediate representation for a single non-recursive
   -- declaration.
   --
   -- The main purpose of this function is to handle code generation for comments.
@@ -166,15 +166,15 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
   withPos Nothing js = return js
 
   -- |
-  -- Generate code in the simplified Javascript intermediate representation for a variable based on a
+  -- Generate code in the simplified JavaScript intermediate representation for a variable based on a
   -- PureScript identifier.
   --
   var :: Ident -> JS
   var = JSVar Nothing . identToJs
 
   -- |
-  -- Generate code in the simplified Javascript intermediate representation for an accessor based on
-  -- a PureScript identifier. If the name is not valid in Javascript (symbol based, reserved name) an
+  -- Generate code in the simplified JavaScript intermediate representation for an accessor based on
+  -- a PureScript identifier. If the name is not valid in JavaScript (symbol based, reserved name) an
   -- indexer is returned.
   --
   accessor :: Ident -> JS -> JS
@@ -185,7 +185,7 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
   accessorString prop = JSIndexer Nothing (JSStringLiteral Nothing prop)
 
   -- |
-  -- Generate code in the simplified Javascript intermediate representation for a value or expression.
+  -- Generate code in the simplified JavaScript intermediate representation for a value or expression.
   --
   valueToJs :: Expr Ann -> m JS
   valueToJs e =
@@ -301,7 +301,7 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
     return $ JSApp Nothing (JSFunction Nothing Nothing [] block) []
 
   -- |
-  -- Generate code in the simplified Javascript intermediate representation for a reference to a
+  -- Generate code in the simplified JavaScript intermediate representation for a reference to a
   -- variable.
   --
   varToJs :: Qualified Ident -> JS
@@ -309,7 +309,7 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
   varToJs qual = qualifiedToJS id qual
 
   -- |
-  -- Generate code in the simplified Javascript intermediate representation for a reference to a
+  -- Generate code in the simplified JavaScript intermediate representation for a reference to a
   -- variable that may have a qualified name.
   --
   qualifiedToJS :: (a -> Ident) -> Qualified a -> JS
@@ -321,7 +321,7 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
   foreignIdent ident = accessorString (mkString $ runIdent ident) (JSVar Nothing "$foreign")
 
   -- |
-  -- Generate code in the simplified Javascript intermediate representation for pattern match binders
+  -- Generate code in the simplified JavaScript intermediate representation for pattern match binders
   -- and guards.
   --
   bindersToJs :: Maybe SourceSpan -> [CaseAlternative Ann] -> [JS] -> m JS
@@ -382,7 +382,7 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
     traverse (withPos ss) =<< binderToJs' s done binder
 
   -- |
-  -- Generate code in the simplified Javascript intermediate representation for a pattern match
+  -- Generate code in the simplified JavaScript intermediate representation for a pattern match
   -- binder.
   --
   binderToJs' :: Text -> [JS] -> Binder Ann -> m [JS]

--- a/src/Language/PureScript/CodeGen/JS/AST.hs
+++ b/src/Language/PureScript/CodeGen/JS/AST.hs
@@ -1,5 +1,5 @@
 -- |
--- Data types for the intermediate simplified-Javascript AST
+-- Data types for the intermediate simplified-JavaScript AST
 --
 module Language.PureScript.CodeGen.JS.AST where
 
@@ -123,7 +123,7 @@ data BinaryOperator
   deriving (Show, Eq)
 
 -- |
--- Data type for simplified Javascript expressions
+-- Data type for simplified JavaScript expressions
 --
 data JS
   -- |
@@ -231,11 +231,11 @@ data JS
   --
   | JSContinue (Maybe SourceSpan) Text
   -- |
-  -- Raw Javascript (generated when parsing fails for an inline foreign import declaration)
+  -- Raw JavaScript (generated when parsing fails for an inline foreign import declaration)
   --
   | JSRaw (Maybe SourceSpan) Text
   -- |
-  -- Commented Javascript
+  -- Commented JavaScript
   --
   | JSComment (Maybe SourceSpan) [Comment] JS
   deriving (Show, Eq)

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -19,7 +19,7 @@ moduleNameToJs (ModuleName pns) =
   in if nameIsJsBuiltIn name then "$$" <> name else name
 
 -- |
--- Convert an Ident into a valid Javascript identifier:
+-- Convert an Ident into a valid JavaScript identifier:
 --
 --  * Alphanumeric characters are kept unmodified.
 --
@@ -73,14 +73,14 @@ identCharToText '\'' = "$prime"
 identCharToText c = '$' `T.cons` T.pack (show (ord c))
 
 -- |
--- Checks whether an identifier name is reserved in Javascript.
+-- Checks whether an identifier name is reserved in JavaScript.
 --
 nameIsJsReserved :: Text -> Bool
 nameIsJsReserved name =
   name `elem` jsAnyReserved
 
 -- |
--- Checks whether a name matches a built-in value in Javascript.
+-- Checks whether a name matches a built-in value in JavaScript.
 --
 nameIsJsBuiltIn :: Text -> Bool
 nameIsJsBuiltIn name =

--- a/src/Language/PureScript/CodeGen/JS/Optimizer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer.hs
@@ -1,4 +1,4 @@
--- | This module optimizes code in the simplified-Javascript intermediate representation.
+-- | This module optimizes code in the simplified-JavaScript intermediate representation.
 --
 -- The following optimizations are supported:
 --
@@ -16,7 +16,7 @@
 --
 --  * Inline Prelude.($), Prelude.(#), Prelude.(++), Prelude.(!!)
 --
---  * Inlining primitive Javascript operators
+--  * Inlining primitive JavaScript operators
 module Language.PureScript.CodeGen.JS.Optimizer (optimize) where
 
 import Prelude.Compat
@@ -30,7 +30,7 @@ import Language.PureScript.CodeGen.JS.Optimizer.MagicDo
 import Language.PureScript.CodeGen.JS.Optimizer.TCO
 import Language.PureScript.CodeGen.JS.Optimizer.Unused
 
--- | Apply a series of optimizer passes to simplified Javascript code
+-- | Apply a series of optimizer passes to simplified JavaScript code
 optimize :: MonadSupply m => JS -> m JS
 optimize js = do
   js' <- untilFixedPoint (inlineFnComposition . inlineUnsafePartial . tidyUp . applyAll

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/Blocks.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/Blocks.hs
@@ -1,5 +1,5 @@
 -- |
--- Optimizer steps for simplifying Javascript blocks
+-- Optimizer steps for simplifying JavaScript blocks
 --
 module Language.PureScript.CodeGen.JS.Optimizer.Blocks
   ( collapseNestedBlocks

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -94,7 +94,7 @@ renderProgressMessage (CompilingModule mn) = "Compiling " ++ T.unpack (runModule
 --
 -- This type exists to make two things abstract:
 --
--- * The particular backend being used (Javascript, C++11, etc.)
+-- * The particular backend being used (JavaScript, C++11, etc.)
 --
 -- * The details of how files are read/written etc.
 data MakeActions m = MakeActions

--- a/src/Language/PureScript/Pretty/JS.hs
+++ b/src/Language/PureScript/Pretty/JS.hs
@@ -1,5 +1,5 @@
 -- |
--- Pretty printer for the Javascript AST
+-- Pretty printer for the JavaScript AST
 --
 module Language.PureScript.Pretty.JS
   ( prettyPrintJS
@@ -240,13 +240,13 @@ prettyStatements sts = do
   return $ intercalate (emit "\n") $ map ((<> emit ";") . (indentString <>)) jss
 
 -- |
--- Generate a pretty-printed string representing a Javascript expression
+-- Generate a pretty-printed string representing a JavaScript expression
 --
 prettyPrintJS1 :: (Emit gen) => JS -> gen
 prettyPrintJS1 = fromMaybe (internalError "Incomplete pattern") . flip evalStateT (PrinterState 0) . prettyPrintJS'
 
 -- |
--- Generate a pretty-printed string representing a collection of Javascript expressions at the same indentation level
+-- Generate a pretty-printed string representing a collection of JavaScript expressions at the same indentation level
 --
 prettyPrintJSWithSourceMaps :: [JS] -> (Text, [SMap])
 prettyPrintJSWithSourceMaps js =
@@ -256,7 +256,7 @@ prettyPrintJSWithSourceMaps js =
 prettyPrintJS :: [JS] -> Text
 prettyPrintJS = maybe (internalError "Incomplete pattern") runPlainString . flip evalStateT (PrinterState 0) . prettyStatements
 -- |
--- Generate an indented, pretty-printed string representing a Javascript expression
+-- Generate an indented, pretty-printed string representing a JavaScript expression
 --
 prettyPrintJS' :: (Emit gen) => JS -> StateT PrinterState Maybe gen
 prettyPrintJS' = A.runKleisli $ runPattern matchValue


### PR DESCRIPTION
This PR changes Javascript and Purescript into JavaScript and PureScript, which are official names as I understand.

I also would like 'Javascript' in header descriptions in the following pages to be changed. (In [the PureScript homepage](http://www.purescript.org/), it's correctly written in JavaScript)

- https://github.com/purescript
- https://github.com/purescript/purescript