### PR TITLE
PSCi command changes

### DIFF
--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -35,9 +35,8 @@ psciCommand = choice (map try parsers)
   where
   parsers =
     [ psciImport
-    , psciOtherDeclaration
+    , psciDeclaration
     , psciExpression
-    , psciLet
     ]
 
 trim :: String -> String
@@ -75,18 +74,6 @@ parseDirective cmd =
 psciExpression :: P.TokenParser Command
 psciExpression = Expression <$> P.parseValue
 
--- |
--- PSCI version of @let@.
--- This is essentially let from do-notation.
--- However, since we don't support the @Eff@ monad,
--- we actually want the normal @let@.
---
-psciLet :: P.TokenParser Command
-psciLet = Decls <$> (P.reserved "let" *> P.indented *> manyDecls)
-  where
-  manyDecls :: P.TokenParser [P.Declaration]
-  manyDecls = mark (many1 (same *> P.parseLocalDeclaration))
-
 -- | Imports must be handled separately from other declarations, so that
 -- :show import works, for example.
 psciImport :: P.TokenParser Command
@@ -94,10 +81,10 @@ psciImport = do
   (mn, declType, asQ) <- P.parseImportDeclaration'
   return $ Import (mn, declType, asQ)
 
--- | Any other declaration that we don't need a 'special case' parser for
--- (like let or import declarations).
-psciOtherDeclaration :: P.TokenParser Command
-psciOtherDeclaration = Decls . (:[]) <$> do
+-- | Any declaration that we don't need a 'special case' parser for
+-- (like import declarations).
+psciDeclaration :: P.TokenParser Command
+psciDeclaration = fmap Decls $ mark $ many1 $ same *> do
   decl <- discardPositionInfo <$> P.parseDeclaration
   if acceptable decl
     then return decl
@@ -115,6 +102,7 @@ acceptable P.ExternDataDeclaration{} = True
 acceptable P.TypeClassDeclaration{} = True
 acceptable P.TypeInstanceDeclaration{} = True
 acceptable P.ExternKindDeclaration{} = True
+acceptable P.TypeDeclaration{} = True
 acceptable P.ValueDeclaration{} = True
 acceptable _ = False
 

--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -115,6 +115,7 @@ acceptable P.ExternDataDeclaration{} = True
 acceptable P.TypeClassDeclaration{} = True
 acceptable P.TypeInstanceDeclaration{} = True
 acceptable P.ExternKindDeclaration{} = True
+acceptable P.ValueDeclaration{} = True
 acceptable _ = False
 
 parseReplQuery' :: String -> Either String ReplQuery

--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -34,10 +34,10 @@ psciCommand :: P.TokenParser Command
 psciCommand = choice (map try parsers)
   where
   parsers =
-    [ psciLet
-    , psciImport
+    [ psciImport
     , psciOtherDeclaration
     , psciExpression
+    , psciLet
     ]
 
 trim :: String -> String


### PR DESCRIPTION
Resolve #2630.

This PR includes the followings:

1. Enable `let ... in` in PSCi
2. Add support for value declaration without `let` in PSCi
3. Remove special `let` from PSCi

I personally think 3 makes sense, but surely it can be reverted as discussed in the original issue.