### PR TITLE
[purs ide] Removes unnecessary clause in import pretty printing

### DIFF
--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -282,9 +282,6 @@ addImportForIdentifier fp ident filters = do
       decideRedundantCase _ _ = Nothing
 
 prettyPrintImport' :: Import -> Text
--- TODO: remove this clause once P.prettyPrintImport can properly handle PositionedRefs
-prettyPrintImport' (Import mn (P.Explicit refs) qual) =
-  "import " <> P.prettyPrintImport mn (P.Explicit (unwrapPositionedRef <$> refs)) qual
 prettyPrintImport' (Import mn idt qual) =
   "import " <> P.prettyPrintImport mn idt qual
 


### PR DESCRIPTION
The compilers prettyPrinter can now handle PositionedRefs properly