### PR TITLE
Include git commit information in non-release builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,14 +30,14 @@ build_script:
 - echo ""
 test_script:
 - ps: |
-  if ($env:APPVEYOR_REPO_TAG_NAME)
-  {
-    stack -j1 --no-terminal test --pedantic --flag purescript:RELEASE
-  }
-  else
-  {
-    stack -j1 --no-terminal test --pedantic
-  }
+    if ($env:APPVEYOR_REPO_TAG_NAME)
+    {
+      stack -j1 --no-terminal test --pedantic --flag purescript:RELEASE
+    }
+    else
+    {
+      stack -j1 --no-terminal test --pedantic
+    }
 on_success:
 - ps: |
     function UploadFile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,15 @@ build_script:
 # Override the default build script.
 - echo ""
 test_script:
-- stack -j1 --no-terminal test --pedantic
+- ps: |
+  if ($env:APPVEYOR_REPO_TAG_NAME)
+  {
+    stack -j1 --no-terminal test --pedantic --flag purescript:RELEASE
+  }
+  else
+  {
+    stack -j1 --no-terminal test --pedantic
+  }
 on_success:
 - ps: |
     function UploadFile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,15 +32,9 @@ build_script:
 # failed.
 - echo ""
 test_script:
-- ps: |
-    if ($env:APPVEYOR_REPO_TAG_NAME)
-    {
-      stack -j1 --no-terminal test --pedantic --flag purescript:RELEASE 2>&1
-    }
-    else
-    {
-      stack -j1 --no-terminal test --pedantic 2>&1
-    }
+- if defined APPVEYOR_REPO_TAG_NAME (set stack_extra_flags="--flag purescript:RELEASE")
+- echo "stack_extra_flags=%stack_extra_flags%"
+- stack --jobs=1 --no-terminal test --pedantic %stack_extra_flags%
 on_success:
 - ps: |
     function UploadFile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,16 +27,19 @@ install:
 
 build_script:
 # Override the default build script.
+# In PowerShell it seems to be necessary to redirect stderr to stdout because
+# any text sent to stderr seems to cause appveyor to think the build has
+# failed.
 - echo ""
 test_script:
 - ps: |
     if ($env:APPVEYOR_REPO_TAG_NAME)
     {
-      stack -j1 --no-terminal test --pedantic --flag purescript:RELEASE
+      stack -j1 --no-terminal test --pedantic --flag purescript:RELEASE 2>&1
     }
     else
     {
-      stack -j1 --no-terminal test --pedantic
+      stack -j1 --no-terminal test --pedantic 2>&1
     }
 on_success:
 - ps: |

--- a/license-generator/generate.hs
+++ b/license-generator/generate.hs
@@ -6,7 +6,7 @@
 --
 -- It is recommended to run this as follows:
 --
--- stack list-dependencies | stack exec runhaskell license-generator/generate.hs > LICENSE
+-- stack list-dependencies --flag purescript:RELEASE | stack exec runhaskell license-generator/generate.hs > LICENSE
 --
 
 module Main (main) where

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -111,6 +111,11 @@ source-repository head
     type: git
     location: https://github.com/purescript/purescript.git
 
+flag release
+  description: Mark this build as a release build: prevents inclusion of extra
+               info e.g. commit SHA in --version output)
+  default: False
+
 library
     build-depends: base >=4.8 && <5,
                    aeson >= 0.8 && < 1.1,
@@ -390,6 +395,11 @@ executable purs
                    Command.Publish
                    Command.REPL
     ghc-options: -Wall -O2 -fno-warn-unused-do-bind -threaded -rtsopts "-with-rtsopts=-N"
+
+    if flag(release)
+      cpp-options: -DRELEASE
+    else
+      build-depends: gitrev >= 1.2.0 && <1.3
 
 test-suite tests
     build-depends: base >=4 && <5,

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -28,6 +28,9 @@ if [ -z "$TRAVIS_TAG" ]
 then
   # On non-release builds, disable optimizations.
   STACK_EXTRA_FLAGS="--fast"
+else
+  # On release builds, set the 'release' cabal flag.
+  STACK_EXTRA_FLAGS="--flag purescript:RELEASE"
 fi
 
 if [ "$STACKAGE_NIGHTLY" = "true" ]


### PR DESCRIPTION
I've wanted to do this for a while but only just learned about the `gitrev` Haskell package, which makes this much easier.

---

This should help avoid confusion like in #2610. The output of `purs
--version` is unchanged for release builds but includes extra
information like the git tag for non-release builds.

By default, `stack build` will produce a non-release build, which means
that `purs --version` will include information like this:

$ purs --version
0.10.6 [development build; commit: b8136e312fbda48990a576e0802e0c0c7d6cda5f]

To make a release build, set the "release" cabal flag. With stack:

$ stack build --flag purescript:RELEASE

The Travis CI and AppVeyor scripts have been modified to do this where
appropriate.