### PR TITLE
publish: Allow for older git versions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -56,6 +56,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@LiamGoodacre](https://github.com/LiamGoodacre) | Liam Goodacre | [MIT license](http://opensource.org/licenses/MIT) |
 | [@lukerandall](https://github.com/lukerandall) | Luke Randall | [MIT license](http://opensource.org/licenses/MIT) |
 | [@matthewleon](https://github.com/matthewleon) | Matthew Leon | [MIT license](http://opensource.org/licenses/MIT) |
+| [@mcoffin](https://github.com/mcoffin) | Matt Coffin | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mgmeier](https://github.com/mgmeier) | Michael Gilliland | [MIT license](http://opensource.org/licenses/MIT) |
 | [@michaelficarra](https://github.com/michaelficarra) | Michael Ficarra | [MIT license](http://opensource.org/licenses/MIT) |
 | [@MichaelXavier](https://github.com/MichaelXavier) | Michael Xavier | MIT license |


### PR DESCRIPTION
Not adding any tests per same reasoning as #2613.

Currently, git versions < 2.2 will fail with `psc-publish` because they don't have the `iso-strict` date format available. Since we're just parsing in to unix time anyway, we can easily have git just output the unix timestamp in epoch seconds and parse that instead, ensuring compatibility with older git versions (most notably the one currently used by travis-ci).

EDIT: Some discussion also happened in #2610 