### PR TITLE
Use Stackage LTS 8.0

### DIFF
--- a/stack-ghc-8.0.yaml
+++ b/stack-ghc-8.0.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2017-01-31
+resolver: lts-8.0
 packages:
 - '.'
 extra-deps:


### PR DESCRIPTION
Stackage LTS 8.0 which uses GHC 8.0.2 has been released.

This PR modifies `stack-ghc-8.0.yaml` to use it.