### PR TITLE
Make superclass codegen less ugly

### DIFF
--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -392,9 +392,6 @@ symbol = "Symbol"
 
 -- Code Generation
 
-__superclass_ :: forall a. (IsString a) => a
-__superclass_ = "__superclass_"
-
 __unused :: forall a. (IsString a) => a
 __unused = "__unused"
 

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -26,7 +26,6 @@ import Data.List (minimumBy)
 import Data.Maybe (fromMaybe, maybeToList, mapMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
-import qualified Data.Text as T
 import Data.Text (Text)
 
 import Language.PureScript.AST
@@ -222,7 +221,7 @@ entails SolverOptions{..} constraint context hints =
                 -- Solve any necessary subgoals
                 args <- solveSubgoals subst'' (tcdDependencies tcd)
                 initDict <- lift . lift $ mkDictionary (tcdValue tcd) args
-                let match = foldr (\(superclassName, index) dict -> subclassDictionaryValue dict superclassName index)
+                let match = foldr (\(className, index) dict -> subclassDictionaryValue dict className index)
                                   initDict
                                   (tcdPath tcd)
                 return match
@@ -331,11 +330,9 @@ entails SolverOptions{..} constraint context hints =
               return $ TypeClassDictionaryConstructorApp C.AppendSymbol (Literal (ObjectLiteral []))
 
         -- Turn a DictionaryValue into a Expr
-        subclassDictionaryValue :: Expr -> Qualified (ProperName a) -> Integer -> Expr
-        subclassDictionaryValue dict superclassName index =
-          App (Accessor (mkString (C.__superclass_ <> showQualified runProperName superclassName <> "_" <> T.pack (show index)))
-                        dict)
-              valUndefined
+        subclassDictionaryValue :: Expr -> Qualified (ProperName 'ClassName) -> Integer -> Expr
+        subclassDictionaryValue dict className index =
+          App (Accessor (mkString (superclassName className index)) dict) valUndefined
 
 -- Check if an instance matches our list of types, allowing for types
 -- to be solved via functional dependencies. If the types match, we return a

--- a/src/Language/PureScript/TypeClassDictionaries.hs
+++ b/src/Language/PureScript/TypeClassDictionaries.hs
@@ -4,6 +4,9 @@ module Language.PureScript.TypeClassDictionaries where
 
 import Prelude.Compat
 
+import Data.Monoid ((<>))
+import Data.Text (Text, pack)
+
 import Language.PureScript.Names
 import Language.PureScript.Types
 
@@ -27,3 +30,7 @@ data TypeClassDictionaryInScope v
 
 type NamedDict = TypeClassDictionaryInScope (Qualified Ident)
 
+-- | Generate a name for a superclass reference which can be used in
+-- generated code.
+superclassName :: Qualified (ProperName 'ClassName) -> Integer -> Text
+superclassName pn index = runProperName (disqualify pn) <> pack (show index)

--- a/tests/support/bower.json
+++ b/tests/support/bower.json
@@ -6,7 +6,7 @@
     "purescript-console": "2.0.0",
     "purescript-eff": "2.0.0",
     "purescript-functions": "2.0.0",
-    "purescript-prelude": "2.4.0",
+    "purescript-prelude": "2.5.0",
     "purescript-st": "2.0.0",
     "purescript-partial": "1.1.2",
     "purescript-newtype": "1.1.0",


### PR DESCRIPTION
Fixes #1186 

Here is a sample of the output from `Control.Monad.Writer.Class`. Notice that the accessors are much easier to read now, since they use accessors, not indexers:

```js
var MonadWriter = function (MonadTell0, listen, pass) {
    this.MonadTell0 = MonadTell0;
    this.listen = listen;
    this.pass = pass;
};
var listens = function (dictMonadWriter) {
    return function (f) {
        return function (m) {
            return Control_Bind.bind(((dictMonadWriter.MonadTell0()).Monad0()).Bind1())(listen(dictMonadWriter)(m))(function (v) {
                return Control_Applicative.pure(((dictMonadWriter.MonadTell0()).Monad0()).Applicative0())(new Data_Tuple.Tuple(v.value0, f(v.value1)));
            });
        };
    };
};
```