### PR TITLE
Desugar pattern guards *after* type checking

### DIFF
--- a/examples/passing/2795.purs
+++ b/examples/passing/2795.purs
@@ -1,0 +1,14 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console (log)
+
+data X = X Int | Y
+
+x :: X -> Int
+x = case _ of
+      Y -> 0
+      X n | 1 <- n -> 1
+          | otherwise -> 2
+
+main = log "Done"

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -556,12 +556,7 @@ checkBinders nvals ret (CaseAlternative binders result : bs) = do
     let ns = concatMap binderNames binders in length (ordNub ns) == length ns
   m1 <- M.unions <$> zipWithM inferBinder nvals binders
   r <- bindLocalVariables [ (name, ty, Defined) | (name, ty) <- M.toList m1 ] $
-    CaseAlternative binders <$>
-      case result of
-        [MkUnguarded val] -> do
-          val' <- TypedValue True <$> check val ret <*> pure ret
-          return [MkUnguarded val']
-        gs -> forM gs (\ge -> checkGuardedRhs ge ret)
+       CaseAlternative binders <$> forM result (\ge -> checkGuardedRhs ge ret)
   rs <- checkBinders nvals ret bs
   return $ r : rs
 
@@ -573,12 +568,18 @@ checkGuardedRhs
 checkGuardedRhs (GuardedExpr [] rhs) ret = do
   rhs' <- TypedValue True <$> check rhs ret <*> pure ret
   return $ GuardedExpr [] rhs'
-checkGuardedRhs (GuardedExpr [ConditionGuard cond] rhs) ret = do
+checkGuardedRhs (GuardedExpr (ConditionGuard cond : guards) rhs) ret = do
   cond' <- withErrorMessageHint ErrorCheckingGuard $ check cond tyBoolean
-  rhs' <- TypedValue True <$> check rhs ret <*> pure ret
-  return $ GuardedExpr [ConditionGuard cond'] rhs'
-checkGuardedRhs _ _ =
-  internalError "Pattern not desugared"
+  GuardedExpr guards' rhs' <- checkGuardedRhs (GuardedExpr guards rhs) ret
+  return $ GuardedExpr (ConditionGuard cond' : guards') rhs'
+checkGuardedRhs (GuardedExpr (PatternGuard binder expr : guards) rhs) ret = do
+  expr'@(TypedValue _ _ ty) <- infer expr
+  variables <- inferBinder ty binder
+  GuardedExpr guards' rhs' <- bindLocalVariables [ (name, bty, Defined)
+                                                 | (name, bty) <- M.toList variables
+                                                 ] $
+    checkGuardedRhs (GuardedExpr guards rhs) ret
+  return $ GuardedExpr (PatternGuard binder expr' : guards') rhs'
 
 -- |
 -- Check the type of a value, rethrowing errors to provide a better error message


### PR DESCRIPTION
@paf31 

This is a fix for https://github.com/purescript/purescript/issues/2795

It's not working properly currently:
```
purs.exe: An internal error occurred during compilation: "Binders should have been desugared"
Please report this at https://github.com/purescript/purescript/issues
CallStack (from HasCallStack):
  error, called at src\Language\PureScript\Crash.hs:24:3 in purescript-0.11.1-inplace:Language.PureScript.Crash
  internalError, called at src\Language\PureScript\Sugar\BindingGroups.hs:112:33 in purescript-0.11.1-inplace:Language.PureScript.Sugar.BindingGroups
purs.exe: thread blocked indefinitely in an MVar operation
```

I am using `everywhereOnValuesM` traversal to traverse the list of `Declaration`s. It seems to miss the expressions in there. Please take a look at `desugarCaseGuards` for a hint. Any pointer on how to fix this? 