### PR TITLE
Qualify types as necessary in hints in warnings/errors

### DIFF
--- a/examples/failing/RequalifyErrors.purs
+++ b/examples/failing/RequalifyErrors.purs
@@ -1,0 +1,8 @@
+-- @shouldFailWith TypesDoNotUnify
+module RequalifyErrors where
+
+import RequalifyErrors.M1 as M1
+import RequalifyErrors.M2 as M2
+
+test M1.X = true
+test M2.X = false

--- a/examples/failing/RequalifyErrors/M1.purs
+++ b/examples/failing/RequalifyErrors/M1.purs
@@ -1,0 +1,3 @@
+module RequalifyErrors.M1 where
+
+data X = X

--- a/examples/failing/RequalifyErrors/M2.purs
+++ b/examples/failing/RequalifyErrors/M2.purs
@@ -1,0 +1,3 @@
+module RequalifyErrors.M2 where
+
+data X = X

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -236,6 +236,9 @@ extra-source-files:
       examples/failing/ProgrammableTypeErrors.purs
       examples/failing/ProgrammableTypeErrorsTypeString.purs
       examples/failing/Rank2Types.purs
+      examples/failing/RequalifyErrors.purs
+      examples/failing/RequalifyErrors/M1.purs
+      examples/failing/RequalifyErrors/M2.purs
       examples/failing/RequiredHiddenType.purs
       examples/failing/Reserved.purs
       examples/failing/RowConstructors1.purs

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -9,6 +9,7 @@ module Language.PureScript.Errors
 import           Prelude.Compat
 import           Protolude (ordNub)
 
+import           Control.Applicative ((<|>))
 import           Control.Arrow ((&&&))
 import           Control.Monad
 import           Control.Monad.Error.Class (MonadError(..))
@@ -1213,6 +1214,44 @@ prettyPrintRef (ReExportRef _ _) =
   Nothing
 prettyPrintRef (PositionedDeclarationRef _ _ ref) =
   prettyPrintRef ref
+
+-- | Unqualify names based on the imports in the current module
+withUnqualifiedNames :: [Declaration] -> Type -> Type
+withUnqualifiedNames decls = everywhereOnTypes go where
+  go (TypeConstructor tyName) = TypeConstructor (findImportFor tyName)
+  go other = other
+
+  findImportFor :: Qualified (ProperName 'TypeName) -> Qualified (ProperName 'TypeName)
+  findImportFor tyName = fromMaybe tyName (foldr (<|>) Nothing (map (matchImport tyName) decls))
+
+  matchImport
+    :: Qualified (ProperName 'TypeName)
+    -> Declaration
+    -> Maybe (Qualified (ProperName 'TypeName))
+  matchImport (Qualified (Just mn) tyName) (ImportDeclaration mn' impTy qualName)
+    | mn == mn'
+    , matchesImportType impTy tyName
+    = Just (Qualified qualName tyName)
+  matchImport tyName (PositionedDeclaration _ _ decl) = matchImport tyName decl
+  matchImport _ _ = Nothing
+
+  matchesImportType :: ImportDeclarationType -> ProperName 'TypeName -> Bool
+  matchesImportType Implicit        _      = True
+  matchesImportType (Explicit refs) tyName = any (exportsType tyName) refs
+  matchesImportType (Hiding refs)   tyName = not (any (exportsType tyName) refs)
+
+  exportsType :: ProperName 'TypeName -> DeclarationRef -> Bool
+  exportsType tyName (TypeRef tyName' _) = tyName == tyName'
+  exportsType tyName (PositionedDeclarationRef _ _ ref) = exportsType tyName ref
+  exportsType _ _ = False
+
+rethrowUnqualified
+  :: (MonadError MultipleErrors m, MonadWriter MultipleErrors m)
+  => [Declaration]
+  -> m a
+  -> m a
+rethrowUnqualified decls =
+  warnAndRethrow ((onErrorMessages . onTypesInErrorMessage) (withUnqualifiedNames decls))
 
 -- | Pretty print multiple errors
 prettyPrintMultipleErrors :: PPEOptions -> MultipleErrors -> String

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -136,7 +136,7 @@ rebuildModule
   -> [ExternsFile]
   -> Module
   -> m ExternsFile
-rebuildModule MakeActions{..} externs m@(Module _ _ moduleName _ _) = do
+rebuildModule MakeActions{..} externs m@(Module _ _ moduleName decls _) = rethrowUnqualified decls $ do
   progress $ CompilingModule moduleName
   let env = foldl' (flip applyExternsFileToEnvironment) initEnvironment externs
       withPrim = importPrim m

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -126,7 +126,7 @@ matchTypeAtom tro@TypeRenderOptions{troSuggesting = suggesting} =
       match (TypeVar var) = Just $ text $ T.unpack var
       match (TypeLevelString s) = Just $ text $ T.unpack $ prettyPrintString s
       match (PrettyPrintObject row) = Just $ prettyPrintRowWith tro '{' '}' row
-      match (TypeConstructor ctor) = Just $ text $ T.unpack $ runProperName $ disqualify ctor
+      match (TypeConstructor ctor) = Just $ text $ T.unpack $ showQualified runProperName ctor
       match (TUnknown u)
         | suggesting = Just $ text "_"
         | otherwise = Just $ text $ 't' : show u


### PR DESCRIPTION
Fixes #1647

The new test case gives this error now:

```
Error found:
in module RequalifyErrors
at examples/failing/RequalifyErrors.purs line 7, column 6 - line 7, column 10

  Could not match type
        
    M2.X
        
  with type
        
    M1.X
```

It might be nice to test that at some point.

I was originally planning to build a `Map` data structure, but I figured we can do that later if the types become big enough that it becomes a performance issue. Since this only gets evaluated if there is an error, I can't see it being a big problem.