### PR TITLE
#2787 Fix special case in guard codegen

### DIFF
--- a/examples/passing/2787.purs
+++ b/examples/passing/2787.purs
@@ -1,0 +1,8 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console
+
+main
+  | between 0 1 2 = log "Fail"
+  | otherwise = log "Done"

--- a/src/Language/PureScript/CoreImp/Optimizer/Blocks.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Blocks.hs
@@ -10,19 +10,19 @@ import Language.PureScript.CoreImp.AST
 
 -- | Collapse blocks which appear nested directly below another block
 collapseNestedBlocks :: AST -> AST
-collapseNestedBlocks = everywhere collapse
-  where
+collapseNestedBlocks = everywhere collapse where
   collapse :: AST -> AST
   collapse (Block ss sts) = Block ss (concatMap go sts)
   collapse js = js
+  
   go :: AST -> [AST]
   go (Block _ sts) = sts
   go s = [s]
 
 collapseNestedIfs :: AST -> AST
-collapseNestedIfs = everywhere collapse
-  where
+collapseNestedIfs = everywhere collapse where
   collapse :: AST -> AST
+  collapse (IfElse _ (BooleanLiteral _ True) (Block _ [js]) _) = js
   collapse (IfElse s1 cond1 (Block _ [IfElse s2 cond2 body Nothing]) Nothing) =
       IfElse s1 (Binary s2 And cond1 cond2) body Nothing
   collapse js = js


### PR DESCRIPTION
`foldr`/`foldl` mixup. I optimize the `true` case away elsewhere now, which should be simpler.

I think we should perhaps make a 0.11.1 tag soon after this gets merged.