### PR TITLE
Better error message for removed PSCi let decl

### DIFF
--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -123,4 +123,4 @@ psciDeprecatedLet = do
   P.indented
   _ <- mark (many1 (same *> P.parseLocalDeclaration))
   notFollowedBy $ P.reserved "in"
-  fail "for declaration in PSCi, try without \"let\""
+  fail "Declarations in PSCi no longer require \"let\", as of version 0.11.0"

--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -122,4 +122,5 @@ psciDeprecatedLet = do
   P.reserved "let"
   P.indented
   _ <- mark (many1 (same *> P.parseLocalDeclaration))
+  notFollowedBy $ P.reserved "in"
   fail "for declaration in PSCi, try without \"let\""

--- a/src/Language/PureScript/Interactive/Types.hs
+++ b/src/Language/PureScript/Interactive/Types.hs
@@ -94,6 +94,7 @@ data Command
   | ShowInfo ReplQuery
   -- | Paste multiple lines
   | PasteLines
+  deriving Show
 
 data ReplQuery
   = QueryLoaded


### PR DESCRIPTION
Regarding #2665.

PSCi will suggest declaration without `let` for the obsolete `let` usage.

```
> a = 10
> let b = 10
(line 1, column 9):
unexpected end of input
expecting ., {, ::, operator, "where", indentation at column 5 or "in"
For declarations, try without 'let'
```

How to tell the obsolete case is somewhat rough, but I guess it works well enough.