### PR TITLE
Allow user to propagate Warn constraints

### DIFF
--- a/examples/warning/CustomWarning2.purs
+++ b/examples/warning/CustomWarning2.purs
@@ -1,0 +1,11 @@
+-- @shouldWarnWith UserDefinedWarning
+module Main where
+
+foo :: Warn "foo" => Int -> Int
+foo x = x
+
+bar :: Warn "foo" => Int
+bar = foo 42
+
+baz :: Int
+baz = bar

--- a/examples/warning/CustomWarning3.purs
+++ b/examples/warning/CustomWarning3.purs
@@ -1,4 +1,5 @@
 -- @shouldWarnWith UserDefinedWarning
+-- @shouldWarnWith UserDefinedWarning
 module Main where
 
 foo :: Warn "foo" => Int -> Int

--- a/examples/warning/CustomWarning3.purs
+++ b/examples/warning/CustomWarning3.purs
@@ -1,0 +1,12 @@
+-- @shouldWarnWith UserDefinedWarning
+module Main where
+
+foo :: Warn "foo" => Int -> Int
+foo x = x
+
+-- Defer the "foo" warning and warn with "bar" as well
+bar :: Warn "foo" => Warn "bar" => Int
+bar = foo 42
+
+baz :: Int
+baz = bar

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -152,7 +152,9 @@ entails SolverOptions{..} constraint context hints =
     solve constraint
   where
     forClassName :: InstanceContext -> Qualified (ProperName 'ClassName) -> [Type] -> [TypeClassDict]
-    forClassName _ C.Warn [msg] =
+    forClassName ctx cn@C.Warn [msg] | [] <- findDicts ctx cn Nothing =
+      -- Only generate a warning dictionary if there is not already one in scope.
+      -- This allows us to defer a warning by propagating the constraint.
       [TypeClassDictionaryInScope (WarnInstance msg) [] C.Warn [msg] Nothing]
     forClassName _ C.IsSymbol [TypeLevelString sym] =
       [TypeClassDictionaryInScope (IsSymbolInstance sym) [] C.IsSymbol [TypeLevelString sym] Nothing]

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -152,10 +152,10 @@ entails SolverOptions{..} constraint context hints =
     solve constraint
   where
     forClassName :: InstanceContext -> Qualified (ProperName 'ClassName) -> [Type] -> [TypeClassDict]
-    forClassName ctx cn@C.Warn [msg] | [] <- findDicts ctx cn Nothing =
-      -- Only generate a warning dictionary if there is not already one in scope.
+    forClassName ctx cn@C.Warn [msg] =
+      -- Prefer a warning dictionary in scope if there is one available.
       -- This allows us to defer a warning by propagating the constraint.
-      [TypeClassDictionaryInScope (WarnInstance msg) [] C.Warn [msg] Nothing]
+      findDicts ctx cn Nothing ++ [TypeClassDictionaryInScope (WarnInstance msg) [] C.Warn [msg] Nothing]
     forClassName _ C.IsSymbol [TypeLevelString sym] =
       [TypeClassDictionaryInScope (IsSymbolInstance sym) [] C.IsSymbol [TypeLevelString sym] Nothing]
     forClassName _ C.CompareSymbol [arg0@(TypeLevelString lhs), arg1@(TypeLevelString rhs), _] =


### PR DESCRIPTION
Fixes #2813 

_Edit_: This actually doesn't _quite_ work, since in this case:

```purescript
foo :: Warn "foo" => Int -> Int
foo x = x

bar :: Warn "bar" => Int
bar = foo 42
```

we don't generate a dictionary for `Warn "foo"`, since `Warn "bar"` is available. But then `"foo"` doesn't match `"bar"` and you get a `NoInstanceFound` error, which is a bit weird. I don't think it's worth resorting to backtracking though.

_Edit 2_: I've fixed the issue described above now. See the `CustomWarning3` example.