### PR TITLE
Add a bunch of NFData instances

### DIFF
--- a/src/Language/PureScript/AST/Operators.hs
+++ b/src/Language/PureScript/AST/Operators.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 -- |
 -- Operators fixity and associativity
 --
@@ -5,6 +6,8 @@ module Language.PureScript.AST.Operators where
 
 import Prelude.Compat
 
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
 import Data.Aeson ((.=))
 import qualified Data.Aeson as A
 
@@ -19,7 +22,9 @@ type Precedence = Integer
 -- Associativity for infix operators
 --
 data Associativity = Infixl | Infixr | Infix
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData Associativity
 
 showAssoc :: Associativity -> String
 showAssoc Infixl = "infixl"
@@ -42,7 +47,9 @@ instance A.FromJSON Associativity where
 -- Fixity data for infix operators
 --
 data Fixity = Fixity Associativity Precedence
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData Fixity
 
 instance A.ToJSON Fixity where
   toJSON (Fixity associativity precedence) =

--- a/src/Language/PureScript/AST/SourcePos.hs
+++ b/src/Language/PureScript/AST/SourcePos.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 -- |
 -- Source position information
 --
@@ -5,6 +6,8 @@ module Language.PureScript.AST.SourcePos where
 
 import Prelude.Compat
 
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
 import Data.Aeson ((.=), (.:))
 import qualified Data.Aeson as A
 import Data.Monoid
@@ -23,7 +26,9 @@ data SourcePos = SourcePos
     -- Column number
     --
   , sourcePosColumn :: Int
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic)
+
+instance NFData SourcePos
 
 displaySourcePos :: SourcePos -> Text
 displaySourcePos sp =
@@ -51,7 +56,9 @@ data SourceSpan = SourceSpan
     -- End of the span
     --
   , spanEnd :: SourcePos
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic)
+
+instance NFData SourceSpan
 
 displayStartEndPos :: SourceSpan -> Text
 displayStartEndPos sp =

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 module Language.PureScript.Docs.Types
   ( module Language.PureScript.Docs.Types
   , module ReExports
@@ -7,6 +9,8 @@ module Language.PureScript.Docs.Types
 import Protolude hiding (to, from)
 import Prelude (String, unlines, lookup)
 
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
 import Control.Arrow ((***))
 
 import Data.Aeson ((.=))
@@ -55,10 +59,14 @@ data Package a = Package
     -- ^ The version of the PureScript compiler which was used to generate
     -- this data. We store this in order to reject packages which are too old.
   }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData a => NFData (Package a)
 
 data NotYetKnown = NotYetKnown
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData NotYetKnown
 
 type UploadedPackage = Package NotYetKnown
 type VerifiedPackage = Package GithubUser
@@ -111,7 +119,9 @@ data Module = Module
   -- Re-exported values from other modules
   , modReExports    :: [(InPackage P.ModuleName, [Declaration])]
   }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData Module
 
 data Declaration = Declaration
   { declTitle      :: Text
@@ -120,7 +130,9 @@ data Declaration = Declaration
   , declChildren   :: [ChildDeclaration]
   , declInfo       :: DeclarationInfo
   }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData Declaration
 
 -- |
 -- A value of this type contains information that is specific to a particular
@@ -170,7 +182,9 @@ data DeclarationInfo
   -- A kind declaration
   --
   | ExternKindDeclaration
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData DeclarationInfo
 
 convertFundepsToStrings :: [(Text, Maybe P.Kind)] -> [P.FunctionalDependency] -> [([Text], [Text])]
 convertFundepsToStrings args fundeps =
@@ -265,7 +279,9 @@ data ChildDeclaration = ChildDeclaration
   , cdeclSourceSpan :: Maybe P.SourceSpan
   , cdeclInfo       :: ChildDeclarationInfo
   }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData ChildDeclaration
 
 data ChildDeclarationInfo
   -- |
@@ -284,7 +300,9 @@ data ChildDeclarationInfo
   -- example, `pure` from `Applicative` would be `forall a. a -> f a`.
   --
   | ChildTypeClassMember P.Type
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData ChildDeclarationInfo
 
 childDeclInfoToString :: ChildDeclarationInfo -> Text
 childDeclInfoToString (ChildInstance _ _)      = "instance"
@@ -319,11 +337,15 @@ isDataConstructor ChildDeclaration{..} =
 
 newtype GithubUser
   = GithubUser { runGithubUser :: Text }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData GithubUser
 
 newtype GithubRepo
   = GithubRepo { runGithubRepo :: Text }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData GithubRepo
 
 data PackageError
   = CompilerTooOld Version Version
@@ -337,12 +359,16 @@ data PackageError
   | InvalidKind Text
   | InvalidDataDeclType Text
   | InvalidTime
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData PackageError
 
 data InPackage a
   = Local a
   | FromDep PackageName a
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData a => NFData (InPackage a)
 
 instance Functor InPackage where
   fmap f (Local x) = Local (f x)
@@ -370,14 +396,18 @@ data LinksContext = LinksContext
   , ctxVersion              :: Version
   , ctxVersionTag           :: Text
   }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData LinksContext
 
 data DocLink = DocLink
   { linkLocation  :: LinkLocation
   , linkTitle     :: Text
   , linkNamespace :: Namespace
   }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData DocLink
 
 data LinkLocation
   -- | A link to a declaration in the same module.
@@ -397,7 +427,9 @@ data LinkLocation
   -- module. In this case we only need to store the module that the builtin
   -- comes from (at the time of writing, this will only ever be "Prim").
   | BuiltinModule P.ModuleName
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData LinkLocation
 
 -- | Given a links context, the current module name, the namespace of a thing
 -- to link to, its title, and its containing module, attempt to create a

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -1,8 +1,12 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 module Language.PureScript.Environment where
 
 import           Prelude.Compat
 import           Protolude (ordNub)
 
+import           GHC.Generics (Generic)
+import           Control.DeepSeq (NFData)
 import           Data.Aeson ((.=), (.:))
 import qualified Data.Aeson as A
 import qualified Data.Map as M
@@ -38,7 +42,9 @@ data Environment = Environment
   -- ^ Type classes
   , kinds :: S.Set (Qualified (ProperName 'KindName))
   -- ^ Kinds in scope
-  } deriving Show
+  } deriving (Show, Generic)
+
+instance NFData Environment
 
 -- | Information about a type class
 data TypeClassData = TypeClassData
@@ -59,7 +65,9 @@ data TypeClassData = TypeClassData
   -- typeClassArguments and typeClassDependencies.
   , typeClassCoveringSets :: S.Set (S.Set Int)
   -- ^ A sets of arguments that can be used to infer all other arguments.
-  } deriving Show
+  } deriving (Show, Generic)
+
+instance NFData TypeClassData
 
 -- | A functional dependency indicates a relationship between two sets of
 -- type arguments in a class declaration.
@@ -68,7 +76,9 @@ data FunctionalDependency = FunctionalDependency
   -- ^ the type arguments which determine the determined type arguments
   , fdDetermined  :: [Int]
   -- ^ the determined type arguments
-  } deriving Show
+  } deriving (Show, Generic)
+
+instance NFData FunctionalDependency
 
 instance A.FromJSON FunctionalDependency where
   parseJSON = A.withObject "FunctionalDependency" $ \o ->
@@ -164,7 +174,9 @@ data NameVisibility
   -- ^ The name is defined in the current binding group, but is not visible
   | Defined
   -- ^ The name is defined in the another binding group, or has been made visible by a function binder
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
+
+instance NFData NameVisibility
 
 -- | A flag for whether a name is for an private or public value - only public values will be
 -- included in a generated externs file.
@@ -176,7 +188,9 @@ data NameKind
   -- ^ A public value for a module member or foreing import declaration
   | External
   -- ^ A name for member introduced by foreign import
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
+
+instance NFData NameKind
 
 -- | The kinds of a type
 data TypeKind
@@ -190,7 +204,9 @@ data TypeKind
   -- ^ A local type variable
   | ScopedTypeVar
   -- ^ A scoped type variable
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
+
+instance NFData TypeKind
 
 instance A.ToJSON TypeKind where
   toJSON (DataType args ctors) =
@@ -221,7 +237,9 @@ data DataDeclType
   -- ^ A standard data constructor
   | Newtype
   -- ^ A newtype constructor
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData DataDeclType
 
 showDataDeclType :: DataDeclType -> Text
 showDataDeclType Data = "data"

--- a/src/Language/PureScript/Kinds.hs
+++ b/src/Language/PureScript/Kinds.hs
@@ -1,7 +1,11 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 module Language.PureScript.Kinds where
 
 import Prelude.Compat
 
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Aeson.BetterErrors (Parse, key, asText, asIntegral, nth, fromAesonParser, toAesonParser, throwCustomError)
@@ -21,7 +25,9 @@ data Kind
   | FunKind Kind Kind
   -- | A named kind
   | NamedKind (Qualified (ProperName 'KindName))
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData Kind
 
 -- This is equivalent to the derived Aeson ToJSON instance, except that we
 -- write it out manually so that we can define a parser which is

--- a/src/Language/PureScript/Label.hs
+++ b/src/Language/PureScript/Label.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
+
 module Language.PureScript.Label (Label(..)) where
 
 import Prelude.Compat hiding (lex)
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
 import Data.Monoid ()
 import Data.String (IsString(..))
 import qualified Data.Aeson as A
@@ -13,4 +17,6 @@ import Language.PureScript.PSString (PSString)
 -- because records are indexable by PureScript strings at runtime.
 --
 newtype Label = Label { runLabel :: PSString }
-  deriving (Show, Eq, Ord, IsString, Monoid, A.ToJSON, A.FromJSON)
+  deriving (Show, Eq, Ord, IsString, Monoid, A.ToJSON, A.FromJSON, Generic)
+
+instance NFData Label

--- a/src/Language/PureScript/Names.hs
+++ b/src/Language/PureScript/Names.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 -- |
 -- Data types for names
@@ -8,7 +9,9 @@ module Language.PureScript.Names where
 import Prelude.Compat
 
 import Control.Monad.Supply.Class
+import Control.DeepSeq (NFData)
 
+import GHC.Generics (Generic)
 import Data.Aeson
 import Data.Aeson.TH
 import Data.Monoid ((<>))
@@ -25,7 +28,9 @@ data Name
   | TyClassName (ProperName 'ClassName)
   | ModName ModuleName
   | KiName (ProperName 'KindName)
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+
+instance NFData Name
 
 getIdentName :: Name -> Maybe Ident
 getIdentName (IdentName name) = Just name
@@ -67,7 +72,9 @@ data Ident
   -- A generated name for an identifier
   --
   | GenIdent (Maybe Text) Integer
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData Ident
 
 runIdent :: Ident -> Text
 runIdent (Ident i) = i
@@ -87,7 +94,9 @@ freshIdent' = GenIdent Nothing <$> fresh
 -- Operator alias names.
 --
 newtype OpName (a :: OpNameType) = OpName { runOpName :: Text }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData (OpName a)
 
 instance ToJSON (OpName a) where
   toJSON = toJSON . runOpName
@@ -107,7 +116,9 @@ data OpNameType = ValueOpName | TypeOpName
 -- Proper names, i.e. capitalized names for e.g. module names, type//data constructors.
 --
 newtype ProperName (a :: ProperNameType) = ProperName { runProperName :: Text }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData (ProperName a)
 
 instance ToJSON (ProperName a) where
   toJSON = toJSON . runProperName
@@ -137,7 +148,9 @@ coerceProperName = ProperName . runProperName
 -- Module names
 --
 newtype ModuleName = ModuleName [ProperName 'Namespace]
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData ModuleName
 
 runModuleName :: ModuleName -> Text
 runModuleName (ModuleName pns) = T.intercalate "." (runProperName <$> pns)
@@ -154,7 +167,9 @@ moduleNameFromString = ModuleName . splitProperNames
 -- A qualified name, i.e. a name with an optional module name
 --
 data Qualified a = Qualified (Maybe ModuleName) a
-  deriving (Show, Eq, Ord, Functor)
+  deriving (Show, Eq, Ord, Functor, Generic)
+
+instance NFData a => NFData (Qualified a)
 
 showQualified :: (a -> Text) -> Qualified a -> Text
 showQualified f (Qualified Nothing a) = f a

--- a/src/Language/PureScript/PSString.hs
+++ b/src/Language/PureScript/PSString.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+
 module Language.PureScript.PSString
   ( PSString
   , toUTF16CodeUnits
@@ -12,6 +14,8 @@ module Language.PureScript.PSString
   ) where
 
 import Prelude.Compat
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
 import Control.Exception (try, evaluate)
 import Control.Applicative ((<|>))
 import Data.Char (chr)
@@ -48,7 +52,9 @@ import qualified Data.Aeson.Types as A
 -- and arrays of UTF-16 code units (integers) otherwise.
 --
 newtype PSString = PSString { toUTF16CodeUnits :: [Word16] }
-  deriving (Eq, Ord, Monoid)
+  deriving (Eq, Ord, Monoid, Generic)
+
+instance NFData PSString
 
 instance Show PSString where
   show = show . codePoints

--- a/src/Language/PureScript/TypeClassDictionaries.hs
+++ b/src/Language/PureScript/TypeClassDictionaries.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE DeriveFoldable    #-}
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DeriveGeneric     #-}
 module Language.PureScript.TypeClassDictionaries where
 
 import Prelude.Compat
 
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
 import Data.Monoid ((<>))
 import Data.Text (Text, pack)
 
@@ -26,7 +29,9 @@ data TypeClassDictionaryInScope v
     -- | Type class dependencies which must be satisfied to construct this dictionary
     , tcdDependencies :: Maybe [Constraint]
     }
-    deriving (Show, Functor, Foldable, Traversable)
+    deriving (Show, Functor, Foldable, Traversable, Generic)
+
+instance NFData v => NFData (TypeClassDictionaryInScope v)
 
 type NamedDict = TypeClassDictionaryInScope (Qualified Ident)
 

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 -- |
 -- Data types for types
@@ -10,6 +11,7 @@ import Prelude.Compat
 import Protolude (ordNub)
 
 import Control.Arrow (first)
+import Control.DeepSeq (NFData)
 import Control.Monad ((<=<))
 import qualified Data.Aeson as A
 import qualified Data.Aeson.TH as A
@@ -19,6 +21,7 @@ import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
+import GHC.Generics (Generic)
 
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.Kinds
@@ -30,7 +33,9 @@ import Language.PureScript.PSString (PSString)
 -- An identifier for the scope of a skolem variable
 --
 newtype SkolemScope = SkolemScope { runSkolemScope :: Int }
-  deriving (Show, Eq, Ord, A.ToJSON, A.FromJSON)
+  deriving (Show, Eq, Ord, A.ToJSON, A.FromJSON, Generic)
+
+instance NFData SkolemScope
 
 -- |
 -- The type of types
@@ -78,7 +83,9 @@ data Type
   -- Note: although it seems this constructor is not used, it _is_ useful,
   -- since it prevents certain traversals from matching.
   | ParensInType Type
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData Type
 
 -- | Additional data relevant to type class constraints
 data ConstraintData
@@ -88,7 +95,9 @@ data ConstraintData
   -- not matched, and a flag indicating whether the list was truncated or not.
   -- Note: we use 'Text' here because using 'Binder' would introduce a cyclic
   -- dependency in the module graph.
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance NFData ConstraintData
 
 -- | A typeclass constraint
 data Constraint = Constraint
@@ -98,7 +107,9 @@ data Constraint = Constraint
   -- ^ type arguments
   , constraintData  :: Maybe ConstraintData
   -- ^ additional data relevant to this constraint
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic)
+
+instance NFData Constraint
 
 mapConstraintArgs :: ([Type] -> [Type]) -> Constraint -> Constraint
 mapConstraintArgs f c = c { constraintArgs = f (constraintArgs c) }


### PR DESCRIPTION
I also added derived Generic instances in order to be able to define
the NFData instances without having to write the necessary code by hand;
I expect I'll do it incorrectly if I try to do it by hand.

I am mainly doing this because I want to use it to help diagnose bugs
like #2772 but I also think it might come in handy in real code at some
point too; e.g. if we ever want to store these types in Pursuit's
database.