### PR TITLE
Accept print function as handleCommand argument

### DIFF
--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -334,7 +334,7 @@ command = loop <$> options
                              . runInputT (setComplete completion settings)
 
                     handleCommand' :: state -> Command -> StateT PSCiState (ReaderT PSCiConfig IO) ()
-                    handleCommand' state = handleCommand (liftIO . eval state) (liftIO (reload state))
+                    handleCommand' state = handleCommand (liftIO . eval state) (liftIO (reload state)) (liftIO . putStrLn)
 
                     go :: state -> InputT (StateT PSCiState (ReaderT PSCiConfig IO)) ()
                     go state = do

--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -334,9 +334,7 @@ command = loop <$> options
                              . runInputT (setComplete completion settings)
 
                     handleCommand' :: state -> Command -> StateT PSCiState (ReaderT PSCiConfig IO) ()
-                    handleCommand' state cmd =
-                      let fns = PSCiFns (eval state) (reload state) putStrLn
-                      in runPSCiT (handleCommand cmd) fns
+                    handleCommand' state = handleCommand (liftIO . eval state) (liftIO (reload state)) (liftIO . putStrLn)
 
                     go :: state -> InputT (StateT PSCiState (ReaderT PSCiConfig IO)) ()
                     go state = do

--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -334,7 +334,9 @@ command = loop <$> options
                              . runInputT (setComplete completion settings)
 
                     handleCommand' :: state -> Command -> StateT PSCiState (ReaderT PSCiConfig IO) ()
-                    handleCommand' state = handleCommand (liftIO . eval state) (liftIO (reload state)) (liftIO . putStrLn)
+                    handleCommand' state cmd =
+                      let fns = PSCiFns (eval state) (reload state) putStrLn
+                      in runPSCiT (handleCommand cmd) fns
 
                     go :: state -> InputT (StateT PSCiState (ReaderT PSCiConfig IO)) ()
                     go state = do

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -89,27 +89,31 @@ make ms = do
 
 -- | Performs a PSCi command
 handleCommand
-  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m, MonadPSCi m)
-  => Command
+  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m)
+  => (String -> m ()) -- ^ evaluate JS
+  -> m () -- ^ reload
+  -> (String -> m ()) -- ^ print into console
+  -> Command
   -> m ()
-handleCommand ShowHelp                  = psciPrint helpMessage
-handleCommand ReloadState               = handleReloadState
-handleCommand ClearState                = handleClearState
-handleCommand (Expression val)          = handleExpression val
-handleCommand (Import im)               = handleImport im
-handleCommand (Decls l)                 = handleDecls l
-handleCommand (TypeOf val)              = handleTypeOf val
-handleCommand (KindOf typ)              = handleKindOf typ
-handleCommand (BrowseModule moduleName) = handleBrowse moduleName
-handleCommand (ShowInfo QueryLoaded)    = handleShowLoadedModules
-handleCommand (ShowInfo QueryImport)    = handleShowImportedModules
-handleCommand _                         = P.internalError "handleCommand: unexpected command"
+handleCommand _ _ p ShowHelp                  = p helpMessage
+handleCommand _ r _ ReloadState               = handleReloadState r
+handleCommand _ r _ ClearState                = handleClearState r
+handleCommand e _ _ (Expression val)          = handleExpression e val
+handleCommand _ _ _ (Import im)               = handleImport im
+handleCommand _ _ _ (Decls l)                 = handleDecls l
+handleCommand _ _ p (TypeOf val)              = handleTypeOf p val
+handleCommand _ _ p (KindOf typ)              = handleKindOf p typ
+handleCommand _ _ p (BrowseModule moduleName) = handleBrowse p moduleName
+handleCommand _ _ p (ShowInfo QueryLoaded)    = handleShowLoadedModules p
+handleCommand _ _ p (ShowInfo QueryImport)    = handleShowImportedModules p
+handleCommand _ _ _ _                         = P.internalError "handleCommand: unexpected command"
 
 -- | Reload the application state
 handleReloadState
-  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m, MonadPSCi m)
+  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m)
   => m ()
-handleReloadState = do
+  -> m ()
+handleReloadState reload = do
   modify $ updateLets (const [])
   files <- asks psciLoadedFiles
   e <- runExceptT $ do
@@ -120,22 +124,24 @@ handleReloadState = do
     Left errs -> printErrors errs
     Right (modules, externs) -> do
       modify (updateLoadedExterns (const (zip modules externs)))
-      psciReload
+      reload
 
 -- | Clear the application state
 handleClearState
-  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m, MonadPSCi m)
+  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m)
   => m ()
-handleClearState = do
+  -> m ()
+handleClearState reload = do
   modify $ updateImportedModules (const [])
-  handleReloadState
+  handleReloadState reload
 
 -- | Takes a value expression and evaluates it with the current state.
 handleExpression
-  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m, MonadPSCi m)
-  => P.Expr
+  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m)
+  => (String -> m ())
+  -> P.Expr
   -> m ()
-handleExpression val = do
+handleExpression evaluate val = do
   st <- get
   let m = createTemporaryModule True st val
   e <- liftIO . runMake $ rebuild (map snd (psciLoadedExterns st)) m
@@ -143,7 +149,7 @@ handleExpression val = do
     Left errs -> printErrors errs
     Right _ -> do
       js <- liftIO $ readFile (modulesDir </> "$PSCI" </> "index.js")
-      psciEvalJS js
+      evaluate js
 
 -- |
 -- Takes a list of declarations and updates the environment, then run a make. If the declaration fails,
@@ -163,21 +169,23 @@ handleDecls ds = do
 
 -- | Show actual loaded modules in psci.
 handleShowLoadedModules
-  :: (MonadState PSCiState m, MonadIO m, MonadPSCi m)
-  => m ()
-handleShowLoadedModules = do
+  :: (MonadState PSCiState m, MonadIO m)
+  => (String -> m ())
+  -> m ()
+handleShowLoadedModules print' = do
     loadedModules <- gets psciLoadedExterns
-    psciPrint $ readModules loadedModules
+    print' $ readModules loadedModules
   where
     readModules = unlines . sort . ordNub . map (T.unpack . P.runModuleName . P.getModuleName . fst)
 
 -- | Show the imported modules in psci.
 handleShowImportedModules
-  :: (MonadState PSCiState m, MonadIO m, MonadPSCi m)
-  => m ()
-handleShowImportedModules = do
+  :: (MonadState PSCiState m, MonadIO m)
+  => (String -> m ())
+  -> m ()
+handleShowImportedModules print' = do
   PSCiState { psciImportedModules = importedModules } <- get
-  psciPrint $ showModules importedModules
+  print' $ showModules importedModules
   return ()
   where
   showModules = unlines . sort . map (T.unpack . showModule)
@@ -230,10 +238,11 @@ handleImport im = do
 
 -- | Takes a value and prints its type
 handleTypeOf
-  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m, MonadPSCi m)
-  => P.Expr
+  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m)
+  => (String -> m ())
+  -> P.Expr
   -> m ()
-handleTypeOf val = do
+handleTypeOf print' val = do
   st <- get
   let m = createTemporaryModule False st val
   e <- liftIO . runMake $ rebuild (map snd (psciLoadedExterns st)) m
@@ -241,15 +250,16 @@ handleTypeOf val = do
     Left errs -> printErrors errs
     Right (_, env') ->
       case M.lookup (P.mkQualified (P.Ident "it") (P.ModuleName [P.ProperName "$PSCI"])) (P.names env') of
-        Just (ty, _, _) -> psciPrint . P.prettyPrintType $ ty
-        Nothing -> psciPrint "Could not find type"
+        Just (ty, _, _) -> print' . P.prettyPrintType $ ty
+        Nothing -> print' "Could not find type"
 
 -- | Takes a type and prints its kind
 handleKindOf
-  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m, MonadPSCi m)
-  => P.Type
+  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m)
+  => (String -> m ())
+  -> P.Type
   -> m ()
-handleKindOf typ = do
+handleKindOf print' typ = do
   st <- get
   let m = createTemporaryModuleForKind st typ
       mName = P.ModuleName [P.ProperName "$PSCI"]
@@ -266,23 +276,24 @@ handleKindOf typ = do
               check sew = fst . runWriter . runExceptT . runStateT sew
           case k of
             Left err        -> printErrors err
-            Right (kind, _) -> psciPrint . T.unpack . P.prettyPrintKind $ kind
-        Nothing -> psciPrint "Could not find kind"
+            Right (kind, _) -> print' . T.unpack . P.prettyPrintKind $ kind
+        Nothing -> print' "Could not find kind"
 
 -- | Browse a module and displays its signature
 handleBrowse
-  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m, MonadPSCi m)
-  => P.ModuleName
+  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m)
+  => (String -> m ())
+  -> P.ModuleName
   -> m ()
-handleBrowse moduleName = do
+handleBrowse print' moduleName = do
   st <- get
   env <- asks psciEnvironment
   if isModInEnv moduleName st
-    then psciPrint $ printModuleSignatures moduleName env
+    then print' $ printModuleSignatures moduleName env
     else case lookupUnQualifiedModName moduleName st of
       Just unQualifiedName ->
         if isModInEnv unQualifiedName st
-          then psciPrint $ printModuleSignatures unQualifiedName env
+          then print' $ printModuleSignatures unQualifiedName env
           else failNotInEnv moduleName
       Nothing ->
         failNotInEnv moduleName
@@ -290,6 +301,6 @@ handleBrowse moduleName = do
     isModInEnv modName =
         any ((== modName) . P.getModuleName . fst) . psciLoadedExterns
     failNotInEnv modName =
-        psciPrint $ T.unpack $ "Module '" <> N.runModuleName modName <> "' is not valid."
+        print' $ T.unpack $ "Module '" <> N.runModuleName modName <> "' is not valid."
     lookupUnQualifiedModName quaModName st =
         (\(modName,_,_) -> modName) <$> find ( \(_, _, mayQuaName) -> mayQuaName == Just quaModName) (psciImportedModules st)

--- a/src/Language/PureScript/Interactive/Types.hs
+++ b/src/Language/PureScript/Interactive/Types.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 -- |
 -- Type declarations and associated basic functions for PSCI.
 --
@@ -8,12 +5,6 @@ module Language.PureScript.Interactive.Types where
 
 import Prelude.Compat
 
-import           Control.Applicative (liftA2)
-import           Control.Monad (liftM2)
-import           Control.Monad.IO.Class (MonadIO(..))
-import           Control.Monad.Reader.Class (MonadReader(..))
-import           Control.Monad.State.Class (MonadState(..))
-import           Control.Monad.Trans.Class (MonadTrans(..))
 import qualified Language.PureScript as P
 
 -- | The PSCI configuration.
@@ -139,47 +130,3 @@ data Directive
   | Show
   | Paste
   deriving (Eq, Show)
-
--- | A list of functions used in PSCi
-data PSCiFns = PSCiFns { _evalJS :: String -> IO ()
-                       , _reload :: IO ()
-                       , _print :: String -> IO ()
-                       }
-
--- | A monad transformer to use PSCi functions
-newtype PSCiT m a = PSCiT { runPSCiT :: PSCiFns -> m a }
-
-instance Functor f => Functor (PSCiT f) where
-  fmap f (PSCiT m) = PSCiT $ fmap (fmap f) m
-
-instance Applicative f => Applicative (PSCiT f) where
-  pure = PSCiT . const . pure
-  PSCiT f <*> PSCiT a = PSCiT $ liftA2 (<*>) f a
-
-instance Monad m => Monad (PSCiT m) where
-  return = pure
-  PSCiT m >>= f = PSCiT $ liftM2 (>>=) m $ flip (runPSCiT . f)
-
-instance MonadTrans PSCiT where
-  lift = PSCiT . const
-
-instance MonadIO m => MonadIO (PSCiT m) where
-  liftIO = lift . liftIO
-
-instance MonadReader r m => MonadReader r (PSCiT m) where
-  ask = lift ask
-  local f = PSCiT . fmap (local f) . runPSCiT
-
-instance MonadState s m => MonadState s (PSCiT m) where
-  state = lift . state
-
--- | A monadic type class for PSCiT
-class MonadPSCi m where
-  psciEvalJS :: String -> m ()
-  psciReload :: m ()
-  psciPrint :: String -> m ()
-
-instance MonadIO m => MonadPSCi (PSCiT m) where
-  psciEvalJS js = PSCiT $ \ (PSCiFns e _ _) -> liftIO $ e js
-  psciReload = PSCiT $ \ (PSCiFns _ r _) -> liftIO r
-  psciPrint str = PSCiT $ \ (PSCiFns _ _ p) -> liftIO $ p str

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -64,7 +64,7 @@ runAndEval comm eval =
     Right command ->
       -- the JS result can be ignored, as it's already written in a source file
       -- for the detail, please refer to Interactive.hs
-      handleCommand (\_ -> eval) (return ()) command
+      handleCommand (\_ -> eval) (return ()) (\_ -> return ()) command
 
 -- | Run a PSCi command and ignore the output
 run :: String -> TestPSCi ()

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -46,8 +46,8 @@ execTestPSCi i = do
 -- | Evaluate JS to which a PSCi input is compiled. The actual JS input is not
 -- needed as an argument, as it is already written in the file during the
 -- command evaluation.
-jsEval :: TestPSCi String
-jsEval = liftIO $ do
+jsEval :: IO String
+jsEval = do
   writeFile indexFile "require('$PSCI')['$main']();"
   process <- findNodeProcess
   result <- traverse (\node -> readProcessWithExitCode node [indexFile] "") process
@@ -57,14 +57,15 @@ jsEval = liftIO $ do
     Nothing                      -> putStrLn "Couldn't find node.js" >> exitFailure
 
 -- | Run a PSCi command and evaluate the output with 'eval'.
-runAndEval :: String -> TestPSCi () -> TestPSCi ()
+runAndEval :: String -> IO () -> TestPSCi ()
 runAndEval comm eval =
   case parseCommand comm of
     Left errStr -> liftIO $ putStrLn errStr >> exitFailure
-    Right command ->
+    Right command -> do
       -- the JS result can be ignored, as it's already written in a source file
       -- for the detail, please refer to Interactive.hs
-      handleCommand (\_ -> eval) (return ()) (\_ -> return ()) command
+      let fns = PSCiFns (\_ -> eval) (return ()) (\_ -> return ())
+      runPSCiT (handleCommand command) fns
 
 -- | Run a PSCi command and ignore the output
 run :: String -> TestPSCi ()
@@ -78,4 +79,4 @@ equalsTo x y = liftIO $ x `shouldBe` y
 evaluatesTo :: String -> String -> TestPSCi ()
 evaluatesTo command expected = runAndEval command $ do
   actual <- jsEval
-  actual `equalsTo` (expected ++ "\n")
+  actual `shouldBe` (expected ++ "\n")


### PR DESCRIPTION
Currently I'm working on #2722 and found that output of `:show import` is printed into console, and thus there is no way to test the output.

This PR makes PSCi `handleCommand` to accept a print function as its argument, and enables checking output of PSCi commands and adding test suites for them in the future.