### PR TITLE
Turn off coveralls upload for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ matrix:
       sudo: required
       env: BUILD_TYPE=normal
 
-    - os: linux
-      dist: trusty
-      sudo: required
-      env: BUILD_TYPE=sdist COVERAGE=true
+    # - os: linux
+    #   dist: trusty
+    #   sudo: required
+    #   env: BUILD_TYPE=sdist COVERAGE=true
 
     - os: linux
       dist: trusty


### PR DESCRIPTION
Seems `stack-hpc-coveralls` doesn't like the new `http-client` API, or something like that.