### PR TITLE
Bumps lower bound for directory

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,7 @@ dependencies:
   - containers
   - data-ordlist >=0.4.7.0
   - deepseq
-  - directory >=1.2
+  - directory >=1.2.3
   - dlist
   - edit-distance
   - filepath

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -662,7 +662,7 @@ library
         , containers
         , data-ordlist >=0.4.7.0
         , deepseq
-        , directory >=1.2
+        , directory >=1.2.3
         , dlist
         , edit-distance
         , filepath
@@ -870,7 +870,7 @@ executable purs
         , containers
         , data-ordlist >=0.4.7.0
         , deepseq
-        , directory >=1.2
+        , directory >=1.2.3
         , dlist
         , edit-distance
         , filepath
@@ -958,7 +958,7 @@ test-suite tests
         , containers
         , data-ordlist >=0.4.7.0
         , deepseq
-        , directory >=1.2
+        , directory >=1.2.3
         , dlist
         , edit-distance
         , filepath


### PR DESCRIPTION
fixes #2856

The PR for the .cabal file in #2816 coincided with the switch to `hpack` and so it seems like the change was overwritten unnoticed. 