### PR TITLE
Use git show to get tag date

### DIFF
--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -196,7 +196,7 @@ getVersionFromGitTag = do
 -- | Given a git tag, get the time it was created.
 getTagTime :: Text -> PrepareM UTCTime
 getTagTime tag = do
-  out <- readProcess' "git" ["tag", "-l", T.unpack tag, "--format=%(taggerdate:unix)"] ""
+  out <- readProcess' "git" ["show", "-s", "--format=%ct", T.unpack tag] ""
   case mapMaybe readMaybe (lines out) of
     [t] -> pure . posixSecondsToUTCTime . fromInteger $ t
     _ -> internalError (CouldntParseGitTagDate tag)


### PR DESCRIPTION
Fixes #2753 for me (I was having the same problem while testing `purs publish`)