### PR TITLE
replace nub with ordNub

### DIFF
--- a/app/Command/Docs.hs
+++ b/app/Command/Docs.hs
@@ -2,6 +2,8 @@
 
 module Command.Docs (command, infoModList) where
 
+import           Protolude (ordNub)
+
 import           Command.Docs.Etags
 import           Command.Docs.Ctags
 import           Control.Applicative
@@ -122,7 +124,7 @@ takeModulesByName' getModuleName modules = foldl go ([], [])
 
 dumpTags :: [FilePath] -> ([(String, P.Module)] -> [String]) -> IO ()
 dumpTags input renderTags = do
-  e <- P.parseModulesFromFiles (fromMaybe "") <$> mapM (fmap (first Just) . parseFile) (nub input)
+  e <- P.parseModulesFromFiles (fromMaybe "") <$> mapM (fmap (first Just) . parseFile) (ordNub input)
   case e of
     Left err -> do
       hPrint stderr err

--- a/app/Command/Hierarchy.hs
+++ b/app/Command/Hierarchy.hs
@@ -18,9 +18,11 @@
 
 module Command.Hierarchy (command) where
 
+import           Protolude (ordNub)
+
 import           Control.Applicative (optional)
 import           Control.Monad (unless)
-import           Data.List (intercalate,nub,sort)
+import           Data.List (intercalate, sort)
 import           Data.Foldable (for_)
 import           Data.Monoid ((<>))
 import qualified Data.Text as T
@@ -69,7 +71,7 @@ compile (HierarchyOptions inputGlob mOutput) = do
       for_ ms $ \(P.Module _ _ moduleName decls _) ->
         let name = runModuleName moduleName
             tcs = filter P.isTypeClassDeclaration decls
-            supers = sort . nub . filter (not . null) $ fmap superClasses tcs
+            supers = sort . ordNub . filter (not . null) $ fmap superClasses tcs
             prologue = "digraph " ++ name ++ " {\n"
             body = intercalate "\n" (concatMap (fmap (\s -> "  " ++ show s ++ ";")) supers)
             epilogue = "\n}"

--- a/src/Language/PureScript/AST/Binders.hs
+++ b/src/Language/PureScript/AST/Binders.hs
@@ -61,7 +61,7 @@ data Binder
   -- A binder with a type annotation
   --
   | TypedBinder Type Binder
-  deriving (Show, Eq)
+  deriving (Show, Eq, Ord)
 
 -- |
 -- Collect all names introduced in binders in an expression

--- a/src/Language/PureScript/Bundle.hs
+++ b/src/Language/PureScript/Bundle.hs
@@ -17,6 +17,7 @@ module Language.PureScript.Bundle
   ) where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
 import Control.Monad
 import Control.Monad.Error.Class
@@ -25,7 +26,7 @@ import Control.Arrow ((&&&))
 import Data.Char (chr, digitToInt)
 import Data.Generics (everything, everywhere, mkQ, mkT)
 import Data.Graph
-import Data.List (nub, stripPrefix)
+import Data.List (stripPrefix)
 import Data.Maybe (mapMaybe, catMaybes)
 import Data.Version (showVersion)
 import qualified Data.Set as S
@@ -184,10 +185,10 @@ withDeps (Module modulePath fn es) = Module modulePath fn (map expandDeps es)
 
   -- | Calculate dependencies and add them to the current element.
   expandDeps :: ModuleElement -> ModuleElement
-  expandDeps (Member n f nm decl _) = Member n f nm decl (nub $ dependencies modulePath decl)
+  expandDeps (Member n f nm decl _) = Member n f nm decl (ordNub $ dependencies modulePath decl)
   expandDeps (ExportsList exps) = ExportsList (map expand exps)
       where
-      expand (ty, nm, n1, _) = (ty, nm, n1, nub (dependencies modulePath n1))
+      expand (ty, nm, n1, _) = (ty, nm, n1, ordNub (dependencies modulePath n1))
   expandDeps other = other
 
   dependencies :: ModuleIdentifier -> JSExpression -> [(ModuleIdentifier, String)]

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -8,6 +8,7 @@ module Language.PureScript.CodeGen.JS
   ) where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
 import Control.Arrow ((&&&), second)
 import Control.Monad (forM, replicateM, void)
@@ -15,7 +16,7 @@ import Control.Monad.Except (MonadError, throwError)
 import Control.Monad.Reader (MonadReader, asks)
 import Control.Monad.Supply.Class
 
-import Data.List ((\\), delete, intersect, nub)
+import Data.List ((\\), delete, intersect)
 import qualified Data.Foldable as F
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isNothing)
@@ -55,7 +56,7 @@ moduleToJs (Module coms mn imps exps foreigns decls) foreign_ =
   rethrow (addHint (ErrorInModule mn)) $ do
     let usedNames = concatMap getNames decls
     let mnLookup = renameImports usedNames imps
-    jsImports <- traverse (importToJs mnLookup) . delete (ModuleName [ProperName C.prim]) . (\\ [mn]) $ nub $ map snd imps
+    jsImports <- traverse (importToJs mnLookup) . delete (ModuleName [ProperName C.prim]) . (\\ [mn]) $ ordNub $ map snd imps
     let decls' = renameModules mnLookup decls
     jsDecls <- mapM bindToJs decls'
     optimized <- traverse (traverse optimize) jsDecls

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/MagicDo.hs
@@ -3,8 +3,8 @@
 module Language.PureScript.CodeGen.JS.Optimizer.MagicDo (magicDo) where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
-import Data.List (nub)
 import Data.Maybe (fromJust, isJust)
 
 import Language.PureScript.CodeGen.JS.AST
@@ -92,7 +92,7 @@ inlineST = everywhereOnJS convertBlock
   -- If all STRefs are used in the scope of the same runST, only using { read, write, modify }STRef then
   -- we can be more aggressive about inlining, and actually turn STRefs into local variables.
   convertBlock (JSApp _ f [arg]) | isSTFunc C.runST f =
-    let refs = nub . findSTRefsIn $ arg
+    let refs = ordNub . findSTRefsIn $ arg
         usages = findAllSTUsagesIn arg
         allUsagesAreLocalVars = all (\u -> let v = toVar u in isJust v && fromJust v `elem` refs) usages
         localVarsDoNotEscape = all (\r -> length (r `appearingIn` arg) == length (filter (\u -> let v = toVar u in v == Just r) usages)) refs

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -1,11 +1,12 @@
 module Language.PureScript.CoreFn.Desugar (moduleToCoreFn) where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
 import Control.Arrow (second)
 
 import Data.Function (on)
-import Data.List (sort, sortBy, nub)
+import Data.List (sort, sortBy)
 import Data.Maybe (mapMaybe)
 import qualified Data.Map as M
 
@@ -35,9 +36,9 @@ moduleToCoreFn _ (A.Module _ _ _ _ Nothing) =
   internalError "Module exports were not elaborated before moduleToCoreFn"
 moduleToCoreFn env (A.Module _ coms mn decls (Just exps)) =
   let imports = mapMaybe importToCoreFn decls ++ findQualModules decls
-      imports' = nub $ filter (keepImp imports) imports-- TODO could be more efficient
-      exps' = nub $ concatMap exportToCoreFn exps
-      externs = nub $ mapMaybe externToCoreFn decls
+      imports' = ordNub $ filter (keepImp imports) imports-- TODO could be more efficient
+      exps' = ordNub $ concatMap exportToCoreFn exps
+      externs = ordNub $ mapMaybe externToCoreFn decls
       decls' = concatMap (declToCoreFn Nothing []) decls
   in Module coms mn imports' exps' externs decls'
 

--- a/src/Language/PureScript/CoreFn/Meta.hs
+++ b/src/Language/PureScript/CoreFn/Meta.hs
@@ -26,7 +26,7 @@ data Meta
   -- |
   -- The contained reference is for a foreign member
   --
-  | IsForeign deriving (Show, Eq)
+  | IsForeign deriving (Show, Eq, Ord)
 
 -- |
 -- Data constructor metadata
@@ -39,4 +39,4 @@ data ConstructorType
   -- |
   -- The constructor is for a type with multiple construcors
   --
-  | SumType deriving (Show, Eq)
+  | SumType deriving (Show, Eq, Ord)

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -3,6 +3,7 @@
 module Language.PureScript.Environment where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
 import Data.Aeson.TH
 import qualified Data.Aeson as A
@@ -11,7 +12,6 @@ import qualified Data.Set as S
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.List (nub)
 import Data.Tree (Tree, rootLabel)
 import qualified Data.Graph as G
 import Data.Foldable (toList)
@@ -119,7 +119,7 @@ makeTypeClassData args m s deps = TypeClassData args m s deps determinedArgs cov
       (src, fdDetermined fd) : map (, []) (fdDetermined fd)
 
     -- build a graph of which arguments determine other arguments
-    (depGraph, fromVertex, fromKey) = G.graphFromEdges ((\(n, v) -> (n, n, nub v)) <$> M.toList contributingDeps)
+    (depGraph, fromVertex, fromKey) = G.graphFromEdges ((\(n, v) -> (n, n, ordNub v)) <$> M.toList contributingDeps)
 
     -- do there exist any arguments that contribute to `arg` that `arg` doesn't contribute to
     isFunDepDetermined :: Int -> Bool

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -7,6 +7,7 @@ module Language.PureScript.Errors
   ) where
 
 import           Prelude.Compat
+import           Protolude (ordNub)
 
 import           Control.Arrow ((&&&))
 import           Control.Monad
@@ -17,7 +18,7 @@ import           Data.Char (isSpace)
 import           Data.Either (lefts, rights)
 import           Data.Foldable (fold)
 import           Data.Functor.Identity (Identity(..))
-import           Data.List (transpose, nub, nubBy, sortBy, partition)
+import           Data.List (transpose, nubBy, sortBy, partition)
 import           Data.Maybe (maybeToList, fromMaybe, mapMaybe)
 import           Data.Ord (comparing)
 import           Data.String (fromString)
@@ -1259,7 +1260,7 @@ prettyPrintParseErrorMessages msgOr msgUnknown msgExpecting msgUnExpected msgEnd
   separate   _ [m]    = m
   separate sep (m:ms) = m ++ sep ++ separate sep ms
 
-  clean             = nub . filter (not . null)
+  clean             = ordNub . filter (not . null)
 
 -- | Indent to the right, and pad on top and bottom.
 indent :: Box.Box -> Box.Box

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -11,8 +11,9 @@ module Language.PureScript.Interactive
 
 import           Prelude ()
 import           Prelude.Compat
+import           Protolude (ordNub)
 
-import           Data.List (nub, sort, find, foldl')
+import           Data.List (sort, find, foldl')
 import           Data.Maybe (mapMaybe)
 import qualified Data.Map as M
 import           Data.Monoid ((<>))
@@ -164,7 +165,7 @@ handleShowLoadedModules = do
     loadedModules <- gets psciLoadedExterns
     liftIO $ putStrLn (readModules loadedModules)
   where
-    readModules = unlines . sort . nub . map (T.unpack . P.runModuleName . P.getModuleName . fst)
+    readModules = unlines . sort . ordNub . map (T.unpack . P.runModuleName . P.getModuleName . fst)
 
 -- | Show the imported modules in psci.
 handleShowImportedModules

--- a/src/Language/PureScript/Interactive/Completion.hs
+++ b/src/Language/PureScript/Interactive/Completion.hs
@@ -6,13 +6,14 @@ module Language.PureScript.Interactive.Completion
   ) where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
 import           Control.Arrow (second)
 import           Control.Monad.IO.Class (MonadIO(..))
 import           Control.Monad.State.Class (MonadState(..))
 import           Control.Monad.Trans.Reader (asks, runReaderT, ReaderT)
 import           Data.Function (on)
-import           Data.List (nub, nubBy, isPrefixOf, sortBy, stripPrefix)
+import           Data.List (nubBy, isPrefixOf, sortBy, stripPrefix)
 import           Data.Maybe (mapMaybe)
 import           Data.Text (Text)
 import qualified Data.Text as T
@@ -169,7 +170,7 @@ getAllQualifications :: (a -> Text) -> P.Module -> (a, P.Declaration) -> Complet
 getAllQualifications sho m (declName, decl) = do
   imports <- getAllImportsOf m
   let fullyQualified = qualifyWith (Just (P.getModuleName m))
-  let otherQuals = nub (concatMap qualificationsUsing imports)
+  let otherQuals = ordNub (concatMap qualificationsUsing imports)
   return $ fullyQualified : otherQuals
   where
   qualifyWith mMod = T.unpack (P.showQualified sho (P.Qualified mMod declName))
@@ -220,4 +221,4 @@ dctorNames = nubOnFst . concatMap go . P.exportedDeclarations
   go _ = []
 
 moduleNames :: [P.Module] -> [String]
-moduleNames = nub . map (T.unpack . P.runModuleName . P.getModuleName)
+moduleNames = ordNub . map (T.unpack . P.runModuleName . P.getModuleName)

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -4,10 +4,11 @@
 module Language.PureScript.Linter (lint, module L) where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
 import Control.Monad.Writer.Class
 
-import Data.List (nub, (\\))
+import Data.List ((\\))
 import Data.Maybe (mapMaybe)
 import Data.Monoid
 import qualified Data.Set as S
@@ -28,7 +29,7 @@ lint :: forall m. (MonadWriter MultipleErrors m) => Module -> m ()
 lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDeclaration ds
   where
   moduleNames :: S.Set Ident
-  moduleNames = S.fromList (nub (mapMaybe getDeclIdent ds))
+  moduleNames = S.fromList (ordNub (mapMaybe getDeclIdent ds))
 
   getDeclIdent :: Declaration -> Maybe Ident
   getDeclIdent (PositionedDeclaration _ _ d) = getDeclIdent d
@@ -91,7 +92,7 @@ lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDecl
     findUnused ty' =
       let used = usedTypeVariables ty'
           declared = everythingOnTypes (++) go ty'
-          unused = nub declared \\ nub used
+          unused = ordNub declared \\ ordNub used
       in foldl (<>) mempty $ map (errorMessage . UnusedTypeVar) unused
       where
       go :: Type -> [Text]

--- a/src/Language/PureScript/Names.hs
+++ b/src/Language/PureScript/Names.hs
@@ -25,7 +25,7 @@ data Name
   | TyClassName (ProperName 'ClassName)
   | ModName ModuleName
   | KiName (ProperName 'KindName)
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 getIdentName :: Name -> Maybe Ident
 getIdentName (IdentName name) = Just name

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -10,12 +10,13 @@ module Language.PureScript.Sugar.BindingGroups
   ) where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
 import Control.Monad ((<=<))
 import Control.Monad.Error.Class (MonadError(..))
 
 import Data.Graph
-import Data.List (nub, intersect)
+import Data.List (intersect)
 import Data.Maybe (isJust, mapMaybe)
 import qualified Data.Set as S
 
@@ -103,7 +104,7 @@ collapseBindingGroupsForValue (Let ds val) = Let (collapseBindingGroups ds) val
 collapseBindingGroupsForValue other = other
 
 usedIdents :: ModuleName -> Declaration -> [Ident]
-usedIdents moduleName = nub . usedIdents' S.empty . getValue
+usedIdents moduleName = ordNub . usedIdents' S.empty . getValue
   where
   def _ _ = []
 
@@ -124,7 +125,7 @@ usedIdents moduleName = nub . usedIdents' S.empty . getValue
 usedImmediateIdents :: ModuleName -> Declaration -> [Ident]
 usedImmediateIdents moduleName =
   let (f, _, _, _, _) = everythingWithContextOnValues True [] (++) def usedNamesE def def def
-  in nub . f
+  in ordNub . f
   where
   def s _ = (s, [])
 
@@ -138,7 +139,7 @@ usedImmediateIdents moduleName =
 usedTypeNames :: ModuleName -> Declaration -> [ProperName 'TypeName]
 usedTypeNames moduleName =
   let (f, _, _, _, _) = accumTypes (everythingOnTypes (++) usedNames)
-  in nub . f
+  in ordNub . f
   where
   usedNames :: Type -> [ProperName 'TypeName]
   usedNames (ConstrainedType constraints _) =

--- a/src/Language/PureScript/Sugar/CaseDeclarations.hs
+++ b/src/Language/PureScript/Sugar/CaseDeclarations.hs
@@ -8,8 +8,9 @@ module Language.PureScript.Sugar.CaseDeclarations
   ) where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
-import Data.List (nub, groupBy, foldl1')
+import Data.List (groupBy, foldl1')
 import Data.Maybe (catMaybes, mapMaybe)
 
 import Control.Monad ((<=<), forM, replicateM, join, unless)
@@ -323,7 +324,7 @@ toDecls :: forall m. (MonadSupply m, MonadError MultipleErrors m) => [Declaratio
 toDecls [ValueDeclaration ident nameKind bs [MkUnguarded val]] | all isIrrefutable bs = do
   args <- mapM fromVarBinder bs
   let body = foldr (Abs . Left) val args
-  guardWith (errorMessage (OverlappingArgNames (Just ident))) $ length (nub args) == length args
+  guardWith (errorMessage (OverlappingArgNames (Just ident))) $ length (ordNub args) == length args
   return [ValueDeclaration ident nameKind [] [MkUnguarded body]]
   where
   fromVarBinder :: Binder -> m Ident
@@ -379,8 +380,8 @@ makeCaseDeclaration ident alternatives = do
 
   -- We still have to make sure the generated names are unique, or else
   -- we will end up constructing an invalid function.
-  allUnique :: (Eq a) => [a] -> Bool
-  allUnique xs = length xs == length (nub xs)
+  allUnique :: (Ord a) => [a] -> Bool
+  allUnique xs = length xs == length (ordNub xs)
 
   argName :: Maybe Ident -> m Ident
   argName (Just name) = return name

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -9,6 +9,7 @@ module Language.PureScript.Sugar.Names
   ) where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
 import Control.Arrow (first)
 import Control.Monad
@@ -16,7 +17,6 @@ import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Lazy
 import Control.Monad.Writer (MonadWriter(..), censor)
 
-import Data.List (nub)
 import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -206,7 +206,7 @@ renameInModule imports (Module ss coms mn decls exps) =
     return ((pos, arg : bound), Abs (Left arg) val')
   updateValue (pos, bound) (Let ds val') = do
     let args = mapMaybe letBoundVariable ds
-    unless (length (nub args) == length args) $
+    unless (length (ordNub args) == length args) $
       maybe id rethrowWithPosition pos $
         throwError . errorMessage $ OverlappingNamesInLet
     return ((pos, args ++ bound), Let ds val')

--- a/src/Language/PureScript/Sugar/Names/Common.hs
+++ b/src/Language/PureScript/Sugar/Names/Common.hs
@@ -1,12 +1,13 @@
 module Language.PureScript.Sugar.Names.Common (warnDuplicateRefs) where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
 import Control.Monad.Writer (MonadWriter(..))
 
 import Data.Foldable (for_)
 import Data.Function (on)
-import Data.List (nub, nubBy, (\\))
+import Data.List (nubBy, (\\))
 import Data.Maybe (mapMaybe)
 
 import Language.PureScript.AST
@@ -52,7 +53,7 @@ warnDuplicateRefs pos toError refs = do
   extractCtors :: SourceSpan -> DeclarationRef -> Maybe [(SourceSpan, Name)]
   extractCtors _ (PositionedDeclarationRef pos' _ ref) = extractCtors pos' ref
   extractCtors pos' (TypeRef _ (Just dctors)) =
-    let dupes = dctors \\ nub dctors
+    let dupes = dctors \\ ordNub dctors
     in if null dupes then Nothing else Just $ ((pos',) . DctorName) <$> dupes
   extractCtors _ _ = Nothing
 

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -12,6 +12,7 @@ module Language.PureScript.TypeChecker.Entailment
   ) where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
 import Control.Arrow (second)
 import Control.Monad.Error.Class (MonadError(..))
@@ -21,7 +22,7 @@ import Control.Monad.Writer
 
 import Data.Foldable (for_, fold, toList)
 import Data.Function (on)
-import Data.List (minimumBy, nub)
+import Data.List (minimumBy)
 import Data.Maybe (fromMaybe, maybeToList, mapMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -160,7 +161,7 @@ entails SolverOptions{..} constraint context hints =
     forClassName _ C.AppendSymbol [arg0@(TypeLevelString lhs), arg1@(TypeLevelString rhs), _] =
       let args = [arg0, arg1, TypeLevelString (lhs <> rhs)]
       in [TypeClassDictionaryInScope AppendSymbolInstance [] C.AppendSymbol args Nothing]
-    forClassName ctx cn@(Qualified (Just mn) _) tys = concatMap (findDicts ctx cn) (nub (Nothing : Just mn : map Just (mapMaybe ctorModules tys)))
+    forClassName ctx cn@(Qualified (Just mn) _) tys = concatMap (findDicts ctx cn) (ordNub (Nothing : Just mn : map Just (mapMaybe ctorModules tys)))
     forClassName _ _ _ = internalError "forClassName: expected qualified class name"
 
     ctorModules :: Type -> Maybe ModuleName

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -16,13 +16,14 @@ module Language.PureScript.TypeChecker.Unify
   ) where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Class (MonadState(..), gets, modify)
 import Control.Monad.Writer.Class (MonadWriter(..))
 
-import Data.List (nub, sort)
+import Data.List (sort)
 import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -181,7 +182,7 @@ replaceTypeWildcards = everywhereOnTypesM replace
 --
 varIfUnknown :: Type -> Type
 varIfUnknown ty =
-  let unks = nub $ unknownsInType ty
+  let unks = ordNub $ unknownsInType ty
       toName = T.cons 't' . T.pack .  show
       ty' = everywhereOnTypes typeToVar ty
       typeToVar :: Type -> Type

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -7,11 +7,11 @@
 module Language.PureScript.Types where
 
 import Prelude.Compat
+import Protolude (ordNub)
 
 import Control.Monad ((<=<))
 import qualified Data.Aeson as A
 import qualified Data.Aeson.TH as A
-import Data.List (nub)
 import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
 import Data.Text (Text)
@@ -179,7 +179,7 @@ replaceAllTypeVars = go []
 -- Collect all type variables appearing in a type
 --
 usedTypeVariables :: Type -> [Text]
-usedTypeVariables = nub . everythingOnTypes (++) go
+usedTypeVariables = ordNub . everythingOnTypes (++) go
   where
   go (TypeVar v) = [v]
   go _ = []
@@ -188,7 +188,7 @@ usedTypeVariables = nub . everythingOnTypes (++) go
 -- Collect all free type variables appearing in a type
 --
 freeTypeVariables :: Type -> [Text]
-freeTypeVariables = nub . go []
+freeTypeVariables = ordNub . go []
   where
   go :: [Text] -> Type -> [Text]
   go bound (TypeVar v) | v `notElem` bound = [v]


### PR DESCRIPTION
Replace pervasive uses of `nub` with `ordNub` from Protolude, which has better asymptotics. Where necessary, derive some new `Ord` instances to help.

Would be very curious to see some benchmarks with this change. I don't have anything at hand to test (sorry).