### PR TITLE
[purs ide] Work around laziness when measuring command perf

### DIFF
--- a/app/Command/Ide.hs
+++ b/app/Command/Ide.hs
@@ -170,9 +170,9 @@ startServer port env = withSocketsDo $ do
                       <> displayTimeSpec duration
               logPerf message $ do
                 result <- runExceptT (handleCommand cmd')
-                case result of
-                  Right r  -> liftIO $ catchGoneHandle (BSL8.hPutStrLn h (Aeson.encode r))
-                  Left err -> liftIO $ catchGoneHandle (BSL8.hPutStrLn h (Aeson.encode err))
+                liftIO $ catchGoneHandle $ BSL8.hPutStrLn h $ case result of
+                  Right r  -> Aeson.encode r
+                  Left err -> Aeson.encode err
               liftIO (hFlush stdout)
             Nothing -> do
               $(logError) ("Parsing the command failed. Command: " <> cmd)

--- a/app/Command/Ide.hs
+++ b/app/Command/Ide.hs
@@ -164,15 +164,16 @@ startServer port env = withSocketsDo $ do
           case decodeT cmd of
             Just cmd' -> do
               let message duration =
-                    "Command " <> commandName cmd'
-                    <> " took "
-                    <> displayTimeSpec duration
-              result <- logPerf message (runExceptT (handleCommand cmd'))
-              -- $(logDebug) ("Answer was: " <> T.pack (show result))
+                    "Command "
+                      <> commandName cmd'
+                      <> " took "
+                      <> displayTimeSpec duration
+              logPerf message $ do
+                result <- runExceptT (handleCommand cmd')
+                case result of
+                  Right r  -> liftIO $ catchGoneHandle (BSL8.hPutStrLn h (Aeson.encode r))
+                  Left err -> liftIO $ catchGoneHandle (BSL8.hPutStrLn h (Aeson.encode err))
               liftIO (hFlush stdout)
-              case result of
-                Right r  -> liftIO $ catchGoneHandle (BSL8.hPutStrLn h (Aeson.encode r))
-                Left err -> liftIO $ catchGoneHandle (BSL8.hPutStrLn h (Aeson.encode err))
             Nothing -> do
               $(logError) ("Parsing the command failed. Command: " <> cmd)
               liftIO $ do


### PR DESCRIPTION
Before this completion and type commands would always be measured as 0.01ms. Laziness is a tricky beast when you want to measure things ^^