### PR TITLE
WIP - Imperative core expressions and statements

### DIFF
--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -1,7 +1,11 @@
--- | Pretty printer for the JavaScript AST
+{-# LANGUAGE GADTs #-}
+
+-- | Pretty printer for the JavaScript AST 'Expression (Maybe SourceSpan)
 module Language.PureScript.CodeGen.JS.Printer
-  ( prettyPrintJS
-  , prettyPrintJSWithSourceMaps
+  ( prettyPrintStatement
+  , prettyPrintStatementsAsText
+  , prettyPrintStatementsWithSourceMaps
+  , prettyPrintExpression
   ) where
 
 import Prelude.Compat
@@ -27,27 +31,100 @@ import Language.PureScript.PSString (PSString, decodeString, prettyPrintStringJS
 
 -- TODO (Christoph): Get rid of T.unpack / pack
 
-literals :: (Emit gen) => Pattern PrinterState AST gen
-literals = mkPattern' match'
-  where
-  match' :: (Emit gen) => AST -> StateT PrinterState Maybe gen
+prettyPrintStatement :: Emit gen => AST 'Statement (Maybe SourceSpan) -> StateT PrinterState Maybe gen
+prettyPrintStatement (VariableIntroduction _ ident value) = mconcat <$> sequence
+  [ return $ emit $ "var " <> ident
+  , maybe (return mempty) (fmap (emit " = " <>) . prettyPrintExpression) value
+  ]
+prettyPrintStatement (Assignment _ target value) = mconcat <$> sequence
+  [ prettyPrintExpression target
+  , return $ emit " = "
+  , prettyPrintExpression value
+  ]
+prettyPrintStatement (While _ cond sts) = mconcat <$> sequence
+  [ return $ emit "while ("
+  , prettyPrintExpression cond
+  , return $ emit ") "
+  , prettyPrintStatement sts
+  ]
+prettyPrintStatement (For _ ident start end sts) = mconcat <$> sequence
+  [ return $ emit $ "for (var " <> ident <> " = "
+  , prettyPrintExpression start
+  , return $ emit $ "; " <> ident <> " < "
+  , prettyPrintExpression end
+  , return $ emit $ "; " <> ident <> "++) "
+  , prettyPrintStatement sts
+  ]
+prettyPrintStatement (ForIn _ ident obj sts) = mconcat <$> sequence
+  [ return $ emit $ "for (var " <> ident <> " in "
+  , prettyPrintExpression obj
+  , return $ emit ") "
+  , prettyPrintStatement sts
+  ]
+prettyPrintStatement (IfElse _ cond thens elses) = mconcat <$> sequence
+  [ return $ emit "if ("
+  , prettyPrintExpression cond
+  , return $ emit ") "
+  , prettyPrintStatement thens
+  , maybe (return mempty) (fmap (emit " else " <>) . prettyPrintStatement) elses
+  ]
+prettyPrintStatement (Return _ value) = mconcat <$> sequence
+  [ return $ emit "return "
+  , prettyPrintExpression value
+  ]
+prettyPrintStatement (ReturnNoResult _) = return $ emit "return"
+prettyPrintStatement (Throw _ value) = mconcat <$> sequence
+  [ return $ emit "throw "
+  , prettyPrintExpression value
+  ]
+prettyPrintStatement (Block _ sts) = mconcat <$> sequence
+  [ return $ emit "{\n"
+  , withIndent $ prettyPrintStatements sts
+  , return $ emit "\n"
+  , currentIndent
+  , return $ emit "}"
+  ]
+prettyPrintStatement (MethodCall _ e) = prettyPrintExpression e
+prettyPrintStatement (Comment _ com js) = mconcat <$> sequence
+  [ mconcat <$> forM com comment
+  , prettyPrintStatement js
+  ]
+
+prettyPrintStatements :: Emit gen => [AST 'Statement (Maybe SourceSpan)] -> StateT PrinterState Maybe gen
+prettyPrintStatements sts = do
+  jss <- forM sts prettyPrintStatement
+  indentString <- currentIndent
+  return $ intercalate (emit "\n") $ map ((<> emit ";") . (indentString <>)) jss
+
+-- | Generate a pretty-printed string representing a collection of JavaScript expressions at the same indentation level
+prettyPrintStatementsWithSourceMaps :: [AST 'Statement (Maybe SourceSpan)] -> (Text, [SMap])
+prettyPrintStatementsWithSourceMaps js =
+  let StrPos (_, s, mp) = (fromMaybe (internalError "Incomplete pattern") . flip evalStateT (PrinterState 0) . prettyPrintStatements) js
+  in (s, mp)
+
+prettyPrintStatementsAsText :: [AST 'Statement (Maybe SourceSpan)] -> Text
+prettyPrintStatementsAsText = maybe (internalError "Incomplete pattern") runPlainString . flip evalStateT (PrinterState 0) . prettyPrintStatements
+
+literals :: Emit gen => Pattern PrinterState (AST 'Expression (Maybe SourceSpan)) gen
+literals = mkPattern' match' where
+  match' :: Emit gen => AST 'Expression (Maybe SourceSpan) -> StateT PrinterState Maybe gen
   match' js = (addMapping' (getSourceSpan js) <>) <$> match js
 
-  match :: (Emit gen) => AST -> StateT PrinterState Maybe gen
+  match :: Emit gen => AST 'Expression (Maybe SourceSpan) -> StateT PrinterState Maybe gen
   match (NumericLiteral _ n) = return $ emit $ T.pack $ either show show n
   match (StringLiteral _ s) = return $ emit $ prettyPrintStringJS s
   match (BooleanLiteral _ True) = return $ emit "true"
   match (BooleanLiteral _ False) = return $ emit "false"
   match (ArrayLiteral _ xs) = mconcat <$> sequence
     [ return $ emit "[ "
-    , intercalate (emit ", ") <$> forM xs prettyPrintJS'
+    , intercalate (emit ", ") <$> forM xs prettyPrintExpression
     , return $ emit " ]"
     ]
   match (ObjectLiteral _ []) = return $ emit "{}"
   match (ObjectLiteral _ ps) = mconcat <$> sequence
     [ return $ emit "{\n"
     , withIndent $ do
-        jss <- forM ps $ \(key, value) -> fmap ((objectPropertyToString key <> emit ": ") <>) . prettyPrintJS' $ value
+        jss <- forM ps $ \(key, value) -> fmap ((objectPropertyToString key <> emit ": ") <>) . prettyPrintExpression $ value
         indentString <- currentIndent
         return $ intercalate (emit ", \n") $ map (indentString <>) jss
     , return $ emit "\n"
@@ -55,79 +132,23 @@ literals = mkPattern' match'
     , return $ emit "}"
     ]
     where
-    objectPropertyToString :: (Emit gen) => PSString -> gen
+    objectPropertyToString :: Emit gen => PSString -> gen
     objectPropertyToString s =
       emit $ case decodeString s of
         Just s' | not (identNeedsEscaping s') ->
           s'
         _ ->
           prettyPrintStringJS s
-  match (Block _ sts) = mconcat <$> sequence
-    [ return $ emit "{\n"
-    , withIndent $ prettyStatements sts
-    , return $ emit "\n"
-    , currentIndent
-    , return $ emit "}"
-    ]
   match (Var _ ident) = return $ emit ident
-  match (VariableIntroduction _ ident value) = mconcat <$> sequence
-    [ return $ emit $ "var " <> ident
-    , maybe (return mempty) (fmap (emit " = " <>) . prettyPrintJS') value
-    ]
-  match (Assignment _ target value) = mconcat <$> sequence
-    [ prettyPrintJS' target
-    , return $ emit " = "
-    , prettyPrintJS' value
-    ]
-  match (While _ cond sts) = mconcat <$> sequence
-    [ return $ emit "while ("
-    , prettyPrintJS' cond
-    , return $ emit ") "
-    , prettyPrintJS' sts
-    ]
-  match (For _ ident start end sts) = mconcat <$> sequence
-    [ return $ emit $ "for (var " <> ident <> " = "
-    , prettyPrintJS' start
-    , return $ emit $ "; " <> ident <> " < "
-    , prettyPrintJS' end
-    , return $ emit $ "; " <> ident <> "++) "
-    , prettyPrintJS' sts
-    ]
-  match (ForIn _ ident obj sts) = mconcat <$> sequence
-    [ return $ emit $ "for (var " <> ident <> " in "
-    , prettyPrintJS' obj
-    , return $ emit ") "
-    , prettyPrintJS' sts
-    ]
-  match (IfElse _ cond thens elses) = mconcat <$> sequence
-    [ return $ emit "if ("
-    , prettyPrintJS' cond
-    , return $ emit ") "
-    , prettyPrintJS' thens
-    , maybe (return mempty) (fmap (emit " else " <>) . prettyPrintJS') elses
-    ]
-  match (Return _ value) = mconcat <$> sequence
-    [ return $ emit "return "
-    , prettyPrintJS' value
-    ]
-  match (ReturnNoResult _) = return $ emit "return"
-  match (Throw _ value) = mconcat <$> sequence
-    [ return $ emit "throw "
-    , prettyPrintJS' value
-    ]
-  match (Comment _ com js) = mconcat <$> sequence
-    [ mconcat <$> forM com comment
-    , prettyPrintJS' js
-    ]
   match _ = mzero
 
-  comment :: (Emit gen) => Comment -> StateT PrinterState Maybe gen
-  comment (LineComment com) = fmap mconcat $ sequence $
-    [ return $ emit "\n"
-    , currentIndent
-    , return $ emit "//" <> emit com <> emit "\n"
-    ]
-  comment (BlockComment com) = fmap mconcat $ sequence $
+comment :: Emit gen => Comment -> StateT PrinterState Maybe gen
+comment (LineComment com) = fmap mconcat $ sequence $
+  [ return $ emit "\n"
+  , currentIndent
+  , return $ emit "//" <> emit com <> emit "\n"
+  ]
+comment (BlockComment com) = fmap mconcat $ sequence $
     [ return $ emit "\n"
     , currentIndent
     , return $ emit "/**\n"
@@ -137,8 +158,8 @@ literals = mkPattern' match'
     , return $ emit " */\n"
     , currentIndent
     ]
-    where
-    asLine :: (Emit gen) => Text -> StateT PrinterState Maybe gen
+  where
+    asLine :: Emit gen => Text -> StateT PrinterState Maybe gen
     asLine s = do
       i <- currentIndent
       return $ i <> emit " * " <> (emit . removeComments) s <> emit "\n"
@@ -151,101 +172,95 @@ literals = mkPattern' match'
           Just (x, xs) -> x `T.cons` removeComments xs
           Nothing -> ""
 
-accessor :: Pattern PrinterState AST (Text, AST)
-accessor = mkPattern match
-  where
+accessor :: Pattern PrinterState (AST 'Expression (Maybe SourceSpan)) (Text, AST 'Expression (Maybe SourceSpan))
+accessor = mkPattern match where
+  match :: AST 'Expression (Maybe SourceSpan) -> Maybe (Text, AST 'Expression (Maybe SourceSpan))
   match (Indexer _ (StringLiteral _ prop) val) =
     case decodeString prop of
       Just s | not (identNeedsEscaping s) -> Just (s, val)
       _ -> Nothing
   match _ = Nothing
 
-indexer :: (Emit gen) => Pattern PrinterState AST (gen, AST)
-indexer = mkPattern' match
-  where
-  match (Indexer _ index val) = (,) <$> prettyPrintJS' index <*> pure val
+indexer :: Emit gen => Pattern PrinterState (AST 'Expression (Maybe SourceSpan)) (gen, AST 'Expression (Maybe SourceSpan))
+indexer = mkPattern' match where
+  match (Indexer _ index val) = (,) <$> prettyPrintExpression index <*> pure val
   match _ = mzero
 
-lam :: Pattern PrinterState AST ((Maybe Text, [Text], Maybe SourceSpan), AST)
-lam = mkPattern match
-  where
-  match (Function ss name args ret) = Just ((name, args, ss), ret)
-  match _ = Nothing
-
-app :: (Emit gen) => Pattern PrinterState AST (gen, AST)
-app = mkPattern' match
-  where
+app :: Emit gen => Pattern PrinterState (AST 'Expression (Maybe SourceSpan)) (gen, AST 'Expression (Maybe SourceSpan))
+app = mkPattern' match where
   match (App _ val args) = do
-    jss <- traverse prettyPrintJS' args
+    jss <- traverse prettyPrintExpression args
     return (intercalate (emit ", ") jss, val)
   match _ = mzero
 
-instanceOf :: Pattern PrinterState AST (AST, AST)
-instanceOf = mkPattern match
-  where
+instanceOf :: Pattern PrinterState (AST 'Expression (Maybe SourceSpan)) (AST 'Expression (Maybe SourceSpan), AST 'Expression (Maybe SourceSpan))
+instanceOf = mkPattern match where
+  match :: AST 'Expression (Maybe SourceSpan) -> Maybe (AST 'Expression (Maybe SourceSpan), AST 'Expression (Maybe SourceSpan))
   match (InstanceOf _ val ty) = Just (val, ty)
   match _ = Nothing
 
-unary' :: (Emit gen) => UnaryOperator -> (AST -> Text) -> Operator PrinterState AST gen
-unary' op mkStr = Wrap match (<>)
-  where
-  match :: (Emit gen) => Pattern PrinterState AST (gen, AST)
-  match = mkPattern match'
-    where
+unary' :: forall gen. Emit gen => UnaryOperator -> (AST 'Expression (Maybe SourceSpan) -> Text) -> Operator PrinterState (AST 'Expression (Maybe SourceSpan)) gen
+unary' op mkStr = Wrap match (<>) where
+  match :: Pattern PrinterState (AST 'Expression (Maybe SourceSpan)) (gen, AST 'Expression (Maybe SourceSpan))
+  match = mkPattern match' where
     match' (Unary _ op' val) | op' == op = Just (emit $ mkStr val, val)
     match' _ = Nothing
 
-unary :: (Emit gen) => UnaryOperator -> Text -> Operator PrinterState AST gen
+unary :: Emit gen => UnaryOperator -> Text -> Operator PrinterState (AST 'Expression (Maybe SourceSpan)) gen
 unary op str = unary' op (const str)
 
-negateOperator :: (Emit gen) => Operator PrinterState AST gen
+negateOperator :: Emit gen => Operator PrinterState (AST 'Expression (Maybe SourceSpan)) gen
 negateOperator = unary' Negate (\v -> if isNegate v then "- " else "-")
   where
   isNegate (Unary _ Negate _) = True
   isNegate _ = False
 
-binary :: (Emit gen) => BinaryOperator -> Text -> Operator PrinterState AST gen
+binary :: Emit gen => BinaryOperator -> Text -> Operator PrinterState (AST 'Expression (Maybe SourceSpan)) gen
 binary op str = AssocL match (\v1 v2 -> v1 <> emit (" " <> str <> " ") <> v2)
   where
-  match :: Pattern PrinterState AST (AST, AST)
+  match :: Pattern PrinterState (AST 'Expression (Maybe SourceSpan)) (AST 'Expression (Maybe SourceSpan), AST 'Expression (Maybe SourceSpan))
   match = mkPattern match'
     where
     match' (Binary _ op' v1 v2) | op' == op = Just (v1, v2)
     match' _ = Nothing
 
-prettyStatements :: (Emit gen) => [AST] -> StateT PrinterState Maybe gen
-prettyStatements sts = do
-  jss <- forM sts prettyPrintJS'
-  indentString <- currentIndent
-  return $ intercalate (emit "\n") $ map ((<> emit ";") . (indentString <>)) jss
-
--- | Generate a pretty-printed string representing a collection of JavaScript expressions at the same indentation level
-prettyPrintJSWithSourceMaps :: [AST] -> (Text, [SMap])
-prettyPrintJSWithSourceMaps js =
-  let StrPos (_, s, mp) = (fromMaybe (internalError "Incomplete pattern") . flip evalStateT (PrinterState 0) . prettyStatements) js
-  in (s, mp)
-
-prettyPrintJS :: [AST] -> Text
-prettyPrintJS = maybe (internalError "Incomplete pattern") runPlainString . flip evalStateT (PrinterState 0) . prettyStatements
-
 -- | Generate an indented, pretty-printed string representing a JavaScript expression
-prettyPrintJS' :: (Emit gen) => AST -> StateT PrinterState Maybe gen
-prettyPrintJS' = A.runKleisli $ runPattern matchValue
-  where
-  matchValue :: (Emit gen) => Pattern PrinterState AST gen
-  matchValue = buildPrettyPrinter operators (literals <+> fmap parensPos matchValue)
-  operators :: (Emit gen) => OperatorTable PrinterState AST gen
-  operators =
+prettyPrintExpression :: forall gen. Emit gen => AST 'Expression (Maybe SourceSpan) -> StateT PrinterState Maybe gen
+prettyPrintExpression = A.runKleisli $ runPattern matchValue where
+  matchValue :: Emit gen => Pattern PrinterState (AST 'Expression (Maybe SourceSpan)) gen
+  matchValue =
+    buildPrettyPrinter operators2
+      (matchLam
+        (buildPrettyPrinter operators1 (literals <+> fmap parensPos matchValue)))
+
+  -- This is a bit of a hack. Solving it properly would require changing
+  -- the pattern-arrows library to allow stateful functions in the argument to
+  -- 'Wrap'. For now, we just break the operator table into two parts.
+  matchLam
+    :: Pattern PrinterState (AST 'Expression (Maybe SourceSpan)) gen
+    -> Pattern PrinterState (AST 'Expression (Maybe SourceSpan)) gen
+  matchLam p = mkPattern' match <+> p where
+    match :: AST 'Expression (Maybe SourceSpan) -> StateT PrinterState Maybe gen
+    match (Function ss name args ret) = do
+      retgen <- prettyPrintStatement ret
+      pure $ addMapping' ss <>
+        emit ("function "
+          <> fromMaybe "" name
+          <> "(" <> intercalate ", " args <> ") ")
+          <> retgen
+    match _ = mzero
+
+  operators1 :: OperatorTable PrinterState (AST 'Expression (Maybe SourceSpan)) gen
+  operators1 =
     OperatorTable [ [ Wrap indexer $ \index val -> val <> emit "[" <> index <> emit "]" ]
                   , [ Wrap accessor $ \prop val -> val <> emit "." <> emit prop ]
                   , [ Wrap app $ \args val -> val <> emit "(" <> args <> emit ")" ]
                   , [ unary New "new " ]
-                  , [ Wrap lam $ \(name, args, ss) ret -> addMapping' ss <>
-                      emit ("function "
-                        <> fromMaybe "" name
-                        <> "(" <> intercalate ", " args <> ") ")
-                        <> ret ]
-                  , [ unary     Not                  "!"
+                  ]
+
+  operators2 :: OperatorTable PrinterState (AST 'Expression (Maybe SourceSpan)) gen
+  operators2 =
+    OperatorTable [ [ unary     Not                  "!"
                     , unary     BitwiseNot           "~"
                     , unary     Positive             "+"
                     , negateOperator ]

--- a/src/Language/PureScript/CoreImp/Optimizer.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer.hs
@@ -31,7 +31,7 @@ import Language.PureScript.CoreImp.Optimizer.TCO
 import Language.PureScript.CoreImp.Optimizer.Unused
 
 -- | Apply a series of optimizer passes to simplified JavaScript code
-optimize :: MonadSupply m => AST -> m AST
+optimize :: (MonadSupply m, Eq ann) => AST ty (Maybe ann) -> m (AST ty (Maybe ann))
 optimize js = do
     js' <- untilFixedPoint (inlineFnComposition . inlineUnsafePartial . tidyUp . applyAll
       [ inlineCommonValues
@@ -39,7 +39,7 @@ optimize js = do
       ]) js
     untilFixedPoint (return . tidyUp) . tco . magicDo $ js'
   where
-    tidyUp :: AST -> AST
+    tidyUp :: AST ty (Maybe ann) -> AST ty (Maybe ann)
     tidyUp = applyAll
       [ collapseNestedBlocks
       , collapseNestedIfs

--- a/src/Language/PureScript/CoreImp/Optimizer/Blocks.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Blocks.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+
 -- | Optimizer steps for simplifying JavaScript blocks
 module Language.PureScript.CoreImp.Optimizer.Blocks
   ( collapseNestedBlocks
@@ -9,20 +11,19 @@ import Prelude.Compat
 import Language.PureScript.CoreImp.AST
 
 -- | Collapse blocks which appear nested directly below another block
-collapseNestedBlocks :: AST -> AST
-collapseNestedBlocks = everywhere collapse
-  where
-  collapse :: AST -> AST
+collapseNestedBlocks :: AST ty ann -> AST ty ann
+collapseNestedBlocks = everywhere collapse where
+  collapse :: AST ty ann -> AST ty ann
   collapse (Block ss sts) = Block ss (concatMap go sts)
   collapse js = js
-  go :: AST -> [AST]
+
+  go :: AST ty ann -> [AST ty ann]
   go (Block _ sts) = sts
   go s = [s]
 
-collapseNestedIfs :: AST -> AST
-collapseNestedIfs = everywhere collapse
-  where
-  collapse :: AST -> AST
+collapseNestedIfs :: AST ty ann -> AST ty ann
+collapseNestedIfs = everywhere collapse where
+  collapse :: AST ty ann -> AST ty ann
   collapse (IfElse s1 cond1 (Block _ [IfElse s2 cond2 body Nothing]) Nothing) =
       IfElse s1 (Binary s2 And cond1 cond2) body Nothing
   collapse js = js

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 -- | This module implements the "Magic Do" optimization, which inlines calls to return
 -- and bind for the Eff monad, as well as some of its actions.
 module Language.PureScript.CoreImp.Optimizer.MagicDo (magicDo) where
@@ -6,10 +9,12 @@ import Prelude.Compat
 import Protolude (ordNub)
 
 import Data.Maybe (fromJust, isJust)
+import Data.String (IsString)
+import Data.Text (Text)
 
 import Language.PureScript.CoreImp.AST
 import Language.PureScript.CoreImp.Optimizer.Common
-import Language.PureScript.PSString (mkString)
+import Language.PureScript.PSString (PSString, mkString)
 import qualified Language.PureScript.Constants as C
 
 -- | Inline type class dictionaries for >>= and return for the Eff monad
@@ -26,18 +31,19 @@ import qualified Language.PureScript.Constants as C
 --    var x = m1();
 --    ...
 --  }
-magicDo :: AST -> AST
-magicDo = inlineST . everywhere undo . everywhereTopDown convert
-  where
+magicDo :: AST ty ann -> AST ty ann
+magicDo = inlineST . everywhere undo . everywhereTopDown convert where
   -- The name of the function block which is added to denote a do block
+  fnName :: IsString s => s
   fnName = "__do"
+
   -- Desugar monomorphic calls to >>= and return for the Eff monad
-  convert :: AST -> AST
+  convert :: AST ty ann -> AST ty ann
   -- Desugar pure
   convert (App _ (App _ pure' [val]) []) | isPure pure' = val
   -- Desugar discard
   convert (App _ (App _ bind [m]) [Function s1 Nothing [] (Block s2 js)]) | isDiscard bind =
-    Function s1 (Just fnName) [] $ Block s2 (App s2 m [] : map applyReturns js )
+    Function s1 (Just fnName) [] $ Block s2 (MethodCall s2 (App s2 m []) : map applyReturns js )
   -- Desugar bind
   convert (App _ (App _ bind [m]) [Function s1 Nothing [arg] (Block s2 js)]) | isBind bind =
     Function s1 (Just fnName) [] $ Block s2 (VariableIntroduction s2 arg (Just (App s2 m [])) : map applyReturns js)
@@ -46,36 +52,50 @@ magicDo = inlineST . everywhere undo . everywhereTopDown convert
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (Unary s1 Not (App s1 arg [])) (Block s1 []), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar whileE
   convert (App _ (App _ (App s1 f [arg1]) [arg2]) []) | isEffFunc C.whileE f =
-    App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
+    App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ MethodCall s1 (App s1 arg2 []) ]), Return s1 $ ObjectLiteral s1 []])) []
   convert other = other
+
   -- Check if an expression represents a monomorphic call to >>= for the Eff monad
+  isBind :: AST 'Expression ann -> Bool
   isBind (App _ fn [dict]) | isDict (C.eff, C.bindEffDictionary) dict && isBindPoly fn = True
   isBind _ = False
+
   -- Check if an expression represents a call to @discard@
+  isDiscard :: AST 'Expression ann -> Bool
   isDiscard (App _ (App _ fn [dict1]) [dict2])
     | isDict (C.controlBind, C.discardUnitDictionary) dict1 &&
       isDict (C.eff, C.bindEffDictionary) dict2 &&
       isDiscardPoly fn = True
   isDiscard _ = False
+
   -- Check if an expression represents a monomorphic call to pure or return for the Eff applicative
+  isPure :: AST 'Expression ann -> Bool
   isPure (App _ fn [dict]) | isDict (C.eff, C.applicativeEffDictionary) dict && isPurePoly fn = True
   isPure _ = False
+
   -- Check if an expression represents the polymorphic >>= function
+  isBindPoly :: AST 'Expression ann -> Bool
   isBindPoly = isDict (C.controlBind, C.bind)
+
   -- Check if an expression represents the polymorphic pure function
+  isPurePoly :: AST 'Expression ann -> Bool
   isPurePoly = isDict (C.controlApplicative, C.pure')
+
   -- Check if an expression represents the polymorphic discard function
+  isDiscardPoly :: AST 'Expression ann -> Bool
   isDiscardPoly = isDict (C.controlBind, C.discard)
+
   -- Check if an expression represents a function in the Eff module
+  isEffFunc :: PSString -> AST 'Expression ann -> Bool
   isEffFunc name (Indexer _ (StringLiteral _ name') (Var _ eff)) = eff == C.eff && name == name'
   isEffFunc _ _ = False
 
   -- Remove __do function applications which remain after desugaring
-  undo :: AST -> AST
+  undo :: AST ty ann -> AST ty ann
   undo (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body
   undo other = other
 
-  applyReturns :: AST -> AST
+  applyReturns :: AST ty ann -> AST ty ann
   applyReturns (Return ss ret) = Return ss (App ss ret [])
   applyReturns (Block ss jss) = Block ss (map applyReturns jss)
   applyReturns (While ss cond js) = While ss cond (applyReturns js)
@@ -85,50 +105,62 @@ magicDo = inlineST . everywhere undo . everywhereTopDown convert
   applyReturns other = other
 
 -- | Inline functions in the ST module
-inlineST :: AST -> AST
-inlineST = everywhere convertBlock
-  where
+inlineST :: AST ty ann -> AST ty ann
+inlineST = everywhere convertBlock where
   -- Look for runST blocks and inline the STRefs there.
   -- If all STRefs are used in the scope of the same runST, only using { read, write, modify }STRef then
   -- we can be more aggressive about inlining, and actually turn STRefs into local variables.
+  convertBlock :: AST ty ann -> AST ty ann
   convertBlock (App _ f [arg]) | isSTFunc C.runST f =
     let refs = ordNub . findSTRefsIn $ arg
         usages = findAllSTUsagesIn arg
         allUsagesAreLocalVars = all (\u -> let v = toVar u in isJust v && fromJust v `elem` refs) usages
         localVarsDoNotEscape = all (\r -> length (r `appearingIn` arg) == length (filter (\u -> let v = toVar u in v == Just r) usages)) refs
-    in everywhere (convert (allUsagesAreLocalVars && localVarsDoNotEscape)) arg
+    in everywhere (convert (False && allUsagesAreLocalVars && localVarsDoNotEscape)) arg
   convertBlock other = other
+
   -- Convert a block in a safe way, preserving object wrappers of references,
   -- or in a more aggressive way, turning wrappers into local variables depending on the
   -- agg(ressive) parameter.
+  convert :: Bool -> AST ty ann -> AST ty ann
   convert agg (App s1 f [arg]) | isSTFunc C.newSTRef f =
    Function s1 Nothing [] (Block s1 [Return s1 $ if agg then arg else ObjectLiteral s1 [(mkString C.stRefValue, arg)]])
   convert agg (App _ (App s1 f [ref]) []) | isSTFunc C.readSTRef f =
     if agg then ref else Indexer s1 (StringLiteral s1 C.stRefValue) ref
-  convert agg (App _ (App _ (App s1 f [ref]) [arg]) []) | isSTFunc C.writeSTRef f =
+  convert agg (MethodCall _ (App _ (App _ (App s1 f [ref]) [arg]) [])) | isSTFunc C.writeSTRef f =
     if agg then Assignment s1 ref arg else Assignment s1 (Indexer s1 (StringLiteral s1 C.stRefValue) ref) arg
-  convert agg (App _ (App _ (App s1 f [ref]) [func]) []) | isSTFunc C.modifySTRef f =
+  convert agg (MethodCall _ (App _ (App _ (App s1 f [ref]) [func]) [])) | isSTFunc C.modifySTRef f =
     if agg then Assignment s1 ref (App s1 func [ref]) else Assignment s1 (Indexer s1 (StringLiteral s1 C.stRefValue) ref) (App s1 func [Indexer s1 (StringLiteral s1 C.stRefValue) ref])
   convert _ other = other
+
   -- Check if an expression represents a function in the ST module
+  isSTFunc :: PSString -> AST 'Expression ann -> Bool
   isSTFunc name (Indexer _ (StringLiteral _ name') (Var _ st)) = st == C.st && name == name'
   isSTFunc _ _ = False
+
   -- Find all ST Refs initialized in this block
-  findSTRefsIn = everything (++) isSTRef
-    where
+  findSTRefsIn :: AST ty ann -> [Text]
+  findSTRefsIn = everything (++) isSTRef where
+    isSTRef :: AST ty ann -> [Text]
     isSTRef (VariableIntroduction _ ident (Just (App _ (App _ f [_]) []))) | isSTFunc C.newSTRef f = [ident]
     isSTRef _ = []
+
   -- Find all STRefs used as arguments to readSTRef, writeSTRef, modifySTRef
-  findAllSTUsagesIn = everything (++) isSTUsage
-    where
+  findAllSTUsagesIn :: AST ty ann -> [AST 'Expression ann]
+  findAllSTUsagesIn = everything (++) isSTUsage where
+    isSTUsage :: AST ty ann -> [AST 'Expression ann]
     isSTUsage (App _ (App _ f [ref]) []) | isSTFunc C.readSTRef f = [ref]
     isSTUsage (App _ (App _ (App _ f [ref]) [_]) []) | isSTFunc C.writeSTRef f || isSTFunc C.modifySTRef f = [ref]
     isSTUsage _ = []
+
   -- Find all uses of a variable
-  appearingIn ref = everything (++) isVar
-    where
+  appearingIn :: Text -> AST ty ann -> [AST 'Expression ann]
+  appearingIn ref = everything (++) isVar where
+    isVar :: AST ty ann -> [AST 'Expression ann]
     isVar e@(Var _ v) | v == ref = [e]
     isVar _ = []
+
   -- Convert a AST value to a String if it is a Var
+  toVar :: AST 'Expression ann -> Maybe Text
   toVar (Var _ v) = Just v
   toVar _ = Nothing

--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+
 -- | This module implements tail call elimination.
 module Language.PureScript.CoreImp.Optimizer.TCO (tco) where
 
@@ -6,10 +8,9 @@ import Prelude.Compat
 import Data.Text (Text)
 import Data.Monoid ((<>))
 import Language.PureScript.CoreImp.AST
-import Language.PureScript.AST.SourcePos (SourceSpan)
 
 -- | Eliminate tail calls
-tco :: AST -> AST
+tco :: AST ty ann -> AST ty ann
 tco = everywhere convert where
   tcoVar :: Text -> Text
   tcoVar arg = "__tco_" <> arg
@@ -26,33 +27,34 @@ tco = everywhere convert where
   tcoResult :: Text
   tcoResult = tcoVar "result"
 
-  convert :: AST -> AST
-  convert (VariableIntroduction ss name (Just fn@Function {}))
+  convert :: AST ty ann -> AST ty ann
+  convert (VariableIntroduction ss name (Just fn@Function{}))
       | isTailRecursive name body'
-      = VariableIntroduction ss name (Just (replace (toLoop name allArgs body')))
+      = VariableIntroduction ss name (Just (replace (toLoop ss name allArgs body')))
     where
-      (argss, body', replace) = collectAllFunctionArgs [] id fn
+      (argss, body', replace) = collectAllFunctionArgs fn
       allArgs = concat $ reverse argss
   convert js = js
 
-  collectAllFunctionArgs :: [[Text]] -> (AST -> AST) -> AST -> ([[Text]], AST, AST -> AST)
-  collectAllFunctionArgs allArgs f (Function s1 ident args (Block s2 (body@(Return _ _):_))) =
-    collectAllFunctionArgs (args : allArgs) (\b -> f (Function s1 ident (map copyVar args) (Block s2 [b]))) body
-  collectAllFunctionArgs allArgs f (Function ss ident args body@(Block _ _)) =
-    (args : allArgs, body, f . Function ss ident (map copyVar args))
-  collectAllFunctionArgs allArgs f (Return s1 (Function s2 ident args (Block s3 [body]))) =
-    collectAllFunctionArgs (args : allArgs) (\b -> f (Return s1 (Function s2 ident (map copyVar args) (Block s3 [b])))) body
-  collectAllFunctionArgs allArgs f (Return s1 (Function s2 ident args body@(Block _ _))) =
-    (args : allArgs, body, f . Return s1 . Function s2 ident (map copyVar args))
-  collectAllFunctionArgs allArgs f body = (allArgs, body, f)
+  collectAllFunctionArgs
+    :: AST 'Expression ann
+    -> ([[Text]], AST 'Statement ann, AST 'Statement ann -> AST 'Expression ann)
+  collectAllFunctionArgs (Function s1 ident args (Block s2 [Return s3 fn@Function{}])) =
+    let (argss, body, replace) = collectAllFunctionArgs fn
+    in (argss ++ [args], body, \b -> Function s1 ident (map copyVar args) (Block s2 [Return s3 (replace b)]))
+  collectAllFunctionArgs (Function ss ident args body) =
+    ([args], body, Function ss ident (map copyVar args))
+  collectAllFunctionArgs _ = error "collectAllFunctionArgs: expected Function"
 
-  isTailRecursive :: Text -> AST -> Bool
+  isTailRecursive :: forall ty ann. Text -> AST ty ann -> Bool
   isTailRecursive ident js = countSelfReferences js > 0 && allInTailPosition js where
+    countSelfReferences :: forall ty1. AST ty1 ann -> Int
     countSelfReferences = everything (+) match where
-      match :: AST -> Int
+      match :: forall ty2. AST ty2 ann -> Int
       match (Var _ ident') | ident == ident' = 1
       match _ = 0
 
+    allInTailPosition :: forall ty1. AST ty1 ann -> Bool
     allInTailPosition (Return _ expr)
       | isSelfCall ident expr = countSelfReferences expr == 1
       | otherwise = countSelfReferences expr == 0
@@ -69,8 +71,8 @@ tco = everywhere convert where
     allInTailPosition _
       = False
 
-  toLoop :: Text -> [Text] -> AST -> AST
-  toLoop ident allArgs js =
+  toLoop :: ann -> Text -> [Text] -> AST 'Statement ann -> AST 'Statement ann
+  toLoop rootSS ident allArgs js =
       Block rootSS $
         map (\arg -> VariableIntroduction rootSS arg (Just (Var rootSS (copyVar arg)))) allArgs ++
         [ VariableIntroduction rootSS tcoDone (Just (BooleanLiteral rootSS False))
@@ -78,7 +80,9 @@ tco = everywhere convert where
         ] ++
         map (\arg ->
           VariableIntroduction rootSS (tcoVar arg) Nothing) allArgs ++
-        [ Function rootSS (Just tcoLoop) allArgs (Block rootSS [loopify js])
+        [ VariableIntroduction rootSS tcoLoop
+            (Just (Function rootSS (Just tcoLoop) allArgs
+              (Block rootSS [loopify js])))
         , While rootSS (Unary rootSS Not (Var rootSS tcoDone))
             (Block rootSS
               (Assignment rootSS (Var rootSS tcoResult) (App rootSS (Var rootSS tcoLoop) (map (Var rootSS) allArgs))
@@ -87,35 +91,33 @@ tco = everywhere convert where
         , Return rootSS (Var rootSS tcoResult)
         ]
     where
-    rootSS = Nothing
+      loopify :: AST ty ann -> AST ty ann
+      loopify (Return ss ret)
+        | isSelfCall ident ret =
+          let
+            allArgumentValues = concat $ collectArgs [] ret
+          in
+            Block ss $
+              zipWith (\val arg ->
+                Assignment ss (Var ss (tcoVar arg)) val) allArgumentValues allArgs
+              ++ [ ReturnNoResult ss ]
+        | otherwise = Block ss [ markDone ss, Return ss ret ]
+      loopify (ReturnNoResult ss) = Block ss [ markDone ss, ReturnNoResult ss ]
+      loopify (While ss cond body) = While ss cond (loopify body)
+      loopify (For ss i js1 js2 body) = For ss i js1 js2 (loopify body)
+      loopify (ForIn ss i js1 body) = ForIn ss i js1 (loopify body)
+      loopify (IfElse ss cond body el) = IfElse ss cond (loopify body) (fmap loopify el)
+      loopify (Block ss body) = Block ss (map loopify body)
+      loopify other = other
 
-    loopify :: AST -> AST
-    loopify (Return ss ret)
-      | isSelfCall ident ret =
-        let
-          allArgumentValues = concat $ collectArgs [] ret
-        in
-          Block ss $
-            zipWith (\val arg ->
-              Assignment ss (Var ss (tcoVar arg)) val) allArgumentValues allArgs
-            ++ [ ReturnNoResult ss ]
-      | otherwise = Block ss [ markDone ss, Return ss ret ]
-    loopify (ReturnNoResult ss) = Block ss [ markDone ss, ReturnNoResult ss ]
-    loopify (While ss cond body) = While ss cond (loopify body)
-    loopify (For ss i js1 js2 body) = For ss i js1 js2 (loopify body)
-    loopify (ForIn ss i js1 body) = ForIn ss i js1 (loopify body)
-    loopify (IfElse ss cond body el) = IfElse ss cond (loopify body) (fmap loopify el)
-    loopify (Block ss body) = Block ss (map loopify body)
-    loopify other = other
+      markDone :: ann -> AST 'Statement ann
+      markDone ss = Assignment ss (Var ss tcoDone) (BooleanLiteral ss True)
 
-    markDone :: Maybe SourceSpan -> AST
-    markDone ss = Assignment ss (Var ss tcoDone) (BooleanLiteral ss True)
+      collectArgs :: [[AST ty ann]] -> AST ty ann -> [[AST ty ann]]
+      collectArgs acc (App _ fn args') = collectArgs (args' : acc) fn
+      collectArgs acc _ = acc
 
-    collectArgs :: [[AST]] -> AST -> [[AST]]
-    collectArgs acc (App _ fn args') = collectArgs (args' : acc) fn
-    collectArgs acc _ = acc
-
-  isSelfCall :: Text -> AST -> Bool
+  isSelfCall :: Text -> AST ty ann -> Bool
   isSelfCall ident (App _ (Var _ ident') _) = ident == ident'
   isSelfCall ident (App _ fn _) = isSelfCall ident fn
   isSelfCall _ _ = False

--- a/src/Language/PureScript/CoreImp/Optimizer/Unused.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Unused.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+
 -- | Removes unused variables
 module Language.PureScript.CoreImp.Optimizer.Unused
   ( removeCodeAfterReturnStatements
@@ -11,24 +13,23 @@ import Language.PureScript.CoreImp.AST
 import Language.PureScript.CoreImp.Optimizer.Common
 import qualified Language.PureScript.Constants as C
 
-removeCodeAfterReturnStatements :: AST -> AST
-removeCodeAfterReturnStatements = everywhere (removeFromBlock go)
-  where
-  go :: [AST] -> [AST]
+removeCodeAfterReturnStatements :: AST ty ann -> AST ty ann
+removeCodeAfterReturnStatements = everywhere (removeFromBlock go) where
+  go :: [AST ty ann] -> [AST ty ann]
   go jss | not (any isReturn jss) = jss
          | otherwise = let (body, ret : _) = break isReturn jss in body ++ [ret]
   isReturn (Return _ _) = True
   isReturn (ReturnNoResult _) = True
   isReturn _ = False
 
-removeUnusedArg :: AST -> AST
-removeUnusedArg = everywhere convert
-  where
+removeUnusedArg :: AST ty ann -> AST ty ann
+removeUnusedArg = everywhere convert where
+  convert :: AST ty ann -> AST ty ann
   convert (Function ss name [arg] body) | arg == C.__unused = Function ss name [] body
   convert js = js
 
-removeUndefinedApp :: AST -> AST
-removeUndefinedApp = everywhere convert
-  where
+removeUndefinedApp :: AST ty ann -> AST ty ann
+removeUndefinedApp = everywhere convert where
+  convert :: AST ty ann -> AST ty ann
   convert (App ss fn [Var _ arg]) | arg == C.undefined = App ss fn []
   convert js = js

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -358,8 +358,11 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
     rawJs <- J.moduleToJs m foreignInclude
     dir <- lift $ makeIO (const (ErrorMessage [] $ CannotGetFileInfo ".")) getCurrentDirectory
     sourceMaps <- lift $ asks optionsSourceMaps
-    let (pjs, mappings) = if sourceMaps then prettyPrintJSWithSourceMaps rawJs else (prettyPrintJS rawJs, [])
-    let filePath = T.unpack (runModuleName mn)
+    let (pjs, mappings) =
+          if sourceMaps
+            then prettyPrintStatementsWithSourceMaps rawJs
+            else (prettyPrintStatementsAsText rawJs, [])
+        filePath = T.unpack (runModuleName mn)
         jsFile = outputDir </> filePath </> "index.js"
         mapFile = outputDir </> filePath </> "index.js.map"
         externsFile = outputDir </> filePath </> "externs.json"


### PR DESCRIPTION
Rebasing my other PR

This is still a work in progress. It should work, but notice that the "aggressive mode" of the ST inliner is disabled. I think there is an issue with `MethodCall` there.

Anyway, I wanted to try something different instead of our usual approach to traversals, so this uses a GADT to capture the different node types. This way required much less refactoring and allows us to reuse all of the existing traversals.

- [ ] Fix the ST inliner
- [ ] Find out why TCO isn't firing on `examples/passing/TailCall.purs`