### PR TITLE
[purs ide] Reuses lenient import parsing for the list import command

### DIFF
--- a/psc-ide/PROTOCOL.md
+++ b/psc-ide/PROTOCOL.md
@@ -379,73 +379,73 @@ The list commmand can also list the imports for a given file.
 
 #### Response:
 
-The list import command returns a list of imports where imports are of the following form:
+The list import command returns the parse module name as well as a list of
+imports like so:
+
+```json
+
+{
+  "moduleName": "MyModule",
+  "imports": [Import]
+}
+
+The different kind of imports are returned like so:
+
+```
 
 Implicit Import (`import Data.Array`):
 ```json
-[
-  {
+{
   "module": "Data.Array",
   "importType": "implicit"
-  }
-]
+}
 ```
 
 Implicit qualified Import (`import Data.Array as A`):
 ```json
-[
-  {
+{
   "module": "Data.Array",
   "importType": "implicit",
   "qualifier": "A"
-  }
-]
+}
 ```
 
 Explicit Import (`import Data.Array (filter, filterM, join)`):
 ```json
-[
-  {
+{
   "module": "Data.Array",
   "importType": "explicit",
   "identifiers": ["filter", "filterM", "join"]
-  }
-]
+}
 ```
 
 Explicit qualified Import (`import Data.Array (filter, filterM, join) as A`):
 ```json
-[
-  {
+{
   "module": "Data.Array",
   "importType": "explicit",
   "identifiers": ["filter", "filterM", "join"],
   "qualifier": "A"
-  }
-]
+}
 ```
 
 Hiding Import (`import Data.Array hiding (filter, filterM, join)`):
 ```json
-[
-  {
+{
   "module": "Data.Array",
   "importType": "hiding",
   "identifiers": ["filter", "filterM", "join"]
-  }
-]
+}
 ```
 
 Qualified Hiding Import (`import Data.Array hiding (filter, filterM, join) as A`):
 ```json
-[
-  {
+{
   "module": "Data.Array",
   "importType": "hiding",
   "identifiers": ["filter", "filterM", "join"],
   "qualifier": "A"
-  }
-]
+}
 ```
 
 ### Cwd/Quit/Reset

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -67,7 +67,7 @@ handleCommand c = case c of
   List AvailableModules ->
     listAvailableModules
   List (Imports fp) ->
-    ImportList <$> getImportsForFile fp
+    ImportList <$> parseImportsFromFile fp
   CaseSplit l b e wca t ->
     caseSplit l b e wca t
   AddClause l wca ->


### PR DESCRIPTION
Also changes the list import commands result to return imports as well as the parsed module name, for convience for the editors.

This should finally make the list imports command useful and lift the regex burden from the editors. Should help with https://github.com/FrigoEU/psc-ide-vim/pull/24 as well.

Note that this is a breaking change, but the command wasn't really useful as it was so I figured returning the parsed module name was a nice bonus.

/cc @nwolverson @bsermons @FrigoEU @chexxor