### PR TITLE
[purs ide] Parses modules in parallel

### DIFF
--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -208,7 +208,7 @@ loadModules moduleNames = do
   -- We parse all source files, log eventual parse failures and insert the
   -- successful parses into the state.
   (failures, allModules) <-
-    partitionEithers <$> (traverse parseModule =<< findAllSourceFiles)
+    partitionEithers <$> (parseModulesFromFiles =<< findAllSourceFiles)
   unless (null failures) $
     $(logWarn) ("Failed to parse: " <> show failures)
   traverse_ insertModule allModules


### PR DESCRIPTION
Fixes #2783 

Empty project with just Halogen:
```
before: 
[perf] Command Load took 3092.80ms
after:  
[perf] Command Load took 1994.84ms
```


Slamdata:
```
before:
  λ purs ide server --log-level perf "src/**/*.purs" "bower_components/*/src/**/*.purs"
  [perf] Command Load took 12572.22ms
after:
  λ purs ide server --log-level perf "src/**/*.purs" "bower_components/*/src/**/*.purs"
  [perf] Command Load took 7251.82ms
```