### PR TITLE
Errors for open rows in derived instances

### DIFF
--- a/examples/failing/2616.purs
+++ b/examples/failing/2616.purs
@@ -1,0 +1,9 @@
+-- @shouldFailWith NoInstanceFound
+module Main where
+	
+import Prelude
+
+newtype Foo r = Foo { | r }
+
+derive instance eqFoo :: Eq (Foo r)
+derive instance ordFoo :: Ord (Foo r)

--- a/examples/passing/2616.purs
+++ b/examples/passing/2616.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console (log)
+
+newtype F r a = F { x :: a | r }
+
+unF :: forall r a. F r a -> { x :: a | r }
+unF (F x) = x
+
+derive instance functorF :: Functor (F r)
+
+main = log (unF (map id (F { x: "Done", y: 42 }))).x


### PR DESCRIPTION
Fixes #2616

Note, open rows are allowed in `Functor` instances, but not elsewhere. While the `Eq` and `Ord` instances are technically valid, I don't think we want to derive instances like that, right?