### PR TITLE
Wrap decl title in span for better double-click selection

### DIFF
--- a/src/Language/PureScript/Docs/AsHtml.hs
+++ b/src/Language/PureScript/Docs/AsHtml.hs
@@ -126,7 +126,7 @@ declAsHtml r d@Declaration{..} = do
   H.div ! A.class_ "decl" ! A.id (v (T.drop 1 declFragment)) $ do
     h3 ! A.class_ "decl__title clearfix" $ do
       a ! A.class_ "decl__anchor" ! A.href (v declFragment) $ "#"
-      span $ declTitle
+      H.span $ declTitle
       for_ declSourceSpan (linkToSource r)
 
     H.div ! A.class_ "decl__body" $ do

--- a/src/Language/PureScript/Docs/AsHtml.hs
+++ b/src/Language/PureScript/Docs/AsHtml.hs
@@ -126,7 +126,7 @@ declAsHtml r d@Declaration{..} = do
   H.div ! A.class_ "decl" ! A.id (v (T.drop 1 declFragment)) $ do
     h3 ! A.class_ "decl__title clearfix" $ do
       a ! A.class_ "decl__anchor" ! A.href (v declFragment) $ "#"
-      H.span $ declTitle
+      H.span $ text declTitle
       for_ declSourceSpan (linkToSource r)
 
     H.div ! A.class_ "decl__body" $ do

--- a/src/Language/PureScript/Docs/AsHtml.hs
+++ b/src/Language/PureScript/Docs/AsHtml.hs
@@ -126,7 +126,7 @@ declAsHtml r d@Declaration{..} = do
   H.div ! A.class_ "decl" ! A.id (v (T.drop 1 declFragment)) $ do
     h3 ! A.class_ "decl__title clearfix" $ do
       a ! A.class_ "decl__anchor" ! A.href (v declFragment) $ "#"
-      text declTitle
+      span $ declTitle
       for_ declSourceSpan (linkToSource r)
 
     H.div ! A.class_ "decl__body" $ do


### PR DESCRIPTION
Without this, double-clicking the decl title will also select the source link, which makes copying the name too difficult.