### PR TITLE
Use hpack to generate the .cabal file

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,155 @@
+name: purescript
+version: '0.11.1'
+synopsis: PureScript Programming Language Compiler
+description: A small strongly, statically typed programming language with expressive
+  types, inspired by Haskell and compiling to JavaScript.
+category: Language
+author: >
+  Phil Freeman <paf31@cantab.net>,
+  Gary Burgess <gary.burgess@gmail.com>,
+  Hardy Jones <jones3.hardy@gmail.com>,
+  Harry Garrood <harry@garrood.me>,
+  Christoph Hegemann <christoph.hegemann1337@gmail.com>
+maintainer: Phil Freeman <paf31@cantab.net>
+copyright: (c) 2013-16 Phil Freeman, (c) 2014-16 Gary Burgess
+license: BSD3
+github: purescript/purescript.git
+homepage: http://www.purescript.org/
+extra-source-files:
+  - examples/**/*.js
+  - examples/**/*.purs
+  - examples/**/*.json
+  - app/static/*
+  - tests/support/*.json
+  - tests/support/setup-win.cmd
+  - tests/support/psci/*.purs
+  - tests/support/pscide/src/*.purs
+  - tests/support/pscide/src/*.js
+  - tests/support/pscide/src/*.fail
+  - stack.yaml
+  - README.md
+  - INSTALL.md
+  - CONTRIBUTORS.md
+  - CONTRIBUTING.md
+dependencies:
+  - aeson >=0.8 && <1.1
+  - aeson-better-errors >=0.8
+  - ansi-terminal >=0.6.2 && <0.7
+  - base >=4.8 && <5
+  - base-compat >=0.6.0
+  - blaze-html >=0.8.1 && <0.9
+  - bower-json >=1.0.0.1 && <1.1
+  - boxes >=0.1.4 && <0.2.0
+  - bytestring
+  - cheapskate >=0.1 && <0.2
+  - clock
+  - containers
+  - data-ordlist >=0.4.7.0
+  - deepseq
+  - directory >=1.2
+  - dlist
+  - edit-distance
+  - filepath
+  - fsnotify >=0.2.1
+  - Glob >=0.7 && <0.8
+  - haskeline >=0.7.0.0
+  - http-client >=0.4.30 && <0.6.0
+  - http-types
+  - language-javascript >=0.6.0.9 && <0.7
+  - lens ==4.*
+  - lifted-base >=0.2.3 && <0.2.4
+  - monad-control >=1.0.0.0 && <1.1
+  - monad-logger >=0.3 && <0.4
+  - mtl >=2.1.0 && <2.3.0
+  - parallel >=3.2 && <3.3
+  - parsec >=3.1.10
+  - pattern-arrows >=0.0.2 && <0.1
+  - pipes >=4.0.0 && <4.4.0
+  - pipes-http
+  - process >=1.2.0 && <1.5
+  - protolude >=0.1.6
+  - regex-tdfa
+  - safe >=0.3.9 && <0.4
+  - scientific >=0.3.4.9 && <0.4
+  - semigroups >=0.16.2 && <0.19
+  - sourcemap >=0.1.6
+  - spdx ==0.2.*
+  - split
+  - stm >=0.2.4.0
+  - syb
+  - text
+  - time
+  - transformers >=0.3.0 && <0.6
+  - transformers-base >=0.4.0 && <0.5
+  - transformers-compat >=0.3.0
+  - unordered-containers
+  - utf8-string >=1 && <2
+  - vector
+
+library:
+  source-dirs: src
+  ghc-options: -Wall -O2
+  other-modules: Paths_purescript
+  default-extensions:
+    - ConstraintKinds
+    - DataKinds
+    - DeriveFunctor
+    - EmptyDataDecls
+    - FlexibleContexts
+    - KindSignatures
+    - LambdaCase
+    - MultiParamTypeClasses
+    - NoImplicitPrelude
+    - PatternGuards
+    - PatternSynonyms
+    - RankNTypes
+    - RecordWildCards
+    - OverloadedStrings
+    - ScopedTypeVariables
+    - TupleSections
+    - ViewPatterns
+
+executables:
+  purs:
+    main: Main.hs
+    source-dirs: app
+    ghc-options: -Wall -O2 -fno-warn-unused-do-bind -threaded -rtsopts -with-rtsopts=-N
+    dependencies:
+      - ansi-wl-pprint
+      - file-embed
+      - network
+      - optparse-applicative >=0.13.0
+      - purescript
+      - wai ==3.*
+      - wai-websockets ==3.*
+      - warp ==3.*
+      - websockets >=0.9 && <0.11
+    when:
+    - condition: flag(release)
+      then:
+        cpp-options: -DRELEASE
+      else:
+        dependencies:
+        - gitrev >=1.2.0 && <1.3
+
+tests:
+  tests:
+    main: Main.hs
+    source-dirs: tests
+    ghc-options: -Wall
+    dependencies:
+    - purescript
+    - hspec
+    - hspec-discover
+    - HUnit
+    - silently
+
+flags:
+  release:
+    description: >
+        Mark this build as a release build: prevents inclusion of extra
+        info e.g. commit SHA in --version output)
+    manual: false
+    default: false
+
+stability: experimental

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -1,468 +1,1025 @@
-name: purescript
-version: 0.11.1
-cabal-version: >=1.8
-build-type: Simple
-license: BSD3
-license-file: LICENSE
-copyright: (c) 2013-16 Phil Freeman, (c) 2014-16 Gary Burgess
-maintainer: Phil Freeman <paf31@cantab.net>
-stability: experimental
-synopsis: PureScript Programming Language Compiler
-description: A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
-category: Language
-Homepage: http://www.purescript.org/
-author: Phil Freeman <paf31@cantab.net>,
-        Gary Burgess <gary.burgess@gmail.com>,
-        Hardy Jones <jones3.hardy@gmail.com>,
-        Harry Garrood <harry@garrood.me>,
-        Christoph Hegemann <christoph.hegemann1337@gmail.com>
+-- This file has been generated from package.yaml by hpack version 0.15.0.
+--
+-- see: https://github.com/sol/hpack
 
-tested-with: GHC==7.10.3
+name:           purescript
+version:        0.11.1
+cabal-version:  >= 1.10
+build-type:     Simple
+license:        BSD3
+license-file:   LICENSE
+copyright:      (c) 2013-16 Phil Freeman, (c) 2014-16 Gary Burgess
+maintainer:     Phil Freeman <paf31@cantab.net>
+stability:      experimental
+homepage:       http://www.purescript.org/
+bug-reports:    https://github.com/purescript/purescript.git/issues
+synopsis:       PureScript Programming Language Compiler
+description:    A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
+category:       Language
+author:         Phil Freeman <paf31@cantab.net>, Gary Burgess <gary.burgess@gmail.com>, Hardy Jones <jones3.hardy@gmail.com>, Harry Garrood <harry@garrood.me>, Christoph Hegemann <christoph.hegemann1337@gmail.com>
 
-extra-source-files: examples/passing/*.purs
-                  , examples/passing/*.js
-                  , examples/passing/2018/*.purs
-                  , examples/passing/2138/*.purs
-                  , examples/passing/2609/*.purs
-                  , examples/passing/ClassRefSyntax/*.purs
-                  , examples/passing/DctorOperatorAlias/*.purs
-                  , examples/passing/ExplicitImportReExport/*.purs
-                  , examples/passing/ExportExplicit/*.purs
-                  , examples/passing/ExportExplicit2/*.purs
-                  , examples/passing/ForeignKind/*.purs
-                  , examples/passing/Import/*.purs
-                  , examples/passing/ImportExplicit/*.purs
-                  , examples/passing/ImportQualified/*.purs
-                  , examples/passing/Module/*.purs
-                  , examples/passing/ModuleDeps/*.purs
-                  , examples/passing/ModuleExport/*.purs
-                  , examples/passing/ModuleExportDupes/*.purs
-                  , examples/passing/ModuleExportExcluded/*.purs
-                  , examples/passing/ModuleExportQualified/*.purs
-                  , examples/passing/ModuleExportSelf/*.purs
-                  , examples/passing/NonConflictingExports/*.purs
-                  , examples/passing/NonOrphanInstanceMulti/*.purs
-                  , examples/passing/NonOrphanInstanceFunDepExtra/*.purs
-                  , examples/passing/OperatorAliasElsewhere/*.purs
-                  , examples/passing/Operators/*.purs
-                  , examples/passing/PendingConflictingImports/*.purs
-                  , examples/passing/PendingConflictingImports2/*.purs
-                  , examples/passing/QualifiedNames/*.purs
-                  , examples/passing/RedefinedFixity/*.purs
-                  , examples/passing/ReExportQualified/*.purs
-                  , examples/passing/ResolvableScopeConflict/*.purs
-                  , examples/passing/ResolvableScopeConflict2/*.purs
-                  , examples/passing/ResolvableScopeConflict3/*.purs
-                  , examples/passing/ShadowedModuleName/*.purs
-                  , examples/passing/SolvingIsSymbol/*.purs
-                  , examples/passing/StringEdgeCases/*.purs
-                  , examples/passing/TransitiveImport/*.purs
-                  , examples/passing/TypeOperators/*.purs
-                  , examples/passing/TypeWithoutParens/*.purs
-                  , examples/failing/*.purs
-                  , examples/failing/1733/*.purs
-                  , examples/failing/2378/*.purs
-                  , examples/failing/2379/*.purs
-                  , examples/failing/ConflictingExports/*.purs
-                  , examples/failing/ConflictingImports/*.purs
-                  , examples/failing/ConflictingImports2/*.purs
-                  , examples/failing/ConflictingQualifiedImports/*.purs
-                  , examples/failing/ConflictingQualifiedImports2/*.purs
-                  , examples/failing/DiffKindsSameName/*.purs
-                  , examples/failing/DuplicateModule/*.purs
-                  , examples/failing/ExportConflictClass/*.purs
-                  , examples/failing/ExportConflictCtor/*.purs
-                  , examples/failing/ExportConflictType/*.purs
-                  , examples/failing/ExportConflictTypeOp/*.purs
-                  , examples/failing/ExportConflictValue/*.purs
-                  , examples/failing/ExportConflictValueOp/*.purs
-                  , examples/failing/ExportExplicit1/*.purs
-                  , examples/failing/ExportExplicit3/*.purs
-                  , examples/failing/ImportExplicit/*.purs
-                  , examples/failing/ImportExplicit2/*.purs
-                  , examples/failing/ImportHidingModule/*.purs
-                  , examples/failing/ImportModule/*.purs
-                  , examples/failing/InstanceExport/*.purs
-                  , examples/failing/OrphanInstance/*.purs
-                  , examples/failing/OrphanInstanceFunDepCycle/*.purs
-                  , examples/failing/OrphanInstanceWithDetermined/*.purs
-                  , examples/failing/OrphanInstanceNullary/*.purs
-                  , examples/warning/*.purs
-                  , examples/warning/*.js
-                  , examples/warning/UnusedExplicitImportTypeOp/*.purs
-                  , examples/docs/bower_components/purescript-prelude/src/*.purs
-                  , examples/docs/bower.json
-                  , examples/docs/src/*.purs
-                  , examples/docs/resolutions.json
-                  , app/static/index.html
-                  , app/static/index.js
-                  , app/static/*.css
-                  , tests/support/package.json
-                  , tests/support/bower.json
-                  , tests/support/setup-win.cmd
-                  , tests/support/psci/*.purs
-                  , tests/support/pscide/src/*.purs
-                  , tests/support/pscide/src/*.js
-                  , tests/support/pscide/src/*.fail
-                  , tests/support/prelude-resolutions.json
-                  , stack.yaml
-                  , README.md
-                  , INSTALL.md
-                  , CONTRIBUTORS.md
-                  , CONTRIBUTING.md
+
+extra-source-files:
+      app/static/index.html
+      app/static/index.js
+      app/static/normalize.css
+      app/static/pursuit.css
+      CONTRIBUTING.md
+      CONTRIBUTORS.md
+      examples/docs/bower.json
+      examples/docs/bower_components/purescript-prelude/src/Prelude.purs
+      examples/docs/resolutions.json
+      examples/docs/src/Clash.purs
+      examples/docs/src/Clash1.purs
+      examples/docs/src/Clash1a.purs
+      examples/docs/src/Clash2.purs
+      examples/docs/src/Clash2a.purs
+      examples/docs/src/ConstrainedArgument.purs
+      examples/docs/src/DocComments.purs
+      examples/docs/src/DuplicateNames.purs
+      examples/docs/src/Example.purs
+      examples/docs/src/Example2.purs
+      examples/docs/src/ExplicitTypeSignatures.purs
+      examples/docs/src/ImportedTwice.purs
+      examples/docs/src/ImportedTwiceA.purs
+      examples/docs/src/ImportedTwiceB.purs
+      examples/docs/src/MultiVirtual.purs
+      examples/docs/src/MultiVirtual1.purs
+      examples/docs/src/MultiVirtual2.purs
+      examples/docs/src/MultiVirtual3.purs
+      examples/docs/src/NewOperators.purs
+      examples/docs/src/NewOperators2.purs
+      examples/docs/src/NotAllCtors.purs
+      examples/docs/src/ReExportedTypeClass.purs
+      examples/docs/src/SolitaryTypeClassMember.purs
+      examples/docs/src/SomeTypeClass.purs
+      examples/docs/src/Transitive1.purs
+      examples/docs/src/Transitive2.purs
+      examples/docs/src/Transitive3.purs
+      examples/docs/src/TypeClassWithFunDeps.purs
+      examples/docs/src/TypeClassWithoutMembers.purs
+      examples/docs/src/TypeClassWithoutMembersIntermediate.purs
+      examples/docs/src/TypeOpAliases.purs
+      examples/docs/src/UTF8.purs
+      examples/docs/src/Virtual.purs
+      examples/failing/1071.purs
+      examples/failing/1169.purs
+      examples/failing/1175.purs
+      examples/failing/1310.purs
+      examples/failing/1570.purs
+      examples/failing/1733.purs
+      examples/failing/1733/Thingy.purs
+      examples/failing/1825.purs
+      examples/failing/1881.purs
+      examples/failing/2128-class.purs
+      examples/failing/2128-instance.purs
+      examples/failing/2378.purs
+      examples/failing/2378/Lib.purs
+      examples/failing/2379.purs
+      examples/failing/2379/Lib.purs
+      examples/failing/2434.purs
+      examples/failing/2534.purs
+      examples/failing/2542.purs
+      examples/failing/2567.purs
+      examples/failing/2601.purs
+      examples/failing/2616.purs
+      examples/failing/365.purs
+      examples/failing/438.purs
+      examples/failing/881.purs
+      examples/failing/AnonArgument1.purs
+      examples/failing/AnonArgument2.purs
+      examples/failing/AnonArgument3.purs
+      examples/failing/ArgLengthMismatch.purs
+      examples/failing/Arrays.purs
+      examples/failing/ArrayType.purs
+      examples/failing/BindInDo-2.purs
+      examples/failing/BindInDo.purs
+      examples/failing/CannotDeriveNewtypeForData.purs
+      examples/failing/CaseBinderLengthsDiffer.purs
+      examples/failing/CaseDoesNotMatchAllConstructorArgs.purs
+      examples/failing/ConflictingExports.purs
+      examples/failing/ConflictingExports/A.purs
+      examples/failing/ConflictingExports/B.purs
+      examples/failing/ConflictingImports.purs
+      examples/failing/ConflictingImports/A.purs
+      examples/failing/ConflictingImports/B.purs
+      examples/failing/ConflictingImports2.purs
+      examples/failing/ConflictingImports2/A.purs
+      examples/failing/ConflictingImports2/B.purs
+      examples/failing/ConflictingQualifiedImports.purs
+      examples/failing/ConflictingQualifiedImports/A.purs
+      examples/failing/ConflictingQualifiedImports/B.purs
+      examples/failing/ConflictingQualifiedImports2.purs
+      examples/failing/ConflictingQualifiedImports2/A.purs
+      examples/failing/ConflictingQualifiedImports2/B.purs
+      examples/failing/ConstraintFailure.purs
+      examples/failing/ConstraintInference.purs
+      examples/failing/DctorOperatorAliasExport.purs
+      examples/failing/DeclConflictClassCtor.purs
+      examples/failing/DeclConflictClassSynonym.purs
+      examples/failing/DeclConflictClassType.purs
+      examples/failing/DeclConflictCtorClass.purs
+      examples/failing/DeclConflictCtorCtor.purs
+      examples/failing/DeclConflictDuplicateCtor.purs
+      examples/failing/DeclConflictSynonymClass.purs
+      examples/failing/DeclConflictSynonymType.purs
+      examples/failing/DeclConflictTypeClass.purs
+      examples/failing/DeclConflictTypeSynonym.purs
+      examples/failing/DeclConflictTypeType.purs
+      examples/failing/DiffKindsSameName.purs
+      examples/failing/DiffKindsSameName/LibA.purs
+      examples/failing/DiffKindsSameName/LibB.purs
+      examples/failing/Do.purs
+      examples/failing/DoNotSuggestComposition.purs
+      examples/failing/DoNotSuggestComposition2.purs
+      examples/failing/DuplicateDeclarationsInLet.purs
+      examples/failing/DuplicateModule.purs
+      examples/failing/DuplicateModule/M1.purs
+      examples/failing/DuplicateProperties.purs
+      examples/failing/DuplicateTypeVars.purs
+      examples/failing/Eff.purs
+      examples/failing/EmptyCase.purs
+      examples/failing/EmptyClass.purs
+      examples/failing/EmptyDo.purs
+      examples/failing/ExportConflictClass.purs
+      examples/failing/ExportConflictClass/A.purs
+      examples/failing/ExportConflictClass/B.purs
+      examples/failing/ExportConflictCtor.purs
+      examples/failing/ExportConflictCtor/A.purs
+      examples/failing/ExportConflictCtor/B.purs
+      examples/failing/ExportConflictType.purs
+      examples/failing/ExportConflictType/A.purs
+      examples/failing/ExportConflictType/B.purs
+      examples/failing/ExportConflictTypeOp.purs
+      examples/failing/ExportConflictTypeOp/A.purs
+      examples/failing/ExportConflictTypeOp/B.purs
+      examples/failing/ExportConflictValue.purs
+      examples/failing/ExportConflictValue/A.purs
+      examples/failing/ExportConflictValue/B.purs
+      examples/failing/ExportConflictValueOp.purs
+      examples/failing/ExportConflictValueOp/A.purs
+      examples/failing/ExportConflictValueOp/B.purs
+      examples/failing/ExportExplicit.purs
+      examples/failing/ExportExplicit1.purs
+      examples/failing/ExportExplicit1/M1.purs
+      examples/failing/ExportExplicit2.purs
+      examples/failing/ExportExplicit3.purs
+      examples/failing/ExportExplicit3/M1.purs
+      examples/failing/ExtraRecordField.purs
+      examples/failing/Foldable.purs
+      examples/failing/Generalization1.purs
+      examples/failing/Generalization2.purs
+      examples/failing/ImportExplicit.purs
+      examples/failing/ImportExplicit/M1.purs
+      examples/failing/ImportExplicit2.purs
+      examples/failing/ImportExplicit2/M1.purs
+      examples/failing/ImportHidingModule.purs
+      examples/failing/ImportHidingModule/A.purs
+      examples/failing/ImportHidingModule/B.purs
+      examples/failing/ImportModule.purs
+      examples/failing/ImportModule/M2.purs
+      examples/failing/InfiniteKind.purs
+      examples/failing/InfiniteType.purs
+      examples/failing/InstanceExport.purs
+      examples/failing/InstanceExport/InstanceExport.purs
+      examples/failing/IntOutOfRange.purs
+      examples/failing/InvalidDerivedInstance.purs
+      examples/failing/InvalidDerivedInstance2.purs
+      examples/failing/InvalidOperatorInBinder.purs
+      examples/failing/KindError.purs
+      examples/failing/KindStar.purs
+      examples/failing/LeadingZeros1.purs
+      examples/failing/LeadingZeros2.purs
+      examples/failing/Let.purs
+      examples/failing/LetPatterns1.purs
+      examples/failing/LetPatterns2.purs
+      examples/failing/LetPatterns3.purs
+      examples/failing/LetPatterns4.purs
+      examples/failing/MissingClassExport.purs
+      examples/failing/MissingClassMemberExport.purs
+      examples/failing/MissingRecordField.purs
+      examples/failing/MPTCs.purs
+      examples/failing/MultipleErrors.purs
+      examples/failing/MultipleErrors2.purs
+      examples/failing/MultipleTypeOpFixities.purs
+      examples/failing/MultipleValueOpFixities.purs
+      examples/failing/MutRec.purs
+      examples/failing/MutRec2.purs
+      examples/failing/NewtypeInstance.purs
+      examples/failing/NewtypeInstance2.purs
+      examples/failing/NewtypeInstance3.purs
+      examples/failing/NewtypeInstance4.purs
+      examples/failing/NewtypeInstance5.purs
+      examples/failing/NewtypeInstance6.purs
+      examples/failing/NewtypeMultiArgs.purs
+      examples/failing/NewtypeMultiCtor.purs
+      examples/failing/NonExhaustivePatGuard.purs
+      examples/failing/NonWildcardNewtypeInstance.purs
+      examples/failing/NullaryAbs.purs
+      examples/failing/Object.purs
+      examples/failing/OperatorAliasNoExport.purs
+      examples/failing/OperatorSections.purs
+      examples/failing/OrphanInstance.purs
+      examples/failing/OrphanInstance/Class.purs
+      examples/failing/OrphanInstanceFunDepCycle.purs
+      examples/failing/OrphanInstanceFunDepCycle/Lib.purs
+      examples/failing/OrphanInstanceNullary.purs
+      examples/failing/OrphanInstanceNullary/Lib.purs
+      examples/failing/OrphanInstanceWithDetermined.purs
+      examples/failing/OrphanInstanceWithDetermined/Lib.purs
+      examples/failing/OrphanTypeDecl.purs
+      examples/failing/OverlappingArguments.purs
+      examples/failing/OverlappingBinders.purs
+      examples/failing/OverlappingVars.purs
+      examples/failing/ProgrammableTypeErrors.purs
+      examples/failing/ProgrammableTypeErrorsTypeString.purs
+      examples/failing/Rank2Types.purs
+      examples/failing/RequiredHiddenType.purs
+      examples/failing/Reserved.purs
+      examples/failing/RowConstructors1.purs
+      examples/failing/RowConstructors2.purs
+      examples/failing/RowConstructors3.purs
+      examples/failing/RowInInstanceNotDetermined0.purs
+      examples/failing/RowInInstanceNotDetermined1.purs
+      examples/failing/RowInInstanceNotDetermined2.purs
+      examples/failing/SkolemEscape.purs
+      examples/failing/SkolemEscape2.purs
+      examples/failing/SuggestComposition.purs
+      examples/failing/Superclasses1.purs
+      examples/failing/Superclasses2.purs
+      examples/failing/Superclasses3.purs
+      examples/failing/Superclasses5.purs
+      examples/failing/TooFewClassInstanceArgs.purs
+      examples/failing/TopLevelCaseNoArgs.purs
+      examples/failing/TransitiveDctorExport.purs
+      examples/failing/TransitiveSynonymExport.purs
+      examples/failing/TypeClasses2.purs
+      examples/failing/TypeClassInstances.purs
+      examples/failing/TypedBinders.purs
+      examples/failing/TypedBinders2.purs
+      examples/failing/TypedBinders3.purs
+      examples/failing/TypedHole.purs
+      examples/failing/TypeError.purs
+      examples/failing/TypeOperatorAliasNoExport.purs
+      examples/failing/TypeSynonyms.purs
+      examples/failing/TypeSynonyms2.purs
+      examples/failing/TypeSynonyms3.purs
+      examples/failing/TypeSynonyms4.purs
+      examples/failing/TypeSynonyms5.purs
+      examples/failing/TypeWildcards1.purs
+      examples/failing/TypeWildcards2.purs
+      examples/failing/TypeWildcards3.purs
+      examples/failing/UnderscoreModuleName.purs
+      examples/failing/UnknownType.purs
+      examples/failing/UnusableTypeClassMethod.purs
+      examples/failing/UnusableTypeClassMethodConflictingIdent.purs
+      examples/failing/UnusableTypeClassMethodSynonym.purs
+      examples/passing/1110.purs
+      examples/passing/1185.purs
+      examples/passing/1335.purs
+      examples/passing/1570.purs
+      examples/passing/1664.purs
+      examples/passing/1697.purs
+      examples/passing/1807.purs
+      examples/passing/1881.purs
+      examples/passing/1991.purs
+      examples/passing/2018.purs
+      examples/passing/2018/A.purs
+      examples/passing/2018/B.purs
+      examples/passing/2049.purs
+      examples/passing/2136.purs
+      examples/passing/2138.purs
+      examples/passing/2138/Lib.purs
+      examples/passing/2172.js
+      examples/passing/2172.purs
+      examples/passing/2252.purs
+      examples/passing/2288.purs
+      examples/passing/2378.purs
+      examples/passing/2438.purs
+      examples/passing/2609.purs
+      examples/passing/2609/Eg.purs
+      examples/passing/2616.purs
+      examples/passing/2626.purs
+      examples/passing/2663.purs
+      examples/passing/2689.purs
+      examples/passing/2695.purs
+      examples/passing/2756.purs
+      examples/passing/2787.purs
+      examples/passing/652.purs
+      examples/passing/810.purs
+      examples/passing/862.purs
+      examples/passing/922.purs
+      examples/passing/Applicative.purs
+      examples/passing/ArrayType.purs
+      examples/passing/Auto.purs
+      examples/passing/AutoPrelude.purs
+      examples/passing/AutoPrelude2.purs
+      examples/passing/BindersInFunctions.purs
+      examples/passing/BindingGroups.purs
+      examples/passing/BlockString.purs
+      examples/passing/CaseInDo.purs
+      examples/passing/CaseInputWildcard.purs
+      examples/passing/CaseMultipleExpressions.purs
+      examples/passing/CaseStatement.purs
+      examples/passing/CheckFunction.purs
+      examples/passing/CheckSynonymBug.purs
+      examples/passing/CheckTypeClass.purs
+      examples/passing/Church.purs
+      examples/passing/ClassRefSyntax.purs
+      examples/passing/ClassRefSyntax/Lib.purs
+      examples/passing/Collatz.purs
+      examples/passing/Comparisons.purs
+      examples/passing/Conditional.purs
+      examples/passing/Console.purs
+      examples/passing/ConstraintInference.purs
+      examples/passing/ConstraintParens.purs
+      examples/passing/ConstraintParsingIssue.purs
+      examples/passing/ContextSimplification.purs
+      examples/passing/DataAndType.purs
+      examples/passing/DctorName.purs
+      examples/passing/DctorOperatorAlias.purs
+      examples/passing/DctorOperatorAlias/List.purs
+      examples/passing/DeepArrayBinder.purs
+      examples/passing/DeepCase.purs
+      examples/passing/DeriveNewtype.purs
+      examples/passing/DeriveWithNestedSynonyms.purs
+      examples/passing/Deriving.purs
+      examples/passing/DerivingFunctor.purs
+      examples/passing/Do.purs
+      examples/passing/Dollar.purs
+      examples/passing/DuplicateProperties.purs
+      examples/passing/Eff.purs
+      examples/passing/EmptyDataDecls.purs
+      examples/passing/EmptyRow.purs
+      examples/passing/EmptyTypeClass.purs
+      examples/passing/EntailsKindedType.purs
+      examples/passing/EqOrd.purs
+      examples/passing/ExplicitImportReExport.purs
+      examples/passing/ExplicitImportReExport/Bar.purs
+      examples/passing/ExplicitImportReExport/Foo.purs
+      examples/passing/ExplicitOperatorSections.purs
+      examples/passing/ExportedInstanceDeclarations.purs
+      examples/passing/ExportExplicit.purs
+      examples/passing/ExportExplicit/M1.purs
+      examples/passing/ExportExplicit2.purs
+      examples/passing/ExportExplicit2/M1.purs
+      examples/passing/ExtendedInfixOperators.purs
+      examples/passing/Fib.purs
+      examples/passing/FieldConsPuns.purs
+      examples/passing/FieldPuns.purs
+      examples/passing/FinalTagless.purs
+      examples/passing/ForeignKind.purs
+      examples/passing/ForeignKind/Lib.purs
+      examples/passing/FunctionalDependencies.purs
+      examples/passing/Functions.purs
+      examples/passing/Functions2.purs
+      examples/passing/FunctionScope.purs
+      examples/passing/FunWithFunDeps.js
+      examples/passing/FunWithFunDeps.purs
+      examples/passing/Generalization1.purs
+      examples/passing/GenericsRep.purs
+      examples/passing/Guards.purs
+      examples/passing/HasOwnProperty.purs
+      examples/passing/HoistError.purs
+      examples/passing/IfThenElseMaybe.purs
+      examples/passing/IfWildcard.purs
+      examples/passing/ImplicitEmptyImport.purs
+      examples/passing/Import.purs
+      examples/passing/Import/M1.purs
+      examples/passing/Import/M2.purs
+      examples/passing/ImportExplicit.purs
+      examples/passing/ImportExplicit/M1.purs
+      examples/passing/ImportHiding.purs
+      examples/passing/ImportQualified.purs
+      examples/passing/ImportQualified/M1.purs
+      examples/passing/InferRecFunWithConstrainedArgument.purs
+      examples/passing/InstanceBeforeClass.purs
+      examples/passing/IntAndChar.purs
+      examples/passing/iota.purs
+      examples/passing/JSReserved.purs
+      examples/passing/KindedType.purs
+      examples/passing/LargeSumType.purs
+      examples/passing/Let.purs
+      examples/passing/Let2.purs
+      examples/passing/LetInInstance.purs
+      examples/passing/LetPattern.purs
+      examples/passing/LiberalTypeSynonyms.purs
+      examples/passing/Match.purs
+      examples/passing/Module.purs
+      examples/passing/Module/M1.purs
+      examples/passing/Module/M2.purs
+      examples/passing/ModuleDeps.purs
+      examples/passing/ModuleDeps/M1.purs
+      examples/passing/ModuleDeps/M2.purs
+      examples/passing/ModuleDeps/M3.purs
+      examples/passing/ModuleExport.purs
+      examples/passing/ModuleExport/A.purs
+      examples/passing/ModuleExportDupes.purs
+      examples/passing/ModuleExportDupes/A.purs
+      examples/passing/ModuleExportDupes/B.purs
+      examples/passing/ModuleExportDupes/C.purs
+      examples/passing/ModuleExportExcluded.purs
+      examples/passing/ModuleExportExcluded/A.purs
+      examples/passing/ModuleExportQualified.purs
+      examples/passing/ModuleExportQualified/A.purs
+      examples/passing/ModuleExportSelf.purs
+      examples/passing/ModuleExportSelf/A.purs
+      examples/passing/Monad.purs
+      examples/passing/MonadState.purs
+      examples/passing/MPTCs.purs
+      examples/passing/MultiArgFunctions.purs
+      examples/passing/MutRec.purs
+      examples/passing/MutRec2.purs
+      examples/passing/MutRec3.purs
+      examples/passing/NakedConstraint.purs
+      examples/passing/NamedPatterns.purs
+      examples/passing/NegativeBinder.purs
+      examples/passing/NegativeIntInRange.purs
+      examples/passing/Nested.purs
+      examples/passing/NestedRecordUpdate.purs
+      examples/passing/NestedRecordUpdateWildcards.purs
+      examples/passing/NestedTypeSynonyms.purs
+      examples/passing/NestedWhere.purs
+      examples/passing/Newtype.purs
+      examples/passing/NewtypeClass.purs
+      examples/passing/NewtypeEff.purs
+      examples/passing/NewtypeInstance.purs
+      examples/passing/NewtypeWithRecordUpdate.purs
+      examples/passing/NonConflictingExports.purs
+      examples/passing/NonConflictingExports/A.purs
+      examples/passing/NonOrphanInstanceFunDepExtra.purs
+      examples/passing/NonOrphanInstanceFunDepExtra/Lib.purs
+      examples/passing/NonOrphanInstanceMulti.purs
+      examples/passing/NonOrphanInstanceMulti/Lib.purs
+      examples/passing/NumberLiterals.purs
+      examples/passing/ObjectGetter.purs
+      examples/passing/Objects.purs
+      examples/passing/ObjectSynonym.purs
+      examples/passing/ObjectUpdate.purs
+      examples/passing/ObjectUpdate2.purs
+      examples/passing/ObjectUpdater.purs
+      examples/passing/ObjectWildcards.purs
+      examples/passing/OneConstructor.purs
+      examples/passing/OperatorAlias.purs
+      examples/passing/OperatorAliasElsewhere.purs
+      examples/passing/OperatorAliasElsewhere/Def.purs
+      examples/passing/OperatorAssociativity.purs
+      examples/passing/OperatorInlining.purs
+      examples/passing/Operators.purs
+      examples/passing/Operators/Other.purs
+      examples/passing/OperatorSections.purs
+      examples/passing/OptimizerBug.purs
+      examples/passing/OptionalQualified.purs
+      examples/passing/OverlappingInstances.purs
+      examples/passing/OverlappingInstances2.purs
+      examples/passing/OverlappingInstances3.purs
+      examples/passing/ParensInTypedBinder.purs
+      examples/passing/PartialFunction.purs
+      examples/passing/Patterns.purs
+      examples/passing/PendingConflictingImports.purs
+      examples/passing/PendingConflictingImports/A.purs
+      examples/passing/PendingConflictingImports/B.purs
+      examples/passing/PendingConflictingImports2.purs
+      examples/passing/PendingConflictingImports2/A.purs
+      examples/passing/Person.purs
+      examples/passing/PolyLabels.js
+      examples/passing/PolyLabels.purs
+      examples/passing/PrimedTypeName.purs
+      examples/passing/QualifiedNames.purs
+      examples/passing/QualifiedNames/Either.purs
+      examples/passing/QualifiedQualifiedImports.purs
+      examples/passing/Rank2Data.purs
+      examples/passing/Rank2Object.purs
+      examples/passing/Rank2Types.purs
+      examples/passing/Rank2TypeSynonym.purs
+      examples/passing/RebindableSyntax.purs
+      examples/passing/Recursion.purs
+      examples/passing/RedefinedFixity.purs
+      examples/passing/RedefinedFixity/M1.purs
+      examples/passing/RedefinedFixity/M2.purs
+      examples/passing/RedefinedFixity/M3.purs
+      examples/passing/ReExportQualified.purs
+      examples/passing/ReExportQualified/A.purs
+      examples/passing/ReExportQualified/B.purs
+      examples/passing/ReExportQualified/C.purs
+      examples/passing/ReservedWords.purs
+      examples/passing/ResolvableScopeConflict.purs
+      examples/passing/ResolvableScopeConflict/A.purs
+      examples/passing/ResolvableScopeConflict/B.purs
+      examples/passing/ResolvableScopeConflict2.purs
+      examples/passing/ResolvableScopeConflict2/A.purs
+      examples/passing/ResolvableScopeConflict3.purs
+      examples/passing/ResolvableScopeConflict3/A.purs
+      examples/passing/RowConstructors.purs
+      examples/passing/RowInInstanceHeadDetermined.purs
+      examples/passing/RowPolyInstanceContext.purs
+      examples/passing/RowsInInstanceContext.purs
+      examples/passing/RowUnion.js
+      examples/passing/RowUnion.purs
+      examples/passing/RuntimeScopeIssue.purs
+      examples/passing/s.purs
+      examples/passing/ScopedTypeVariables.purs
+      examples/passing/Sequence.purs
+      examples/passing/SequenceDesugared.purs
+      examples/passing/ShadowedModuleName.purs
+      examples/passing/ShadowedModuleName/Test.purs
+      examples/passing/ShadowedName.purs
+      examples/passing/ShadowedRename.purs
+      examples/passing/ShadowedTCO.purs
+      examples/passing/ShadowedTCOLet.purs
+      examples/passing/SignedNumericLiterals.purs
+      examples/passing/SolvingAppendSymbol.purs
+      examples/passing/SolvingCompareSymbol.purs
+      examples/passing/SolvingIsSymbol.purs
+      examples/passing/SolvingIsSymbol/Lib.purs
+      examples/passing/Stream.purs
+      examples/passing/StringEdgeCases.purs
+      examples/passing/StringEdgeCases/Records.purs
+      examples/passing/StringEdgeCases/Symbols.purs
+      examples/passing/StringEscapes.purs
+      examples/passing/Superclasses1.purs
+      examples/passing/Superclasses3.purs
+      examples/passing/TailCall.purs
+      examples/passing/TCO.purs
+      examples/passing/TCOCase.purs
+      examples/passing/Tick.purs
+      examples/passing/TopLevelCase.purs
+      examples/passing/TransitiveImport.purs
+      examples/passing/TransitiveImport/Middle.purs
+      examples/passing/TransitiveImport/Test.purs
+      examples/passing/TypeClasses.purs
+      examples/passing/TypeClassesInOrder.purs
+      examples/passing/TypeClassesWithOverlappingTypeVariables.purs
+      examples/passing/TypeClassMemberOrderChange.purs
+      examples/passing/TypedBinders.purs
+      examples/passing/TypeDecl.purs
+      examples/passing/TypedWhere.purs
+      examples/passing/TypeOperators.purs
+      examples/passing/TypeOperators/A.purs
+      examples/passing/TypeSynonymInData.purs
+      examples/passing/TypeSynonyms.purs
+      examples/passing/TypeWildcards.purs
+      examples/passing/TypeWildcardsRecordExtension.purs
+      examples/passing/TypeWithoutParens.purs
+      examples/passing/TypeWithoutParens/Lib.purs
+      examples/passing/UnderscoreIdent.purs
+      examples/passing/UnicodeIdentifier.purs
+      examples/passing/UnicodeOperators.purs
+      examples/passing/UnicodeType.purs
+      examples/passing/UnifyInTypeInstanceLookup.purs
+      examples/passing/Unit.purs
+      examples/passing/UnknownInTypeClassLookup.purs
+      examples/passing/UntupledConstraints.purs
+      examples/passing/UsableTypeClassMethods.purs
+      examples/passing/UTF8Sourcefile.purs
+      examples/passing/Where.purs
+      examples/passing/WildcardInInstance.purs
+      examples/passing/WildcardType.purs
+      examples/psci/BasicEval.purs
+      examples/psci/Multiline.purs
+      examples/warning/2140.purs
+      examples/warning/2383.purs
+      examples/warning/2411.purs
+      examples/warning/2542.purs
+      examples/warning/CustomWarning.purs
+      examples/warning/DuplicateExportRef.purs
+      examples/warning/DuplicateImport.purs
+      examples/warning/DuplicateImportRef.purs
+      examples/warning/DuplicateSelectiveImport.purs
+      examples/warning/HidingImport.purs
+      examples/warning/ImplicitImport.purs
+      examples/warning/ImplicitQualifiedImport.purs
+      examples/warning/MissingTypeDeclaration.purs
+      examples/warning/OverlappingInstances.purs
+      examples/warning/OverlappingPattern.purs
+      examples/warning/ScopeShadowing.purs
+      examples/warning/ShadowedBinderPatternGuard.purs
+      examples/warning/ShadowedNameParens.purs
+      examples/warning/ShadowedTypeVar.purs
+      examples/warning/UnnecessaryFFIModule.js
+      examples/warning/UnnecessaryFFIModule.purs
+      examples/warning/UnusedDctorExplicitImport.purs
+      examples/warning/UnusedDctorImportAll.purs
+      examples/warning/UnusedDctorImportExplicit.purs
+      examples/warning/UnusedExplicitImport.purs
+      examples/warning/UnusedExplicitImportTypeOp.purs
+      examples/warning/UnusedExplicitImportTypeOp/Lib.purs
+      examples/warning/UnusedExplicitImportValOp.purs
+      examples/warning/UnusedFFIImplementations.js
+      examples/warning/UnusedFFIImplementations.purs
+      examples/warning/UnusedImport.purs
+      examples/warning/UnusedTypeVar.purs
+      examples/warning/WildcardInferredType.purs
+      INSTALL.md
+      README.md
+      stack.yaml
+      tests/support/bower.json
+      tests/support/package.json
+      tests/support/prelude-resolutions.json
+      tests/support/psci/Sample.purs
+      tests/support/pscide/src/ImportsSpec.purs
+      tests/support/pscide/src/ImportsSpec1.purs
+      tests/support/pscide/src/MatcherSpec.purs
+      tests/support/pscide/src/RebuildSpecDep.purs
+      tests/support/pscide/src/RebuildSpecSingleModule.fail
+      tests/support/pscide/src/RebuildSpecSingleModule.purs
+      tests/support/pscide/src/RebuildSpecWithDeps.purs
+      tests/support/pscide/src/RebuildSpecWithForeign.js
+      tests/support/pscide/src/RebuildSpecWithForeign.purs
+      tests/support/pscide/src/RebuildSpecWithHiddenIdent.purs
+      tests/support/pscide/src/RebuildSpecWithMissingForeign.fail
+      tests/support/setup-win.cmd
 
 source-repository head
     type: git
     location: https://github.com/purescript/purescript.git
 
 flag release
-  description: Mark this build as a release build: prevents inclusion of extra
-               info e.g. commit SHA in --version output)
-  default: False
+    description: Mark this build as a release build: prevents inclusion of extra info e.g. commit SHA in --version output)
+
+    manual: False
+    default: False
 
 library
-    build-depends: base >=4.8 && <5,
-                   aeson >= 0.8 && < 1.1,
-                   aeson-better-errors >= 0.8,
-                   ansi-terminal >= 0.6.2 && < 0.7,
-                   base-compat >=0.6.0,
-                   blaze-html >= 0.8.1 && < 0.9,
-                   bower-json >= 1.0.0.1 && < 1.1,
-                   boxes >= 0.1.4 && < 0.2.0,
-                   bytestring -any,
-                   cheapskate >= 0.1 && < 0.2,
-                   containers -any,
-                   clock -any,
-                   data-ordlist >= 0.4.7.0,
-                   deepseq -any,
-                   directory >= 1.2,
-                   dlist -any,
-                   edit-distance -any,
-                   filepath -any,
-                   fsnotify >= 0.2.1,
-                   Glob >= 0.7 && < 0.8,
-                   haskeline >= 0.7.0.0,
-                   http-client >= 0.4.30 && < 0.6.0,
-                   http-types -any,
-                   language-javascript >= 0.6.0.9 && < 0.7,
-                   lens == 4.*,
-                   lifted-base >= 0.2.3 && < 0.2.4,
-                   monad-control >= 1.0.0.0 && < 1.1,
-                   monad-logger >= 0.3 && < 0.4,
-                   mtl >= 2.1.0 && < 2.3.0,
-                   parallel >= 3.2 && < 3.3,
-                   parsec >=3.1.10,
-                   pattern-arrows >= 0.0.2 && < 0.1,
-                   pipes >= 4.0.0 && < 4.4.0,
-                   pipes-http -any,
-                   process >= 1.2.0 && < 1.5,
-                   protolude >= 0.1.6,
-                   regex-tdfa -any,
-                   safe >= 0.3.9 && < 0.4,
-                   scientific >= 0.3.4.9 && < 0.4,
-                   semigroups >= 0.16.2 && < 0.19,
-                   sourcemap >= 0.1.6,
-                   spdx == 0.2.*,
-                   split -any,
-                   stm >= 0.2.4.0,
-                   syb -any,
-                   text -any,
-                   time -any,
-                   transformers >= 0.3.0 && < 0.6,
-                   transformers-base >= 0.4.0 && < 0.5,
-                   transformers-compat >= 0.3.0,
-                   unordered-containers -any,
-                   utf8-string >= 1 && < 2,
-                   vector -any
-
-    exposed-modules: Language.PureScript
-                     Language.PureScript.AST
-                     Language.PureScript.AST.Binders
-                     Language.PureScript.AST.Declarations
-                     Language.PureScript.AST.Operators
-                     Language.PureScript.AST.Literals
-                     Language.PureScript.AST.SourcePos
-                     Language.PureScript.AST.Traversals
-                     Language.PureScript.AST.Exported
-                     Language.PureScript.Bundle
-                     Language.PureScript.Crash
-                     Language.PureScript.Externs
-                     Language.PureScript.CodeGen
-                     Language.PureScript.CodeGen.JS
-                     Language.PureScript.CodeGen.JS.Common
-                     Language.PureScript.CodeGen.JS.Printer
-                     Language.PureScript.Constants
-                     Language.PureScript.CoreFn
-                     Language.PureScript.CoreFn.Ann
-                     Language.PureScript.CoreFn.Binders
-                     Language.PureScript.CoreFn.Desugar
-                     Language.PureScript.CoreFn.Expr
-                     Language.PureScript.CoreFn.Meta
-                     Language.PureScript.CoreFn.Module
-                     Language.PureScript.CoreFn.Traversals
-                     Language.PureScript.CoreFn.ToJSON
-                     Language.PureScript.CoreImp
-                     Language.PureScript.CoreImp.AST
-                     Language.PureScript.CoreImp.Optimizer
-                     Language.PureScript.CoreImp.Optimizer.Blocks
-                     Language.PureScript.CoreImp.Optimizer.Common
-                     Language.PureScript.CoreImp.Optimizer.Inliner
-                     Language.PureScript.CoreImp.Optimizer.MagicDo
-                     Language.PureScript.CoreImp.Optimizer.TCO
-                     Language.PureScript.CoreImp.Optimizer.Unused
-                     Language.PureScript.Comments
-                     Language.PureScript.Environment
-                     Language.PureScript.Errors
-                     Language.PureScript.Errors.JSON
-                     Language.PureScript.Kinds
-                     Language.PureScript.Label
-                     Language.PureScript.Linter
-                     Language.PureScript.Linter.Exhaustive
-                     Language.PureScript.Linter.Imports
-                     Language.PureScript.Make
-                     Language.PureScript.ModuleDependencies
-                     Language.PureScript.Names
-                     Language.PureScript.Options
-                     Language.PureScript.Parser
-                     Language.PureScript.Parser.Lexer
-                     Language.PureScript.Parser.Common
-                     Language.PureScript.Parser.Declarations
-                     Language.PureScript.Parser.Kinds
-                     Language.PureScript.Parser.State
-                     Language.PureScript.Parser.Types
-                     Language.PureScript.Pretty
-                     Language.PureScript.Pretty.Common
-                     Language.PureScript.Pretty.Kinds
-                     Language.PureScript.Pretty.Types
-                     Language.PureScript.Pretty.Values
-                     Language.PureScript.PSString
-                     Language.PureScript.Renamer
-                     Language.PureScript.Sugar
-                     Language.PureScript.Sugar.BindingGroups
-                     Language.PureScript.Sugar.CaseDeclarations
-                     Language.PureScript.Sugar.DoNotation
-                     Language.PureScript.Sugar.LetPattern
-                     Language.PureScript.Sugar.Names
-                     Language.PureScript.Sugar.Names.Common
-                     Language.PureScript.Sugar.Names.Env
-                     Language.PureScript.Sugar.Names.Exports
-                     Language.PureScript.Sugar.Names.Imports
-                     Language.PureScript.Sugar.ObjectWildcards
-                     Language.PureScript.Sugar.Operators
-                     Language.PureScript.Sugar.Operators.Common
-                     Language.PureScript.Sugar.Operators.Expr
-                     Language.PureScript.Sugar.Operators.Binders
-                     Language.PureScript.Sugar.Operators.Types
-                     Language.PureScript.Sugar.TypeClasses
-                     Language.PureScript.Sugar.TypeClasses.Deriving
-                     Language.PureScript.Sugar.TypeDeclarations
-                     Language.PureScript.Traversals
-                     Language.PureScript.TypeChecker
-                     Language.PureScript.TypeChecker.Entailment
-                     Language.PureScript.TypeChecker.Kinds
-                     Language.PureScript.TypeChecker.Monad
-                     Language.PureScript.TypeChecker.Skolems
-                     Language.PureScript.TypeChecker.Subsumption
-                     Language.PureScript.TypeChecker.Synonyms
-                     Language.PureScript.TypeChecker.Types
-                     Language.PureScript.TypeChecker.TypeSearch
-                     Language.PureScript.TypeChecker.Unify
-                     Language.PureScript.TypeClassDictionaries
-                     Language.PureScript.Types
-
-                     Language.PureScript.Docs
-                     Language.PureScript.Docs.Convert
-                     Language.PureScript.Docs.Convert.Single
-                     Language.PureScript.Docs.Convert.ReExports
-                     Language.PureScript.Docs.Prim
-                     Language.PureScript.Docs.Render
-                     Language.PureScript.Docs.Types
-                     Language.PureScript.Docs.RenderedCode
-                     Language.PureScript.Docs.RenderedCode.Types
-                     Language.PureScript.Docs.RenderedCode.RenderType
-                     Language.PureScript.Docs.RenderedCode.RenderKind
-                     Language.PureScript.Docs.AsMarkdown
-                     Language.PureScript.Docs.AsHtml
-                     Language.PureScript.Docs.ParseInPackage
-                     Language.PureScript.Docs.Utils.MonoidExtras
-
-                     Language.PureScript.Publish
-                     Language.PureScript.Publish.Utils
-                     Language.PureScript.Publish.ErrorsWarnings
-                     Language.PureScript.Publish.BoxesHelpers
-
-                     Language.PureScript.Ide
-                     Language.PureScript.Ide.CaseSplit
-                     Language.PureScript.Ide.Command
-                     Language.PureScript.Ide.Completion
-                     Language.PureScript.Ide.Externs
-                     Language.PureScript.Ide.Error
-                     Language.PureScript.Ide.Filter
-                     Language.PureScript.Ide.Imports
-                     Language.PureScript.Ide.Logging
-                     Language.PureScript.Ide.Matcher
-                     Language.PureScript.Ide.Pursuit
-                     Language.PureScript.Ide.Rebuild
-                     Language.PureScript.Ide.Reexports
-                     Language.PureScript.Ide.SourceFile
-                     Language.PureScript.Ide.State
-                     Language.PureScript.Ide.Types
-                     Language.PureScript.Ide.Util
-                     Language.PureScript.Ide.Watcher
-
-                     Language.PureScript.Interactive
-                     Language.PureScript.Interactive.Types
-                     Language.PureScript.Interactive.Parser
-                     Language.PureScript.Interactive.Directive
-                     Language.PureScript.Interactive.Completion
-                     Language.PureScript.Interactive.IO
-                     Language.PureScript.Interactive.Message
-                     Language.PureScript.Interactive.Module
-                     Language.PureScript.Interactive.Printer
-
-                     Control.Monad.Logger
-                     Control.Monad.Supply
-                     Control.Monad.Supply.Class
-
-                     System.IO.UTF8
-
-    extensions:      ConstraintKinds
-                     DataKinds
-                     DeriveFunctor
-                     EmptyDataDecls
-                     FlexibleContexts
-                     KindSignatures
-                     LambdaCase
-                     MultiParamTypeClasses
-                     NoImplicitPrelude
-                     PatternGuards
-                     PatternSynonyms
-                     RankNTypes
-                     RecordWildCards
-                     OverloadedStrings
-                     ScopedTypeVariables
-                     TupleSections
-                     ViewPatterns
-    exposed: True
-    buildable: True
-    hs-source-dirs: src
-    other-modules: Paths_purescript
+    build-depends:
+          aeson >=0.8 && <1.1
+        , aeson-better-errors >=0.8
+        , ansi-terminal >=0.6.2 && <0.7
+        , base >=4.8 && <5
+        , base-compat >=0.6.0
+        , blaze-html >=0.8.1 && <0.9
+        , bower-json >=1.0.0.1 && <1.1
+        , boxes >=0.1.4 && <0.2.0
+        , bytestring
+        , cheapskate >=0.1 && <0.2
+        , clock
+        , containers
+        , data-ordlist >=0.4.7.0
+        , deepseq
+        , directory >=1.2
+        , dlist
+        , edit-distance
+        , filepath
+        , fsnotify >=0.2.1
+        , Glob >=0.7 && <0.8
+        , haskeline >=0.7.0.0
+        , http-client >=0.4.30 && <0.6.0
+        , http-types
+        , language-javascript >=0.6.0.9 && <0.7
+        , lens ==4.*
+        , lifted-base >=0.2.3 && <0.2.4
+        , monad-control >=1.0.0.0 && <1.1
+        , monad-logger >=0.3 && <0.4
+        , mtl >=2.1.0 && <2.3.0
+        , parallel >=3.2 && <3.3
+        , parsec >=3.1.10
+        , pattern-arrows >=0.0.2 && <0.1
+        , pipes >=4.0.0 && <4.4.0
+        , pipes-http
+        , process >=1.2.0 && <1.5
+        , protolude >=0.1.6
+        , regex-tdfa
+        , safe >=0.3.9 && <0.4
+        , scientific >=0.3.4.9 && <0.4
+        , semigroups >=0.16.2 && <0.19
+        , sourcemap >=0.1.6
+        , spdx ==0.2.*
+        , split
+        , stm >=0.2.4.0
+        , syb
+        , text
+        , time
+        , transformers >=0.3.0 && <0.6
+        , transformers-base >=0.4.0 && <0.5
+        , transformers-compat >=0.3.0
+        , unordered-containers
+        , utf8-string >=1 && <2
+        , vector
+    exposed-modules:
+          Control.Monad.Logger
+          Control.Monad.Supply
+          Control.Monad.Supply.Class
+          Language.PureScript
+          Language.PureScript.AST
+          Language.PureScript.AST.Binders
+          Language.PureScript.AST.Declarations
+          Language.PureScript.AST.Exported
+          Language.PureScript.AST.Literals
+          Language.PureScript.AST.Operators
+          Language.PureScript.AST.SourcePos
+          Language.PureScript.AST.Traversals
+          Language.PureScript.Bundle
+          Language.PureScript.CodeGen
+          Language.PureScript.CodeGen.JS
+          Language.PureScript.CodeGen.JS.Common
+          Language.PureScript.CodeGen.JS.Printer
+          Language.PureScript.Comments
+          Language.PureScript.Constants
+          Language.PureScript.CoreFn
+          Language.PureScript.CoreFn.Ann
+          Language.PureScript.CoreFn.Binders
+          Language.PureScript.CoreFn.Desugar
+          Language.PureScript.CoreFn.Expr
+          Language.PureScript.CoreFn.Meta
+          Language.PureScript.CoreFn.Module
+          Language.PureScript.CoreFn.ToJSON
+          Language.PureScript.CoreFn.Traversals
+          Language.PureScript.CoreImp
+          Language.PureScript.CoreImp.AST
+          Language.PureScript.CoreImp.Optimizer
+          Language.PureScript.CoreImp.Optimizer.Blocks
+          Language.PureScript.CoreImp.Optimizer.Common
+          Language.PureScript.CoreImp.Optimizer.Inliner
+          Language.PureScript.CoreImp.Optimizer.MagicDo
+          Language.PureScript.CoreImp.Optimizer.TCO
+          Language.PureScript.CoreImp.Optimizer.Unused
+          Language.PureScript.Crash
+          Language.PureScript.Docs
+          Language.PureScript.Docs.AsHtml
+          Language.PureScript.Docs.AsMarkdown
+          Language.PureScript.Docs.Convert
+          Language.PureScript.Docs.Convert.ReExports
+          Language.PureScript.Docs.Convert.Single
+          Language.PureScript.Docs.ParseInPackage
+          Language.PureScript.Docs.Prim
+          Language.PureScript.Docs.Render
+          Language.PureScript.Docs.RenderedCode
+          Language.PureScript.Docs.RenderedCode.RenderKind
+          Language.PureScript.Docs.RenderedCode.RenderType
+          Language.PureScript.Docs.RenderedCode.Types
+          Language.PureScript.Docs.Types
+          Language.PureScript.Docs.Utils.MonoidExtras
+          Language.PureScript.Environment
+          Language.PureScript.Errors
+          Language.PureScript.Errors.JSON
+          Language.PureScript.Externs
+          Language.PureScript.Ide
+          Language.PureScript.Ide.CaseSplit
+          Language.PureScript.Ide.Command
+          Language.PureScript.Ide.Completion
+          Language.PureScript.Ide.Error
+          Language.PureScript.Ide.Externs
+          Language.PureScript.Ide.Filter
+          Language.PureScript.Ide.Imports
+          Language.PureScript.Ide.Logging
+          Language.PureScript.Ide.Matcher
+          Language.PureScript.Ide.Pursuit
+          Language.PureScript.Ide.Rebuild
+          Language.PureScript.Ide.Reexports
+          Language.PureScript.Ide.SourceFile
+          Language.PureScript.Ide.State
+          Language.PureScript.Ide.Types
+          Language.PureScript.Ide.Util
+          Language.PureScript.Ide.Watcher
+          Language.PureScript.Interactive
+          Language.PureScript.Interactive.Completion
+          Language.PureScript.Interactive.Directive
+          Language.PureScript.Interactive.IO
+          Language.PureScript.Interactive.Message
+          Language.PureScript.Interactive.Module
+          Language.PureScript.Interactive.Parser
+          Language.PureScript.Interactive.Printer
+          Language.PureScript.Interactive.Types
+          Language.PureScript.Kinds
+          Language.PureScript.Label
+          Language.PureScript.Linter
+          Language.PureScript.Linter.Exhaustive
+          Language.PureScript.Linter.Imports
+          Language.PureScript.Make
+          Language.PureScript.ModuleDependencies
+          Language.PureScript.Names
+          Language.PureScript.Options
+          Language.PureScript.Parser
+          Language.PureScript.Parser.Common
+          Language.PureScript.Parser.Declarations
+          Language.PureScript.Parser.Kinds
+          Language.PureScript.Parser.Lexer
+          Language.PureScript.Parser.State
+          Language.PureScript.Parser.Types
+          Language.PureScript.Pretty
+          Language.PureScript.Pretty.Common
+          Language.PureScript.Pretty.Kinds
+          Language.PureScript.Pretty.Types
+          Language.PureScript.Pretty.Values
+          Language.PureScript.PSString
+          Language.PureScript.Publish
+          Language.PureScript.Publish.BoxesHelpers
+          Language.PureScript.Publish.ErrorsWarnings
+          Language.PureScript.Publish.Utils
+          Language.PureScript.Renamer
+          Language.PureScript.Sugar
+          Language.PureScript.Sugar.BindingGroups
+          Language.PureScript.Sugar.CaseDeclarations
+          Language.PureScript.Sugar.DoNotation
+          Language.PureScript.Sugar.LetPattern
+          Language.PureScript.Sugar.Names
+          Language.PureScript.Sugar.Names.Common
+          Language.PureScript.Sugar.Names.Env
+          Language.PureScript.Sugar.Names.Exports
+          Language.PureScript.Sugar.Names.Imports
+          Language.PureScript.Sugar.ObjectWildcards
+          Language.PureScript.Sugar.Operators
+          Language.PureScript.Sugar.Operators.Binders
+          Language.PureScript.Sugar.Operators.Common
+          Language.PureScript.Sugar.Operators.Expr
+          Language.PureScript.Sugar.Operators.Types
+          Language.PureScript.Sugar.TypeClasses
+          Language.PureScript.Sugar.TypeClasses.Deriving
+          Language.PureScript.Sugar.TypeDeclarations
+          Language.PureScript.Traversals
+          Language.PureScript.TypeChecker
+          Language.PureScript.TypeChecker.Entailment
+          Language.PureScript.TypeChecker.Kinds
+          Language.PureScript.TypeChecker.Monad
+          Language.PureScript.TypeChecker.Skolems
+          Language.PureScript.TypeChecker.Subsumption
+          Language.PureScript.TypeChecker.Synonyms
+          Language.PureScript.TypeChecker.Types
+          Language.PureScript.TypeChecker.TypeSearch
+          Language.PureScript.TypeChecker.Unify
+          Language.PureScript.TypeClassDictionaries
+          Language.PureScript.Types
+          System.IO.UTF8
+    other-modules:
+          Paths_purescript
+    hs-source-dirs:
+          src
+    default-extensions: ConstraintKinds DataKinds DeriveFunctor EmptyDataDecls FlexibleContexts KindSignatures LambdaCase MultiParamTypeClasses NoImplicitPrelude PatternGuards PatternSynonyms RankNTypes RecordWildCards OverloadedStrings ScopedTypeVariables TupleSections ViewPatterns
+    default-language: Haskell2010
     ghc-options: -Wall -O2
 
 executable purs
-    build-depends: base >=4 && <5,
-                   aeson >= 0.8 && < 1.1,
-                   ansi-terminal >= 0.6.2 && < 0.7,
-                   ansi-wl-pprint -any,
-                   base-compat >=0.6.0,
-                   blaze-html -any,
-                   boxes >= 0.1.4 && < 0.2.0,
-                   bytestring -any,
-                   containers -any,
-                   directory -any,
-                   file-embed -any,
-                   filepath -any,
-                   Glob >= 0.7 && < 0.8,
-                   haskeline >= 0.7.0.0,
-                   http-types == 0.9.*,
-                   monad-logger -any,
-                   mtl -any,
-                   network -any,
-                   optparse-applicative >= 0.13.0,
-                   parsec -any,
-                   process -any,
-                   protolude >= 0.1.6,
-                   purescript -any,
-                   sourcemap >= 0.1.6,
-                   split -any,
-                   stm >= 0.2.4.0,
-                   text -any,
-                   time -any,
-                   transformers -any,
-                   transformers-compat -any,
-                   utf8-string >= 1 && < 2,
-                   wai == 3.*,
-                   wai-websockets == 3.*,
-                   warp == 3.*,
-                   websockets >= 0.9 && <0.11
-    main-is: Main.hs
-    buildable: True
-    hs-source-dirs: app
-    other-modules: Paths_purescript
-                   Command.Bundle
-                   Command.Compile
-                   Command.Docs
-                   Command.Docs.Ctags
-                   Command.Docs.Etags
-                   Command.Docs.Tags
-                   Command.Docs.Html
-                   Command.Hierarchy
-                   Command.Ide
-                   Command.Publish
-                   Command.REPL
-                   Version
-    ghc-options: -Wall -O2 -fno-warn-unused-do-bind -threaded -rtsopts "-with-rtsopts=-N"
-
+    build-depends:
+          aeson >=0.8 && <1.1
+        , aeson-better-errors >=0.8
+        , ansi-terminal >=0.6.2 && <0.7
+        , base >=4.8 && <5
+        , base-compat >=0.6.0
+        , blaze-html >=0.8.1 && <0.9
+        , bower-json >=1.0.0.1 && <1.1
+        , boxes >=0.1.4 && <0.2.0
+        , bytestring
+        , cheapskate >=0.1 && <0.2
+        , clock
+        , containers
+        , data-ordlist >=0.4.7.0
+        , deepseq
+        , directory >=1.2
+        , dlist
+        , edit-distance
+        , filepath
+        , fsnotify >=0.2.1
+        , Glob >=0.7 && <0.8
+        , haskeline >=0.7.0.0
+        , http-client >=0.4.30 && <0.6.0
+        , http-types
+        , language-javascript >=0.6.0.9 && <0.7
+        , lens ==4.*
+        , lifted-base >=0.2.3 && <0.2.4
+        , monad-control >=1.0.0.0 && <1.1
+        , monad-logger >=0.3 && <0.4
+        , mtl >=2.1.0 && <2.3.0
+        , parallel >=3.2 && <3.3
+        , parsec >=3.1.10
+        , pattern-arrows >=0.0.2 && <0.1
+        , pipes >=4.0.0 && <4.4.0
+        , pipes-http
+        , process >=1.2.0 && <1.5
+        , protolude >=0.1.6
+        , regex-tdfa
+        , safe >=0.3.9 && <0.4
+        , scientific >=0.3.4.9 && <0.4
+        , semigroups >=0.16.2 && <0.19
+        , sourcemap >=0.1.6
+        , spdx ==0.2.*
+        , split
+        , stm >=0.2.4.0
+        , syb
+        , text
+        , time
+        , transformers >=0.3.0 && <0.6
+        , transformers-base >=0.4.0 && <0.5
+        , transformers-compat >=0.3.0
+        , unordered-containers
+        , utf8-string >=1 && <2
+        , vector
+        , ansi-wl-pprint
+        , file-embed
+        , network
+        , optparse-applicative >=0.13.0
+        , purescript
+        , wai ==3.*
+        , wai-websockets ==3.*
+        , warp ==3.*
+        , websockets >=0.9 && <0.11
     if flag(release)
-      cpp-options: -DRELEASE
+        cpp-options: -DRELEASE
     else
-      build-depends: gitrev >= 1.2.0 && <1.3
+        build-depends:
+              gitrev >=1.2.0 && <1.3
+    main-is: Main.hs
+    hs-source-dirs:
+          app
+    other-modules:
+          Command.Bundle
+          Command.Compile
+          Command.Docs
+          Command.Docs.Ctags
+          Command.Docs.Etags
+          Command.Docs.Html
+          Command.Docs.Tags
+          Command.Hierarchy
+          Command.Ide
+          Command.Publish
+          Command.REPL
+          Version
+    default-language: Haskell2010
+    ghc-options: -Wall -O2 -fno-warn-unused-do-bind -threaded -rtsopts -with-rtsopts=-N
 
 test-suite tests
-    build-depends: base >=4 && <5,
-                   purescript -any,
-                   aeson -any,
-                   aeson-better-errors -any,
-                   base-compat -any,
-                   bower-json -any,
-                   boxes -any,
-                   bytestring -any,
-                   containers -any,
-                   directory -any,
-                   filepath -any,
-                   Glob -any,
-                   haskeline >= 0.7.0.0,
-                   hspec -any,
-                   hspec-discover -any,
-                   HUnit -any,
-                   lens -any,
-                   monad-logger -any,
-                   mtl -any,
-                   optparse-applicative -any,
-                   parsec -any,
-                   process -any,
-                   protolude >= 0.1.6,
-                   silently -any,
-                   split -any,
-                   stm -any,
-                   text -any,
-                   time -any,
-                   transformers -any,
-                   transformers-compat -any,
-                   utf8-string -any,
-                   vector -any
+    build-depends:
+          aeson >=0.8 && <1.1
+        , aeson-better-errors >=0.8
+        , ansi-terminal >=0.6.2 && <0.7
+        , base >=4.8 && <5
+        , base-compat >=0.6.0
+        , blaze-html >=0.8.1 && <0.9
+        , bower-json >=1.0.0.1 && <1.1
+        , boxes >=0.1.4 && <0.2.0
+        , bytestring
+        , cheapskate >=0.1 && <0.2
+        , clock
+        , containers
+        , data-ordlist >=0.4.7.0
+        , deepseq
+        , directory >=1.2
+        , dlist
+        , edit-distance
+        , filepath
+        , fsnotify >=0.2.1
+        , Glob >=0.7 && <0.8
+        , haskeline >=0.7.0.0
+        , http-client >=0.4.30 && <0.6.0
+        , http-types
+        , language-javascript >=0.6.0.9 && <0.7
+        , lens ==4.*
+        , lifted-base >=0.2.3 && <0.2.4
+        , monad-control >=1.0.0.0 && <1.1
+        , monad-logger >=0.3 && <0.4
+        , mtl >=2.1.0 && <2.3.0
+        , parallel >=3.2 && <3.3
+        , parsec >=3.1.10
+        , pattern-arrows >=0.0.2 && <0.1
+        , pipes >=4.0.0 && <4.4.0
+        , pipes-http
+        , process >=1.2.0 && <1.5
+        , protolude >=0.1.6
+        , regex-tdfa
+        , safe >=0.3.9 && <0.4
+        , scientific >=0.3.4.9 && <0.4
+        , semigroups >=0.16.2 && <0.19
+        , sourcemap >=0.1.6
+        , spdx ==0.2.*
+        , split
+        , stm >=0.2.4.0
+        , syb
+        , text
+        , time
+        , transformers >=0.3.0 && <0.6
+        , transformers-base >=0.4.0 && <0.5
+        , transformers-compat >=0.3.0
+        , unordered-containers
+        , utf8-string >=1 && <2
+        , vector
+        , purescript
+        , hspec
+        , hspec-discover
+        , HUnit
+        , silently
     ghc-options: -Wall
     type: exitcode-stdio-1.0
     main-is: Main.hs
-    other-modules: TestUtils
-                   TestCompiler
-                   TestDocs
-                   TestPrimDocs
-                   TestPscPublish
-                   TestPsci
-                   TestPsci.CommandTest
-                   TestPsci.CompletionTest
-                   TestPsci.EvalTest
-                   TestPsci.TestEnv
-                   TestPscIde
-                   PscIdeSpec
-                   Language.PureScript.Ide.Test
-                   Language.PureScript.Ide.FilterSpec
-                   Language.PureScript.Ide.ImportsSpec
-                   Language.PureScript.Ide.MatcherSpec
-                   Language.PureScript.Ide.RebuildSpec
-                   Language.PureScript.Ide.ReexportsSpec
-                   Language.PureScript.Ide.SourceFileSpec
-                   Language.PureScript.Ide.StateSpec
-    buildable: True
-    hs-source-dirs: tests
+    other-modules:
+          Language.PureScript.Ide.FilterSpec
+          Language.PureScript.Ide.ImportsSpec
+          Language.PureScript.Ide.MatcherSpec
+          Language.PureScript.Ide.RebuildSpec
+          Language.PureScript.Ide.ReexportsSpec
+          Language.PureScript.Ide.SourceFileSpec
+          Language.PureScript.Ide.StateSpec
+          Language.PureScript.Ide.Test
+          PscIdeSpec
+          TestCompiler
+          TestDocs
+          TestPrimDocs
+          TestPsci
+          TestPsci.CommandTest
+          TestPsci.CompletionTest
+          TestPsci.EvalTest
+          TestPsci.TestEnv
+          TestPscIde
+          TestPscPublish
+          TestUtils
+    default-language: Haskell2010
+    hs-source-dirs:
+          tests


### PR DESCRIPTION
I recently stumbled upon https://github.com/sol/hpack and thought it did solve some of the annoyances with the `.cabal` format. Also the integration with stack is neat, since it automatically generates the `.cabal` file without any extra options.

If we were to use this, I think we'd want to keep the generated `.cabal` file checked in, so someone could still attempt to build the compiler with `cabal` without having to install `hpack` beforehand.

I think this is an improvement, but I'm totally fine with just closing this if there is a good reason to do so.