### PR TITLE
[purs ide] Use the user-specified log level for file-watcher logs

### DIFF
--- a/app/Command/Ide.hs
+++ b/app/Command/Ide.hs
@@ -119,7 +119,7 @@ command = Opts.helper <*> subcommands where
       putText "psc-ide needs you to compile your project (for example by running pulp build)"
 
     unless noWatch $
-      void (forkFinally (watcher polling ideState fullOutputPath) print)
+      void (forkFinally (watcher polling logLevel ideState fullOutputPath) print)
     let conf = Configuration {confLogLevel = logLevel, confOutputPath = outputPath, confGlobs = globs}
         env = IdeEnvironment {ideStateVar = ideState, ideConfiguration = conf}
     startServer port env

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -83,6 +83,7 @@ extra-source-files:
       examples/failing/2567.purs
       examples/failing/2601.purs
       examples/failing/2616.purs
+      examples/failing/2806.purs
       examples/failing/365.purs
       examples/failing/438.purs
       examples/failing/881.purs
@@ -306,6 +307,7 @@ extra-source-files:
       examples/passing/2756.purs
       examples/passing/2787.purs
       examples/passing/2795.purs
+      examples/passing/2806.purs
       examples/passing/652.purs
       examples/passing/810.purs
       examples/passing/862.purs

--- a/src/Language/PureScript/Ide/Watcher.hs
+++ b/src/Language/PureScript/Ide/Watcher.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PackageImports #-}
 -----------------------------------------------------------------------------
 --
 -- Module      : Language.PureScript.Ide.Watcher
@@ -16,38 +17,39 @@ module Language.PureScript.Ide.Watcher
  ( watcher
  ) where
 
-import           Protolude
+import                Protolude
 
-import           Control.Concurrent.STM
-import           Language.PureScript.Ide.Externs
-import           Language.PureScript.Ide.State
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util
-import           System.FilePath
-import           System.FSNotify
+import                Control.Concurrent.STM
+import "monad-logger" Control.Monad.Logger
+import                Language.PureScript.Ide.Externs
+import                Language.PureScript.Ide.State
+import                Language.PureScript.Ide.Types
+import                Language.PureScript.Ide.Util
+import                System.FSNotify
+import                System.FilePath
 
 -- | Reloads an ExternsFile from Disc. If the Event indicates the ExternsFile
 -- was deleted we don't do anything.
-reloadFile :: TVar IdeState -> Event -> IO ()
-reloadFile _ Removed{} = pure ()
-reloadFile ref ev = do
+reloadFile :: IdeLogLevel -> TVar IdeState -> Event -> IO ()
+reloadFile _ _ Removed{} = pure ()
+reloadFile logLevel ref ev = do
   let fp = eventPath ev
-  ef' <- runLogger LogDefault (runExceptT (readExternFile fp))
+  ef' <- runLogger logLevel (runExceptT (readExternFile fp))
   case ef' of
     Left _ -> pure ()
     Right ef -> do
       void $ atomically (insertExternsSTM ref ef *> populateStage3STM ref)
-      putStrLn ("Reloaded File at: " ++ fp)
+      runLogger logLevel (logDebugN ("Reloaded File at: " <> toS fp))
 
 -- | Installs filewatchers for the given directory and reloads ExternsFiles when
 -- they change on disc
-watcher :: Bool -> TVar IdeState -> FilePath -> IO ()
-watcher polling stateVar fp =
+watcher :: Bool -> IdeLogLevel -> TVar IdeState -> FilePath -> IO ()
+watcher polling logLevel stateVar fp =
   withManagerConf
     (defaultConfig { confDebounce = NoDebounce
                    , confUsePolling = polling
                    }) $ \mgr -> do
       _ <- watchTree mgr fp
         (\ev -> takeFileName (eventPath ev) == "externs.json")
-        (reloadFile stateVar)
+        (reloadFile logLevel stateVar)
       forever (threadDelay 100000)


### PR DESCRIPTION
Also makes for a more consistent log output.