### PR TITLE
Add "--format html" to psc-docs

### DIFF
--- a/app/Command/Docs.hs
+++ b/app/Command/Docs.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Command.Docs (command, infoModList) where
 
@@ -260,4 +258,3 @@ examples =
     , "      --docgen Data.List:docs/Data.List.md \\"
     , "      --docgen Data.List.Lazy:docs/Data.List.Lazy.md"
     ]
-

--- a/app/Command/Docs.hs
+++ b/app/Command/Docs.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Command.Docs (command, infoModList) where
 
@@ -6,6 +8,7 @@ import           Protolude (ordNub)
 
 import           Command.Docs.Etags
 import           Command.Docs.Ctags
+import           Command.Docs.Html
 import           Control.Applicative
 import           Control.Arrow (first, second)
 import           Control.Category ((>>>))
@@ -30,11 +33,13 @@ import           System.FilePath.Glob (glob)
 import           System.IO (hPutStrLn, hPrint, stderr)
 import           System.IO.UTF8 (readUTF8FileT, writeUTF8FileT)
 
--- Available output formats
-data Format = Markdown -- Output documentation in Markdown format
-               | Ctags -- Output ctags symbol index suitable for use with vi
-               | Etags -- Output etags symbol index suitable for use with emacs
-               deriving (Show, Eq, Ord)
+-- | Available output formats
+data Format
+  = Markdown
+  | Html
+  | Ctags -- Output ctags symbol index suitable for use with vi
+  | Etags -- Output etags symbol index suitable for use with emacs
+  deriving (Show, Eq, Ord)
 
 -- | Available methods of outputting Markdown documentation
 data DocgenOutput
@@ -53,13 +58,22 @@ data PSCDocsOptions = PSCDocsOptions
 docgen :: PSCDocsOptions -> IO ()
 docgen (PSCDocsOptions fmt inputGlob output) = do
   input <- concat <$> mapM glob inputGlob
+  when (null input) $ do
+    hPutStrLn stderr "purs docs: no input files."
+    exitFailure
+
   case fmt of
     Etags -> dumpTags input dumpEtags
     Ctags -> dumpTags input dumpCtags
+    Html -> do
+      let outputDir = "./generated-docs" -- TODO: make this configurable
+      ms <- parseAndConvert input
+      let msHtml = map asHtml (D.primDocsModule : ms)
+      createDirectoryIfMissing False outputDir
+      writeHtmlModules outputDir msHtml
+
     Markdown -> do
-      ms <- runExceptT (D.parseFilesInPackages input []
-                           >>= uncurry D.convertModulesInPackage)
-               >>= successOrExit
+      ms <- parseAndConvert input
 
       case output of
         EverythingToStdOut ->
@@ -100,6 +114,11 @@ docgen (PSCDocsOptions fmt inputGlob output) = do
 
   takeByName = takeModulesByName D.modName
   takeByName' = takeModulesByName' D.modName
+
+  parseAndConvert input =
+    runExceptT (D.parseFilesInPackages input []
+               >>= uncurry D.convertModulesInPackage)
+    >>= successOrExit
 
 -- |
 -- Given a list of module names and a list of modules, return a list of modules
@@ -151,13 +170,14 @@ instance Read Format where
   readsPrec _ "etags" = [(Etags, "")]
   readsPrec _ "ctags" = [(Ctags, "")]
   readsPrec _ "markdown" = [(Markdown, "")]
+  readsPrec _ "html" = [(Html, "")]
   readsPrec _ _ = []
 
 format :: Opts.Parser Format
 format = Opts.option Opts.auto $ Opts.value Markdown
          <> Opts.long "format"
          <> Opts.metavar "FORMAT"
-         <> Opts.help "Set output FORMAT (markdown | etags | ctags)"
+         <> Opts.help "Set output FORMAT (markdown | html | etags | ctags)"
 
 docgenModule :: Opts.Parser String
 docgenModule = Opts.strOption $
@@ -240,3 +260,4 @@ examples =
     , "      --docgen Data.List:docs/Data.List.md \\"
     , "      --docgen Data.List.Lazy:docs/Data.List.Lazy.md"
     ]
+

--- a/app/Command/Docs/Html.hs
+++ b/app/Command/Docs/Html.hs
@@ -1,0 +1,181 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Command.Docs.Html
+  ( asHtml
+  , layout
+  , writeHtmlModule
+  , writeHtmlModules
+  ) where
+
+import           Control.Applicative
+import           Control.Arrow ((&&&))
+import           Control.Monad.Writer
+import           Data.List (sort)
+import           Data.Text (Text)
+import           Data.Text.Lazy (toStrict)
+import qualified Data.Text as T
+import           Data.FileEmbed (embedStringFile)
+import qualified Language.PureScript as P
+import qualified Language.PureScript.Docs as D
+import qualified Language.PureScript.Docs.AsHtml as D
+import           Text.Blaze.Html5 (Html, (!), toMarkup)
+import qualified Text.Blaze.Html5 as H
+import qualified Text.Blaze.Html5.Attributes as A
+import qualified Text.Blaze.Html.Renderer.Text as Blaze
+import           System.IO.UTF8 (writeUTF8FileT)
+import           System.FilePath.Glob (glob)
+import           System.Directory (removeFile)
+import           Version (versionString)
+
+writeHtmlModules :: FilePath -> [(P.ModuleName, D.HtmlOutputModule Html)] -> IO ()
+writeHtmlModules outputDir modules = do
+  glob (outputDir <> "/*.html") >>= mapM_ removeFile
+  let moduleList = sort $ map fst modules
+  writeHtmlFile (outputDir ++ "/index.html") (renderIndexModule moduleList)
+  mapM_ (writeHtmlModule outputDir . (fst &&& layout moduleList)) modules
+
+asHtml :: D.Module -> (P.ModuleName, D.HtmlOutputModule Html)
+asHtml m = D.moduleAsHtml (getHtmlRenderContext (D.modName m)) m
+
+writeHtmlModule :: FilePath -> (P.ModuleName, Html) -> IO ()
+writeHtmlModule outputDir (mn, html) = do
+  let filepath = outputDir ++ "/" ++ T.unpack (P.runModuleName mn) ++ ".html"
+  writeHtmlFile filepath html
+
+writeHtmlFile :: FilePath -> Html -> IO ()
+writeHtmlFile filepath =
+  writeUTF8FileT filepath . toStrict . Blaze.renderHtml
+
+getHtmlRenderContext :: P.ModuleName -> D.HtmlRenderContext
+getHtmlRenderContext mn = D.HtmlRenderContext
+  { D.currentModuleName = mn
+  , D.buildDocLink = getLink mn
+  , D.renderDocLink = renderLink
+  , D.renderSourceLink = const Nothing
+  }
+
+-- TODO: try to combine this with the one in Docs.Types?
+getLink :: P.ModuleName -> D.Namespace -> Text -> D.ContainingModule -> Maybe D.DocLink
+getLink curMn namespace target containingMod = do
+  location <- getLinkLocation
+  return D.DocLink
+    { D.linkLocation = location
+    , D.linkTitle = target
+    , D.linkNamespace = namespace
+    }
+
+  where
+  getLinkLocation = builtinLinkLocation <|> normalLinkLocation
+
+  normalLinkLocation = do
+    case containingMod of
+      D.ThisModule ->
+        return D.SameModule
+      D.OtherModule destMn ->
+        -- This is OK because all modules count as 'local' for purs docs in
+        -- html mode
+        return $ D.LocalModule curMn destMn
+
+  builtinLinkLocation = do
+    let primMn = P.moduleNameFromString "Prim"
+    guard $ containingMod == D.OtherModule primMn
+    return $ D.BuiltinModule primMn
+
+renderLink :: D.DocLink -> Text
+renderLink l =
+  case D.linkLocation l of
+    D.SameModule ->
+      ""
+    D.LocalModule _ dest ->
+      P.runModuleName dest <> ".html"
+    D.DepsModule{} ->
+      P.internalError "DepsModule: not implemented"
+    D.BuiltinModule dest  ->
+      P.runModuleName dest <> ".html"
+
+layout :: [P.ModuleName] -> (P.ModuleName, D.HtmlOutputModule Html) -> Html
+layout moduleList (mn, htmlDocs) =
+  basicLayout ("PureScript: " <> modName) $ do
+    H.div ! A.class_ "page-title clearfix" $ do
+      H.div ! A.class_ "page-title__label" $ "Module"
+      H.h1 ! A.class_ "page-title__title" $ toMarkup modName
+
+    H.div ! A.class_ "col col--main" $ do
+      D.htmlOutputModuleLocals htmlDocs
+      mapM_ renderReExports (D.htmlOutputModuleReExports htmlDocs)
+
+    H.div ! A.class_ "col col--aside" $ do
+      H.h3 "Modules"
+      renderModuleList moduleList
+  where
+  modName = P.runModuleName mn
+
+  renderReExports :: (D.InPackage P.ModuleName, Html) -> Html
+  renderReExports (reExpFrom, html) = do
+    H.h2 ! A.class_ "re-exports" $ do
+      toMarkup ("Re-exports from " :: Text)
+      H.a ! A.href (H.toValue (toText reExpFrom <> ".html")) $
+        toMarkup (toText reExpFrom)
+    html
+
+  toText = P.runModuleName . D.ignorePackage
+
+basicLayout :: Text -> Html -> Html
+basicLayout title inner =
+  H.docTypeHtml $ do
+    H.head $ do
+      H.meta ! A.charset "utf-8"
+      H.meta ! A.httpEquiv "X-UA-Compatible" ! A.content "IE=edge"
+      H.meta ! A.name "viewport" ! A.content "width=device-width, initial-scale=1"
+      H.title (toMarkup title)
+
+      H.link ! A.href "https://fonts.googleapis.com/css?family=Roboto+Mono|Roboto:300,400,400i,700,700i"
+             ! A.type_ "text/css" ! A.rel "stylesheet"
+      H.style ! A.type_ "text/css" $
+        toMarkup normalize_css
+      H.style ! A.type_ "text/css" $
+        toMarkup pursuit_css
+    H.body $ do
+      H.div ! A.class_ "everything-except-footer" $ do
+        H.div ! A.class_ "top-banner clearfix" $ do
+          H.div ! A.class_ "container clearfix" $ do
+            H.div ! A.style inlineHeaderStyles $ do
+              "PureScript API documentation"
+
+            H.div ! A.class_ "top-banner__actions" $ do
+              H.div ! A.class_ "top-banner__actions__item" $ do
+                H.a ! A.href "index.html" $ "Index"
+
+        H.main ! A.class_ "container clearfix" ! H.customAttribute "role" "main" $ do
+          inner
+
+      H.div ! A.class_ "footer clearfix" $
+        H.p $ toMarkup $ "Generated by purs " <> versionString
+
+  where
+  -- Like Pursuit's .top-banner__logo except without the 'hover' styles
+  inlineHeaderStyles = "float: left; font-size: 2.44em; font-weight: 300; line-height: 90px; margin: 0"
+
+renderIndexModule :: [P.ModuleName] -> Html
+renderIndexModule moduleList =
+  basicLayout "PureScript API documentation" $ do
+    H.div ! A.class_ "page-title clearfix" $ do
+      H.h1 ! A.class_ "page-title__title" $ "Index"
+    H.div ! A.class_ "col col--main" $ do
+      renderModuleList moduleList
+
+renderModuleList :: [P.ModuleName] -> Html
+renderModuleList moduleList =
+  H.ul $ mapM_ listItem moduleList
+
+  where
+  listItem mn = H.li $
+    H.a ! A.href (H.toValue (P.runModuleName mn <> ".html")) $
+      toMarkup (P.runModuleName mn)
+
+normalize_css :: Text
+normalize_css = $(embedStringFile "app/static/normalize.css")
+
+pursuit_css :: Text
+pursuit_css = $(embedStringFile "app/static/pursuit.css")

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE CPP #-}
 
 module Main where
 
@@ -18,14 +16,10 @@ import qualified Command.Publish as Publish
 import qualified Command.REPL as REPL
 import           Data.Foldable (fold)
 import           Data.Monoid ((<>))
-import           Data.Version (showVersion)
 import qualified Options.Applicative as Opts
-import qualified Paths_purescript as Paths
 import qualified System.IO as IO
+import           Version (versionString)
 
-#ifndef RELEASE
-import qualified Development.GitRev as GitRev
-#endif
 
 main :: IO ()
 main = do
@@ -37,7 +31,7 @@ main = do
     opts        = Opts.info (versionInfo <*> Opts.helper <*> commands) infoModList
     infoModList = Opts.fullDesc <> headerInfo <> footerInfo
     headerInfo  = Opts.progDesc "The PureScript compiler and tools"
-    footerInfo  = Opts.footer $ "purs " ++ showVersion Paths.version
+    footerInfo  = Opts.footer $ "purs " ++ versionString
 
     versionInfo :: Opts.Parser (a -> a)
     versionInfo = Opts.abortOption (Opts.InfoMsg versionString) $
@@ -68,15 +62,3 @@ main = do
             (Opts.info REPL.command
               (Opts.progDesc "Enter the interactive mode (PSCi)"))
         ]
-
-versionString :: String
-versionString = showVersion Paths.version ++ extra
-  where
-#ifdef RELEASE
-  extra = ""
-#else
-  extra = " [development build; commit: " ++ $(GitRev.gitHash) ++ dirty ++ "]"
-  dirty
-    | $(GitRev.gitDirty) = " DIRTY"
-    | otherwise = ""
-#endif

--- a/app/Version.hs
+++ b/app/Version.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Version where
+
+import Data.Version (showVersion)
+import Paths_purescript as Paths
+
+#ifndef RELEASE
+import qualified Development.GitRev as GitRev
+#endif
+
+versionString :: String
+versionString = showVersion Paths.version ++ extra
+  where
+#ifdef RELEASE
+  extra = ""
+#else
+  extra = " [development build; commit: " ++ $(GitRev.gitHash) ++ dirty ++ "]"
+  dirty
+    | $(GitRev.gitDirty) = " DIRTY"
+    | otherwise = ""
+#endif

--- a/app/static/normalize.css
+++ b/app/static/normalize.css
@@ -1,0 +1,427 @@
+/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
+
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS text size adjust after orientation change, without disabling
+ *    user zoom.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/**
+ * Remove default margin.
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
+   ========================================================================== */
+
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
+ */
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * Improve readability when focused and also mouse hovered in all browsers.
+ */
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+
+b,
+strong {
+  font-weight: bold;
+}
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Address styling not present in IE 8/9.
+ */
+
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+
+img {
+  border: 0;
+}
+
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * Address differences between Firefox and other browsers.
+ */
+
+hr {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 0;
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit; /* 1 */
+  font: inherit; /* 2 */
+  margin: 0; /* 3 */
+}
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+
+button,
+select {
+  text-transform: none;
+}
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+
+button,
+html input[type="button"], /* 1 */
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
+}
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+input {
+  line-height: normal;
+}
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
+ *    (include `-moz` to future-proof).
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box; /* 2 */
+  box-sizing: content-box;
+}
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+
+optgroup {
+  font-weight: bold;
+}
+
+/* Tables
+   ========================================================================== */
+
+/**
+ * Remove most spacing between table cells.
+ */
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}

--- a/app/static/pursuit.css
+++ b/app/static/pursuit.css
@@ -1,0 +1,703 @@
+/** ************************************************************************* *
+ ** Pursuit CSS
+ **
+ ** STRUCTURE
+ **
+ ** This CSS file is structured into several sections, from general to
+ ** specific, and (mostly) alphabetically within the sections.
+ **
+ ** Several global element styles are used. This is not encouraged and should
+ ** be kept to a minimum. If you want to add new styles you'll most likely
+ ** want to add a new CSS component. See the Components section for examples.
+ **
+ ** CSS components use three simple naming ideas from the BEM system:
+ **   - Block:    `.my-component`
+ **   - Element:  `.my-component__item`
+ **   - Modifier: `.my-component.my-component--highlighted`
+ **
+ **   Example:
+ **   <div .my-component>
+ **     <div .my-component__item>
+ **     <div .my-component__item>
+ **   ...
+ **   <div .my-component.my-component--highlighted>
+ **     <div .my-component__item>
+ **     <div .my-component__item>
+ **
+ ** Components can be nested.
+ **
+ **
+ ** TYPOGRAPHY
+ **
+ ** Typographic choices for sizes, line-heights and margins are based on a
+ ** musical major third scale (4:5). This gives us a way to find numbers
+ ** and relationships between them that are perceived as harmonic.
+ **
+ ** To make use of this modular scale, use a ratio of the form
+ **   (5/4)^n
+ ** where n ∈ ℤ, -6 ≤ n ≤ 8.
+ ** ************************************************************************* */
+/* Section: Variables
+ * ========================================================================== */
+/* Section: Document Styles
+ * ========================================================================== */
+html {
+  box-sizing: border-box;
+  /* This overflow rule prevents everything from shifting slightly to the side
+     when moving from a page which isn't large enough to generate a scrollbar
+     to one that is. */
+  overflow-y: scroll;
+}
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+body {
+  background-color: #ffffff;
+  color: #000;
+  font-family: "Roboto", sans-serif;
+  font-size: 87.5%;
+  line-height: 1.563;
+}
+@media (min-width: 38em) {
+  body {
+    font-size: 100%;
+  }
+}
+/* Section: Utility Classes
+ * ========================================================================== */
+.clear-floats {
+  clear: both;
+}
+.clearfix::before,
+.clearfix::after {
+  content: " ";
+  display: table;
+}
+.clearfix::after {
+  clear: both;
+}
+/* Content hidden like this will still be read by a screen reader */
+.hide-visually {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+/* Section: Layout
+ * ========================================================================== */
+.container {
+  display: block;
+  max-width: 66em;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+.col {
+  display: block;
+  position: relative;
+  width: 100%;
+}
+.col.col--main {
+  margin-bottom: 3.08em;
+}
+.col.col--aside {
+  margin-bottom: 2.44em;
+}
+@media (min-width: 52em) {
+  .container {
+    padding-left: 30px;
+    padding-right: 30px;
+  }
+  .col.col--main {
+    float: left;
+    width: 63.655%;
+    /* 66.6…% - 30px */
+  }
+  .col.col--aside {
+    float: right;
+    font-size: 87.5%;
+    width: 33.333333%;
+  }
+}
+@media (min-width: 66em) {
+  .col.col--aside {
+    font-size: inherit;
+  }
+}
+/* Footer
+ * Based on http://www.lwis.net/journal/2008/02/08/pure-css-sticky-footer/
+ * Except we don't support IE6
+ * -------------------------------------------------------------------------- */
+html,
+body {
+  height: 100%;
+}
+.everything-except-footer {
+  min-height: 100%;
+  padding-bottom: 3em;
+}
+.footer {
+  position: relative;
+  height: 3em;
+  margin-top: -3em;
+  width: 100%;
+  text-align: center;
+  background-color: #1d222d;
+  color: #f0f0f0;
+}
+.footer * {
+  margin-bottom: 0;
+}
+/* Section: Element Styles
+ *
+ * Have as few of these as possible and keep them general, because they will
+ * influence every component hereafter.
+ * ========================================================================== */
+:target {
+  background-color: #f1f5f9;
+}
+a,
+a:visited {
+  color: #c4953a;
+  text-decoration: none;
+  font-weight: bold;
+}
+a:hover {
+  color: #7b5904;
+  text-decoration: none;
+}
+code,
+pre {
+  background-color: #f1f5f9;
+  border-radius: 3px;
+  color: #194a5b;
+  font-family: "Roboto Mono", monospace;
+  font-size: 87.5%;
+}
+:target code,
+:target pre {
+  background-color: #dfe8f1;
+}
+code {
+  padding: 0.2em 0;
+  margin: 0;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+code::before,
+code::after {
+  letter-spacing: -0.2em;
+  content: "\00a0";
+}
+a > code {
+  font-weight: normal;
+}
+a > code::before {
+  content: "🡒";
+  letter-spacing: 0.33em;
+}
+a:hover > code {
+  color: #c4953a;
+}
+pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding: 1em 1.25rem;
+  /* Using rem here to align with lists etc. */
+  overflow: auto;
+  white-space: pre;
+  word-wrap: normal;
+}
+pre code {
+  background-color: transparent;
+  border: 0;
+  font-size: 100%;
+  max-width: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  white-space: pre;
+  word-break: normal;
+  word-wrap: normal;
+}
+pre code::before,
+pre code::after {
+  content: normal;
+}
+h1 {
+  font-size: 3.052em;
+  font-weight: 300;
+  letter-spacing: -0.5px;
+  line-height: 1.125;
+  margin-top: 1.563rem;
+  margin-bottom: 1.25rem;
+}
+@media (min-width: 52em) {
+  h1 {
+    font-size: 3.814em;
+    margin-top: 5.96rem;
+  }
+}
+h2 {
+  font-size: 1.953em;
+  font-weight: normal;
+  line-height: 1.250;
+  margin-top: 3.052rem;
+  margin-bottom: 1rem;
+}
+h3 {
+  font-size: 1.563em;
+  font-weight: normal;
+  line-height: 1.250;
+  margin-top: 2.441rem;
+  margin-bottom: 1rem;
+}
+h4 {
+  font-size: 1.25em;
+  font-weight: normal;
+  margin-top: 2.441rem;
+  margin-bottom: 1rem;
+}
+h1 + h2,
+h1 + h3,
+h1 + h4,
+h2 + h3,
+h2 + h4,
+h3 + h4 {
+  margin-top: 1rem;
+}
+hr {
+  border: none;
+  height: 1px;
+  background-color: #cccccc;
+}
+img {
+  border-style: none;
+  max-width: 100%;
+}
+p {
+  font-size: 1em;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+table {
+  border-bottom: 1px solid #cccccc;
+  border-collapse: collapse;
+  border-spacing: 0;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  width: 100%;
+}
+td,
+th {
+  text-align: left;
+  padding: 0.41em 0.51em;
+}
+td {
+  border-top: 1px solid #cccccc;
+}
+td:first-child,
+th:first-child {
+  padding-left: 0;
+}
+td:last-child,
+th:last-child {
+  padding-right: 0;
+}
+ul {
+  list-style-type: none;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  padding-left: 0;
+}
+ul li {
+  position: relative;
+  padding-left: 1.250em;
+}
+ul li::before {
+  position: absolute;
+  color: #a0a0a0;
+  content: "–";
+  display: inline-block;
+  margin-left: -1.25em;
+  width: 1.250em;
+}
+/* Tying this tightly to ul at the moment because it's a slight variation thereof */
+ul.ul--search li::before {
+  content: "⚲";
+  top: -0.2em;
+  transform: rotate(-45deg);
+}
+ol {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  padding-left: 1.250em;
+}
+ol li {
+  position: relative;
+  padding-left: 0;
+}
+/* Section: Components
+ * ========================================================================== */
+/* Component: Badge
+ * -------------------------------------------------------------------------- */
+.badge {
+  position: relative;
+  top: -0.1em;
+  display: inline-block;
+  background-color: #000;
+  border-radius: 1.3em;
+  color: #fff;
+  font-size: 77%;
+  font-weight: bold;
+  line-height: 1.563;
+  text-align: center;
+  height: 1.5em;
+  width: 1.5em;
+}
+.badge.badge--package {
+  background-color: #c4953a;
+  letter-spacing: -0.1em;
+}
+.badge.badge--module {
+  background-color: #75B134;
+}
+/* Component: Declarations
+ * -------------------------------------------------------------------------- */
+.decl__title {
+  position: relative;
+  padding-bottom: 0.328em;
+  margin-bottom: 0.262em;
+}
+.decl__source {
+  display: block;
+  float: right;
+  font-size: 64%;
+  position: relative;
+  top: 0.57em;
+}
+.decl__anchor,
+.decl__anchor:visited {
+  position: absolute;
+  left: -0.8em;
+  color: #bababa;
+}
+.decl__anchor:hover {
+  color: #c4953a;
+}
+.decl__signature {
+  background-color: transparent;
+  border-radius: 0;
+  border-top: 1px solid #cccccc;
+  border-bottom: 1px solid #cccccc;
+  padding: 0.328em 0;
+}
+.decl__signature code {
+  display: block;
+  padding-left: 2.441em;
+  text-indent: -2.441em;
+  white-space: normal;
+}
+:target .decl__signature,
+:target .decl__signature code {
+  /* We want the background to be transparent, even when the parent is a target */
+  background-color: transparent;
+}
+.decl__body .keyword,
+.decl__body .syntax {
+  color: #0B71B4;
+}
+/* Component: Dependency Link
+ * -------------------------------------------------------------------------- */
+.deplink {
+  /* Currently no root styles, but keep the class as a namespace */
+}
+.deplink__link {
+  display: inline-block;
+  margin-right: 0.41em;
+}
+.deplink__version {
+  color: #666666;
+  display: inline-block;
+  font-size: 0.8em;
+  line-height: 1;
+}
+/* Component: Grouped List
+ * -------------------------------------------------------------------------- */
+.grouped-list {
+  border-top: 1px solid #cccccc;
+  margin: 0 0 2.44em 0;
+}
+.grouped-list__title {
+  color: #666666;
+  font-size: 0.8em;
+  font-weight: 300;
+  letter-spacing: 1px;
+  margin: 0.8em 0 -0.1em 0;
+  text-transform: uppercase;
+}
+.grouped-list__item {
+  margin: 0;
+}
+/* Component: Message
+ * -------------------------------------------------------------------------- */
+.message {
+  border: 5px solid;
+  border-radius: 5px;
+  padding: 1em !important;
+}
+.message.message--error {
+  background-color: #fff0f0;
+  border-color: #c85050;
+}
+.message.message--not-available {
+  background-color: #f0f096;
+  border-color: #e3e33d;
+}
+/* Component: Multi Col
+ * Multiple columns side by side
+ * -------------------------------------------------------------------------- */
+.multi-col {
+  margin-bottom: 2.44em;
+}
+.multi-col__col {
+  display: block;
+  padding-right: 1em;
+  position: relative;
+  width: 100%;
+}
+@media (min-width: 38em) and (max-width: 51.999999em) {
+  .multi-col__col {
+    float: left;
+    width: 50%;
+  }
+  .multi-col__col:nth-child(2n+3) {
+    clear: both;
+  }
+}
+@media (min-width: 52em) {
+  .multi-col__col {
+    float: left;
+    width: 33.333333%;
+  }
+  .multi-col__col:nth-child(3n+4) {
+    clear: both;
+  }
+}
+/* Component: Page Title
+ * -------------------------------------------------------------------------- */
+.page-title {
+  margin: 4.77em 0 1.56em;
+  padding-bottom: 1.25em;
+  position: relative;
+}
+.page-title__title {
+  margin: 0 0 0 -0.05em;
+  /* Visually align on left edge */
+}
+.page-title__label {
+  position: relative;
+  color: #666666;
+  font-size: 0.8rem;
+  font-weight: 300;
+  letter-spacing: 1px;
+  margin-bottom: -0.8em;
+  text-transform: uppercase;
+  z-index: 1;
+}
+/* Component: Top Banner
+ * -------------------------------------------------------------------------- */
+.top-banner {
+  background-color: #1d222d;
+  color: #f0f0f0;
+  font-weight: normal;
+}
+.top-banner__logo,
+.top-banner__logo:visited {
+  float: left;
+  color: #f0f0f0;
+  font-size: 2.44em;
+  font-weight: 300;
+  line-height: 90px;
+  margin: 0;
+}
+.top-banner__logo:hover {
+  color: #c4953a;
+  text-decoration: none;
+}
+.top-banner__form {
+  margin-bottom: 1.25em;
+}
+.top-banner__form input {
+  border: 1px solid #1d222d;
+  border-radius: 3px;
+  color: #1d222d;
+  font-weight: 300;
+  line-height: 2;
+  padding: 0.21em 0.512em;
+  width: 100%;
+}
+.top-banner__actions {
+  float: right;
+  text-align: right;
+}
+.top-banner__actions__item {
+  display: inline-block;
+  line-height: 90px;
+  margin: 0;
+  padding-left: 1.25em;
+}
+.top-banner__actions__item:first-child {
+  padding-left: 0;
+}
+.top-banner__actions__item a,
+.top-banner__actions__item a:visited {
+  color: #f0f0f0;
+}
+.top-banner__actions__item a:hover {
+  color: #c4953a;
+}
+@media (min-width: 38em) {
+  .top-banner__logo {
+    float: left;
+    width: 25%;
+  }
+  .top-banner__form {
+    float: left;
+    line-height: 90px;
+    margin-bottom: 0;
+    width: 50%;
+  }
+  .top-banner__actions {
+    float: right;
+    width: 25%;
+  }
+}
+/* Component: Search Results
+ * -------------------------------------------------------------------------- */
+.result.result--empty {
+  font-size: 1.25em;
+}
+.result__title {
+  font-size: 1.25em;
+  margin-bottom: 0.2rem;
+}
+.result__badge {
+  margin-left: -0.1em;
+}
+.result__body > *:first-child {
+  margin-top: 0!important;
+}
+.result__body > *:last-child {
+  margin-bottom: 0!important;
+}
+.result__signature {
+  background-color: transparent;
+  border-radius: 0;
+  border-top: 1px solid #cccccc;
+  border-bottom: 1px solid #cccccc;
+  padding: 0.328em 0;
+}
+.result__signature code {
+  display: block;
+  padding-left: 2.441em;
+  text-indent: -2.441em;
+  white-space: normal;
+}
+.result__actions {
+  margin-top: 0.2rem;
+}
+.result__actions__item {
+  font-size: 80%;
+}
+.result__actions__item + .result__actions__item {
+  margin-left: 0.65em;
+}
+/* Component: Version Selector
+ * -------------------------------------------------------------------------- */
+.version-selector {
+  margin-bottom: 0.8em;
+}
+@media (min-width: 38em) {
+  .version-selector {
+    position: absolute;
+    top: 0.8em;
+    right: 0;
+    margin-bottom: 0;
+  }
+}
+/* Section: FIXME
+ * These styles should be cleaned up
+ * ========================================================================== */
+/* Help paragraphs */
+.help {
+  padding: 5px 0;
+}
+.help h3 {
+  /* FIXME: target with class */
+  margin-top: 16px;
+}
+/* Section: Markdown
+ * Github rendered README
+ * ========================================================================== */
+.markdown-body {
+  /*
+  Useful for narrow screens, such as mobiles. Documentation often contains URLs
+  which would otherwise force the page to become wider, and force creation of
+  horizontal scrollbars. Yuck.
+  */
+  word-wrap: break-word;
+}
+.markdown-body > *:first-child {
+  margin-top: 0 !important;
+}
+.markdown-body > *:last-child {
+  margin-bottom: 0 !important;
+}
+.markdown-body a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}
+.markdown-body blockquote {
+  margin: 0;
+  padding: 0 1em;
+  color: #777;
+  border-left: 0.25em solid #ddd;
+}
+.markdown-body blockquote > :first-child {
+  margin-top: 0;
+}
+.markdown-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+.markdown-body .anchor {
+  /* We hide the anchor because the link doesn't point to a valid location */
+  display: none;
+}
+.markdown-body .pl-k {
+  /* Keyword */
+  color: #a0a0a0;
+}
+.markdown-body .pl-c1,
+.markdown-body .pl-en {
+  /* Not really sure what this is */
+  color: #39d;
+}
+.markdown-body .pl-s {
+  /* String literals */
+  color: #1a1;
+}
+.markdown-body .pl-cce {
+  /* String literal escape sequences */
+  color: #921;
+}
+.markdown-body .pl-smi {
+  /* type variables? */
+  color: #62b;
+}

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -353,6 +353,7 @@ executable purs
                    ansi-terminal >= 0.6.2 && < 0.7,
                    ansi-wl-pprint -any,
                    base-compat >=0.6.0,
+                   blaze-html -any,
                    boxes >= 0.1.4 && < 0.2.0,
                    bytestring -any,
                    containers -any,
@@ -392,10 +393,12 @@ executable purs
                    Command.Docs.Ctags
                    Command.Docs.Etags
                    Command.Docs.Tags
+                   Command.Docs.Html
                    Command.Hierarchy
                    Command.Ide
                    Command.Publish
                    Command.REPL
+                   Version
     ghc-options: -Wall -O2 -fno-warn-unused-do-bind -threaded -rtsopts "-with-rtsopts=-N"
 
     if flag(release)

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -96,6 +96,7 @@ extra-source-files: examples/passing/*.purs
                   , examples/docs/resolutions.json
                   , app/static/index.html
                   , app/static/index.js
+                  , app/static/*.css
                   , tests/support/package.json
                   , tests/support/bower.json
                   , tests/support/setup-win.cmd

--- a/src/Language/PureScript/Docs/AsHtml.hs
+++ b/src/Language/PureScript/Docs/AsHtml.hs
@@ -55,7 +55,7 @@ data HtmlRenderContext = HtmlRenderContext
   { currentModuleName :: P.ModuleName
   , buildDocLink :: Namespace -> Text -> ContainingModule -> Maybe DocLink
   , renderDocLink :: DocLink -> Text
-  , renderSourceLink :: P.SourceSpan -> Text
+  , renderSourceLink :: P.SourceSpan -> Maybe Text
   }
 
 -- |
@@ -65,7 +65,7 @@ nullRenderContext mn = HtmlRenderContext
   { currentModuleName = mn
   , buildDocLink = const (const (const Nothing))
   , renderDocLink = const ""
-  , renderSourceLink = const ""
+  , renderSourceLink = const Nothing
   }
 
 packageAsHtml :: (P.ModuleName -> HtmlRenderContext) -> Package a -> HtmlOutput Html
@@ -155,8 +155,11 @@ declAsHtml r d@Declaration{..} = do
   where
     linkToSource :: HtmlRenderContext -> P.SourceSpan -> Html
     linkToSource ctx srcspan =
-      H.span ! A.class_ "decl__source" $
-        a ! A.href (v (renderSourceLink ctx srcspan)) $ text "Source"
+      maybe (return ()) go (renderSourceLink ctx srcspan)
+      where
+      go href =
+        H.span ! A.class_ "decl__source" $
+          a ! A.href (v href) $ text "Source"
 
 renderChildren :: HtmlRenderContext -> [ChildDeclaration] -> Html
 renderChildren _ [] = return ()


### PR DESCRIPTION
Following on from #2520. This commit adds a --format html option to
psc-docs which produces HTML documentation in a given directory.

All HTML pages are self-contained (in particular, the CSS is duplicated
in every page; it's not very large though, so I don't think this is a
problem), and all links are relative, so it should be easy to just stick
these HTML files pretty much anywhere and have them 'just work'.

The CSS is copied from Pursuit's CSS, with a minor change made via
inline styles where we want to differ slightly from what Pursuit does in
the header.

We also generate an 'index.html' file with a list of all the modules in
the documentation bundle.

---

This is a WIP, because there's just one thing left to do: sort out what the CLI should look like. Ideally it would be similar to the Markdown one (which I have wanted to do something about for a long time, because the `--docgen` option's API feels like a bit of a hack to me). The issue stems from the fact that (IMO) you always want to generate HTML for everything so that links work, whereas with Markdown you might not necessarily want to do that.

Speaking of which, do we want to continue to support producing Markdown in `purs docs` after this?