### PR TITLE
Use git log to get tag versions

### DIFF
--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -196,7 +196,7 @@ getVersionFromGitTag = do
 -- | Given a git tag, get the time it was created.
 getTagTime :: Text -> PrepareM UTCTime
 getTagTime tag = do
-  out <- readProcess' "git" ["tag", "-l", T.unpack tag, "--format=%(taggerdate:unix)"] ""
+  out <- readProcess' "git" ["show", "-s", "--format=%ct", T.unpack tag] ""
   case mapMaybe readMaybe (lines out) of
     [t] -> pure . posixSecondsToUTCTime . fromInteger $ t
     _ -> internalError (CouldntParseGitTagDate tag)

--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -196,7 +196,7 @@ getVersionFromGitTag = do
 -- | Given a git tag, get the time it was created.
 getTagTime :: Text -> PrepareM UTCTime
 getTagTime tag = do
-  out <- readProcess' "git" ["show", "-s", "--format=%ct", T.unpack tag] ""
+  out <- readProcess' "git" ["log", "-1", "--format=%ct", T.unpack tag] ""
   case mapMaybe readMaybe (lines out) of
     [t] -> pure . posixSecondsToUTCTime . fromInteger $ t
     _ -> internalError (CouldntParseGitTagDate tag)


### PR DESCRIPTION
Fixes #2753 

cc @rightfold