### PR TITLE
Make paths relative in error messages

### DIFF
--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -21,6 +21,8 @@ import           Language.PureScript.Ide.Logging
 import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
+import           System.Directory (getCurrentDirectory)
+import           System.FilePath (makeRelative)
 
 -- | Given a filepath performs the following steps:
 --
@@ -47,8 +49,9 @@ rebuildFile
 rebuildFile path runOpenBuild = do
 
   input <- ideReadFile path
+  pwd <- liftIO getCurrentDirectory
 
-  m <- case snd <$> P.parseModuleFromFile identity (path, input) of
+  m <- case snd <$> P.parseModuleFromFile (makeRelative pwd) (path, input) of
     Left parseError -> throwError
                        . RebuildError
                        . toJSONErrors False P.Error

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -28,14 +28,17 @@ import qualified Language.PureScript           as P
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
+import           System.Directory (getCurrentDirectory)
+import           System.FilePath (makeRelative)
 
 parseModule
   :: (MonadIO m, MonadError IdeError m)
   => FilePath
   -> m (Either FilePath (FilePath, P.Module))
 parseModule path = do
+  pwd <- liftIO getCurrentDirectory
   contents <- ideReadFile path
-  case P.parseModuleFromFile identity (path, contents) of
+  case P.parseModuleFromFile (makeRelative pwd) (path, contents) of
     Left _ -> pure (Left path)
     Right m -> pure (Right m)
 


### PR DESCRIPTION
This tidies up paths in error messages by making them relative to the working directory.