### PR TITLE
Fix TCO issue when pattern matches can fail

### DIFF
--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -66,6 +66,8 @@ tco = everywhere convert where
       = countSelfReferences js1 == 0 && allInTailPosition body && all allInTailPosition el
     allInTailPosition (Block _ body)
       = all allInTailPosition body
+    allInTailPosition (Throw _ js1)
+      = countSelfReferences js1 == 0
     allInTailPosition _
       = False
 


### PR DESCRIPTION
Fixes #2738. At least, the QuickCheck tests pass again.