### PR TITLE
PSCi eval test suite

### DIFF
--- a/examples/psci/BasicEval.purs
+++ b/examples/psci/BasicEval.purs
@@ -1,7 +1,10 @@
 import Prelude
 import Data.Array
 
-let fac n = foldl mul 1 (1..n) in fac 10 -- 3628800
+-- @shouldEvaluateTo 3628800
+let fac n = foldl mul 1 (1..n) in fac 10
 
 fac n = foldl mul 1 (1..n)
-fac 10 -- 3628800
+
+-- @shouldEvaluateTo 3628800
+fac 10

--- a/examples/psci/BasicEval.purs
+++ b/examples/psci/BasicEval.purs
@@ -1,0 +1,7 @@
+import Prelude
+import Data.Array
+
+let fac n = foldl mul 1 (1..n) in fac 10 -- 3628800
+
+fac n = foldl mul 1 (1..n)
+fac 10 -- 3628800

--- a/examples/psci/Multiline.purs
+++ b/examples/psci/Multiline.purs
@@ -1,0 +1,10 @@
+import Prelude
+import Data.Array
+
+-- @paste
+fac :: Int -> Int
+fac n = foldl mul 1 (1..n)
+-- @paste
+
+-- @shouldEvaluateTo 3628800
+fac 10

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -439,7 +439,8 @@ test-suite tests
                    transformers -any,
                    transformers-compat -any,
                    utf8-string -any,
-                   vector -any
+                   vector -any,
+                   split -any
     ghc-options: -Wall
     type: exitcode-stdio-1.0
     main-is: Main.hs
@@ -451,6 +452,7 @@ test-suite tests
                    TestPsci
                    TestPsci.CommandTest
                    TestPsci.CompletionTest
+                   TestPsci.EvalTest
                    TestPsci.TestEnv
                    TestPscIde
                    PscIdeSpec

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -433,14 +433,14 @@ test-suite tests
                    process -any,
                    protolude >= 0.1.6,
                    silently -any,
+                   split -any,
                    stm -any,
                    text -any,
                    time -any,
                    transformers -any,
                    transformers-compat -any,
                    utf8-string -any,
-                   vector -any,
-                   split -any
+                   vector -any
     ghc-options: -Wall
     type: exitcode-stdio-1.0
     main-is: Main.hs

--- a/tests/TestPsci.hs
+++ b/tests/TestPsci.hs
@@ -1,24 +1,15 @@
-{-# LANGUAGE RecordWildCards #-}
-
 module TestPsci where
 
 import Prelude ()
 import Prelude.Compat
 
-import Control.Monad (when)
-import System.Exit (exitFailure)
-import Test.HUnit
+import Test.Hspec
 import TestPsci.CommandTest (commandTests)
 import TestPsci.CompletionTest (completionTests)
 import TestPsci.EvalTest (evalTests)
 
 main :: IO ()
-main = do
-  Counts{..} <- runTestTT allTests
-  when (errors + failures > 0) exitFailure
-
-allTests :: Test
-allTests = TestList [ completionTests
-                    , commandTests
-                    , evalTests
-                    ]
+main = hspec $ do
+  completionTests
+  commandTests
+  evalTests

--- a/tests/TestPsci.hs
+++ b/tests/TestPsci.hs
@@ -10,6 +10,7 @@ import System.Exit (exitFailure)
 import Test.HUnit
 import TestPsci.CommandTest (commandTests)
 import TestPsci.CompletionTest (completionTests)
+import TestPsci.EvalTest (evalTests)
 
 main :: IO ()
 main = do
@@ -19,4 +20,5 @@ main = do
 allTests :: Test
 allTests = TestList [ completionTests
                     , commandTests
+                    , evalTests
                     ]

--- a/tests/TestPsci/CommandTest.hs
+++ b/tests/TestPsci/CommandTest.hs
@@ -5,27 +5,30 @@ import Prelude.Compat
 
 import Control.Monad.Trans.RWS.Strict (get)
 import Language.PureScript.Interactive
-import Test.HUnit
+import Test.Hspec
 import TestPsci.TestEnv
 
-commandTests :: Test
-commandTests = TestLabel "commandTests" $ TestList $ map (TestCase . execTestPSCi)
-  [ do
-      run "import Prelude"
-      run "import Data.Functor"
-      run "import Control.Monad"
-      before <- psciImportedModules <$> get
-      length before `equalsTo` 3
-      run ":clear"
-      after <- psciImportedModules <$> get
-      length after `equalsTo` 0
-  , do
-      run "import Prelude"
-      run "import Data.Functor"
-      run "import Control.Monad"
-      before <- psciImportedModules <$> get
-      length before `equalsTo` 3
-      run ":reload"
-      after <- psciImportedModules <$> get
-      length after `equalsTo` 3
-  ]
+specPSCi :: String -> TestPSCi () -> Spec
+specPSCi label = specify label . execTestPSCi
+
+commandTests :: Spec
+commandTests = context "commandTests" $ do
+  specPSCi ":clear" $ do
+    run "import Prelude"
+    run "import Data.Functor"
+    run "import Control.Monad"
+    ms <- psciImportedModules <$> get
+    length ms `equalsTo` 3
+    run ":clear"
+    ms' <- psciImportedModules <$> get
+    length ms' `equalsTo` 0
+
+  specPSCi ":reload" $ do
+    run "import Prelude"
+    run "import Data.Functor"
+    run "import Control.Monad"
+    ms <- psciImportedModules <$> get
+    length ms `equalsTo` 3
+    run ":reload"
+    ms' <- psciImportedModules <$> get
+    length ms' `equalsTo` 3

--- a/tests/TestPsci/CommandTest.hs
+++ b/tests/TestPsci/CommandTest.hs
@@ -28,8 +28,4 @@ commandTests = TestLabel "commandTests" $ TestList $ map (TestCase . execTestPSC
       run ":reload"
       after <- psciImportedModules <$> get
       length after `equalsTo` 3
-  , do
-      run "import Prelude"
-      run "import Data.Array"
-      "let fac n = foldl mul 1 (1..n) in fac 10" `evaluatesTo` "3628800"
   ]

--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -3,8 +3,9 @@ module TestPsci.CompletionTest where
 import Prelude ()
 import Prelude.Compat
 
-import Test.HUnit
+import Test.Hspec
 
+import           Control.Monad (mapM_)
 import           Control.Monad.Trans.State.Strict (evalStateT)
 import           Data.List (sort)
 import qualified Data.Text as T
@@ -14,10 +15,9 @@ import           System.Console.Haskeline
 import           TestPsci.TestEnv (initTestPSCiEnv)
 import           TestUtils (supportModules)
 
-completionTests :: Test
-completionTests =
-  TestLabel "completionTests"
-    (TestList (map (TestCase . assertCompletedOk) completionTestData))
+completionTests :: Spec
+completionTests = context "completionTests" $
+  mapM_ assertCompletedOk completionTestData
 
 -- If the cursor is at the right end of the line, with the 1st element of the
 -- pair as the text in the line, then pressing tab should offer all the
@@ -84,12 +84,12 @@ completionTestData =
   , ("Control.Monad.ST.new", ["Control.Monad.ST.newSTRef"])
   ]
 
-assertCompletedOk :: (String, [String]) -> Assertion
-assertCompletedOk (line, expecteds) = do
+assertCompletedOk :: (String, [String]) -> Spec
+assertCompletedOk (line, expecteds) = specify line $ do
   (unusedR, completions) <- runCM (completion' (reverse line, ""))
   let unused = reverse unusedR
   let actuals = map ((unused ++) . replacement) completions
-  sort expecteds @=? sort actuals
+  sort expecteds `shouldBe` sort actuals
 
 runCM :: CompletionM a -> IO a
 runCM act = do

--- a/tests/TestPsci/EvalTest.hs
+++ b/tests/TestPsci/EvalTest.hs
@@ -5,6 +5,7 @@ import Prelude.Compat
 
 import           Control.Monad (forM_)
 import           Data.Char (isSpace)
+import           Data.List (dropWhileEnd)
 import           Data.List.Split (splitOn)
 import           System.Directory (getCurrentDirectory)
 import           System.IO.UTF8 (readUTF8File)
@@ -35,8 +36,7 @@ evalTest f = do
       _ -> run line
 
 trim :: String -> String
-trim = f . f
-  where f = reverse . dropWhile isSpace
+trim = dropWhile isSpace . dropWhileEnd isSpace
 
 trimAndFilter :: [String] -> [String]
 trimAndFilter = filter (not . null) . map trim

--- a/tests/TestPsci/EvalTest.hs
+++ b/tests/TestPsci/EvalTest.hs
@@ -1,0 +1,42 @@
+module TestPsci.EvalTest where
+
+import Prelude ()
+import Prelude.Compat
+
+import           Control.Monad (forM_)
+import           Data.Char (isSpace)
+import           Data.List.Split (splitOn)
+import           System.Directory (getCurrentDirectory)
+import           System.IO.UTF8 (readUTF8File)
+import           System.FilePath ((</>), takeFileName)
+import qualified System.FilePath.Glob as Glob
+import           Test.HUnit
+import           TestPsci.TestEnv
+
+evalTests :: Test
+evalTests = TestLabel "evalTests" . TestCase $ do
+  putStrLn "\nPSCi eval test suites"
+  testFiles <- evalTestFiles
+  forM_ testFiles evalTest
+
+evalTestFiles :: IO [FilePath]
+evalTestFiles = do
+  cwd <- getCurrentDirectory
+  let psciExamples = cwd </> "examples" </> "psci"
+  Glob.globDir1 (Glob.compile "**/*.purs") psciExamples
+
+evalTest :: FilePath -> IO ()
+evalTest f = do
+  putStrLn $ "  " ++ takeFileName f
+  ls <- trimAndFilter . lines <$> readUTF8File f
+  execTestPSCi $ forM_ ls $ \ line ->
+    case trimAndFilter $ splitOn " -- " line of
+      [expr, expected] -> expr `evaluatesTo` expected
+      _ -> run line
+
+trim :: String -> String
+trim = f . f
+  where f = reverse . dropWhile isSpace
+
+trimAndFilter :: [String] -> [String]
+trimAndFilter = filter (not . null) . map trim

--- a/tests/TestPsci/EvalTest.hs
+++ b/tests/TestPsci/EvalTest.hs
@@ -3,14 +3,16 @@ module TestPsci.EvalTest where
 import Prelude ()
 import Prelude.Compat
 
-import           Control.Monad (forM_)
+import           Control.Monad (forM_, foldM_)
+import           Control.Monad.IO.Class (liftIO)
 import           Data.Char (isSpace)
-import           Data.List (dropWhileEnd)
+import           Data.List (dropWhileEnd, isPrefixOf, intercalate)
 import           Data.List.Split (splitOn)
 import           System.Directory (getCurrentDirectory)
-import           System.IO.UTF8 (readUTF8File)
+import           System.Exit (exitFailure)
 import           System.FilePath ((</>), takeFileName)
 import qualified System.FilePath.Glob as Glob
+import           System.IO.UTF8 (readUTF8File)
 import           Test.HUnit
 import           TestPsci.TestEnv
 
@@ -30,10 +32,21 @@ evalTest :: FilePath -> IO ()
 evalTest f = do
   putStrLn $ "  " ++ takeFileName f
   ls <- trimAndFilter . lines <$> readUTF8File f
-  execTestPSCi $ forM_ ls $ \ line ->
-    case trimAndFilter $ splitOn " -- " line of
-      [expr, expected] -> expr `evaluatesTo` expected
-      _ -> run line
+  execTestPSCi $ foldM_ go Nothing ls
+  where
+  go :: Maybe String -> String -> TestPSCi (Maybe String)
+  go (Just expected) line = line `evaluatesTo` expected >> pure Nothing
+  go Nothing         line =
+    if "-- @" `isPrefixOf` line
+    then
+      case trimAndFilter $ splitOn " " $ drop 4 line of
+        "shouldEvaluateTo" : results ->
+          pure . Just $ intercalate " " results
+        _ -> liftIO $ do
+          putStrLn $ "invalid comment: " ++ line
+          exitFailure
+    else
+      run line >> pure Nothing
 
 trim :: String -> String
 trim = dropWhile isSpace . dropWhileEnd isSpace

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -12,7 +12,7 @@ import           System.Exit
 import           System.FilePath ((</>))
 import qualified System.FilePath.Glob as Glob
 import           System.Process (readProcessWithExitCode)
-import           Test.HUnit ((@?=))
+import           Test.Hspec (shouldBe)
 
 -- | A monad transformer for handle PSCi actions in tests
 type TestPSCi a = RWST PSCiConfig () PSCiState IO a
@@ -70,9 +70,9 @@ runAndEval comm eval =
 run :: String -> TestPSCi ()
 run comm = runAndEval comm $ jsEval *> return ()
 
--- | A lifted evaluation of HUnit '@?=' for the TestPSCi
+-- | A lifted evaluation of Hspec 'shouldBe' for the TestPSCi
 equalsTo :: (Eq a, Show a) => a -> a -> TestPSCi ()
-equalsTo x y = liftIO $ x @?= y
+equalsTo x y = liftIO $ x `shouldBe` y
 
 -- | An assertion to check if a command evaluates to a string
 evaluatesTo :: String -> String -> TestPSCi ()


### PR DESCRIPTION
This PR enables writing PSCi eval tests as test suites.

We can write a PSCi test suite like below:

```purescript
import Prelude
import Data.Array

let fac n = foldl mul 1 (1..n) in fac 10 -- 3628800

fac n = foldl mul 1 (1..n)
fac 10 -- 3628800
```

A line with a following comment (`--`) will be evaluated and the result will be compared with the comment. Multiple `--`s in a line will break the test though, I think just splitting by `--` and comparing both sides is quite enough for test suites.

The result output is like below.

Success:
```
###############################################################################
# psci test suite
###############################################################################

Cases: 31  Tried: 30  Errors: 0  Failures: 0
PSCi eval test suites
  BasicEval.purs
  BasicEval2.purs
Cases: 31  Tried: 31  Errors: 0  Failures: 0
```

Failure:
```
###############################################################################
# psci test suite
###############################################################################

Cases: 31  Tried: 30  Errors: 0  Failures: 0
PSCi eval test suites
  BasicEval.purs
  BasicEval2.purs
### Failure in: 2:evalTests
tests/TestPsci/TestEnv.hs:75
expected: "3628801\n"
 but got: "3628800\n"
Cases: 31  Tried: 31  Errors: 0  Failures: 1

Completed 2 action(s).
Test suite failure for package purescript-0.11.0
    tests:  exited with: ExitFailure 1
Logs printed to console
```