### PR TITLE
Implement evaluation test for PSCi

### DIFF
--- a/tests/TestPsci/CommandTest.hs
+++ b/tests/TestPsci/CommandTest.hs
@@ -15,21 +15,21 @@ commandTests = TestLabel "commandTests" $ TestList $ map (TestCase . runTestPSCi
       run "import Data.Functor"
       run "import Control.Monad"
       before <- psciImportedModules <$> get
-      length before @?== 3
+      length before `equalsTo` 3
       run ":clear"
       after <- psciImportedModules <$> get
-      length after @?== 0
+      length after `equalsTo` 0
   , do
       run "import Prelude"
       run "import Data.Functor"
       run "import Control.Monad"
       before <- psciImportedModules <$> get
-      length before @?== 3
+      length before `equalsTo` 3
       run ":reload"
       after <- psciImportedModules <$> get
-      length after @?== 3
+      length after `equalsTo` 3
   , do
       run "import Prelude"
       run "import Data.Array"
-      "let fac n = foldl mul 1 (1..n) in fac 10" @?=> "3628800"
+      "let fac n = foldl mul 1 (1..n) in fac 10" `evaluatesTo` "3628800"
   ]

--- a/tests/TestPsci/CommandTest.hs
+++ b/tests/TestPsci/CommandTest.hs
@@ -9,7 +9,7 @@ import Test.HUnit
 import TestPsci.TestEnv
 
 commandTests :: Test
-commandTests = TestLabel "commandTests" $ TestList $ map (TestCase . runTestPSCi)
+commandTests = TestLabel "commandTests" $ TestList $ map (TestCase . execTestPSCi)
   [ do
       run "import Prelude"
       run "import Data.Functor"

--- a/tests/TestPsci/CommandTest.hs
+++ b/tests/TestPsci/CommandTest.hs
@@ -28,4 +28,8 @@ commandTests = TestLabel "commandTests" $ TestList $ map (TestCase . runTestPSCi
       run ":reload"
       after <- psciImportedModules <$> get
       length after @?== 3
+  , do
+      run "import Prelude"
+      run "import Data.Array"
+      "let fac n = foldl mul 1 (1..n) in fac 10" @?=> "3628800"
   ]

--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -11,7 +11,7 @@ import qualified Data.Text as T
 import qualified Language.PureScript as P
 import           Language.PureScript.Interactive
 import           System.Console.Haskeline
-import           TestPsci.TestEnv (initTestPSCi)
+import           TestPsci.TestEnv (initTestPSCiEnv)
 import           TestUtils (supportModules)
 
 completionTests :: Test
@@ -98,7 +98,7 @@ runCM act = do
 
 getPSCiStateForCompletion :: IO PSCiState
 getPSCiStateForCompletion = do
-  (PSCiState _ bs es, _) <- initTestPSCi
+  (PSCiState _ bs es, _) <- initTestPSCiEnv
   let imports = [controlMonadSTasST, (P.ModuleName [P.ProperName (T.pack "Prelude")], P.Implicit, Nothing)]
   return $ PSCiState imports bs es
 

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -14,33 +14,40 @@ import qualified System.FilePath.Glob as Glob
 import           System.Process (readProcessWithExitCode)
 import           Test.HUnit ((@?=))
 
+-- | A monad transformer for handle PSCi actions in tests
 type TestPSCi a = RWST PSCiConfig () PSCiState IO a
 
-initTestPSCi :: IO (PSCiState, PSCiConfig)
-initTestPSCi = do
+-- | Initialise PSCi state and config for tests
+initTestPSCiEnv :: IO (PSCiState, PSCiConfig)
+initTestPSCiEnv = do
+  -- Load test support packages
   cwd <- getCurrentDirectory
   let supportDir = cwd </> "tests" </> "support" </> "bower_components"
   let supportFiles ext = Glob.globDir1 (Glob.compile ("purescript-*/src/**/*." ++ ext)) supportDir
   pursFiles <- supportFiles "purs"
-
-  modulesOrFirstError <- loadAllModules pursFiles
-  case modulesOrFirstError of
+  modulesOrError <- loadAllModules pursFiles
+  case modulesOrError of
     Left err ->
       print err >> exitFailure
     Right modules -> do
-      resultOrErrors <- runMake . make $ modules
-      case resultOrErrors of
+      -- Make modules
+      makeResultOrError <- runMake . make $ modules
+      case makeResultOrError of
         Left errs -> putStrLn (P.prettyPrintMultipleErrors P.defaultPPEOptions errs) >> exitFailure
         Right (externs, env) ->
           return (PSCiState [] [] (zip (map snd modules) externs), PSCiConfig pursFiles env)
 
-runTestPSCi :: TestPSCi a -> IO a
-runTestPSCi i = do
-  (s, c) <- initTestPSCi
+-- | Execute a TestPSCi, returning IO
+execTestPSCi :: TestPSCi a -> IO a
+execTestPSCi i = do
+  (s, c) <- initTestPSCiEnv -- init state and config
   fst <$> evalRWST i c s
 
-psciEval :: TestPSCi String
-psciEval = liftIO $ do
+-- | Evaluate JS to which a PSCi input is compiled. The actual JS input is not
+-- needed as an argument, as it is already written in the file during the
+-- command evaluation.
+jsEval :: TestPSCi String
+jsEval = liftIO $ do
   writeFile indexFile "require('$PSCI')['$main']();"
   process <- findNodeProcess
   result <- traverse (\node -> readProcessWithExitCode node [indexFile] "") process
@@ -49,19 +56,26 @@ psciEval = liftIO $ do
     Just (ExitFailure _, _, err) -> putStrLn err >> exitFailure
     Nothing                      -> putStrLn "Couldn't find node.js" >> exitFailure
 
-runWithEval :: String -> TestPSCi () -> TestPSCi ()
-runWithEval comm eval =
+-- | Run a PSCi command and evaluate the output with 'eval'.
+runAndEval :: String -> TestPSCi () -> TestPSCi ()
+runAndEval comm eval =
   case parseCommand comm of
     Left errStr -> liftIO $ putStrLn errStr >> exitFailure
-    Right command -> handleCommand (\_ -> eval) (return ()) command
+    Right command ->
+      -- the JS result can be ignored, as it's already written in a source file
+      -- for the detail, please refer to Interactive.hs
+      handleCommand (\_ -> eval) (return ()) command
 
+-- | Run a PSCi command and ignore the output
 run :: String -> TestPSCi ()
-run = flip runWithEval $ () <$ psciEval
+run comm = runAndEval comm $ jsEval *> return ()
 
+-- | A lifted evaluation of HUnit '@?=' for the TestPSCi
 equalsTo :: (Eq a, Show a) => a -> a -> TestPSCi ()
 equalsTo x y = liftIO $ x @?= y
 
+-- | An assertion to check if a command evaluates to a string
 evaluatesTo :: String -> String -> TestPSCi ()
-evaluatesTo command expected = runWithEval command $ do
-  actual <- psciEval
+evaluatesTo command expected = runAndEval command $ do
+  actual <- jsEval
   actual `equalsTo` (expected ++ "\n")

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -58,12 +58,12 @@ runWithEval comm eval =
 run :: String -> TestPSCi ()
 run = flip runWithEval $ () <$ psciEval
 
-(@?==) :: (Eq a, Show a) => a -> a -> TestPSCi ()
-x @?== y = liftIO $ x @?= y
+equalsTo :: (Eq a, Show a) => a -> a -> TestPSCi ()
+equalsTo x y = liftIO $ x @?= y
 
-(@?=>) :: String -> String -> TestPSCi ()
-l @?=> r = runWithEval l $ do
+evaluatesTo :: String -> String -> TestPSCi ()
+evaluatesTo l r = runWithEval l $ do
   actual <- psciEval
   runWithEval r $ do
     expected <- psciEval
-    actual @?== expected
+    actual `equalsTo` expected

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -62,8 +62,6 @@ equalsTo :: (Eq a, Show a) => a -> a -> TestPSCi ()
 equalsTo x y = liftIO $ x @?= y
 
 evaluatesTo :: String -> String -> TestPSCi ()
-evaluatesTo l r = runWithEval l $ do
+evaluatesTo command expected = runWithEval command $ do
   actual <- psciEval
-  runWithEval r $ do
-    expected <- psciEval
-    actual `equalsTo` expected
+  actual `equalsTo` (expected ++ "\n")

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -147,6 +147,7 @@ supportModules =
   , "Data.Unfoldable"
   , "Data.Unit"
   , "Data.Void"
+  , "PSCI.Support"
   , "Partial"
   , "Partial.Unsafe"
   , "Prelude"

--- a/tests/support/bower.json
+++ b/tests/support/bower.json
@@ -11,6 +11,7 @@
     "purescript-newtype": "ps-0.11",
     "purescript-partial": "1.2.0",
     "purescript-prelude": "ps-0.11",
+    "purescript-psci-support": "ps-0.11",
     "purescript-st": "ps-0.11",
     "purescript-symbols": "ps-0.11",
     "purescript-tailrec": "ps-0.11",


### PR DESCRIPTION
*Regarding #2664*

We can write evaluation tests like below:

```haskell
do
  run "import Prelude"
  run "a = 10"
  "a + 100" @?=> "110"
```

It will evaluate both left and right commands and compare the result.

The operator `@?=>` is from `@?=` of HUnit. I thought the operator looked straightforward, but please let me know if there is one more appropriate.