### PR TITLE
[psc-ide] parse imports with hanging right paren

### DIFF
--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -136,7 +136,8 @@ step (ModuleHeader mi) (ix, l)
   | T.isPrefixOf "import " l = ImportSection ix ix
   | otherwise = ModuleHeader mi
 step (ImportSection start lastImportLine) (ix, l)
-  | any (`T.isPrefixOf` l) ["import", " "] = ImportSection start ix
+  | any (`T.isPrefixOf` l) ["import", " "]
+    || l == ")"                            = ImportSection start ix
   | T.isPrefixOf "--" l || l == ""         = ImportSection start lastImportLine
   | otherwise                              = Res start lastImportLine
 step (Res start end) _ = Res start end


### PR DESCRIPTION
Often, when I am doing a lot of explicit imports, I use a multi-line import syntax that looks something like this:

    import X (
      A(..), doThingWithA,
      B(..), doThingWithB
    )

This is valid PS syntax, but it makes psc-ide choke when it tries to add an explicit import through the `addImport` command.

This PR fixes the issue.

It has been tested in two ways.

1. From `ghci`, behavior on `master`:

```
stack ghci --ghci-options Language.PureScript.Ide.Imports
*Language.PureScript.Ide.Imports> sliceImportSection ["module Main where", "", "import Prelude (a,",  "  b", ")", "import Meow", "", "a = b"]
Left "(line 4, column 3):\nunexpected end of input\nexpecting , or )"
```

Behavior with this change:

```
*Language.PureScript.Ide.Imports> sliceImportSection ["module Main where", "", "import Prelude (a,",  "  b", ")", "import Meow", "", "a = b"]
Right (ModuleName [ProperName {runProperName = "Main"}],["module Main where",""],[Import (ModuleName [ProperName {runProperName = "Prelude"}]) (Explicit [ValueRef (Ident "a"),ValueRef (Ident "b")]) Nothing,Import (ModuleName [ProperName {runProperName = "Meow"}]) Implicit Nothing],["","a = b"])
```

2. Ran the newly compiled `purs` command's psc-ide mode, connected to it through the `vim` plugin, and played with imports. They now work with a hanging right paren.