### PR TITLE
Eq1 & Ord1 deriving

### DIFF
--- a/examples/passing/Eq1Deriving.purs
+++ b/examples/passing/Eq1Deriving.purs
@@ -1,0 +1,35 @@
+module Main where
+
+import Prelude
+import Data.Eq (class Eq1, eq1)
+import Control.Monad.Eff.Console (log)
+
+data Foo a
+  = Foo a
+  | Bar a a
+  | Baz
+
+derive instance eq1Foo :: Eq1 Foo
+derive instance eqFoo :: Eq a => Eq (Foo a)
+
+no :: Boolean
+no = Foo true == Bar true true
+
+no1 :: Boolean
+no1 = Foo true `eq1` Bar true true
+
+data FooT f a
+  = FooT (f a)
+  | BarT (f a) a
+  | BazT
+
+derive instance eq1FooT :: Eq1 f => Eq1 (FooT f)
+derive instance eqFooT :: (Eq1 f, Eq a) => Eq (FooT f a)
+
+noT :: Boolean
+noT = FooT (Foo true) == BarT (Foo true) true
+
+noT1 :: Boolean
+noT1 = FooT (Foo true) `eq1` BarT (Foo true) true
+
+main = log "Done"

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -100,6 +100,9 @@ greaterThanOrEq = "greaterThanOrEq"
 eq :: forall a. (IsString a) => a
 eq = "eq"
 
+eq1 :: forall a. (IsString a) => a
+eq1 = "eq1"
+
 (/=) :: forall a. (IsString a) => a
 (/=) = "/="
 

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -72,7 +72,11 @@ deriveInstance mn syns ds (TypeInstanceDeclaration nm deps className tys@[ty] De
   | className == Qualified (Just dataEq) (ProperName "Eq")
   , Just (Qualified mn' tyCon, _) <- unwrapTypeConstructor ty
   , mn == fromMaybe mn mn'
-  = TypeInstanceDeclaration nm deps className tys . ExplicitInstance <$> deriveEq mn syns ds tyCon
+  = TypeInstanceDeclaration nm deps className tys . ExplicitInstance <$> deriveEq (Ident C.eq) mn syns ds tyCon deps
+  | className == Qualified (Just dataEq) (ProperName "Eq1")
+  , Just (Qualified mn' tyCon, _) <- unwrapTypeConstructor ty
+  , mn == fromMaybe mn mn'
+  = TypeInstanceDeclaration nm deps className tys . ExplicitInstance <$> deriveEq (Ident C.eq1) mn syns ds tyCon deps
   | className == Qualified (Just dataOrd) (ProperName "Ord")
   , Just (Qualified mn' tyCon, _) <- unwrapTypeConstructor ty
   , mn == fromMaybe mn mn'
@@ -536,15 +540,17 @@ checkIsWildcard tyConNm _ =
 
 deriveEq ::
   forall m. (MonadError MultipleErrors m, MonadSupply m)
-  => ModuleName
+  => Ident
+  -> ModuleName
   -> SynonymMap
   -> [Declaration]
   -> ProperName 'TypeName
+  -> [Constraint]
   -> m [Declaration]
-deriveEq mn syns ds tyConNm = do
+deriveEq valueName mn syns ds tyConNm deps = do
   tyCon <- findTypeDecl tyConNm ds
   eqFun <- mkEqFunction tyCon
-  return [ ValueDeclaration (Ident C.eq) Public [] (unguarded eqFun) ]
+  return [ ValueDeclaration valueName Public [] (unguarded eqFun) ]
   where
     mkEqFunction :: Declaration -> m Expr
     mkEqFunction (DataDeclaration _ _ _ args) = do
@@ -559,6 +565,9 @@ deriveEq mn syns ds tyConNm = do
 
     preludeEq :: Expr -> Expr -> Expr
     preludeEq = App . App (Var (Qualified (Just dataEq) (Ident C.eq)))
+
+    preludeEq1 :: Expr -> Expr -> Expr
+    preludeEq1 = App . App (Var (Qualified (Just dataEq) (Ident C.eq1)))
 
     addCatch :: [CaseAlternative] -> [CaseAlternative]
     addCatch xs
@@ -587,7 +596,12 @@ deriveEq mn syns ds tyConNm = do
       conjAll
       . map (\((Label str), typ) -> toEqTest (Accessor str l) (Accessor str r) typ)
       $ fields
-    toEqTest l r _ = preludeEq l r
+    toEqTest l r ty
+      | isEq1Constrained ty = preludeEq1 l r
+      | otherwise = preludeEq l r
+
+    isEq1Constrained (TypeApp f _) = any (\Constraint{..} -> constraintArgs == [f]) deps
+    isEq1Constrained _ = False
 
 deriveOrd ::
   forall m. (MonadError MultipleErrors m, MonadSupply m)

--- a/tests/support/bower.json
+++ b/tests/support/bower.json
@@ -6,7 +6,7 @@
     "purescript-console": "2.0.0",
     "purescript-eff": "2.0.0",
     "purescript-functions": "2.0.0",
-    "purescript-prelude": "2.4.0",
+    "purescript-prelude": "2.5.0",
     "purescript-st": "2.0.0",
     "purescript-partial": "1.1.2",
     "purescript-newtype": "1.1.0",


### PR DESCRIPTION
Resolves #2702

Well, just `Eq1` deriving so far... thought I'd open this for discussion before proceeding.

The implementation is a little janky perhaps, I'm not sure how else we could approach this, without having information about the instances the other types have already. Instead of examining the constraints on the instance, ideally we'd check the environment to see whether there's an `Eq1` instance for the thing we're comparing, and switch based on that - obviously we can't do that right now though.

If the current approach seems acceptable enough for now I'll do the same for `Ord1`. Maybe also should look at doing something like `eq1 = eq` if both instances are being defined together, to cut down on the amount of code that is generated (will have to examine the instance constraints a bit for this I guess).