### PR TITLE
[purs ide] Simplify state type

### DIFF
--- a/app/Command/Ide.hs
+++ b/app/Command/Ide.hs
@@ -120,7 +120,7 @@ command = Opts.helper <*> subcommands where
 
     unless noWatch $
       void (forkFinally (watcher polling logLevel ideState fullOutputPath) print)
-    let conf = Configuration {confLogLevel = logLevel, confOutputPath = outputPath, confGlobs = globs}
+    let conf = IdeConfiguration {confLogLevel = logLevel, confOutputPath = outputPath, confGlobs = globs}
         env = IdeEnvironment {ideStateVar = ideState, ideConfiguration = conf}
     startServer port env
 

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -167,7 +167,7 @@ findAllSourceFiles = do
 -- | Looks up the ExternsFiles for the given Modulenames and loads them into the
 -- server state. Then proceeds to parse all the specified sourcefiles and
 -- inserts their ASTs into the state. Finally kicks off an async worker, which
--- populates Stage 2 and 3 of the state.
+-- populates the VolatileState.
 loadModulesAsync
   :: (Ide m, MonadError IdeError m, MonadLogger m)
   => [P.ModuleName]
@@ -179,9 +179,9 @@ loadModulesAsync moduleNames = do
   -- successfully parsed modules.
   env <- ask
   let ll = confLogLevel (ideConfiguration env)
-  -- populateStage2 and 3 return Unit for now, so it's fine to discard this
+  -- populateVolatileState return Unit for now, so it's fine to discard this
   -- result. We might want to block on this in a benchmarking situation.
-  _ <- liftIO (async (runLogger ll (runReaderT (populateStage2 *> populateStage3) env)))
+  _ <- liftIO (async (runLogger ll (runReaderT populateVolatileState env)))
   pure tr
 
 loadModulesSync
@@ -190,7 +190,7 @@ loadModulesSync
   -> m Success
 loadModulesSync moduleNames = do
   tr <- loadModules moduleNames
-  populateStage2 *> populateStage3
+  populateVolatileState
   pure tr
 
 loadModules

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -129,8 +129,8 @@ newtype AstData a = AstData (ModuleMap (DefinitionSites a, TypeAnnotations))
 data IdeLogLevel = LogDebug | LogPerf | LogAll | LogDefault | LogNone
   deriving (Show, Eq)
 
-data Configuration =
-  Configuration
+data IdeConfiguration =
+  IdeConfiguration
   { confOutputPath :: FilePath
   , confLogLevel   :: IdeLogLevel
   , confGlobs      :: [FilePath]
@@ -139,7 +139,7 @@ data Configuration =
 data IdeEnvironment =
   IdeEnvironment
   { ideStateVar      :: TVar IdeState
-  , ideConfiguration :: Configuration
+  , ideConfiguration :: IdeConfiguration
   }
 
 type Ide m = (MonadIO m, MonadReader IdeEnvironment m)

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -122,7 +122,7 @@ emptyAnn = Annotation Nothing Nothing Nothing
 type DefinitionSites a = Map IdeNamespaced a
 type TypeAnnotations = Map P.Ident P.Type
 newtype AstData a = AstData (ModuleMap (DefinitionSites a, TypeAnnotations))
-  -- ^ SourceSpans for the definition sites of Values and Types aswell as type
+  -- ^ SourceSpans for the definition sites of values and types as well as type
   -- annotations found in a module
   deriving (Show, Eq, Ord, Functor, Foldable)
 
@@ -145,35 +145,41 @@ data IdeEnvironment =
 type Ide m = (MonadIO m, MonadReader IdeEnvironment m)
 
 data IdeState = IdeState
-  { ideStage1 :: Stage1
-  , ideStage2 :: Stage2
-  , ideStage3 :: Stage3
+  { ideFileState     :: IdeFileState
+  , ideVolatileState :: IdeVolatileState
   } deriving (Show)
 
 emptyIdeState :: IdeState
-emptyIdeState = IdeState emptyStage1 emptyStage2 emptyStage3
+emptyIdeState = IdeState emptyFileState emptyVolatileState
 
-emptyStage1 :: Stage1
-emptyStage1 = Stage1 M.empty M.empty
+emptyFileState :: IdeFileState
+emptyFileState = IdeFileState M.empty M.empty
 
-emptyStage2 :: Stage2
-emptyStage2 = Stage2 (AstData M.empty)
+emptyVolatileState :: IdeVolatileState
+emptyVolatileState = IdeVolatileState (AstData M.empty) M.empty Nothing
 
-emptyStage3 :: Stage3
-emptyStage3 = Stage3 M.empty Nothing
 
-data Stage1 = Stage1
-  { s1Externs :: ModuleMap P.ExternsFile
-  , s1Modules :: ModuleMap (P.Module, FilePath)
+-- | @IdeFileState@ holds data that corresponds 1-to-1 to an entity on the
+-- filesystem. Externs correspond to the ExternsFiles the compiler emits into
+-- the output folder, and modules are parsed ASTs from source files. This means,
+-- that we can update single modules or ExternsFiles inside this state whenever
+-- the corresponding entity changes on the file system.
+data IdeFileState = IdeFileState
+  { fsExterns :: ModuleMap P.ExternsFile
+  , fsModules :: ModuleMap (P.Module, FilePath)
   } deriving (Show)
 
-data Stage2 = Stage2
-  { s2AstData :: AstData P.SourceSpan
-  } deriving (Show, Eq)
-
-data Stage3 = Stage3
-  { s3Declarations  :: ModuleMap [IdeDeclarationAnn]
-  , s3CachedRebuild :: Maybe (P.ModuleName, P.ExternsFile)
+-- | @IdeVolatileState@ is derived from the @IdeFileState@ and needs to be
+-- invalidated and refreshed carefully. It holds @AstData@, which is the data we
+-- extract from the parsed ASTs, as well as the IdeDeclarations, which contain
+-- lots of denormalized data, so they need to fully rebuilt whenever
+-- @IdeFileState@ changes. The vsCachedRebuild field can hold a rebuild result
+-- with open imports which is used to provide completions for module private
+-- declarations
+data IdeVolatileState = IdeVolatileState
+  { vsAstData       :: AstData P.SourceSpan
+  , vsDeclarations  :: ModuleMap [IdeDeclarationAnn]
+  , vsCachedRebuild :: Maybe (P.ModuleName, P.ExternsFile)
   } deriving (Show)
 
 newtype Match a = Match (P.ModuleName, a)

--- a/src/Language/PureScript/Ide/Watcher.hs
+++ b/src/Language/PureScript/Ide/Watcher.hs
@@ -39,7 +39,7 @@ reloadFile logLevel ref ev = runLogger logLevel $ do
     Left err ->
       logErrorN ("Failed to reload file at: " <> toS fp <> " with error: " <> show err)
     Right ef -> do
-      lift $ void $ atomically (insertExternsSTM ref ef *> populateStage3STM ref)
+      lift $ void $ atomically (insertExternsSTM ref ef *> populateVolatileStateSTM ref)
       logDebugN ("Reloaded File at: " <> toS fp)
 
 -- | Installs filewatchers for the given directory and reloads ExternsFiles when

--- a/tests/Language/PureScript/Ide/SourceFileSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFileSpec.hs
@@ -94,7 +94,7 @@ getLocation s = do
     runIde' defConfig ideState [Type s [] Nothing]
   pure (complLocation c)
   where
-    ideState = emptyIdeState `s3`
+    ideState = emptyIdeState `volatileState`
       [ ("Test",
          [ ideValue "sfValue" Nothing `annLoc` valueSS
          , ideSynonym "SFType" P.tyString P.kindType `annLoc` synonymSS

--- a/tests/Language/PureScript/Ide/Test.hs
+++ b/tests/Language/PureScript/Ide/Test.hs
@@ -35,11 +35,11 @@ runIde' conf s cs = do
 runIde :: [Command] -> IO ([Either IdeError Success], IdeState)
 runIde = runIde' defConfig emptyIdeState
 
-s3 :: IdeState -> [(Text, [IdeDeclarationAnn])] -> IdeState
-s3 s ds =
-  s {ideStage3 = stage3}
+volatileState :: IdeState -> [(Text, [IdeDeclarationAnn])] -> IdeState
+volatileState s ds =
+  s {ideVolatileState = vs}
   where
-    stage3 = Stage3 (Map.fromList decls) Nothing
+    vs = IdeVolatileState (AstData Map.empty) (Map.fromList decls) Nothing
     decls = map (first P.moduleNameFromString) ds
 
 -- | Adding Annotations to IdeDeclarations

--- a/tests/Language/PureScript/Ide/Test.hs
+++ b/tests/Language/PureScript/Ide/Test.hs
@@ -17,14 +17,14 @@ import           System.Process
 
 import qualified Language.PureScript             as P
 
-defConfig :: Configuration
+defConfig :: IdeConfiguration
 defConfig =
-  Configuration { confLogLevel = LogNone
+  IdeConfiguration { confLogLevel = LogNone
                 , confOutputPath = "output/"
                 , confGlobs = ["src/*.purs"]
                 }
 
-runIde' :: Configuration -> IdeState -> [Command] -> IO ([Either IdeError Success], IdeState)
+runIde' :: IdeConfiguration -> IdeState -> [Command] -> IO ([Either IdeError Success], IdeState)
 runIde' conf s cs = do
   stateVar <- newTVarIO s
   let env' = IdeEnvironment {ideStateVar = stateVar, ideConfiguration = conf}


### PR DESCRIPTION
This merges Stage2 into Stage3 and renames the state types into `IdeFileState` and `IdeVolatileState`. While these names are definitely better than their predecessors I'm open to suggestions for better names....

The reasoning for the names is as follows:

- `IdeFileState` contains all the state that directly maps to an entity in the file system

- `IdeVolatileState` contains all the state we derive from IdeFileState and needs to be fully reloaded whenever the file system changes.

I also added some documentation while I was at it.

To give a bit of context, I'm currently working on documenting the architecture and some of the design decision made inside `purs ide` to make it easier to navigate and contribute to. So expect more refactoring/documentation/cleanup PRs.