### PR TITLE
TCO Fixes

### DIFF
--- a/examples/passing/2689.purs
+++ b/examples/passing/2689.purs
@@ -1,0 +1,36 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console
+import Data.Array.Partial
+import Partial.Unsafe
+
+sumTCObug = go id where 
+  go f 0 = f 
+  go f n =
+    let
+      f' a = n + a
+    in
+      go f' 0
+
+sumTCObug' = go id where 
+  go f 0 = f
+  go f n = go (\a -> n + a) 0
+
+count :: forall a. (a -> Boolean) -> Array a -> Int
+count p = count' 0 where
+  count' acc [] = acc
+  count' acc xs =
+    let h = unsafePartial head xs
+    in count' (acc + if p h then 1 else 0) (unsafePartial tail xs)
+
+main = do
+  let x = sumTCObug 7 3
+      y = sumTCObug' 7 3
+      z = count (_ > 0) [-1, 0, 1]
+  logShow x
+  logShow y 
+  logShow z
+  if x == 10 && y == 10 && z == 1
+    then log "Done"
+    else log "Fail"

--- a/src/Language/PureScript/CodeGen/JS/AST.hs
+++ b/src/Language/PureScript/CodeGen/JS/AST.hs
@@ -1,6 +1,4 @@
--- |
--- Data types for the intermediate simplified-JavaScript AST
---
+-- | Data types for the intermediate simplified-JavaScript AST
 module Language.PureScript.CodeGen.JS.AST where
 
 import Prelude.Compat
@@ -14,235 +12,92 @@ import Language.PureScript.Comments
 import Language.PureScript.PSString (PSString)
 import Language.PureScript.Traversals
 
--- |
--- Built-in unary operators
---
+-- | Built-in unary operators
 data UnaryOperator
-  -- |
-  -- Numeric negation
-  --
   = Negate
-  -- |
-  -- Boolean negation
-  --
   | Not
-  -- |
-  -- Bitwise negation
-  --
   | BitwiseNot
-  -- |
-  -- Numeric unary \'plus\'
-  --
   | Positive
-  -- |
-  -- Constructor
-  --
   | JSNew
   deriving (Show, Eq)
 
--- |
--- Built-in binary operators
---
+-- | Built-in binary operators
 data BinaryOperator
-  -- |
-  -- Numeric addition
-  --
   = Add
-  -- |
-  -- Numeric subtraction
-  --
   | Subtract
-  -- |
-  -- Numeric multiplication
-  --
   | Multiply
-  -- |
-  -- Numeric division
-  --
   | Divide
-  -- |
-  -- Remainder
-  --
   | Modulus
-  -- |
-  -- Generic equality test
-  --
   | EqualTo
-  -- |
-  -- Generic inequality test
-  --
   | NotEqualTo
-  -- |
-  -- Numeric less-than
-  --
   | LessThan
-  -- |
-  -- Numeric less-than-or-equal
-  --
   | LessThanOrEqualTo
-  -- |
-  -- Numeric greater-than
-  --
   | GreaterThan
-  -- |
-  -- Numeric greater-than-or-equal
-  --
   | GreaterThanOrEqualTo
-  -- |
-  -- Boolean and
-  --
   | And
-  -- |
-  -- Boolean or
-  --
   | Or
-  -- |
-  -- Bitwise and
-  --
   | BitwiseAnd
-  -- |
-  -- Bitwise or
-  --
   | BitwiseOr
-  -- |
-  -- Bitwise xor
-  --
   | BitwiseXor
-  -- |
-  -- Bitwise left shift
-  --
   | ShiftLeft
-  -- |
-  -- Bitwise right shift
-  --
   | ShiftRight
-  -- |
-  -- Bitwise right shift with zero-fill
-  --
   | ZeroFillShiftRight
   deriving (Show, Eq)
 
--- |
--- Data type for simplified JavaScript expressions
---
+-- | Data type for simplified JavaScript expressions
 data JS
-  -- |
-  -- A numeric literal
-  --
   = JSNumericLiteral (Maybe SourceSpan) (Either Integer Double)
-  -- |
-  -- A string literal
-  --
+  -- ^ A numeric literal
   | JSStringLiteral (Maybe SourceSpan) PSString
-  -- |
-  -- A boolean literal
-  --
+  -- ^ A string literal
   | JSBooleanLiteral (Maybe SourceSpan) Bool
-  -- |
-  -- A unary operator application
-  --
+  -- ^ A boolean literal
   | JSUnary (Maybe SourceSpan) UnaryOperator JS
-  -- |
-  -- A binary operator application
-  --
+  -- ^ A unary operator application
   | JSBinary (Maybe SourceSpan) BinaryOperator JS JS
-  -- |
-  -- An array literal
-  --
+  -- ^ A binary operator application
   | JSArrayLiteral (Maybe SourceSpan) [JS]
-  -- |
-  -- An array indexer expression
-  --
+  -- ^ An array literal
   | JSIndexer (Maybe SourceSpan) JS JS
-  -- |
-  -- An object literal
-  --
+  -- ^ An array indexer expression
   | JSObjectLiteral (Maybe SourceSpan) [(PSString, JS)]
-  -- |
-  -- A function introduction (optional name, arguments, body)
-  --
+  -- ^ An object literal
   | JSFunction (Maybe SourceSpan) (Maybe Text) [Text] JS
-  -- |
-  -- Function application
-  --
+  -- ^ A function introduction (optional name, arguments, body)
   | JSApp (Maybe SourceSpan) JS [JS]
-  -- |
-  -- Variable
-  --
+  -- ^ Function application
   | JSVar (Maybe SourceSpan) Text
-  -- |
-  -- Conditional expression
-  --
-  | JSConditional (Maybe SourceSpan) JS JS JS
-  -- |
-  -- A block of expressions in braces
-  --
+  -- ^ Variable
   | JSBlock (Maybe SourceSpan) [JS]
-  -- |
-  -- A variable introduction and optional initialization
-  --
+  -- ^ A block of expressions in braces
   | JSVariableIntroduction (Maybe SourceSpan) Text (Maybe JS)
-  -- |
-  -- A variable assignment
-  --
+  -- ^ A variable introduction and optional initialization
   | JSAssignment (Maybe SourceSpan) JS JS
-  -- |
-  -- While loop
-  --
+  -- ^ A variable assignment
   | JSWhile (Maybe SourceSpan) JS JS
-  -- |
-  -- For loop
-  --
+  -- ^ While loop
   | JSFor (Maybe SourceSpan) Text JS JS JS
-  -- |
-  -- ForIn loop
-  --
+  -- ^ For loop
   | JSForIn (Maybe SourceSpan) Text JS JS
-  -- |
-  -- If-then-else statement
-  --
+  -- ^ ForIn loop
   | JSIfElse (Maybe SourceSpan) JS JS (Maybe JS)
-  -- |
-  -- Return statement
-  --
+  -- ^ If-then-else statement
   | JSReturn (Maybe SourceSpan) JS
-  -- |
-  -- Throw statement
-  --
+  -- ^ Return statement
+  | JSReturnNoResult (Maybe SourceSpan)
+  -- ^ Return statement with no return value
   | JSThrow (Maybe SourceSpan) JS
-  -- |
-  -- Type-Of operator
-  --
+  -- ^ Throw statement
   | JSTypeOf (Maybe SourceSpan) JS
-  -- |
-  -- InstanceOf test
-  --
+  -- ^ Type-Of operator
   | JSInstanceOf (Maybe SourceSpan) JS JS
-  -- |
-  -- Labelled statement
-  --
-  | JSLabel (Maybe SourceSpan) Text JS
-  -- |
-  -- Break statement
-  --
-  | JSBreak (Maybe SourceSpan) Text
-  -- |
-  -- Continue statement
-  --
-  | JSContinue (Maybe SourceSpan) Text
-  -- |
-  -- Raw JavaScript (generated when parsing fails for an inline foreign import declaration)
-  --
-  | JSRaw (Maybe SourceSpan) Text
-  -- |
-  -- Commented JavaScript
-  --
+  -- ^ instanceof check
   | JSComment (Maybe SourceSpan) [Comment] JS
+  -- ^ Commented JavaScript
   deriving (Show, Eq)
 
 withSourceSpan :: SourceSpan -> JS -> JS
-withSourceSpan withSpan = go
-  where
+withSourceSpan withSpan = go where
   ss :: Maybe SourceSpan
   ss = Just withSpan
 
@@ -258,7 +113,6 @@ withSourceSpan withSpan = go
   go (JSFunction _ name args j) = JSFunction ss name args j
   go (JSApp _ j js) = JSApp ss j js
   go (JSVar _ s) = JSVar ss s
-  go (JSConditional _ j1 j2 j3) = JSConditional ss j1 j2 j3
   go (JSBlock _ js) = JSBlock ss js
   go (JSVariableIntroduction _ name j) = JSVariableIntroduction ss name j
   go (JSAssignment _ j1 j2) = JSAssignment ss j1 j2
@@ -267,18 +121,14 @@ withSourceSpan withSpan = go
   go (JSForIn _ name j1 j2) = JSForIn ss name j1 j2
   go (JSIfElse _ j1 j2 j3) = JSIfElse ss j1 j2 j3
   go (JSReturn _ js) = JSReturn ss js
+  go (JSReturnNoResult _) = JSReturnNoResult ss
   go (JSThrow _ js) = JSThrow ss js
   go (JSTypeOf _ js) = JSTypeOf ss js
   go (JSInstanceOf _ j1 j2) = JSInstanceOf ss j1 j2
-  go (JSLabel _ name js) = JSLabel ss name js
-  go (JSBreak _ s) = JSBreak ss s
-  go (JSContinue _ s) = JSContinue ss s
-  go (JSRaw _ s) = JSRaw ss s
   go (JSComment _ com j) = JSComment ss com j
 
 getSourceSpan :: JS -> Maybe SourceSpan
-getSourceSpan = go
-  where
+getSourceSpan = go where
   go :: JS -> Maybe SourceSpan
   go (JSNumericLiteral ss _) = ss
   go (JSStringLiteral ss _) = ss
@@ -291,7 +141,6 @@ getSourceSpan = go
   go (JSFunction ss _ _ _) = ss
   go (JSApp ss _ _) = ss
   go (JSVar ss _) = ss
-  go (JSConditional ss _ _ _) = ss
   go (JSBlock ss _) = ss
   go (JSVariableIntroduction ss _ _) = ss
   go (JSAssignment ss _ _) = ss
@@ -300,22 +149,14 @@ getSourceSpan = go
   go (JSForIn ss _ _ _) = ss
   go (JSIfElse ss _ _ _) = ss
   go (JSReturn ss _) = ss
+  go (JSReturnNoResult ss) = ss
   go (JSThrow ss _) = ss
   go (JSTypeOf ss _) = ss
   go (JSInstanceOf ss _ _) = ss
-  go (JSLabel ss _ _) = ss
-  go (JSBreak ss _) = ss
-  go (JSContinue ss _) = ss
-  go (JSRaw ss _) = ss
   go (JSComment ss _ _) = ss
 
---
--- Traversals
---
-
 everywhereOnJS :: (JS -> JS) -> JS -> JS
-everywhereOnJS f = go
-  where
+everywhereOnJS f = go where
   go :: JS -> JS
   go (JSUnary ss op j) = f (JSUnary ss op (go j))
   go (JSBinary ss op j1 j2) = f (JSBinary ss op (go j1) (go j2))
@@ -324,7 +165,6 @@ everywhereOnJS f = go
   go (JSObjectLiteral ss js) = f (JSObjectLiteral ss (map (fmap go) js))
   go (JSFunction ss name args j) = f (JSFunction ss name args (go j))
   go (JSApp ss j js) = f (JSApp ss (go j) (map go js))
-  go (JSConditional ss j1 j2 j3) = f (JSConditional ss (go j1) (go j2) (go j3))
   go (JSBlock ss js) = f (JSBlock ss (map go js))
   go (JSVariableIntroduction ss name j) = f (JSVariableIntroduction ss name (fmap go j))
   go (JSAssignment ss j1 j2) = f (JSAssignment ss (go j1) (go j2))
@@ -335,7 +175,6 @@ everywhereOnJS f = go
   go (JSReturn ss js) = f (JSReturn ss (go js))
   go (JSThrow ss js) = f (JSThrow ss (go js))
   go (JSTypeOf ss js) = f (JSTypeOf ss (go js))
-  go (JSLabel ss name js) = f (JSLabel ss name (go js))
   go (JSInstanceOf ss j1 j2) = f (JSInstanceOf ss (go j1) (go j2))
   go (JSComment ss com j) = f (JSComment ss com (go j))
   go other = f other
@@ -344,8 +183,7 @@ everywhereOnJSTopDown :: (JS -> JS) -> JS -> JS
 everywhereOnJSTopDown f = runIdentity . everywhereOnJSTopDownM (Identity . f)
 
 everywhereOnJSTopDownM :: (Monad m) => (JS -> m JS) -> JS -> m JS
-everywhereOnJSTopDownM f = f >=> go
-  where
+everywhereOnJSTopDownM f = f >=> go where
   f' = f >=> go
   go (JSUnary ss op j) = JSUnary ss op <$> f' j
   go (JSBinary ss op j1 j2) = JSBinary ss op <$> f' j1 <*> f' j2
@@ -354,7 +192,6 @@ everywhereOnJSTopDownM f = f >=> go
   go (JSObjectLiteral ss js) = JSObjectLiteral ss <$> traverse (sndM f') js
   go (JSFunction ss name args j) = JSFunction ss name args <$> f' j
   go (JSApp ss j js) = JSApp ss <$> f' j <*> traverse f' js
-  go (JSConditional ss j1 j2 j3) = JSConditional ss <$> f' j1 <*> f' j2 <*> f' j3
   go (JSBlock ss js) = JSBlock ss <$> traverse f' js
   go (JSVariableIntroduction ss name j) = JSVariableIntroduction ss name <$> traverse f' j
   go (JSAssignment ss j1 j2) = JSAssignment ss <$> f' j1 <*> f' j2
@@ -365,14 +202,12 @@ everywhereOnJSTopDownM f = f >=> go
   go (JSReturn ss j) = JSReturn ss <$> f' j
   go (JSThrow ss j) = JSThrow ss <$> f' j
   go (JSTypeOf ss j) = JSTypeOf ss <$> f' j
-  go (JSLabel ss name j) = JSLabel ss name <$> f' j
   go (JSInstanceOf ss j1 j2) = JSInstanceOf ss <$> f' j1 <*> f' j2
   go (JSComment ss com j) = JSComment ss com <$> f' j
   go other = f other
 
 everythingOnJS :: (r -> r -> r) -> (JS -> r) -> JS -> r
-everythingOnJS (<>) f = go
-  where
+everythingOnJS (<>) f = go where
   go j@(JSUnary _ _ j1) = f j <> go j1
   go j@(JSBinary _ _ j1 j2) = f j <> go j1 <> go j2
   go j@(JSArrayLiteral _ js) = foldl (<>) (f j) (map go js)
@@ -380,7 +215,6 @@ everythingOnJS (<>) f = go
   go j@(JSObjectLiteral _ js) = foldl (<>) (f j) (map (go . snd) js)
   go j@(JSFunction _ _ _ j1) = f j <> go j1
   go j@(JSApp _ j1 js) = foldl (<>) (f j <> go j1) (map go js)
-  go j@(JSConditional _ j1 j2 j3) = f j <> go j1 <> go j2 <> go j3
   go j@(JSBlock _ js) = foldl (<>) (f j) (map go js)
   go j@(JSVariableIntroduction _ _ (Just j1)) = f j <> go j1
   go j@(JSAssignment _ j1 j2) = f j <> go j1 <> go j2
@@ -392,7 +226,6 @@ everythingOnJS (<>) f = go
   go j@(JSReturn _ j1) = f j <> go j1
   go j@(JSThrow _ j1) = f j <> go j1
   go j@(JSTypeOf _ j1) = f j <> go j1
-  go j@(JSLabel _ _ j1) = f j <> go j1
   go j@(JSInstanceOf _ j1 j2) = f j <> go j1 <> go j2
   go j@(JSComment _ _ j1) = f j <> go j1
   go other = f other

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/TCO.hs
@@ -10,9 +10,6 @@ import Language.PureScript.CodeGen.JS.AST
 -- | Eliminate tail calls
 tco :: JS -> JS
 tco = everywhereOnJS convert where
-  tcoLabel :: Text
-  tcoLabel = "tco"
-
   tcoVar :: Text -> Text
   tcoVar arg = "__tco_" <> arg
 
@@ -83,12 +80,11 @@ tco = everywhereOnJS convert where
         map (\arg ->
           JSVariableIntroduction rootSS (tcoVar arg) Nothing) allArgs ++
         [ JSFunction rootSS (Just tcoLoop) allArgs (JSBlock rootSS [loopify js])
-        , JSLabel rootSS tcoLabel $
-            JSWhile rootSS (JSUnary rootSS Not (JSVar rootSS tcoDone))
-              (JSBlock rootSS
-                (JSAssignment rootSS (JSVar rootSS tcoResult) (JSApp rootSS (JSVar rootSS tcoLoop) (map (JSVar rootSS) allArgs))
-                : map (\arg ->
-                    JSAssignment rootSS (JSVar rootSS arg) (JSVar rootSS (tcoVar arg))) allArgs))
+        , JSWhile rootSS (JSUnary rootSS Not (JSVar rootSS tcoDone))
+            (JSBlock rootSS
+              (JSAssignment rootSS (JSVar rootSS tcoResult) (JSApp rootSS (JSVar rootSS tcoLoop) (map (JSVar rootSS) allArgs))
+              : map (\arg ->
+                  JSAssignment rootSS (JSVar rootSS arg) (JSVar rootSS (tcoVar arg))) allArgs))
         , JSReturn rootSS (JSVar rootSS tcoResult)
         ]
     where

--- a/src/Language/PureScript/CodeGen/JS/Optimizer/Unused.hs
+++ b/src/Language/PureScript/CodeGen/JS/Optimizer/Unused.hs
@@ -20,6 +20,7 @@ removeCodeAfterReturnStatements = everywhereOnJS (removeFromBlock go)
   go jss | not (any isJSReturn jss) = jss
          | otherwise = let (body, ret : _) = break isJSReturn jss in body ++ [ret]
   isJSReturn (JSReturn _ _) = True
+  isJSReturn (JSReturnNoResult _) = True
   isJSReturn _ = False
 
 removeUnusedArg :: JS -> JS


### PR DESCRIPTION
This moves values which might capture variables into a separate function which introduces new bindings for the same names. This makes TCO more generally applicable and fixes #2689 and #2714.

Here is the generated code for the example: https://gist.github.com/paf31/57cd7d3cce310cf2e9dd347cd7caccf5

@michaelficarra Would you mind having a look at the generated code as well, please?