### PR TITLE
Enable TCO for variable intros and assignments

### DIFF
--- a/examples/passing/TCO.purs
+++ b/examples/passing/TCO.purs
@@ -2,6 +2,8 @@ module Main where
 
 import Prelude
 import Control.Monad.Eff.Console (log, logShow)
+import Control.Monad.Rec.Class
+import Data.Array ((..), span, length)
 
 main = do
   let f x = x + 1
@@ -11,6 +13,12 @@ main = do
   logShow (applyN 2 f v)
   logShow (applyN 3 f v)
   logShow (applyN 4 f v)
+
+  let largeArray = 1..10000
+  logShow (length (span (\_ -> true) largeArray).init)
+
+  logShow (tailRec (\n -> if n < 10000 then Loop (n + 1) else Done 42) 0)
+
   log "Done"
 
 applyN :: forall a. Int -> (a -> a) -> a -> a

--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -69,7 +69,7 @@ tco = everywhere convert where
     allInTailPosition (Throw _ js1)
       = countSelfReferences js1 == 0
     allInTailPosition _
-      = False
+      = True
 
   toLoop :: Text -> [Text] -> AST -> AST
   toLoop ident allArgs js =

--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -68,8 +68,16 @@ tco = everywhere convert where
       = all allInTailPosition body
     allInTailPosition (Throw _ js1)
       = countSelfReferences js1 == 0
-    allInTailPosition _
+    allInTailPosition (ReturnNoResult _)
       = True
+    allInTailPosition (VariableIntroduction _ _ js1)
+      = all ((== 0) . countSelfReferences) js1
+    allInTailPosition (Assignment _ _ js1)
+      = countSelfReferences js1 == 0
+    allInTailPosition (Comment _ _ js1)
+      = allInTailPosition js1
+    allInTailPosition _
+      = False
 
   toLoop :: Text -> [Text] -> AST -> AST
   toLoop ident allArgs js =


### PR DESCRIPTION
Fixes #2779 

Just a stupid mistake when I implemented this originally. The only things which should hit the fallback case are statements, and the only ones left are variable introductions and assignments.