### PR TITLE
Add back .psci file support

### DIFF
--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -363,7 +363,7 @@ command = loop <$> options
                           case parseCommand l of
                             Left err -> liftIO (putStrLn err >> exitFailure)
                             Right cmd@Import{} -> handleCommand' state cmd
-                            Right _ -> liftIO (putStrLn "Only import declarations are supported in the .psci file" >> exitFailure)
+                            Right _ -> liftIO (putStrLn "The .psci file only supports import declarations")
 
                     handleCommandWithInterrupts
                       :: state

--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -30,6 +30,7 @@ import           Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 import           Control.Monad.Trans.State.Strict (StateT, evalStateT)
 import           Control.Monad.Trans.Reader (ReaderT, runReaderT)
 import           Data.FileEmbed (embedStringFile)
+import           Data.Foldable (for_)
 import           Data.Monoid ((<>))
 import           Data.String (IsString(..))
 import           Data.Text (Text, unpack)
@@ -48,6 +49,7 @@ import qualified Options.Applicative as Opts
 import           System.Console.Haskeline
 import           System.IO.UTF8 (readUTF8File)
 import           System.Exit
+import           System.Directory (doesFileExist, getCurrentDirectory)
 import           System.FilePath ((</>))
 import           System.FilePath.Glob (glob)
 import           System.Process (readProcessWithExitCode)
@@ -331,6 +333,9 @@ command = loop <$> options
                              . flip evalStateT initialState
                              . runInputT (setComplete completion settings)
 
+                    handleCommand' :: state -> Command -> StateT PSCiState (ReaderT PSCiConfig IO) ()
+                    handleCommand' state = handleCommand (liftIO . eval state) (liftIO (reload state))
+
                     go :: state -> InputT (StateT PSCiState (ReaderT PSCiConfig IO)) ()
                     go state = do
                       c <- getCommand
@@ -347,14 +352,27 @@ command = loop <$> options
                           liftIO $ shutdown state
                         Right (Just c') -> handleCommandWithInterrupts state c'
 
+                    loadUserConfig :: state -> StateT PSCiState (ReaderT PSCiConfig IO) ()
+                    loadUserConfig state = do
+                      configFile <- (</> ".psci") <$> liftIO getCurrentDirectory
+                      exists <- liftIO $ doesFileExist configFile
+                      when exists $ do
+                        ls <- lines <$> liftIO (readUTF8File configFile)
+                        for_ ls $ \l -> do
+                          liftIO (putStrLn l)
+                          case parseCommand l of
+                            Left err -> liftIO (putStrLn err >> exitFailure)
+                            Right cmd -> handleCommand' state cmd
+
                     handleCommandWithInterrupts
                       :: state
                       -> Command
                       -> InputT (StateT PSCiState (ReaderT PSCiConfig IO)) ()
                     handleCommandWithInterrupts state cmd = do
                       handleInterrupt (outputStrLn "Interrupted.")
-                                      (withInterrupt (lift (handleCommand (liftIO . eval state) (liftIO (reload state)) cmd)))
+                                      (withInterrupt (lift (handleCommand' state cmd)))
                       go state
 
                 putStrLn prologueMessage
-                setup >>= runner . go
+                backendState <- setup
+                runner (lift (loadUserConfig backendState) >> go backendState)

--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -354,7 +354,7 @@ command = loop <$> options
 
                     loadUserConfig :: state -> StateT PSCiState (ReaderT PSCiConfig IO) ()
                     loadUserConfig state = do
-                      configFile <- (</> ".psci") <$> liftIO getCurrentDirectory
+                      configFile <- (</> ".purs-repl") <$> liftIO getCurrentDirectory
                       exists <- liftIO $ doesFileExist configFile
                       when exists $ do
                         ls <- lines <$> liftIO (readUTF8File configFile)
@@ -363,7 +363,7 @@ command = loop <$> options
                           case parseCommand l of
                             Left err -> liftIO (putStrLn err >> exitFailure)
                             Right cmd@Import{} -> handleCommand' state cmd
-                            Right _ -> liftIO (putStrLn "The .psci file only supports import declarations")
+                            Right _ -> liftIO (putStrLn "The .purs-repl file only supports import declarations")
 
                     handleCommandWithInterrupts
                       :: state

--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -362,7 +362,8 @@ command = loop <$> options
                           liftIO (putStrLn l)
                           case parseCommand l of
                             Left err -> liftIO (putStrLn err >> exitFailure)
-                            Right cmd -> handleCommand' state cmd
+                            Right cmd@Import{} -> handleCommand' state cmd
+                            Right _ -> liftIO (putStrLn "Only import declarations are supported in the .psci file" >> exitFailure)
 
                     handleCommandWithInterrupts
                       :: state


### PR DESCRIPTION
Fixes #2734

It looks like this:

```
$ echo "import Prelude" > .psci
$ psc-package repl
PSCi, version 0.11.0
Type :? for help

import Prelude
> 1 + 1
2
```

cc @chexxor