### PR TITLE
New PSCi command: reload

### DIFF
--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -141,8 +141,8 @@ data Backend = forall state. Backend
 data BrowserCommand
   = Eval (MVar String)
   -- ^ Evaluate the latest JS
-  | Reload
-  -- ^ Reload the page
+  | Refresh
+  -- ^ Refresh the page
 
 -- | State for the browser backend
 data BrowserState = BrowserState
@@ -185,7 +185,7 @@ browserBackend serverPort = Backend setup evaluate reload shutdown
                 -- With many connected clients, all but one of
                 -- these attempts will fail.
                 tryPutMVar resultVar (unpack result)
-              Reload ->
+              Refresh ->
                 WS.sendTextData conn ("reload" :: Text)
 
         shutdownHandler :: IO () -> IO ()
@@ -262,7 +262,7 @@ browserBackend serverPort = Backend setup evaluate reload shutdown
     reload :: BrowserState -> IO ()
     reload state = do
       createBundle state
-      atomically $ writeTChan (browserCommands state) Reload
+      atomically $ writeTChan (browserCommands state) Refresh
 
     shutdown :: BrowserState -> IO ()
     shutdown state = putMVar (browserShutdownNotice state) ()

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -95,7 +95,7 @@ handleCommand
   -> Command
   -> m ()
 handleCommand _ _ ShowHelp                  = liftIO $ putStrLn helpMessage
-handleCommand _ r ResetState                = handleResetState r
+handleCommand _ r ClearState                = handleClearState r
 handleCommand c _ (Expression val)          = handleExpression c val
 handleCommand _ _ (Import im)               = handleImport im
 handleCommand _ _ (Decls l)                 = handleDecls l
@@ -106,12 +106,12 @@ handleCommand _ _ (ShowInfo QueryLoaded)    = handleShowLoadedModules
 handleCommand _ _ (ShowInfo QueryImport)    = handleShowImportedModules
 handleCommand _ _ _                         = P.internalError "handleCommand: unexpected command"
 
--- | Reset the application state
-handleResetState
+-- | Clear the application state
+handleClearState
   :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m)
   => m ()
   -> m ()
-handleResetState reload = do
+handleClearState reload = do
   modify $ updateImportedModules (const [])
          . updateLets (const [])
   files <- asks psciLoadedFiles

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -13,7 +13,7 @@ import           Prelude ()
 import           Prelude.Compat
 import           Protolude (ordNub)
 
-import           Data.List (sort, find, foldl', delete)
+import           Data.List (sort, find, foldl')
 import           Data.Maybe (mapMaybe)
 import qualified Data.Map as M
 import           Data.Monoid ((<>))
@@ -226,15 +226,12 @@ handleImport
   => ImportedModule
   -> m ()
 handleImport im = do
-   st <- gets (updateImportedModules (renew im))
+   st <- gets (updateImportedModules (im :))
    let m = createTemporaryModuleForImports st
    e <- liftIO . runMake $ rebuild (map snd (psciLoadedExterns st)) m
    case e of
      Left errs -> printErrors errs
      Right _  -> put st
-   where
-   renew :: ImportedModule -> [ImportedModule] -> [ImportedModule]
-   renew m ms = m : delete m ms
 
 -- | Takes a value and prints its type
 handleTypeOf

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -13,7 +13,7 @@ import           Prelude ()
 import           Prelude.Compat
 import           Protolude (ordNub)
 
-import           Data.List (sort, find, foldl', deleteBy)
+import           Data.List (sort, find, foldl', delete)
 import           Data.Maybe (mapMaybe)
 import qualified Data.Map as M
 import           Data.Monoid ((<>))
@@ -234,7 +234,7 @@ handleImport im = do
      Right _  -> put st
    where
    renew :: ImportedModule -> [ImportedModule] -> [ImportedModule]
-   renew m ms = m : deleteBy (\ (name, _, _) (name', _, _) -> name == name') m ms
+   renew m ms = m : delete m ms
 
 -- | Takes a value and prints its type
 handleTypeOf

--- a/src/Language/PureScript/Interactive/Completion.hs
+++ b/src/Language/PureScript/Interactive/Completion.hs
@@ -121,6 +121,7 @@ completeDirective ws w =
 directiveArg :: String -> Directive -> [CompletionContext]
 directiveArg _ Browse      = [CtxModule]
 directiveArg _ Quit        = []
+directiveArg _ Reload      = []
 directiveArg _ Clear       = []
 directiveArg _ Help        = []
 directiveArg _ Paste       = []

--- a/src/Language/PureScript/Interactive/Completion.hs
+++ b/src/Language/PureScript/Interactive/Completion.hs
@@ -121,7 +121,7 @@ completeDirective ws w =
 directiveArg :: String -> Directive -> [CompletionContext]
 directiveArg _ Browse      = [CtxModule]
 directiveArg _ Quit        = []
-directiveArg _ Reset       = []
+directiveArg _ Clear       = []
 directiveArg _ Help        = []
 directiveArg _ Paste       = []
 directiveArg _ Show        = map CtxFixed replQueryStrings

--- a/src/Language/PureScript/Interactive/Directive.hs
+++ b/src/Language/PureScript/Interactive/Directive.hs
@@ -25,6 +25,7 @@ directiveStrings :: [(Directive, [String])]
 directiveStrings =
     [ (Help   , ["?", "help"])
     , (Quit   , ["quit"])
+    , (Reload , ["reload"])
     , (Clear  , ["clear"])
     , (Browse , ["browse"])
     , (Type   , ["type"])
@@ -82,6 +83,7 @@ parseDirective = listToMaybe . directivesFor
 hasArgument :: Directive -> Bool
 hasArgument Help = False
 hasArgument Quit = False
+hasArgument Reload = False
 hasArgument Clear = False
 hasArgument Paste = False
 hasArgument _ = True
@@ -93,6 +95,7 @@ help :: [(Directive, String, String)]
 help =
   [ (Help,    "",         "Show this help menu")
   , (Quit,    "",         "Quit PSCi")
+  , (Reload,  "",         "Reload all imported modules while discarding bindings")
   , (Clear,   "",         "Discard all imported modules and declared bindings")
   , (Browse,  "<module>", "See all functions in <module>")
   , (Type,    "<expr>",   "Show the type of <expr>")

--- a/src/Language/PureScript/Interactive/Directive.hs
+++ b/src/Language/PureScript/Interactive/Directive.hs
@@ -25,7 +25,7 @@ directiveStrings :: [(Directive, [String])]
 directiveStrings =
     [ (Help   , ["?", "help"])
     , (Quit   , ["quit"])
-    , (Reset  , ["reset"])
+    , (Clear  , ["clear"])
     , (Browse , ["browse"])
     , (Type   , ["type"])
     , (Kind   , ["kind"])
@@ -82,7 +82,7 @@ parseDirective = listToMaybe . directivesFor
 hasArgument :: Directive -> Bool
 hasArgument Help = False
 hasArgument Quit = False
-hasArgument Reset = False
+hasArgument Clear = False
 hasArgument Paste = False
 hasArgument _ = True
 
@@ -93,7 +93,7 @@ help :: [(Directive, String, String)]
 help =
   [ (Help,    "",         "Show this help menu")
   , (Quit,    "",         "Quit PSCi")
-  , (Reset,   "",         "Discard all imported modules and declared bindings")
+  , (Clear,   "",         "Discard all imported modules and declared bindings")
   , (Browse,  "<module>", "See all functions in <module>")
   , (Type,    "<expr>",   "Show the type of <expr>")
   , (Kind,    "<type>",   "Show the kind of <type>")

--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -63,6 +63,7 @@ parseDirective cmd =
   commandFor d = case d of
     Help    -> return ShowHelp
     Quit    -> return QuitPSCi
+    Reload  -> return ReloadState
     Clear   -> return ClearState
     Paste   -> return PasteLines
     Browse  -> BrowseModule <$> parseRest P.moduleName arg

--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -63,7 +63,7 @@ parseDirective cmd =
   commandFor d = case d of
     Help    -> return ShowHelp
     Quit    -> return QuitPSCi
-    Reset   -> return ResetState
+    Clear   -> return ClearState
     Paste   -> return PasteLines
     Browse  -> BrowseModule <$> parseRest P.moduleName arg
     Show    -> ShowInfo <$> parseReplQuery' (trim arg)

--- a/src/Language/PureScript/Interactive/Types.hs
+++ b/src/Language/PureScript/Interactive/Types.hs
@@ -82,8 +82,8 @@ data Command
   | BrowseModule P.ModuleName
   -- | Exit PSCI
   | QuitPSCi
-  -- | Reset the state of the REPL
-  | ResetState
+  -- | Clear the state of the REPL
+  | ClearState
   -- | Add some declarations to the current evaluation context
   | Decls [P.Declaration]
   -- | Find the type of an expression
@@ -120,7 +120,7 @@ parseReplQuery _ = Nothing
 data Directive
   = Help
   | Quit
-  | Reset
+  | Clear
   | Browse
   | Type
   | Kind

--- a/src/Language/PureScript/Interactive/Types.hs
+++ b/src/Language/PureScript/Interactive/Types.hs
@@ -82,6 +82,8 @@ data Command
   | BrowseModule P.ModuleName
   -- | Exit PSCI
   | QuitPSCi
+  -- | Reload all the imported modules of the REPL
+  | ReloadState
   -- | Clear the state of the REPL
   | ClearState
   -- | Add some declarations to the current evaluation context
@@ -120,6 +122,7 @@ parseReplQuery _ = Nothing
 data Directive
   = Help
   | Quit
+  | Reload
   | Clear
   | Browse
   | Type

--- a/tests/TestPsci.hs
+++ b/tests/TestPsci.hs
@@ -134,7 +134,7 @@ initTestPSCi = do
     Right modules -> do
       resultOrErrors <- runMake . make $ modules
       case resultOrErrors of
-        Left errors -> print errors >> exitFailure
+        Left errs -> putStrLn (P.prettyPrintMultipleErrors P.defaultPPEOptions errs) >> exitFailure
         Right (externs, env) ->
           return (PSCiState [] [] (zip (map snd modules) externs), PSCiConfig pursFiles env)
 

--- a/tests/TestPsci.hs
+++ b/tests/TestPsci.hs
@@ -48,6 +48,7 @@ completionTestData :: [(String, [String])]
 completionTestData =
   -- basic directives
   [ (":h",  [":help"])
+  , (":r",  [":reload"])
   , (":c",  [":clear"])
   , (":q",  [":quit"])
   , (":b",  [":browse"])
@@ -60,9 +61,10 @@ completionTestData =
   , ("import Control.Monad.E",    map ("import Control.Monad.Eff" ++) ["", ".Unsafe", ".Class", ".Console"])
   , ("import Control.Monad.Eff.", map ("import Control.Monad.Eff" ++) [".Unsafe", ".Class", ".Console"])
 
-  -- :quit, :help, :clear should not complete
+  -- :quit, :help, :reload, :clear should not complete
   , (":help ", [])
   , (":quit ", [])
+  , (":reload ", [])
   , (":clear ", [])
 
   -- :show should complete to "loaded" and "import"

--- a/tests/TestPsci.hs
+++ b/tests/TestPsci.hs
@@ -6,7 +6,9 @@ module TestPsci where
 import Prelude ()
 import Prelude.Compat
 
+import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.State.Strict (evalStateT)
+import Control.Monad.Trans.RWS.Strict (evalRWST, RWST, get)
 import Control.Monad (when)
 
 import Data.List (sort)
@@ -22,9 +24,7 @@ import Test.HUnit
 
 import qualified Language.PureScript as P
 
-import Language.PureScript.Interactive.Module (loadAllModules)
-import Language.PureScript.Interactive.Completion
-import Language.PureScript.Interactive.Types
+import Language.PureScript.Interactive
 
 import TestUtils (supportModules)
 
@@ -34,7 +34,9 @@ main = do
   when (errors + failures > 0) exitFailure
 
 allTests :: Test
-allTests = completionTests
+allTests = TestList [ completionTests
+                    , commandTests
+                    ]
 
 completionTests :: Test
 completionTests =
@@ -115,11 +117,11 @@ assertCompletedOk (line, expecteds) = do
 
 runCM :: CompletionM a -> IO a
 runCM act = do
-  psciState <- getPSCiState
+  psciState <- getPSCiStateForCompletion
   evalStateT (liftCompletionM act) psciState
 
-getPSCiState :: IO PSCiState
-getPSCiState = do
+initTestPSCi :: IO (PSCiState, PSCiConfig)
+initTestPSCi = do
   cwd <- getCurrentDirectory
   let supportDir = cwd </> "tests" </> "support" </> "bower_components"
   let supportFiles ext = Glob.globDir1 (Glob.compile ("purescript-*/src/**/*." ++ ext)) supportDir
@@ -129,12 +131,61 @@ getPSCiState = do
   case modulesOrFirstError of
     Left err ->
       print err >> exitFailure
-    Right modules ->
-      let imports = [controlMonadSTasST, (P.ModuleName [P.ProperName (T.pack "Prelude")], P.Implicit, Nothing)]
-          dummyExterns = P.internalError "TestPsci: dummyExterns should not be used"
-      in  return (PSCiState imports [] (zip (map snd modules) (repeat dummyExterns)))
+    Right modules -> do
+      resultOrErrors <- runMake . make $ modules
+      case resultOrErrors of
+        Left errors -> print errors >> exitFailure
+        Right (externs, env) ->
+          return (PSCiState [] [] (zip (map snd modules) externs), PSCiConfig pursFiles env)
+
+getPSCiStateForCompletion :: IO PSCiState
+getPSCiStateForCompletion = do
+  (PSCiState _ bs es, _) <- initTestPSCi
+  let imports = [controlMonadSTasST, (P.ModuleName [P.ProperName (T.pack "Prelude")], P.Implicit, Nothing)]
+  return $ PSCiState imports bs es
 
 controlMonadSTasST :: ImportedModule
 controlMonadSTasST = (s "Control.Monad.ST", P.Implicit, Just (s "ST"))
   where
   s = P.moduleNameFromString . T.pack
+
+type TestPSCi a = RWST PSCiConfig () PSCiState IO a
+
+runTestPSCi :: TestPSCi a -> IO a
+runTestPSCi i = do
+  (s, c) <- initTestPSCi
+  fst <$> evalRWST i c s
+
+testEval :: String -> TestPSCi ()
+testEval = const $ return () -- not yet actually eval expr command
+
+testReload :: TestPSCi ()
+testReload = return ()
+
+run :: String -> TestPSCi ()
+run s = case parseCommand s of
+          Left errStr -> liftIO $ putStrLn errStr >> exitFailure
+          Right command ->
+            handleCommand testEval testReload command
+
+commandTests :: Test
+commandTests = TestLabel "commandTests" $ TestList $ map (TestCase . runTestPSCi)
+  [ do
+      run "import Prelude"
+      run "import Data.Functor"
+      run "import Control.Monad"
+      before <- psciImportedModules <$> get
+      liftIO $ length before @?= 3
+      run ":clear"
+      after <- psciImportedModules <$> get
+      liftIO $ length after @?= 0
+  , do
+      run "import Prelude"
+      run "import Data.Functor"
+      run "import Control.Monad"
+      before <- psciImportedModules <$> get
+      liftIO $ length before @?= 3
+      run ":reload"
+      after <- psciImportedModules <$> get
+      liftIO $ length after @?= 3
+  ]

--- a/tests/TestPsci.hs
+++ b/tests/TestPsci.hs
@@ -48,7 +48,7 @@ completionTestData :: [(String, [String])]
 completionTestData =
   -- basic directives
   [ (":h",  [":help"])
-  , (":re", [":reset"])
+  , (":c",  [":clear"])
   , (":q",  [":quit"])
   , (":b",  [":browse"])
 
@@ -60,10 +60,10 @@ completionTestData =
   , ("import Control.Monad.E",    map ("import Control.Monad.Eff" ++) ["", ".Unsafe", ".Class", ".Console"])
   , ("import Control.Monad.Eff.", map ("import Control.Monad.Eff" ++) [".Unsafe", ".Class", ".Console"])
 
-  -- :quit, :help, :reset should not complete
+  -- :quit, :help, :clear should not complete
   , (":help ", [])
   , (":quit ", [])
-  , (":reset ", [])
+  , (":clear ", [])
 
   -- :show should complete to "loaded" and "import"
   , (":show ", [":show import", ":show loaded"])

--- a/tests/TestPsci.hs
+++ b/tests/TestPsci.hs
@@ -172,20 +172,24 @@ commandTests :: Test
 commandTests = TestLabel "commandTests" $ TestList $ map (TestCase . runTestPSCi)
   [ do
       run "import Prelude"
+      run "import Prelude as P"
       run "import Data.Functor"
+      run "import Control.Monad (bind)"
       run "import Control.Monad"
       before <- psciImportedModules <$> get
-      liftIO $ length before @?= 3
+      liftIO $ length before @?= 5
       run ":clear"
       after <- psciImportedModules <$> get
       liftIO $ length after @?= 0
   , do
       run "import Prelude"
+      run "import Prelude as P"
       run "import Data.Functor"
+      run "import Control.Monad (bind)"
       run "import Control.Monad"
       before <- psciImportedModules <$> get
-      liftIO $ length before @?= 3
+      liftIO $ length before @?= 5
       run ":reload"
       after <- psciImportedModules <$> get
-      liftIO $ length after @?= 3
+      liftIO $ length after @?= 5
   ]

--- a/tests/TestPsci.hs
+++ b/tests/TestPsci.hs
@@ -172,24 +172,20 @@ commandTests :: Test
 commandTests = TestLabel "commandTests" $ TestList $ map (TestCase . runTestPSCi)
   [ do
       run "import Prelude"
-      run "import Prelude as P"
       run "import Data.Functor"
-      run "import Control.Monad (bind)"
       run "import Control.Monad"
       before <- psciImportedModules <$> get
-      liftIO $ length before @?= 5
+      liftIO $ length before @?= 3
       run ":clear"
       after <- psciImportedModules <$> get
       liftIO $ length after @?= 0
   , do
       run "import Prelude"
-      run "import Prelude as P"
       run "import Data.Functor"
-      run "import Control.Monad (bind)"
       run "import Control.Monad"
       before <- psciImportedModules <$> get
-      liftIO $ length before @?= 5
+      liftIO $ length before @?= 3
       run ":reload"
       after <- psciImportedModules <$> get
-      liftIO $ length after @?= 5
+      liftIO $ length after @?= 3
   ]


### PR DESCRIPTION
Regarding #2713 

This PR update the list of commands in PSCi. The current `:reset` command is renamed to `:clear`, and a new command `:reload` is added. `:reload` is expected to work the same as `:reload` in GHCi.