### PR TITLE
Row union constraints

### DIFF
--- a/examples/passing/RowUnion.js
+++ b/examples/passing/RowUnion.js
@@ -1,0 +1,10 @@
+"use strict";
+
+exports.merge = function (dict) {
+  return function (l) {
+    return function (r) {
+      var o = {};
+      return Object.assign(o, l, r);
+    };
+  };
+};

--- a/examples/passing/RowUnion.js
+++ b/examples/passing/RowUnion.js
@@ -4,7 +4,7 @@ exports.merge = function (dict) {
   return function (l) {
     return function (r) {
       var o = {};
-      return Object.assign(o, l, r);
+      return Object.assign(o, r, l);
     };
   };
 };

--- a/examples/passing/RowUnion.purs
+++ b/examples/passing/RowUnion.purs
@@ -14,19 +14,35 @@ test1 = merge { x: 1 } { y: true }
 
 test2 = merge { x: 1 } { x: true }
 
-mergeWithExtras
-  :: forall r1 r2 r3
-   . Union r1 r2 r3
-  => Record ( x :: Int | r1 )
-  -> Record ( y :: Boolean | r2 )
-  -> Record ( x :: Int, y :: Boolean | r3)
-mergeWithExtras = merge
+--mergeWithExtras
+--  :: forall r1 r2 r3
+--   . Union r1 r2 r3
+--  => Record ( x :: Int | r1 )
+--  -> Record ( y :: Boolean | r2 )
+--  -> Record ( x :: Int, y :: Boolean | r3)
+--mergeWithExtras = merge
 
 test3 x = merge { x: 1 } x :: { x :: Int, y :: Boolean }
+
+type Mandatory r = (x :: Int | r)
+type Optional r = (x :: Int, y :: Int, z :: Int | r)
+
+withDefaults
+  :: forall r
+   . Union r (y :: Int, z :: Int) (y :: Int, z :: Int | r) 
+  => Record (Mandatory r)
+  -> Record (Optional r)
+withDefaults p = merge p { y: 1, z: 1 }
+
+test4 = withDefaults { x: 1, y: 2 }
 
 main = do
   logShow test1.x
   logShow test1.y
   logShow (test1.x == 1)
-  logShow (mergeWithExtras { x: 1 } { y: true, z: 42.0 }).x
+--  logShow (mergeWithExtras { x: 1 } { y: true, z: 42.0 }).x
+  logShow (withDefaults { x: 1 }).x
+  logShow (withDefaults { x: 1 }).y
+  logShow (withDefaults { x: 1, y: 2 }).x
+  logShow (withDefaults { x: 1, y: 2 }).y
   log "Done"

--- a/examples/passing/RowUnion.purs
+++ b/examples/passing/RowUnion.purs
@@ -1,0 +1,32 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console
+
+foreign import merge 
+  :: forall r1 r2 r3
+   . Union r1 r2 r3
+  => Record r1
+  -> Record r2
+  -> Record r3
+
+test1 = merge { x: 1 } { y: true }
+
+test2 = merge { x: 1 } { x: true }
+
+mergeWithExtras
+  :: forall r1 r2 r3
+   . Union r1 r2 r3
+  => Record ( x :: Int | r1 )
+  -> Record ( y :: Boolean | r2 )
+  -> Record ( x :: Int, y :: Boolean | r3)
+mergeWithExtras = merge
+
+test3 x = merge { x: 1 } x :: { x :: Int, y :: Boolean }
+
+main = do
+  logShow test1.x
+  logShow test1.y
+  logShow (test1.x == 1)
+  logShow (mergeWithExtras { x: 1 } { y: true, z: 42.0 }).x
+  log "Done"

--- a/examples/passing/RowUnion.purs
+++ b/examples/passing/RowUnion.purs
@@ -3,7 +3,7 @@ module Main where
 import Prelude
 import Control.Monad.Eff.Console
 
-foreign import merge 
+foreign import merge
   :: forall r1 r2 r3
    . Union r1 r2 r3
   => Record r1
@@ -14,13 +14,13 @@ test1 = merge { x: 1 } { y: true }
 
 test2 = merge { x: 1 } { x: true }
 
---mergeWithExtras
---  :: forall r1 r2 r3
---   . Union r1 r2 r3
---  => Record ( x :: Int | r1 )
---  -> Record ( y :: Boolean | r2 )
---  -> Record ( x :: Int, y :: Boolean | r3)
---mergeWithExtras = merge
+mergeWithExtras
+ :: forall r1 r2 r3
+  . Union r1 (y :: Boolean | r2) (y :: Boolean | r3)
+ => { x :: Int | r1 }
+ -> { y :: Boolean | r2 }
+ -> { x :: Int, y :: Boolean | r3}
+mergeWithExtras = merge
 
 test3 x = merge { x: 1 } x :: { x :: Int, y :: Boolean }
 
@@ -29,7 +29,7 @@ type Optional r = (x :: Int, y :: Int, z :: Int | r)
 
 withDefaults
   :: forall r
-   . Union r (y :: Int, z :: Int) (y :: Int, z :: Int | r) 
+   . Union r (y :: Int, z :: Int) (y :: Int, z :: Int | r)
   => Record (Mandatory r)
   -> Record (Optional r)
 withDefaults p = merge p { y: 1, z: 1 }
@@ -40,7 +40,7 @@ main = do
   logShow test1.x
   logShow test1.y
   logShow (test1.x == 1)
---  logShow (mergeWithExtras { x: 1 } { y: true, z: 42.0 }).x
+  logShow (mergeWithExtras { x: 1 } { x: 0, y: true, z: 42.0 }).x
   logShow (withDefaults { x: 1 }).x
   logShow (withDefaults { x: 1 }).y
   logShow (withDefaults { x: 1, y: 2 }).x

--- a/examples/passing/RowUnion.purs
+++ b/examples/passing/RowUnion.purs
@@ -37,14 +37,18 @@ withDefaults
 withDefaults p = merge p { y: 1, z: 1 }
 
 withDefaultsClosed
-  :: forall r s t
+  :: forall r s
    . Union r (y :: Int, z :: Int) (y :: Int, z :: Int | s)
-  => Union s t (y :: Int, z :: Int)
+  => Subrow s (y :: Int, z :: Int)
   => Record (Mandatory r)
   -> Record (Optional s)
 withDefaultsClosed p = merge p { y: 1, z: 1 }
 
 test4 = withDefaults { x: 1, y: 2 }
+
+-- r is a subrow of s if Union r t s for some t.
+class Subrow (r :: # Type) (s :: # Type)
+instance subrow :: Union r t s => Subrow r s
 
 main :: Eff (console :: CONSOLE) Unit
 main = do

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -381,6 +381,9 @@ pattern Fail = Qualified (Just Prim) (ProperName "Fail")
 pattern Warn :: Qualified (ProperName 'ClassName)
 pattern Warn = Qualified (Just Prim) (ProperName "Warn")
 
+pattern Union :: Qualified (ProperName 'ClassName)
+pattern Union = Qualified (Just Prim) (ProperName "Union")
+
 typ :: forall a. (IsString a) => a
 typ = "Type"
 

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -25,6 +25,7 @@ primDocsModule = Module
       , partial
       , fail
       , warn
+      , union
       , typeConcat
       , typeString
       , kindType
@@ -226,6 +227,14 @@ warn = primClass "Warn" $ T.unlines
   , ""
   , "For more information, see"
   , "[the Custom Type Errors guide](https://github.com/purescript/documentation/blob/master/guides/Custom-Type-Errors.md)."
+  ]
+
+union :: Declaration
+union = primClass "Union" $ T.unlines
+  [ "The Union type class is used to compute the union of two rows of types"
+  , "(left-biased, including duplicates)."
+  , ""
+  , "The third type argument represents the union of the first two."
   ]
 
 typeConcat :: Declaration

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -358,6 +358,7 @@ primTypes =
     , (primName "Int",        (kindType, ExternData))
     , (primName "Boolean",    (kindType, ExternData))
     , (primName "Partial",    (kindType, ExternData))
+    , (primName "Union",      (FunKind (Row kindType) (FunKind (Row kindType) (FunKind (Row kindType) kindType)), ExternData))
     , (primName "Fail",       (FunKind kindSymbol kindType, ExternData))
     , (primName "Warn",       (FunKind kindSymbol kindType, ExternData))
     , (primName "TypeString", (FunKind kindType kindSymbol, ExternData))
@@ -376,6 +377,12 @@ primClasses =
     [ (primName "Partial", (makeTypeClassData [] [] [] []))
     , (primName "Fail",    (makeTypeClassData [("message", Just kindSymbol)] [] [] []))
     , (primName "Warn",    (makeTypeClassData [("message", Just kindSymbol)] [] [] []))
+    , (primName "Union",   (makeTypeClassData
+                             [ ("l", Just (Row kindType))
+                             , ("r", Just (Row kindType))
+                             , ("u", Just (Row kindType))
+                             ] [] []
+                             [ FunctionalDependency [0, 1] [2] ]))
     ]
 
 -- |

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -382,7 +382,10 @@ primClasses =
                              , ("r", Just (Row kindType))
                              , ("u", Just (Row kindType))
                              ] [] []
-                             [ FunctionalDependency [0, 1] [2] ]))
+                             [ FunctionalDependency [0, 1] [2]
+                             , FunctionalDependency [1, 2] [0]
+                             , FunctionalDependency [2, 0] [1]
+                             ]))
     ]
 
 -- |

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -152,9 +152,9 @@ makeTypeClassData args m s deps = TypeClassData args m s deps determinedArgs cov
 data NameVisibility
   = Undefined
   -- ^ The name is defined in the current binding group, but is not visible
-  | Defined deriving (Show, Eq)
+  | Defined
   -- ^ The name is defined in the another binding group, or has been made visible by a function binder
-
+  deriving (Show, Eq)
 -- | A flag for whether a name is for an private or public value - only public values will be
 -- included in a generated externs file.
 data NameKind

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -72,14 +72,11 @@ data FunctionalDependency = FunctionalDependency
   -- ^ the determined type arguments
   } deriving Show
 
--- |
--- The initial environment with no values and only the default javascript types defined
---
+-- | The initial environment with no values and only the default javascript types defined
 initEnvironment :: Environment
 initEnvironment = Environment M.empty primTypes M.empty M.empty M.empty primClasses primKinds
 
--- |
--- A constructor for TypeClassData that computes which type class arguments are fully determined
+-- | A constructor for TypeClassData that computes which type class arguments are fully determined
 -- and argument covering sets.
 -- Fully determined means that this argument cannot be used when selecting a type class instance.
 -- A covering set is a minimal collection of arguments that can be used to find an instance and
@@ -151,77 +148,45 @@ makeTypeClassData args m s deps = TypeClassData args m s deps determinedArgs cov
     coveringSets = let funDepSets = sequence (mapMaybe sccNonDetermined (G.scc depGraph))
                    in S.fromList (S.fromList <$> funDepSets)
 
--- |
--- The visibility of a name in scope
---
+-- | The visibility of a name in scope
 data NameVisibility
-  -- |
-  -- The name is defined in the current binding group, but is not visible
-  --
   = Undefined
-  -- |
-  -- The name is defined in the another binding group, or has been made visible by a function binder
-  --
+  -- ^ The name is defined in the current binding group, but is not visible
   | Defined deriving (Show, Eq)
+  -- ^ The name is defined in the another binding group, or has been made visible by a function binder
 
--- |
--- A flag for whether a name is for an private or public value - only public values will be
+-- | A flag for whether a name is for an private or public value - only public values will be
 -- included in a generated externs file.
---
 data NameKind
-  -- |
-  -- A private value introduced as an artifact of code generation (class instances, class member
-  -- accessors, etc.)
-  --
   = Private
-  -- |
-  -- A public value for a module member or foreing import declaration
-  --
+  -- ^ A private value introduced as an artifact of code generation (class instances, class member
+  -- accessors, etc.)
   | Public
-  -- |
-  -- A name for member introduced by foreign import
-  --
+  -- ^ A public value for a module member or foreing import declaration
   | External
+  -- ^ A name for member introduced by foreign import
   deriving (Show, Eq)
 
--- |
--- The kinds of a type
---
+-- | The kinds of a type
 data TypeKind
-  -- |
-  -- Data type
-  --
   = DataType [(Text, Maybe Kind)] [(ProperName 'ConstructorName, [Type])]
-  -- |
-  -- Type synonym
-  --
+  -- ^ Data type
   | TypeSynonym
-  -- |
-  -- Foreign data
-  --
+  -- ^ Type synonym
   | ExternData
-  -- |
-  -- A local type variable
-  --
+  -- ^ Foreign data
   | LocalTypeVariable
-  -- |
-  -- A scoped type variable
-  --
+  -- ^ A local type variable
   | ScopedTypeVar
+  -- ^ A scoped type variable
   deriving (Show, Eq)
 
--- |
--- The type ('data' or 'newtype') of a data type declaration
---
+-- | The type ('data' or 'newtype') of a data type declaration
 data DataDeclType
-  -- |
-  -- A standard data constructor
-  --
   = Data
-  -- |
-  -- A newtype constructor
-  --
+  -- ^ A standard data constructor
   | Newtype
+  -- ^ A newtype constructor
   deriving (Show, Eq, Ord)
 
 showDataDeclType :: DataDeclType -> Text
@@ -238,87 +203,61 @@ instance A.FromJSON DataDeclType where
       "newtype" -> return Newtype
       other -> fail $ "invalid type: '" ++ T.unpack other ++ "'"
 
--- |
--- Construct a ProperName in the Prim module
---
+-- | Construct a ProperName in the Prim module
 primName :: Text -> Qualified (ProperName a)
 primName = Qualified (Just $ ModuleName [ProperName C.prim]) . ProperName
 
 primKind :: Text -> Kind
 primKind = NamedKind . primName
 
--- |
--- Kinds in prim
---
+-- | Kind of ground types
 kindType :: Kind
 kindType = primKind C.typ
 
 kindSymbol :: Kind
 kindSymbol = primKind C.symbol
 
--- |
--- Construct a type in the Prim module
---
+-- | Construct a type in the Prim module
 primTy :: Text -> Type
 primTy = TypeConstructor . primName
 
--- |
--- Type constructor for functions
---
+-- | Type constructor for functions
 tyFunction :: Type
 tyFunction = primTy "Function"
 
--- |
--- Type constructor for strings
---
+-- | Type constructor for strings
 tyString :: Type
 tyString = primTy "String"
 
--- |
--- Type constructor for strings
---
+-- | Type constructor for strings
 tyChar :: Type
 tyChar = primTy "Char"
 
--- |
--- Type constructor for numbers
---
+-- | Type constructor for numbers
 tyNumber :: Type
 tyNumber = primTy "Number"
 
--- |
--- Type constructor for integers
---
+-- | Type constructor for integers
 tyInt :: Type
 tyInt = primTy "Int"
 
--- |
--- Type constructor for booleans
---
+-- | Type constructor for booleans
 tyBoolean :: Type
 tyBoolean = primTy "Boolean"
 
--- |
--- Type constructor for arrays
---
+-- | Type constructor for arrays
 tyArray :: Type
 tyArray = primTy "Array"
 
--- |
--- Type constructor for records
---
+-- | Type constructor for records
 tyRecord :: Type
 tyRecord = primTy "Record"
 
--- |
--- Check whether a type is a record
---
+-- | Check whether a type is a record
 isObject :: Type -> Bool
 isObject = isTypeOrApplied tyRecord
 
--- |
--- Check whether a type is a function
---
+-- | Check whether a type is a function
 isFunction :: Type -> Bool
 isFunction = isTypeOrApplied tyFunction
 
@@ -326,14 +265,11 @@ isTypeOrApplied :: Type -> Type -> Bool
 isTypeOrApplied t1 (TypeApp t2 _) = t1 == t2
 isTypeOrApplied t1 t2 = t1 == t2
 
--- |
--- Smart constructor for function types
---
+-- | Smart constructor for function types
 function :: Type -> Type -> Type
 function t1 = TypeApp (TypeApp tyFunction t1)
 
--- |
--- The primitive kinds
+-- | The primitive kinds
 primKinds :: S.Set (Qualified (ProperName 'KindName))
 primKinds =
   S.fromList
@@ -341,11 +277,9 @@ primKinds =
     , primName C.symbol
     ]
 
--- |
--- The primitive types in the external javascript environment with their
+-- | The primitive types in the external javascript environment with their
 -- associated kinds. There are also pseudo `Fail`, `Warn`, and `Partial` types
 -- that correspond to the classes with the same names.
---
 primTypes :: M.Map (Qualified (ProperName 'TypeName)) (Kind, TypeKind)
 primTypes =
   M.fromList
@@ -365,18 +299,19 @@ primTypes =
     , (primName "TypeConcat", (FunKind kindSymbol (FunKind kindSymbol kindSymbol), ExternData))
     ]
 
--- |
--- The primitive class map. This just contains the `Fail`, `Warn`, and `Partial`
+-- | The primitive class map. This just contains the `Fail`, `Warn`, and `Partial`
 -- classes. `Partial` is used as a kind of magic constraint for partial
 -- functions. `Fail` is used for user-defined type errors. `Warn` for
 -- user-defined warnings.
---
 primClasses :: M.Map (Qualified (ProperName 'ClassName)) TypeClassData
 primClasses =
   M.fromList
     [ (primName "Partial", (makeTypeClassData [] [] [] []))
+    -- class Fail (message :: Symbol)
     , (primName "Fail",    (makeTypeClassData [("message", Just kindSymbol)] [] [] []))
+    -- class Warn (message :: Symbol)
     , (primName "Warn",    (makeTypeClassData [("message", Just kindSymbol)] [] [] []))
+    -- class Union (l :: # Type) (r :: # Type) (u :: # Type) | l r -> u, r u -> l, u l -> r
     , (primName "Union",   (makeTypeClassData
                              [ ("l", Just (Row kindType))
                              , ("r", Just (Row kindType))
@@ -388,24 +323,18 @@ primClasses =
                              ]))
     ]
 
--- |
--- Finds information about data constructors from the current environment.
---
+-- | Finds information about data constructors from the current environment.
 lookupConstructor :: Environment -> Qualified (ProperName 'ConstructorName) -> (DataDeclType, ProperName 'TypeName, Type, [Ident])
 lookupConstructor env ctor =
   fromMaybe (internalError "Data constructor not found") $ ctor `M.lookup` dataConstructors env
 
--- |
--- Checks whether a data constructor is for a newtype.
---
+-- | Checks whether a data constructor is for a newtype.
 isNewtypeConstructor :: Environment -> Qualified (ProperName 'ConstructorName) -> Bool
 isNewtypeConstructor e ctor = case lookupConstructor e ctor of
   (Newtype, _, _, _) -> True
   (Data, _, _, _) -> False
 
--- |
--- Finds information about values from the current environment.
---
+-- | Finds information about values from the current environment.
 lookupValue :: Environment -> Qualified Ident -> Maybe (Type, NameKind, NameVisibility)
 lookupValue env ident = ident `M.lookup` names env
 

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -324,14 +324,14 @@ entails SolverOptions{..} constraint context hints =
             mkDictionary (NamedInstance n) args = return $ foldl App (Var n) (fold args)
             mkDictionary UnionInstance (Just [e]) =
               -- We need the subgoal dictionary to appear in the term somewhere
-              return $ App (Abs (VarBinder (Ident C.__unused)) (Literal (ObjectLiteral []))) e
-            mkDictionary UnionInstance _ = return $ Literal (ObjectLiteral [])
+              return $ App (Abs (VarBinder (Ident C.__unused)) valUndefined) e
+            mkDictionary UnionInstance _ = return valUndefined
             mkDictionary (WarnInstance msg) _ = do
               tell . errorMessage $ UserDefinedWarning msg
               -- We cannot call the type class constructor here because Warn is declared in Prim.
               -- This means that it doesn't have a definition that we can import.
-              -- So pass an empty object instead.
-              return $ Literal (ObjectLiteral [])
+              -- So pass an empty placeholder (undefined) instead.
+              return valUndefined
             mkDictionary (IsSymbolInstance sym) _ =
               let fields = [ ("reflectSymbol", Abs (VarBinder (Ident C.__unused)) (Literal (StringLiteral sym))) ] in
               return $ TypeClassDictionaryConstructorApp C.IsSymbol (Literal (ObjectLiteral fields))


### PR DESCRIPTION
This is based on the idea in #2715 and resolves #469, but takes a slightly different approach to the solution in #2715 and #2750.

It adds a single new constraint to `Prim` called `Union`, which acts like a left-biased union on rows. It is generated by instances of the form

```purescript
instance unionClosed :: Union (l_1 :: a_1, ..., l_n :: a_n) r (l_1 :: a_1, ..., l_n :: a_n | r)
```

and

```purescript
instance unionOpen :: Union r1 r2 r3 => Union (l_1 :: a_1, ..., l_n :: a_n | r1) r2 (l_1 :: a_1, ..., l_n :: a_n | r3)
```

Notice that the order of the types for each label is preserved, and we correctly handle duplicates. 

This means that you need to do some work when working with possibly-open rows, but it has the happy consequence that we can express certain types of lacks constraints. For example, the constraint

```purescript
Union r (l :: a) (l :: a | r)
```

means that if `l` appears in `r` at all, then it can only appear associated with the type `a`, since we need to be able to append `l :: a` on the right and have that be equivalent to prepending `l :: a` on the left.

cc @doolse Can you please have a look and tell me if this solves the problem you had? Thanks.