### PR TITLE
Normalised row primitive

### DIFF
--- a/examples/failing/RecordUnionExtra.purs
+++ b/examples/failing/RecordUnionExtra.purs
@@ -1,0 +1,13 @@
+-- @shouldFailWith TypesDoNotUnify
+module Main where
+
+import Prelude
+import Data.Record (merge)
+
+type Mand r = (title :: String, flag :: Boolean | r)
+type Opt = (optional :: Int)
+
+withDefaults :: forall o. Normalised (Mand (optional :: Int|o)) (Mand Opt) => {|Mand o} -> {|Mand Opt}
+withDefaults = merge {optional:1}
+
+main = withDefaults {title:"Title", flag: true, others:""}

--- a/examples/passing/RecordUnionClosed.purs
+++ b/examples/passing/RecordUnionClosed.purs
@@ -1,0 +1,21 @@
+module Main where
+
+import Prelude
+import Data.Record (merge)
+import Control.Monad.Eff.Console (log, CONSOLE)
+import Control.Monad.Eff (Eff)
+
+type Mand r = (title :: String | r)
+type Opt eff r = (onClick :: Unit -> Eff eff Unit | r)
+
+withDefaults :: forall o eff
+   . Normalised (Mand (Opt eff o)) (Mand (Opt eff ()))
+  => Record (Mand o) -> Record (Mand (Opt eff ()))
+withDefaults = merge ({onClick: \_ -> pure unit } :: Record (Opt eff ()))
+
+main :: forall eff. Eff (console::CONSOLE|eff) Unit
+main = do
+  let withoutClick = withDefaults {title:"Title"}
+      withClick = withDefaults {title:"Title", onClick: \_ -> log "Done"}
+  withoutClick.onClick unit
+  withClick.onClick unit

--- a/examples/passing/RecordUnionOpen.purs
+++ b/examples/passing/RecordUnionOpen.purs
@@ -1,0 +1,42 @@
+module Main where
+
+import Prelude
+import Data.Record (merge)
+import Control.Monad.Eff.Console (log, CONSOLE)
+import Control.Monad.Eff (Eff)
+import Unsafe.Coerce (unsafeCoerce)
+
+type Mand r = (title :: String | r)
+type Opt eff r = (onClick :: Unit -> Eff eff Unit | r)
+
+withDefaults :: forall xtra all eff
+   . Normalised (Mand (Opt eff all)) (Mand (Opt eff xtra))
+  => Record (Mand all) -> Record (Mand (Opt eff xtra))
+withDefaults = merge ({onClick: \_ -> pure unit } :: Record (Opt eff ()))
+
+leftClosed :: forall r. Normalised (left::Int|r) (left::Int|r) => {left::Int} -> {|r} -> {left::Int|r}
+leftClosed = merge
+
+rightClosed :: forall l. Normalised (right::Int|l) (right::Int|l) => {|l} -> {right::Int} -> {right::Int|l}
+rightClosed = merge
+
+bothOpen :: forall l r b c
+   . Union r l b
+  => Normalised b c
+  => Normalised (left::Int, right::Int|b) (left::Int,right::Int|c)
+  => {left::Int|l} -> {right::Int|r} -> {left::Int,right::Int|c}
+bothOpen = merge
+
+main :: Eff (console::CONSOLE) Unit
+main = do
+  let withoutClick = withDefaults {title:"Title", totes:""}
+      withClick = withDefaults {title:"Title", onClick: \_ -> log "Done", extraBits:""}
+      compare :: forall l r. (l -> r -> {left::Int,right::Int,three::Int,four::Int}) -> l -> r -> Eff (console::CONSOLE) Unit
+      compare f l r = case f l r of
+        {left:1,right:2,three:3,four:4} -> pure unit
+        p -> log $ unsafeCoerce p
+  compare leftClosed {left:1} {right:2, three:3, four:4}
+  compare rightClosed {left:1, three:3, four:4} {right:2}
+  compare bothOpen {left:1, four:1, three:0} {right:2, three:3, four:4}
+  withoutClick.onClick unit
+  withClick.onClick unit

--- a/examples/passing/RecordUnionOpen.purs
+++ b/examples/passing/RecordUnionOpen.purs
@@ -20,11 +20,14 @@ leftClosed = merge
 rightClosed :: forall l. Normalised (right::Int|l) (right::Int|l) => {|l} -> {right::Int} -> {right::Int|l}
 rightClosed = merge
 
-bothOpen :: forall l r b c
-   . Union r l b
-  => Normalised b c
-  => Normalised (left::Int, right::Int|b) (left::Int,right::Int|c)
-  => {left::Int|l} -> {right::Int|r} -> {left::Int,right::Int|c}
+bothOpen :: forall l r u1 u2 c
+   .
+   Union r l u1
+  => Union l r u2
+  => Normalised (left::Int, right::Int|u1) (left::Int,right::Int|c)
+  => Normalised (left::Int, right::Int|u2) (left::Int,right::Int|c)
+  =>
+  {left::Int|l} -> {right::Int|r} -> {left::Int,right::Int|c}
 bothOpen = merge
 
 main :: Eff (console::CONSOLE) Unit

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -384,6 +384,9 @@ pattern Warn = Qualified (Just Prim) (ProperName "Warn")
 pattern Union :: Qualified (ProperName 'ClassName)
 pattern Union = Qualified (Just Prim) (ProperName "Union")
 
+pattern Normalised :: Qualified (ProperName 'ClassName)
+pattern Normalised = Qualified (Just Prim) (ProperName "Normalised")
+
 typ :: forall a. (IsString a) => a
 typ = "Type"
 

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -359,6 +359,7 @@ primTypes =
     , (primName "Boolean",    (kindType, ExternData))
     , (primName "Partial",    (kindType, ExternData))
     , (primName "Union",      (FunKind (Row kindType) (FunKind (Row kindType) (FunKind (Row kindType) kindType)), ExternData))
+    , (primName "Normalised", (FunKind (Row kindType) (FunKind (Row kindType) kindType), ExternData))
     , (primName "Fail",       (FunKind kindSymbol kindType, ExternData))
     , (primName "Warn",       (FunKind kindSymbol kindType, ExternData))
     , (primName "TypeString", (FunKind kindType kindSymbol, ExternData))
@@ -383,6 +384,11 @@ primClasses =
                              , ("u", Just (Row kindType))
                              ] [] []
                              [ FunctionalDependency [0, 1] [2] ]))
+    , (primName "Normalised",   (makeTypeClassData
+                             [ ("r", Just (Row kindType))
+                             , ("o", Just (Row kindType))
+                             ] [] []
+                             [ FunctionalDependency [0] [1] ]))
     ]
 
 -- |

--- a/tests/support/bower.json
+++ b/tests/support/bower.json
@@ -15,6 +15,7 @@
     "purescript-symbols": "ps-0.11",
     "purescript-tailrec": "ps-0.11",
     "purescript-typelevel-prelude": "ps-0.11",
-    "purescript-unsafe-coerce": "ps-0.11"
+    "purescript-unsafe-coerce": "ps-0.11",
+    "purescript-records": "0.0.3"
   }
 }

--- a/tests/support/bower.json
+++ b/tests/support/bower.json
@@ -16,6 +16,6 @@
     "purescript-tailrec": "ps-0.11",
     "purescript-typelevel-prelude": "ps-0.11",
     "purescript-unsafe-coerce": "ps-0.11",
-    "purescript-records": "0.0.3"
+    "purescript-records": "ps-0.11"
   }
 }


### PR DESCRIPTION
This adds a Prim class for computing a "normalised" row (please suggest a better name).
It will only find an instance if all the types for a label are the same, so:

```
(a :: Int, a :: Int, a :: Int, b :: Int) -> (a::Int, b::Int)
(a :: Int, a :: String, b :: Int) -> No instance
```

This primitive combined with the duplicate label `Union` allows the use cases I was concerned about to work properly.

One thing which I couldn't work out though, was that the `Constraint`s were being ignored if the instances were found during the "defered" pass. I thought this was fixed by having a proper implementation for `EmptyInstance` in `mkDictionary`? Perhaps it's still not right..