### PR TITLE
[purs ide] Fix encoding bug in list import command

### DIFF
--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -229,7 +229,7 @@ instance ToJSON Success where
   toJSON (PursuitResult resp) = encodeSuccess resp
   toJSON (ImportList (moduleName, imports)) = object [ "resultType" .= ("success" :: Text)
                                                      , "result" .= object [ "imports" .= map encodeImport imports
-                                                                          , "moduleName" .= moduleName]]
+                                                                          , "moduleName" .= P.runModuleName moduleName]]
   toJSON (ModuleList modules) = encodeSuccess modules
   toJSON (RebuildSuccess warnings) = encodeSuccess (P.toJSONErrors False P.Warning warnings)
 


### PR DESCRIPTION
Instead of returning `"Data.Array"` we returned `["Data", "Array"]` here, because
the code fell back to the ToJSON instance for `ModuleName`.

Found by @nwolverson in https://github.com/kRITZCREEK/purescript-psc-ide/pull/28