### PR TITLE
Add psc-ide-client script

### DIFF
--- a/scripts/psc
+++ b/scripts/psc
@@ -1,2 +1,2 @@
 #!/bin/sh
-purs compile $@
+purs compile "$@"

--- a/scripts/psc-bundle
+++ b/scripts/psc-bundle
@@ -1,2 +1,2 @@
 #!/bin/sh
-purs bundle $@
+purs bundle "$@"

--- a/scripts/psc-docs
+++ b/scripts/psc-docs
@@ -1,2 +1,2 @@
 #!/bin/sh
-purs docs $@
+purs docs "$@"

--- a/scripts/psc-hierarchy
+++ b/scripts/psc-hierarchy
@@ -1,2 +1,2 @@
 #!/bin/sh
-purs hierarchy $@
+purs hierarchy "$@"

--- a/scripts/psc-ide-client
+++ b/scripts/psc-ide-client
@@ -1,2 +1,2 @@
 #!/bin/sh
-purs ide client $@
+purs ide client "$@"

--- a/scripts/psc-ide-client
+++ b/scripts/psc-ide-client
@@ -1,0 +1,2 @@
+#!/bin/sh
+purs ide client $@

--- a/scripts/psc-ide-server
+++ b/scripts/psc-ide-server
@@ -1,2 +1,2 @@
 #!/bin/sh
-purs ide $@
+purs ide server $@

--- a/scripts/psc-ide-server
+++ b/scripts/psc-ide-server
@@ -1,2 +1,2 @@
 #!/bin/sh
-purs ide server $@
+purs ide server "$@"

--- a/scripts/psc-publish
+++ b/scripts/psc-publish
@@ -1,2 +1,2 @@
 #!/bin/sh
-purs publish $@
+purs publish "$@"

--- a/scripts/psci
+++ b/scripts/psci
@@ -1,2 +1,2 @@
 #!/bin/sh
-purs repl $@
+purs repl $@"


### PR DESCRIPTION
This also modifies the existing scripts to use quotes. This seems to be necessary in order to make things like `scripts/psci 'bower_components/purescript-*/src/**/*.purs'` work properly.