### PR TITLE
[purs ide] Collect more information for classes and synonyms

### DIFF
--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -53,6 +53,7 @@ data IdeType = IdeType
 data IdeTypeSynonym = IdeTypeSynonym
   { _ideSynonymName :: P.ProperName 'P.TypeName
   , _ideSynonymType :: P.Type
+  , _ideSynonymKind :: P.Kind
   } deriving (Show, Eq, Ord)
 
 data IdeDataConstructor = IdeDataConstructor
@@ -63,6 +64,7 @@ data IdeDataConstructor = IdeDataConstructor
 
 data IdeTypeClass = IdeTypeClass
   { _ideTCName :: P.ProperName 'P.ClassName
+  , _ideTCKind :: P.Kind
   , _ideTCInstances :: [IdeInstance]
   } deriving (Show, Eq, Ord)
 

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -74,7 +74,7 @@ completionFromMatch (Match (m, IdeDeclarationAnn ann decl)) =
       IdeDeclType t -> (t ^. ideTypeName . properNameT, t ^. ideTypeKind & P.prettyPrintKind)
       IdeDeclTypeSynonym s -> (s ^. ideSynonymName . properNameT, s ^. ideSynonymType & prettyPrintTypeSingleLine)
       IdeDeclDataConstructor d -> (d ^. ideDtorName . properNameT, d ^. ideDtorType & prettyPrintTypeSingleLine)
-      IdeDeclTypeClass d -> (d ^. ideTCName . properNameT, "type class")
+      IdeDeclTypeClass d -> (d ^. ideTCName . properNameT, d ^. ideTCKind & P.prettyPrintKind)
       IdeDeclValueOperator (IdeValueOperator op ref precedence associativity typeP) ->
         (P.runOpName op, maybe (showFixity precedence associativity (valueOperatorAliasT ref) op) prettyPrintTypeSingleLine typeP)
       IdeDeclTypeOperator (IdeTypeOperator op ref precedence associativity kind) ->

--- a/tests/Language/PureScript/Ide/SourceFileSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFileSpec.hs
@@ -97,12 +97,12 @@ getLocation s = do
     ideState = emptyIdeState `s3`
       [ ("Test",
          [ ideValue "sfValue" Nothing `annLoc` valueSS
-         , ideSynonym "SFType" P.tyString `annLoc` synonymSS
+         , ideSynonym "SFType" P.tyString P.kindType `annLoc` synonymSS
          , ideType "SFData" Nothing `annLoc` typeSS
          , ideDtor "SFOne" "SFData" Nothing `annLoc` typeSS
          , ideDtor "SFTwo" "SFData" Nothing `annLoc` typeSS
          , ideDtor "SFThree" "SFData" Nothing `annLoc` typeSS
-         , ideTypeClass "SFClass" [] `annLoc` classSS
+         , ideTypeClass "SFClass" P.kindType [] `annLoc` classSS
          , ideValueOp "<$>" (P.Qualified Nothing (Left "")) 0 Nothing Nothing
            `annLoc` valueOpSS
          , ideTypeOp "~>" (P.Qualified Nothing "") 0 Nothing Nothing

--- a/tests/Language/PureScript/Ide/StateSpec.hs
+++ b/tests/Language/PureScript/Ide/StateSpec.hs
@@ -6,6 +6,7 @@ import           Protolude
 import           Control.Lens hiding ((&))
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.State
+import           Language.PureScript.Ide.Test
 import qualified Language.PureScript as P
 import           Test.Hspec
 import qualified Data.Map as Map
@@ -33,9 +34,6 @@ testModule = (mn "Test", [ d (IdeDeclValue (IdeValue (P.Ident "function") P.REmp
 
 d :: IdeDeclaration -> IdeDeclarationAnn
 d = IdeDeclarationAnn emptyAnn
-
-mn :: Text -> P.ModuleName
-mn = P.moduleNameFromString
 
 testState :: ModuleMap [IdeDeclarationAnn]
 testState = Map.fromList [testModule]
@@ -72,7 +70,7 @@ ef = P.ExternsFile
  -- }
 
 moduleMap :: ModuleMap [IdeDeclarationAnn]
-moduleMap = Map.singleton (mn "ClassModule") [d (IdeDeclTypeClass (IdeTypeClass (P.ProperName "MyClass") []))]
+moduleMap = Map.singleton (mn "ClassModule") [ideTypeClass "MyClass" P.kindType []]
 
 ideInstance :: IdeInstance
 ideInstance = IdeInstance (mn "InstanceModule") (P.Ident "myClassInstance") mempty mempty

--- a/tests/Language/PureScript/Ide/Test.hs
+++ b/tests/Language/PureScript/Ide/Test.hs
@@ -49,8 +49,8 @@ ann (IdeDeclarationAnn _ d) a = IdeDeclarationAnn a d
 annLoc :: IdeDeclarationAnn -> P.SourceSpan -> IdeDeclarationAnn
 annLoc (IdeDeclarationAnn a d) loc = IdeDeclarationAnn a {_annLocation = Just loc} d
 
-annExp :: IdeDeclarationAnn -> P.ModuleName -> IdeDeclarationAnn
-annExp (IdeDeclarationAnn a d) e = IdeDeclarationAnn a {_annExportedFrom = Just e} d
+annExp :: IdeDeclarationAnn -> Text -> IdeDeclarationAnn
+annExp (IdeDeclarationAnn a d) e = IdeDeclarationAnn a {_annExportedFrom = Just (mn e)} d
 
 annTyp :: IdeDeclarationAnn -> P.Type -> IdeDeclarationAnn
 annTyp (IdeDeclarationAnn a d) ta = IdeDeclarationAnn a {_annTypeAnnotation = Just ta} d
@@ -66,11 +66,11 @@ ideValue i ty = ida (IdeDeclValue (IdeValue (P.Ident i) (fromMaybe P.tyString ty
 ideType :: Text -> Maybe P.Kind -> IdeDeclarationAnn
 ideType pn ki = ida (IdeDeclType (IdeType (P.ProperName pn) (fromMaybe P.kindType ki)))
 
-ideSynonym :: Text -> P.Type -> IdeDeclarationAnn
-ideSynonym pn ty = ida (IdeDeclTypeSynonym (IdeTypeSynonym (P.ProperName pn) ty))
+ideSynonym :: Text -> P.Type -> P.Kind -> IdeDeclarationAnn
+ideSynonym pn ty kind = ida (IdeDeclTypeSynonym (IdeTypeSynonym (P.ProperName pn) ty kind))
 
-ideTypeClass :: Text -> [IdeInstance] -> IdeDeclarationAnn
-ideTypeClass pn instances = ida (IdeDeclTypeClass (IdeTypeClass (P.ProperName pn) instances))
+ideTypeClass :: Text -> P.Kind -> [IdeInstance] -> IdeDeclarationAnn
+ideTypeClass pn kind instances = ida (IdeDeclTypeClass (IdeTypeClass (P.ProperName pn) kind instances))
 
 ideDtor :: Text -> Text -> Maybe P.Type -> IdeDeclarationAnn
 ideDtor pn tn ty = ida (IdeDeclDataConstructor (IdeDataConstructor (P.ProperName pn) (P.ProperName tn) (fromMaybe P.tyString ty)))


### PR DESCRIPTION
When serializing to the Externs format, the compiler decomposes and duplicates
some information about type classes and synonyms. This PR reconstructs that
information and stores it in their respective IdeDeclaration.

I still want to try this on a few codebases, before merging it.