### PR TITLE
[WIP][purs ide] Completion formats

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.15.0.
+-- This file has been generated from package.yaml by hpack version 0.17.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -757,6 +757,7 @@ library
           Language.PureScript.Ide.CaseSplit
           Language.PureScript.Ide.Command
           Language.PureScript.Ide.Completion
+          Language.PureScript.Ide.Completion.Formatter
           Language.PureScript.Ide.Error
           Language.PureScript.Ide.Externs
           Language.PureScript.Ide.Filter
@@ -1000,6 +1001,7 @@ test-suite tests
     type: exitcode-stdio-1.0
     main-is: Main.hs
     other-modules:
+          Language.PureScript.Ide.CompletionSpec
           Language.PureScript.Ide.FilterSpec
           Language.PureScript.Ide.ImportsSpec
           Language.PureScript.Ide.MatcherSpec

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -22,6 +22,7 @@ import           Language.PureScript.Ide.CaseSplit
 import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.Matcher
 import           Language.PureScript.Ide.Types
+import           Language.PureScript.Ide.Completion.Formatter
 
 data Command
     = Load [P.ModuleName]
@@ -34,6 +35,7 @@ data Command
     | Complete
       { completeFilters       :: [Filter]
       , completeMatcher       :: Matcher IdeDeclarationAnn
+      , completeFormatter     :: CompletionFormatter
       , completeCurrentModule :: Maybe P.ModuleName
       }
     | Pursuit
@@ -128,6 +130,7 @@ instance FromJSON Command where
         Complete
           <$> params .:? "filters" .!= []
           <*> params .:? "matcher" .!= mempty
+          <*> params .:? "formatter" .!= defaultFormatter
           <*> (fmap P.moduleNameFromString <$> params .:? "currentModule")
       "pursuit" -> do
         params <- o .: "params"

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -3,11 +3,14 @@ module Language.PureScript.Ide.Completion
        , getExactMatches
        ) where
 
-import           Protolude
+import           Protolude hiding ((&), to, from)
 
+import           Control.Lens
+import qualified Data.Map.Strict as Map
 import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.Matcher
 import           Language.PureScript.Ide.Types
+import           Language.PureScript.Ide.Util
 import qualified Language.PureScript as P
 
 type Module = (P.ModuleName, [IdeDeclarationAnn])

--- a/src/Language/PureScript/Ide/Completion/Formatter.hs
+++ b/src/Language/PureScript/Ide/Completion/Formatter.hs
@@ -1,0 +1,135 @@
+module Language.PureScript.Ide.Completion.Formatter
+  ( CompletionFormatter(..)
+  , ReexportStrategy(..)
+  , runFormatter
+  , defaultFormatter
+  ) where
+
+import Protolude hiding ((&), from, to)
+import Control.Lens hiding (op)
+import Data.Aeson
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Util
+import qualified Language.PureScript as P
+
+data ReexportStrategy
+  = NoFlatten
+  | Flatten
+  | FlattenPrefer [P.ModuleName]
+
+data TypeFormat
+  = TypeFormat
+    { tfsUnicode :: Bool
+    , tfsMultiLine :: Bool
+    }
+
+data CompletionFormatter
+  = CompletionFormatter ReexportStrategy
+  | FullFormatter
+
+defaultFormatter :: CompletionFormatter
+defaultFormatter = CompletionFormatter NoFlatten
+
+runFormatter :: CompletionFormatter -> [Match IdeDeclarationAnn] -> [Completion]
+runFormatter (CompletionFormatter reexportStrategy) =
+  let
+    reexportHandler = case reexportStrategy of
+      NoFlatten -> map (, Nothing)
+      Flatten -> flattenReexports
+      FlattenPrefer _ -> flattenReexports -- TODO: zething
+  in
+    map (completionFromMatch (TypeFormat True False)) . reexportHandler
+
+completionFromMatch :: TypeFormat -> (Match IdeDeclarationAnn, Maybe [P.ModuleName]) -> Completion
+completionFromMatch TypeFormat{..} (Match (m, IdeDeclarationAnn ann decl), reexports) =
+  Completion {..}
+  where
+    ppType =
+      (if tfsMultiLine then T.unwords . map T.strip . T.lines . T.pack else T.pack) .
+      (if tfsUnicode then P.prettyPrintTypeWithUnicode else P.prettyPrintType)
+
+    (complIdentifier, complExpandedType) = case decl of
+      IdeDeclValue v -> (v ^. ideValueIdent . identT, v ^. ideValueType & ppType)
+      IdeDeclType t -> (t ^. ideTypeName . properNameT, t ^. ideTypeKind & P.prettyPrintKind)
+      IdeDeclTypeSynonym s -> (s ^. ideSynonymName . properNameT, s ^. ideSynonymType & ppType)
+      IdeDeclDataConstructor d -> (d ^. ideDtorName . properNameT, d ^. ideDtorType & ppType)
+      IdeDeclTypeClass d -> (d ^. ideTCName . properNameT, "type class")
+      IdeDeclValueOperator (IdeValueOperator op ref precedence associativity typeP) ->
+        (P.runOpName op, maybe (showFixity precedence associativity (valueOperatorAliasT ref) op) ppType typeP)
+      IdeDeclTypeOperator (IdeTypeOperator op ref precedence associativity kind) ->
+        (P.runOpName op, maybe (showFixity precedence associativity (typeOperatorAliasT ref) op) P.prettyPrintKind kind)
+      IdeDeclKind k -> (P.runProperName k, "kind")
+
+    complModule = P.runModuleName m
+
+    complReexports = map (map P.runModuleName) reexports
+
+    complType = maybe complExpandedType ppType (_annTypeAnnotation ann)
+
+    complLocation = _annLocation ann
+
+    complDocumentation = Nothing
+
+    showFixity p a r o =
+      let asso = case a of
+            P.Infix -> "infix"
+            P.Infixl -> "infixl"
+            P.Infixr -> "infixr"
+      in T.unwords [asso, show p, r, "as", P.runOpName o]
+
+flattenReexports :: [Match IdeDeclarationAnn] -> [(Match IdeDeclarationAnn, Maybe [P.ModuleName])]
+flattenReexports initial = second Just <$> Map.elems (foldr go Map.empty initial)
+  where
+    go (Match (moduleName, d@(IdeDeclarationAnn (_annExportedFrom -> Just origin) decl))) =
+      Map.alter
+      (insertReexport moduleName origin d)
+      (getNS decl (P.runModuleName origin <> "." <> identifierFromIdeDeclaration decl))
+    go (Match (moduleName, d@(IdeDeclarationAnn _ decl))) =
+      Map.alter
+      (insertDeclaration moduleName d)
+      (getNS decl (P.runModuleName moduleName <> "." <> identifierFromIdeDeclaration decl))
+    insertReexport moduleName origin d old = case old of
+      Nothing -> Just (Match (origin, d), [moduleName])
+      Just x -> Just (second (moduleName :) x)
+    insertDeclaration moduleName d old = case old of
+      Nothing -> Just (Match (moduleName, d), [])
+      Just x -> Just x
+
+
+getNS :: IdeDeclaration -> Text -> IdeDeclNamespace
+getNS d = case d of
+  IdeDeclValue _ -> IdeNSValue
+  IdeDeclType _ -> IdeNSType
+  IdeDeclTypeSynonym _ -> IdeNSType
+  IdeDeclDataConstructor _ -> IdeNSValue
+  IdeDeclTypeClass _ -> IdeNSType
+  IdeDeclValueOperator _ -> IdeNSValue
+  IdeDeclTypeOperator _ -> IdeNSType
+  IdeDeclKind _ -> IdeNSKind
+
+instance FromJSON ReexportStrategy where
+  parseJSON = withObject "ReexportStrategy" $ \o -> do
+    strategy :: Text <- o .: "strategy"
+    case strategy of
+      "noflatten" -> pure NoFlatten
+      "flatten" -> pure Flatten
+      "flattenPrefer" -> FlattenPrefer <$> o .: "modules"
+      _ -> mzero
+
+instance FromJSON CompletionFormatter where
+  parseJSON = withObject "CompletionFormatter" $ \o -> do
+    formatterType :: Text <- o .: "formatter"
+    case formatterType of
+      "completion" -> do
+        params <- o .:? "params"
+        case params of
+          Just p ->
+            CompletionFormatter <$> p .: "reexportStrategy"
+          Nothing ->
+            pure (CompletionFormatter NoFlatten)
+      "full" -> do
+        pure FullFormatter
+      _ -> mzero
+

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -66,9 +66,9 @@ encodeRebuildErrors = toJSON . map encodeRebuildError . P.runMultipleErrors
     insertTSCompletions _ _ _ v = v
 
     identCompletion (P.Qualified mn i, ty) =
-      Completion (maybe "" P.runModuleName mn) i (prettyPrintTypeSingleLine ty) (prettyPrintTypeSingleLine ty) Nothing Nothing
+      Completion (maybe "" P.runModuleName mn) Nothing i (prettyPrintTypeSingleLine ty) (prettyPrintTypeSingleLine ty) Nothing Nothing
     fieldCompletion (label, ty) =
-      Completion "" ("_." <> P.prettyPrintLabel label) (prettyPrintTypeSingleLine ty) (prettyPrintTypeSingleLine ty) Nothing Nothing
+      Completion "" Nothing ("_." <> P.prettyPrintLabel label) (prettyPrintTypeSingleLine ty) (prettyPrintTypeSingleLine ty) Nothing Nothing
 
 textError :: IdeError -> Text
 textError (GeneralError msg)          = msg

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -20,6 +20,7 @@ module Language.PureScript.Ide.Filter
        , prefixFilter
        , equalityFilter
        , applyFilters
+       , mkFilter
        ) where
 
 import           Protolude                     hiding (isPrefixOf)

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -182,6 +182,7 @@ newtype Match a = Match (P.ModuleName, a)
 -- | A completion as it gets sent to the editors
 data Completion = Completion
   { complModule        :: Text
+  , complReexports     :: Maybe [Text]
   , complIdentifier    :: Text
   , complType          :: Text
   , complExpandedType  :: Text
@@ -192,6 +193,7 @@ data Completion = Completion
 instance ToJSON Completion where
   toJSON (Completion {..}) =
     object [ "module" .= complModule
+           , "reexports" .= complReexports
            , "identifier" .= complIdentifier
            , "type" .= complType
            , "expandedType" .= complExpandedType

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -17,7 +17,6 @@ module Language.PureScript.Ide.Util
   , unwrapMatch
   , unwrapPositioned
   , unwrapPositionedRef
-  , completionFromMatch
   , encodeT
   , decodeT
   , discardAnn
@@ -40,7 +39,7 @@ import qualified Data.Text                           as T
 import qualified Data.Text.Lazy                      as TL
 import           Data.Text.Lazy.Encoding             (decodeUtf8, encodeUtf8)
 import qualified Language.PureScript                 as P
-import           Language.PureScript.Ide.Error       (prettyPrintTypeSingleLine, IdeError(..))
+import           Language.PureScript.Ide.Error       (IdeError(..))
 import           Language.PureScript.Ide.Logging
 import           Language.PureScript.Ide.Types
 import           System.IO.UTF8                      (readUTF8FileT)
@@ -64,37 +63,6 @@ withEmptyAnn = IdeDeclarationAnn emptyAnn
 
 unwrapMatch :: Match a -> a
 unwrapMatch (Match (_, ed)) = ed
-
-completionFromMatch :: Match IdeDeclarationAnn -> Completion
-completionFromMatch (Match (m, IdeDeclarationAnn ann decl)) =
-  Completion {..}
-  where
-    (complIdentifier, complExpandedType) = case decl of
-      IdeDeclValue v -> (v ^. ideValueIdent . identT, v ^. ideValueType & prettyPrintTypeSingleLine)
-      IdeDeclType t -> (t ^. ideTypeName . properNameT, t ^. ideTypeKind & P.prettyPrintKind)
-      IdeDeclTypeSynonym s -> (s ^. ideSynonymName . properNameT, s ^. ideSynonymType & prettyPrintTypeSingleLine)
-      IdeDeclDataConstructor d -> (d ^. ideDtorName . properNameT, d ^. ideDtorType & prettyPrintTypeSingleLine)
-      IdeDeclTypeClass d -> (d ^. ideTCName . properNameT, d ^. ideTCKind & P.prettyPrintKind)
-      IdeDeclValueOperator (IdeValueOperator op ref precedence associativity typeP) ->
-        (P.runOpName op, maybe (showFixity precedence associativity (valueOperatorAliasT ref) op) prettyPrintTypeSingleLine typeP)
-      IdeDeclTypeOperator (IdeTypeOperator op ref precedence associativity kind) ->
-        (P.runOpName op, maybe (showFixity precedence associativity (typeOperatorAliasT ref) op) P.prettyPrintKind kind)
-      IdeDeclKind k -> (P.runProperName k, "kind")
-
-    complModule = P.runModuleName m
-
-    complType = maybe complExpandedType prettyPrintTypeSingleLine (_annTypeAnnotation ann)
-
-    complLocation = _annLocation ann
-
-    complDocumentation = Nothing
-
-    showFixity p a r o =
-      let asso = case a of
-            P.Infix -> "infix"
-            P.Infixl -> "infixl"
-            P.Infixr -> "infixr"
-      in T.unwords [asso, show p, r, "as", P.runOpName o]
 
 valueOperatorAliasT
   :: P.Qualified (Either P.Ident (P.ProperName 'P.ConstructorName)) -> Text

--- a/tests/Language/PureScript/Ide/CompletionSpec.hs
+++ b/tests/Language/PureScript/Ide/CompletionSpec.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Language.PureScript.Ide.CompletionSpec where
+
+import           Protolude hiding (to, from, (&))
+import           Control.Lens
+import           Language.PureScript.Ide.Command
+import           Language.PureScript.Ide.Completion.Formatter
+import           Language.PureScript.Ide.Filter
+import           Language.PureScript.Ide.Test as Test
+import           Language.PureScript.Ide.Types
+import qualified Language.PureScript as P
+import           Test.Hspec
+
+type Module = (P.ModuleName, [IdeDeclarationAnn])
+
+moduleB :: (Text, [IdeDeclarationAnn])
+moduleB = ("ModuleB",
+           [ ideValue "sfValueB" Nothing
+           , ideSynonym "SFTypeB" P.tyString P.kindType
+           , ideType "SFDataB" Nothing
+           ])
+
+moduleC :: (Text, [IdeDeclarationAnn])
+moduleC = ("ModuleC",
+           [ ideValue "sfValueB" Nothing `annExp` "ModuleB"
+           , ideSynonym "SFTypeC" P.tyString P.kindType
+           ])
+
+moduleA :: (Text, [IdeDeclarationAnn])
+moduleA = ("ModuleA",
+           [ ideValue "sfValue" Nothing
+           , ideSynonym "SFType" P.tyString P.kindType
+           , ideType "SFData" Nothing
+           , ideDtor "SFOne" "SFData" Nothing
+           , ideDtor "SFTwo" "SFData" Nothing
+           , ideDtor "SFThree" "SFData" Nothing
+           , ideTypeClass "SFClass" P.kindType []
+           , ideValueOp "<$>" (P.Qualified Nothing (Left "")) 0 Nothing Nothing
+           , ideTypeOp "~>" (P.Qualified Nothing "") 0 Nothing Nothing
+           ])
+m :: Text -> P.ModuleName
+m = P.moduleNameFromString
+
+moduleBCompletions :: [Completion]
+moduleBCompletions = runFormatter defaultFormatter $ map (\decl -> Match (m "ModuleB", decl)) (snd moduleB)
+
+getCompletions :: [Text] -> CompletionFormatter -> IO [Completion]
+getCompletions modules formatter = Test.inProject $ do
+  ([Right (CompletionResult cs)], _) <-
+    Test.runIde' Test.defConfig ideState [Complete [moduleFilter (map m modules)] mempty formatter Nothing]
+  pure cs
+  where
+    ideState = emptyIdeState `s3` [moduleA, moduleB, moduleC]
+
+shouldBeEqualSorted :: (Show a, Ord a) => [a] -> [a] -> Expectation
+shouldBeEqualSorted = shouldBe `on` sort
+
+spec :: Spec
+spec = do
+  describe "Filtering by FilePath" $ do
+    it "should filter by the imported modules" $ do
+      cs <- getCompletions ["ModuleB"] defaultFormatter
+      cs `shouldBeEqualSorted` moduleBCompletions
+    it "should omit reexported definitions that are already in scope and list them as reexported" $ do
+      cs <- getCompletions ["ModuleB", "ModuleC"] (CompletionFormatter Flatten)
+      let cCompletions = runFormatter (CompletionFormatter Flatten) [Match (m "ModuleC", ideSynonym "SFTypeC" P.tyString P.kindType)]
+          bCompletions = moduleBCompletions
+            & map (\c -> c {complReexports = Just []})
+            & ix 0 %~ \c -> c {complReexports = Just ["ModuleC"]}
+      cs `shouldBeEqualSorted` (bCompletions ++ cCompletions)

--- a/tests/Language/PureScript/Ide/RebuildSpec.hs
+++ b/tests/Language/PureScript/Ide/RebuildSpec.hs
@@ -6,6 +6,7 @@ import           Protolude
 
 import           Language.PureScript.Ide.Command
 import           Language.PureScript.Ide.Matcher
+import           Language.PureScript.Ide.Completion.Formatter
 import           Language.PureScript.Ide.Types
 import qualified Language.PureScript.Ide.Test as Test
 import           System.FilePath
@@ -57,5 +58,5 @@ spec = describe "Rebuilding single modules" $ do
     it "completes a hidden identifier after rebuilding" $ do
       ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
         Test.runIde [ rebuildSync "RebuildSpecWithHiddenIdent.purs"
-                    , Complete [] (flexMatcher "hid") (Just (Test.mn "RebuildSpecWithHiddenIdent"))]
+                    , Complete [] (flexMatcher "hid") defaultFormatter (Just (Test.mn "RebuildSpecWithHiddenIdent"))]
       complIdentifier result `shouldBe` "hidden"


### PR DESCRIPTION
After #2798 

Still a work in progress, but I decided to share what I have so we can talk about the design.

Currently the pipeline for completions (and type information) looks as follows:

`Declarations |> Filters |> Matcher |> Completions`

I propose to add a new Formatting step:

`Declarations |> Filters |> Matcher |> _Formatter_ |> Completions`

For now I want to use this to allow configuring whether and how Reexports should be grouped, but in the future I'd like to implement Formatters that are not necessarily tailored at providing completions, but rather the full breadth of information available inside purs ide's state. Some Ideas:

- A GraphQL like specification of the to be returned schema
- Max number of results
- Type format: (Unicode, Single/Multiline, a structured format?)
- Append possible followup commands, like say the correct add import command

/cc @nwolverson @chexxor @FrigoEU 