### PR TITLE
Find record accessors in Type Directed Search

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -39,8 +39,11 @@ data TypeSearch
   = TSBefore Environment
   -- ^ An Environment captured for later consumption by type directed search
   | TSAfter
-    { tsAfterIdentifiers :: [(Qualified Ident, Type)]
+    { tsAfterIdentifiers :: [(Qualified Text, Type)]
+    -- ^ The identifiers that fully satisfy the subsumption check
     , tsAfterRecordFields :: Maybe [(Label, Type)]
+    -- ^ Record fields that are available on the first argument to the typed
+    -- hole
     }
   -- ^ Results of applying type directed search to the previously captured
   -- Environment

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -50,7 +50,7 @@ onTypeSearchTypes :: (Type -> Type) -> TypeSearch -> TypeSearch
 onTypeSearchTypes f = runIdentity . onTypeSearchTypesM (Identity . f)
 
 onTypeSearchTypesM :: (Applicative m) => (Type -> m Type) -> TypeSearch -> m TypeSearch
-onTypeSearchTypesM f (TSAfter i r) = TSAfter <$> (traverse (traverse f) i) <*> (traverse (traverse (traverse f)) r)
+onTypeSearchTypesM f (TSAfter i r) = TSAfter <$> traverse (traverse f) i <*> traverse (traverse (traverse f)) r
 onTypeSearchTypesM _ (TSBefore env) = pure (TSBefore env)
 
 -- | A type of error messages

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -764,7 +764,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs) e = flip evalS
             let
               formatTS (names, types) =
                 let
-                  idBoxes = Box.text . T.unpack . showQualified runIdent <$> names
+                  idBoxes = Box.text . T.unpack . showQualified id <$> names
                   tyBoxes = (\t -> BoxHelpers.indented
                               (Box.text ":: " Box.<> typeAsBox t)) <$> types
                   longestId = maximum (map Box.cols idBoxes)

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -265,7 +265,7 @@ onTypesInErrorMessageM f (ErrorMessage hints simple) = ErrorMessage <$> traverse
   gSimple (ExpectedType ty k) = ExpectedType <$> f ty <*> pure k
   gSimple (OrphanInstance nm cl ts) = OrphanInstance nm cl <$> traverse f ts
   gSimple (WildcardInferredType ty ctx) = WildcardInferredType <$> f ty <*> traverse (sndM f) ctx
-  gSimple (HoleInferredType name ty ctx env) = HoleInferredType name <$> f ty <*> traverse (sndM f) ctx  <*> gTypeSearch env
+  gSimple (HoleInferredType name ty ctx env) = HoleInferredType name <$> f ty <*> traverse (sndM f) ctx  <*> onTypeSearchTypesM f env
   gSimple (MissingTypeDeclaration nm ty) = MissingTypeDeclaration nm <$> f ty
   gSimple (CannotGeneralizeRecursiveFunction nm ty) = CannotGeneralizeRecursiveFunction nm <$> f ty
   gSimple other = pure other
@@ -278,9 +278,6 @@ onTypesInErrorMessageM f (ErrorMessage hints simple) = ErrorMessage <$> traverse
   gHint (ErrorInInstance cl ts) = ErrorInInstance cl <$> traverse f ts
   gHint (ErrorSolvingConstraint con) = ErrorSolvingConstraint <$> overConstraintArgs (traverse f) con
   gHint other = pure other
-
-  gTypeSearch (TSBefore env) = pure (TSBefore env)
-  gTypeSearch (TSAfter result) = TSAfter <$> traverse (traverse f) result
 
 errorDocUri :: ErrorMessage -> Text
 errorDocUri e = "https://github.com/purescript/documentation/blob/master/errors/" <> errorCode e <> ".md"
@@ -763,7 +760,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs) e = flip evalS
       let
         maxTSResults = 15
         tsResult = case ts of
-          (TSAfter idents) | not (null idents) ->
+          (TSAfter{tsAfterIdentifiers=idents}) | not (null idents) ->
             let
               formatTS (names, types) =
                 let

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -14,6 +14,7 @@
 
 module Language.PureScript.Ide.Error
        ( IdeError(..)
+       , prettyPrintTypeSingleLine
        ) where
 
 import           Data.Aeson
@@ -52,3 +53,6 @@ textError (ParseError parseError msg) = let escape = show
                                             -- over the socket as a single line
                                         in msg <> ": " <> escape parseError
 textError (RebuildError err)          = show err
+
+prettyPrintTypeSingleLine :: P.Type -> Text
+prettyPrintTypeSingleLine = T.unwords . map T.strip . T.lines . T.pack . P.prettyPrintTypeWithUnicode

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -61,7 +61,7 @@ encodeRebuildErrors = toJSON . map encodeRebuildError . P.runMultipleErrors
       Aeson.Object
         (HM.insert "pursIde"
          (object [ "name" .= name
-                 , "completions" .= (map identCompletion idents ++ map fieldCompletion fields)
+                 , "completions" .= (ordNub (map identCompletion idents ++ map fieldCompletion fields))
                  ]) value)
     insertTSCompletions _ _ _ v = v
 

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -66,7 +66,7 @@ encodeRebuildErrors = toJSON . map encodeRebuildError . P.runMultipleErrors
     insertTSCompletions _ _ _ v = v
 
     identCompletion (P.Qualified mn i, ty) =
-      Completion (maybe "" P.runModuleName mn) (P.runIdent i) (prettyPrintTypeSingleLine ty) (prettyPrintTypeSingleLine ty) Nothing Nothing
+      Completion (maybe "" P.runModuleName mn) i (prettyPrintTypeSingleLine ty) (prettyPrintTypeSingleLine ty) Nothing Nothing
     fieldCompletion (label, ty) =
       Completion "" ("_." <> P.prettyPrintLabel label) (prettyPrintTypeSingleLine ty) (prettyPrintTypeSingleLine ty) Nothing Nothing
 

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -15,7 +15,6 @@ import qualified Data.Map.Lazy                   as M
 import           Data.Maybe                      (fromJust)
 import qualified Data.Set                        as S
 import qualified Language.PureScript             as P
-import           Language.PureScript.Errors.JSON
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Logging
 import           Language.PureScript.Ide.State
@@ -49,10 +48,8 @@ rebuildFile path runOpenBuild = do
   input <- ideReadFile path
 
   m <- case snd <$> P.parseModuleFromFile identity (path, input) of
-    Left parseError -> throwError
-                       . RebuildError
-                       . toJSONErrors False P.Error
-                       $ P.MultipleErrors [P.toPositionedError parseError]
+    Left parseError ->
+      throwError (RebuildError (P.MultipleErrors [P.toPositionedError parseError]))
     Right m -> pure m
 
   -- Externs files must be sorted ahead of time, so that they get applied
@@ -74,10 +71,10 @@ rebuildFile path runOpenBuild = do
     . P.rebuildModule (buildMakeActions
                         >>= shushProgress $ makeEnv) externs $ m
   case result of
-    Left errors -> throwError (RebuildError (toJSONErrors False P.Error errors))
+    Left errors -> throwError (RebuildError errors)
     Right _ -> do
       runOpenBuild (rebuildModuleOpen makeEnv externs m)
-      pure (RebuildSuccess (toJSONErrors False P.Warning warnings))
+      pure (RebuildSuccess warnings)
 
 rebuildFileAsync
   :: forall m. (Ide m, MonadLogger m, MonadError IdeError m)
@@ -171,7 +168,7 @@ sortExterns m ex = do
            . M.delete (P.getModuleName m) $ ex
   case sorted' of
     Left err ->
-      throwError (RebuildError (toJSONErrors False P.Error err))
+      throwError (RebuildError err)
     Right (sorted, graph) -> do
       let deps = fromJust (List.lookup (P.getModuleName m) graph)
       pure $ mapMaybe getExtern (deps `inOrderOf` map P.getModuleName sorted)

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -240,8 +240,8 @@ data Success =
   | PursuitResult [PursuitResponse]
   | ImportList [ModuleImport]
   | ModuleList [ModuleIdent]
-  | RebuildSuccess [P.JSONError]
-  deriving (Show, Eq)
+  | RebuildSuccess P.MultipleErrors
+  deriving (Show)
 
 encodeSuccess :: (ToJSON a) => a -> Value
 encodeSuccess res =
@@ -254,7 +254,7 @@ instance ToJSON Success where
   toJSON (PursuitResult resp) = encodeSuccess resp
   toJSON (ImportList decls) = encodeSuccess decls
   toJSON (ModuleList modules) = encodeSuccess modules
-  toJSON (RebuildSuccess modules) = encodeSuccess modules
+  toJSON (RebuildSuccess warnings) = encodeSuccess (P.toJSONErrors False P.Warning warnings)
 
 newtype PursuitQuery = PursuitQuery Text
                      deriving (Show, Eq)

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -184,7 +184,7 @@ data Completion = Completion
   , complExpandedType  :: Text
   , complLocation      :: Maybe P.SourceSpan
   , complDocumentation :: Maybe Text
-  } deriving (Show, Eq)
+  } deriving (Show, Eq, Ord)
 
 instance ToJSON Completion where
   toJSON (Completion {..}) =

--- a/src/Language/PureScript/TypeChecker/TypeSearch.hs
+++ b/src/Language/PureScript/TypeChecker/TypeSearch.hs
@@ -4,7 +4,7 @@ module Language.PureScript.TypeChecker.TypeSearch
 
 import           Protolude
 
-import           Control.Monad.Writer
+import           Control.Monad.Writer (WriterT, runWriterT)
 import qualified Data.Map                                    as Map
 import qualified Language.PureScript.TypeChecker.Entailment  as Entailment
 

--- a/src/Language/PureScript/TypeChecker/TypeSearch.hs
+++ b/src/Language/PureScript/TypeChecker/TypeSearch.hs
@@ -83,7 +83,7 @@ accessorSearch
   -> P.Environment
   -> TC.CheckState
   -> P.Type
-  -> ([(Label, Type)], [(Label, Type)])
+  -> ([(Label, P.Type)], [(Label, P.Type)])
   -- ^ (all accessors we found, all accessors we found that match the result type)
 accessorSearch unsolved env st userT = maybe ([], []) fst $ checkInEnvironment env st $ do
   let initializeSkolems =
@@ -113,7 +113,7 @@ typeSearch
   -- ^ The typechecker state
   -> P.Type
   -- ^ The type we are looking for
-  -> ([(P.Qualified P.Ident, P.Type)], Maybe [(Label, Type)])
+  -> ([(P.Qualified P.Ident, P.Type)], Maybe [(Label, P.Type)])
 typeSearch unsolved env st type' =
   let
     resultMap = Map.mapMaybe (\(x, _, _) -> checkSubsume unsolved env st type' x $> x) (P.names env)

--- a/src/Language/PureScript/TypeChecker/TypeSearch.hs
+++ b/src/Language/PureScript/TypeChecker/TypeSearch.hs
@@ -113,11 +113,11 @@ typeSearch
   -- ^ The typechecker state
   -> P.Type
   -- ^ The type we are looking for
-  -> ([(P.Qualified P.Ident, P.Type)], Maybe [(Label, P.Type)])
+  -> ([(P.Qualified Text, P.Type)], Maybe [(Label, P.Type)])
 typeSearch unsolved env st type' =
   let
     resultMap = Map.mapMaybe (\(x, _, _) -> checkSubsume unsolved env st type' x $> x) (P.names env)
     (allLabels, solvedLabels) = accessorSearch unsolved env st type'
-    solvedLabels' = first (P.Qualified Nothing . P.Ident . ("_." <>) . P.prettyPrintLabel) <$> solvedLabels
+    solvedLabels' = first (P.Qualified Nothing . ("_." <>) . P.prettyPrintLabel) <$> solvedLabels
   in
-    (solvedLabels' <> Map.toList resultMap, if null allLabels then Nothing else Just allLabels)
+    (solvedLabels' <> (first (map P.runIdent) <$> Map.toList resultMap), if null allLabels then Nothing else Just allLabels)

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -37,7 +37,6 @@ import Control.Monad.Writer.Class (MonadWriter(..))
 import Data.Bifunctor (bimap)
 import Data.Either (partitionEithers)
 import Data.Functor (($>))
-import Control.Monad.Identity
 import Data.List (transpose, (\\), partition, delete)
 import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))


### PR DESCRIPTION
This PR consists of two parts:

## 1. Infer record accessors for types that subsume `{| r} -> a`

This means that for `?hole {x: 1, y: "hello"}` TDS infers `_.x` and `_.y`. This also works for situations like `{x: 1, y: "hello"} # ?hole`.

These results are not shown in the textual error reporting, because I felt they were to noisy, but they are exposed through the new

## 2. JSON error output for Type Directed Search results

Here I considered using the existing suggestion API to report the results, but decided it lacks two crucial capabilities:
- Reporting multiple suggestions for a single error
- A structured format, since TDS results consist of module name + identifier + type

This is why I decided to use purs ide's existing Completion format and monkeypatch it onto the JSON format for `HoleInferred` errors. Right now this only works for errors reported by purs ide, but this can easily be changed by lifting the `Completion` datatype into a module above `Language.PureScript.Errors`. I wanted to gather feedback before doing that though.

As a proof of concept I've written a branch of psc-ide-emacs that can fill in typed holes by using the result reported through rebuilding.

This PR makes the too fragile #2556 obsolete.