### PR TITLE
Fix #2772, match type level strings in docs renderer

### DIFF
--- a/examples/docs/src/TypeLevelString.purs
+++ b/examples/docs/src/TypeLevelString.purs
@@ -1,0 +1,7 @@
+module TypeLevelString where
+
+data Foo
+
+class Bar a
+
+instance fooBar :: Fail "oops" => Bar Foo

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.15.0.
+-- This file has been generated from package.yaml by hpack version 0.17.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -59,6 +59,7 @@ extra-source-files:
       examples/docs/src/TypeClassWithFunDeps.purs
       examples/docs/src/TypeClassWithoutMembers.purs
       examples/docs/src/TypeClassWithoutMembersIntermediate.purs
+      examples/docs/src/TypeLevelString.purs
       examples/docs/src/TypeOpAliases.purs
       examples/docs/src/UTF8.purs
       examples/docs/src/Virtual.purs

--- a/src/Language/PureScript/Docs/RenderedCode/RenderType.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/RenderType.hs
@@ -26,6 +26,7 @@ import Language.PureScript.Names
 import Language.PureScript.Pretty.Types
 import Language.PureScript.Types
 import Language.PureScript.Label (Label)
+import Language.PureScript.PSString (prettyPrintString)
 
 import Language.PureScript.Docs.RenderedCode.Types
 import Language.PureScript.Docs.Utils.MonoidExtras
@@ -54,6 +55,8 @@ typeLiterals = mkPattern match
     Just $ renderTypeAtom l <> sp <> renderTypeAtom op <> sp <> renderTypeAtom r
   match (TypeOp n) =
     Just (typeOp n)
+  match (TypeLevelString str) =
+    Just (syntax (prettyPrintString str))
   match _ =
     Nothing
 

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -398,6 +398,10 @@ testCases =
   , ("DocComments",
       [ ShouldHaveDocComment (n "DocComments") "example" "    example == 0"
       ])
+
+  , ("TypeLevelString",
+      [ ShouldBeDocumented (n "TypeLevelString") "Foo" ["fooBar"]
+      ])
   ]
 
   where


### PR DESCRIPTION
This might be the same problem as in #2448 but I haven't been able to verify.