### PR TITLE
[purs ide] Decodes source files as UTF8 when parsing out the imports

### DIFF
--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -38,9 +38,8 @@ import           Protolude                           hiding (decodeUtf8,
 import           Control.Lens                        hiding ((&), op)
 import           Data.Aeson
 import qualified Data.Text                           as T
-import qualified Data.Text.IO                        as TIO
 import qualified Data.Text.Lazy                      as TL
-import           Data.Text.Lazy.Encoding             (decodeUtf8, encodeUtf8)
+import           Data.Text.Lazy.Encoding             as TLE
 import qualified Language.PureScript                 as P
 import           Language.PureScript.Ide.Error       (prettyPrintTypeSingleLine, IdeError(..))
 import           Language.PureScript.Ide.Logging
@@ -109,10 +108,10 @@ typeOperatorAliasT i =
   P.showQualified P.runProperName i
 
 encodeT :: (ToJSON a) => a -> Text
-encodeT = TL.toStrict . decodeUtf8 . encode
+encodeT = TL.toStrict . TLE.decodeUtf8 . encode
 
 decodeT :: (FromJSON a) => Text -> Maybe a
-decodeT = decode . encodeUtf8 . TL.fromStrict
+decodeT = decode . TLE.encodeUtf8 . TL.fromStrict
 
 unwrapPositioned :: P.Declaration -> P.Declaration
 unwrapPositioned (P.PositionedDeclaration _ _ x) = unwrapPositioned x
@@ -148,8 +147,8 @@ ideReadFile = ideReadFile' readUTF8FileT
 
 -- | This function is to be used over @ideReadFile@ when the result is not just
 -- passed on to the PureScript parser, but also needs to be treated as lines of
--- text. Because @ideReadFile@ reads the file as ByteString in @BinaryMode@
--- rather than @TextMode@ line endings get mangled on Windows otherwise. This is
--- irrelevant for parsing, because the Lexer strips these additional @\r@'s.
+-- Text. Because @ideReadFile@ reads the file as ByteString line endings get
+-- mangled on Windows otherwise. This is irrelevant for parsing, because the
+-- Lexer strips the additional @\r@s as whitespace.
 ideReadTextFile :: (MonadIO m, MonadError IdeError m) => FilePath -> m Text
-ideReadTextFile = ideReadFile' TIO.readFile
+ideReadTextFile fp = T.replace "\r\n" "\n" <$> ideReadFile fp


### PR DESCRIPTION
The previous change to this used the default Text's readFile, which decodes as UTF16 and thus messed up unicode symbols when adding imports. Encodings & cross platform issues, fun times!