### PR TITLE
[psc-ide] Don't create the output/ directory if it can't be found

### DIFF
--- a/app/Command/Ide.hs
+++ b/app/Command/Ide.hs
@@ -115,9 +115,7 @@ command = Opts.helper <*> subcommands where
     let fullOutputPath = cwd </> outputPath
 
     unlessM (doesDirectoryExist fullOutputPath) $ do
-      putStrLn ("Your output directory didn't exist. I'll create it at: " <> fullOutputPath)
-      createDirectory fullOutputPath
-      putText "This usually means you didn't compile your project yet."
+      putText "Your output directory didn't exist. This usually means you didn't compile your project yet."
       putText "psc-ide needs you to compile your project (for example by running pulp build)"
 
     unless noWatch $


### PR DESCRIPTION
Leaving stray directories around isn't polite and I really dislike the current behaviour (accidentally starting purs ide in a non-purescript project leaves around an empty `output/`).

We're using a safer readFile command in purs ide now, so the issue this was supposed to fix #2030 shouldn't need this anymore.