### PR TITLE
Use XDG Base Directory Specification for psci_history

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -53,6 +53,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@kika](https://github.com/kika) | Kirill Pertsev | MIT license |
 | [@kRITZCREEK](https://github.com/kRITZCREEK) | Christoph Hegemann | MIT license |
 | [@L8D](https://github.com/L8D) | Tenor Biel | [MIT license](http://opensource.org/licenses/MIT) |
+| [@legrostdg](https://github.com/legrostdg) | Félix Sipma | [MIT license](http://opensource.org/licenses/MIT) |
 | [@LiamGoodacre](https://github.com/LiamGoodacre) | Liam Goodacre | [MIT license](http://opensource.org/licenses/MIT) |
 | [@lukerandall](https://github.com/lukerandall) | Luke Randall | [MIT license](http://opensource.org/licenses/MIT) |
 | [@matthewleon](https://github.com/matthewleon) | Matthew Leon | [MIT license](http://opensource.org/licenses/MIT) |

--- a/src/Language/PureScript/Interactive/IO.hs
+++ b/src/Language/PureScript/Interactive/IO.hs
@@ -4,7 +4,9 @@ import Prelude.Compat
 
 import Control.Monad (msum)
 import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
-import System.Directory (createDirectoryIfMissing, getHomeDirectory, findExecutable)
+import System.Directory (XdgDirectory (..), createDirectoryIfMissing,
+                         getAppUserDataDirectory, getXdgDirectory,
+                         findExecutable, doesFileExist)
 import System.FilePath (takeDirectory, (</>))
 
 mkdirp :: FilePath -> IO ()
@@ -28,7 +30,12 @@ findNodeProcess = onFirstFileMatching findExecutable names
 --
 getHistoryFilename :: IO FilePath
 getHistoryFilename = do
-  home <- getHomeDirectory
-  let filename = home </> ".purescript" </> "psci_history"
-  mkdirp filename
-  return filename
+  appuserdata <- getAppUserDataDirectory "purescript"
+  olddirbool <- doesFileExist (appuserdata </> "psci_history")
+  if olddirbool
+      then return (appuserdata </> "psci_history")
+      else do
+        datadir <- getXdgDirectory XdgData "purescript"
+        let filename = datadir </> "psci_history"
+        mkdirp filename
+        return filename


### PR DESCRIPTION
Use $HOME/.purescript/psci_history if it exists, else it uses $XDG_DATA_DIR/purescript/psci_history. Works on Windows, too.

https://www.stackage.org/haddock/lts-8.6/directory-1.3.0.0/System-Directory.html#v:getAppUserDataDirectory