### PR TITLE
[purs ide] Reads files in TextMode for adding imports

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -586,6 +586,8 @@ extra-source-files:
       examples/warning/2411.purs
       examples/warning/2542.purs
       examples/warning/CustomWarning.purs
+      examples/warning/CustomWarning2.purs
+      examples/warning/CustomWarning3.purs
       examples/warning/DuplicateExportRef.purs
       examples/warning/DuplicateImport.purs
       examples/warning/DuplicateImportRef.purs

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -85,7 +85,7 @@ parseImportsFromFile file = do
 parseImportsFromFile' :: (MonadIO m, MonadError IdeError m) =>
                         FilePath -> m (P.ModuleName, [Text], [Import], [Text])
 parseImportsFromFile' fp = do
-  file <- ideReadFile fp
+  file <- ideReadTextFile fp
   case sliceImportSection (T.lines file) of
     Right res -> pure res
     Left err -> throwError (GeneralError err)


### PR DESCRIPTION
The functions provided in System.IO.UTF8 use ByteString's readFile, which uses https://hackage.haskell.org/package/base-4.9.1.0/docs/System-IO.html#v:openBinaryFile under the hood, which in turn causes trouble when we treat source files as text on Windows.

Fixes #2833 (works on my machine :pitchfork: Windows :pitchfork:)