### PR TITLE
[purs ide] Groups reexports in completions

### DIFF
--- a/psc-ide/PROTOCOL.md
+++ b/psc-ide/PROTOCOL.md
@@ -108,7 +108,8 @@ couldn't be extracted from a source file.
     "start": [1, 3],
     "end": [3, 1]
     },
-  "documentation": "A filtering function"
+  "documentation": "A filtering function",
+  "exportedFrom": ["Data.Array"]
   }
 ]
 ```
@@ -615,11 +616,12 @@ Completion options allow to configure the number of returned completion results.
 If specified limits the number of completion results, otherwise return all
 results.
 
-- groupReexports :: Maybe (Array String)
+- groupReexports :: Maybe Boolean (defaults to False)
 
-If specified groups reexports under their original module and prefers the
-specified set of modules.
-
+If set to True, groups all reexports of an identifier under the module it
+originated from (the original export is also treated as a "reexport"). These
+reexports then populate the `exportedFrom` field in their completion results and
+the `module` field contains the originating module.
 
 ### Error
 

--- a/psc-ide/PROTOCOL.md
+++ b/psc-ide/PROTOCOL.md
@@ -81,8 +81,8 @@ The `complete` command looks up possible completions/corrections.
     "matcher": {..},
     "currentModule": "Main",
     "options": {
-      "maxResults": 50
-      "groupReexports": ["Prelude", "Data.Array", "Data.List"]
+      "maxResults": 50,
+      "groupReexports": true
     }
   }
 }

--- a/psc-ide/PROTOCOL.md
+++ b/psc-ide/PROTOCOL.md
@@ -82,6 +82,7 @@ The `complete` command looks up possible completions/corrections.
     "currentModule": "Main",
     "options": {
       "maxResults": 50
+      "groupReexports": ["Prelude", "Data.Array", "Data.List"]
     }
   }
 }
@@ -613,6 +614,12 @@ Completion options allow to configure the number of returned completion results.
 
 If specified limits the number of completion results, otherwise return all
 results.
+
+- groupReexports :: Maybe (Array String)
+
+If specified groups reexports under their original module and prefers the
+specified set of modules.
+
 
 ### Error
 

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -83,7 +83,7 @@ handleCommand c = case c of
     case rs of
       Right rs' -> answerRequest outfp rs'
       Left question ->
-        pure (CompletionResult (map (completionFromMatch . map withEmptyAnn) question))
+        pure (CompletionResult (map (completionFromMatch . simpleExport . map withEmptyAnn) question))
   Rebuild file ->
     rebuildFileAsync file
   RebuildSync file ->
@@ -104,13 +104,13 @@ findCompletions
   -> m Success
 findCompletions filters matcher currentModule complOptions = do
   modules <- getAllModules currentModule
-  pure . CompletionResult . map completionFromMatch . getCompletions filters matcher complOptions $ modules
+  pure (CompletionResult (getCompletions filters matcher complOptions modules))
 
 findType :: Ide m =>
             Text -> [Filter] -> Maybe P.ModuleName -> m Success
 findType search filters currentModule = do
   modules <- getAllModules currentModule
-  pure . CompletionResult . map completionFromMatch . getExactMatches search filters $ modules
+  pure (CompletionResult (getExactCompletions search filters modules))
 
 findPursuitCompletions :: MonadIO m =>
                           PursuitQuery -> m Success

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -38,7 +38,7 @@ getCompletions filters matcher options modules =
   & matchesFromModules
   & runMatcher matcher
   & applyCompletionOptions options
-  & map completionFromMatch
+  <&> completionFromMatch
 
 getExactMatches :: Text -> [Filter] -> [Module] -> [Match IdeDeclarationAnn]
 getExactMatches search filters modules =
@@ -50,8 +50,8 @@ getExactCompletions :: Text -> [Filter] -> [Module] -> [Completion]
 getExactCompletions search filters modules =
   modules
   & getExactMatches search filters
-  & map simpleExport
-  & map completionFromMatch
+  <&> simpleExport
+  <&> completionFromMatch
 
 matchesFromModules :: [Module] -> [Match IdeDeclarationAnn]
 matchesFromModules = foldMap completionFromModule

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -8,11 +8,15 @@ module Language.PureScript.Ide.Completion
 
 import           Protolude
 
+import           Control.Lens (view)
 import           Data.Aeson
+import           Data.List (intersect)
+import qualified Data.Map as Map
+import qualified Language.PureScript as P
 import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.Matcher
 import           Language.PureScript.Ide.Types
-import qualified Language.PureScript as P
+import           Language.PureScript.Ide.Util
 
 type Module = (P.ModuleName, [IdeDeclarationAnn])
 
@@ -43,17 +47,51 @@ completionsFromModules = foldMap completionFromModule
 
 data CompletionOptions = CompletionOptions
   { coMaxResults :: Maybe Int
+  , coGroupReexports :: Maybe [P.ModuleName]
   }
 
 defaultCompletionOptions :: CompletionOptions
-defaultCompletionOptions = CompletionOptions { coMaxResults = Nothing }
+defaultCompletionOptions = CompletionOptions { coMaxResults = Nothing, coGroupReexports = Nothing }
 
-applyCompletionOptions :: CompletionOptions -> [a] -> [a]
-applyCompletionOptions co =
-  maybe identity take (coMaxResults co)
+applyCompletionOptions :: CompletionOptions -> [Match IdeDeclarationAnn] -> [Match IdeDeclarationAnn]
+applyCompletionOptions co decls =
+  maybe identity take (coMaxResults co) decls
+  & maybe identity groupCompletionReexports (coGroupReexports co)
+
+groupCompletionReexports :: [P.ModuleName] -> [Match IdeDeclarationAnn] -> [Match IdeDeclarationAnn]
+groupCompletionReexports preferred initial =
+  concatMap choosePreferred (Map.elems (foldr go Map.empty initial))
+  where
+    go (Match (moduleName, d@(IdeDeclarationAnn (view annExportedFrom -> Just origin) decl))) =
+      Map.alter
+      (insertReexport moduleName origin d)
+      (Namespaced (namespaceForDeclaration decl)
+       (P.runModuleName origin <> "." <> identifierFromIdeDeclaration decl))
+    go (Match (moduleName, d@(IdeDeclarationAnn _ decl))) =
+      Map.alter
+      (insertDeclaration moduleName d)
+      (Namespaced (namespaceForDeclaration decl)
+       (P.runModuleName moduleName <> "." <> identifierFromIdeDeclaration decl))
+    insertReexport moduleName origin d old = case old of
+      Nothing -> Just (Match (origin, d), [moduleName])
+      Just x -> Just (second (moduleName :) x)
+    insertDeclaration moduleName d old = case old of
+      Nothing -> Just (Match (moduleName, d), [])
+      Just x -> Just x
+
+    choosePreferred :: (Match a, [P.ModuleName]) -> [Match a]
+    choosePreferred (Match (mn, decl), reexports) =
+      case intersect reexports preferred of
+        [] -> [Match (mn, decl)]
+        prefs -> map (Match . (, decl)) prefs
+
+data Namespaced a = Namespaced IdeNamespace a
+  deriving (Show, Eq, Ord)
 
 instance FromJSON CompletionOptions where
   parseJSON = withObject "CompletionOptions" $ \o -> do
     maxResults <- o .:? "maxResults"
-    pure (CompletionOptions { coMaxResults = maxResults })
-
+    groupReexports <- o .:? "groupReexports"
+    pure (CompletionOptions { coMaxResults = maxResults
+                            , coGroupReexports = map P.moduleNameFromString <$> groupReexports
+                            })

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -1,6 +1,9 @@
 module Language.PureScript.Ide.Completion
        ( getCompletions
        , getExactMatches
+       , getExactCompletions
+       , simpleExport
+       , completionFromMatch
        , CompletionOptions(..)
        , defaultCompletionOptions
        , applyCompletionOptions
@@ -8,11 +11,12 @@ module Language.PureScript.Ide.Completion
 
 import           Protolude
 
-import           Control.Lens (view)
+import           Control.Lens hiding ((&), op)
 import           Data.Aeson
-import           Data.List (intersect)
 import qualified Data.Map as Map
+import qualified Data.Text as T
 import qualified Language.PureScript as P
+import           Language.PureScript.Ide.Error (prettyPrintTypeSingleLine)
 import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.Matcher
 import           Language.PureScript.Ide.Types
@@ -27,71 +31,111 @@ getCompletions
   -> Matcher IdeDeclarationAnn
   -> CompletionOptions
   -> [Module]
-  -> [Match IdeDeclarationAnn]
+  -> [Completion]
 getCompletions filters matcher options modules =
   modules
   & applyFilters filters
-  & completionsFromModules
+  & matchesFromModules
   & runMatcher matcher
   & applyCompletionOptions options
+  & map completionFromMatch
 
 getExactMatches :: Text -> [Filter] -> [Module] -> [Match IdeDeclarationAnn]
 getExactMatches search filters modules =
-  completionsFromModules (applyFilters (equalityFilter search : filters) modules)
+  modules
+  & applyFilters (equalityFilter search : filters)
+  & matchesFromModules
 
-completionsFromModules :: [Module] -> [Match IdeDeclarationAnn]
-completionsFromModules = foldMap completionFromModule
+getExactCompletions :: Text -> [Filter] -> [Module] -> [Completion]
+getExactCompletions search filters modules =
+  modules
+  & getExactMatches search filters
+  & map simpleExport
+  & map completionFromMatch
+
+matchesFromModules :: [Module] -> [Match IdeDeclarationAnn]
+matchesFromModules = foldMap completionFromModule
   where
     completionFromModule (moduleName, decls) =
       map (\x -> Match (moduleName, x)) decls
 
 data CompletionOptions = CompletionOptions
   { coMaxResults :: Maybe Int
-  , coGroupReexports :: Maybe [P.ModuleName]
+  , coGroupReexports :: Bool
   }
-
-defaultCompletionOptions :: CompletionOptions
-defaultCompletionOptions = CompletionOptions { coMaxResults = Nothing, coGroupReexports = Nothing }
-
-applyCompletionOptions :: CompletionOptions -> [Match IdeDeclarationAnn] -> [Match IdeDeclarationAnn]
-applyCompletionOptions co decls =
-  maybe identity take (coMaxResults co) decls
-  & maybe identity groupCompletionReexports (coGroupReexports co)
-
-groupCompletionReexports :: [P.ModuleName] -> [Match IdeDeclarationAnn] -> [Match IdeDeclarationAnn]
-groupCompletionReexports preferred initial =
-  concatMap choosePreferred (Map.elems (foldr go Map.empty initial))
-  where
-    go (Match (moduleName, d@(IdeDeclarationAnn (view annExportedFrom -> Just origin) decl))) =
-      Map.alter
-      (insertReexport moduleName origin d)
-      (Namespaced (namespaceForDeclaration decl)
-       (P.runModuleName origin <> "." <> identifierFromIdeDeclaration decl))
-    go (Match (moduleName, d@(IdeDeclarationAnn _ decl))) =
-      Map.alter
-      (insertDeclaration moduleName d)
-      (Namespaced (namespaceForDeclaration decl)
-       (P.runModuleName moduleName <> "." <> identifierFromIdeDeclaration decl))
-    insertReexport moduleName origin d old = case old of
-      Nothing -> Just (Match (origin, d), [moduleName])
-      Just x -> Just (second (moduleName :) x)
-    insertDeclaration moduleName d old = case old of
-      Nothing -> Just (Match (moduleName, d), [])
-      Just x -> Just x
-
-    choosePreferred :: (Match a, [P.ModuleName]) -> [Match a]
-    choosePreferred (Match (mn, decl), reexports) =
-      case intersect reexports preferred of
-        [] -> [Match (mn, decl)]
-        prefs -> map (Match . (, decl)) prefs
-
-data Namespaced a = Namespaced IdeNamespace a
-  deriving (Show, Eq, Ord)
 
 instance FromJSON CompletionOptions where
   parseJSON = withObject "CompletionOptions" $ \o -> do
     maxResults <- o .:? "maxResults"
-    groupReexports <- o .:? "groupReexports"
+    groupReexports <- o .:? "groupReexports" .!= False
     pure (CompletionOptions { coMaxResults = maxResults
-                            , coGroupReexports = map P.moduleNameFromString <$> groupReexports
+                            , coGroupReexports = groupReexports
                             })
+
+defaultCompletionOptions :: CompletionOptions
+defaultCompletionOptions = CompletionOptions { coMaxResults = Nothing, coGroupReexports = False }
+
+applyCompletionOptions :: CompletionOptions -> [Match IdeDeclarationAnn] -> [(Match IdeDeclarationAnn, [P.ModuleName])]
+applyCompletionOptions co decls =
+  maybe identity take (coMaxResults co) decls
+  & if coGroupReexports co
+    then groupCompletionReexports
+    else map simpleExport
+
+simpleExport :: Match a -> (Match a, [P.ModuleName])
+simpleExport match@(Match (moduleName, _)) = (match, [moduleName])
+
+groupCompletionReexports :: [Match IdeDeclarationAnn] -> [(Match IdeDeclarationAnn, [P.ModuleName])]
+groupCompletionReexports initial =
+  Map.elems (foldr go Map.empty initial)
+  where
+    go (Match (moduleName, d@(IdeDeclarationAnn ann decl))) =
+      let
+        origin = fromMaybe moduleName (ann^.annExportedFrom)
+      in
+        Map.alter
+        (insertDeclaration moduleName origin d)
+        (Namespaced (namespaceForDeclaration decl)
+         (P.runModuleName origin <> "." <> identifierFromIdeDeclaration decl))
+    insertDeclaration moduleName origin d old = case old of
+      Nothing -> Just ( Match (origin, d & idaAnnotation.annExportedFrom .~ Nothing)
+                      , [moduleName]
+                      )
+      Just x -> Just (second (moduleName :) x)
+
+data Namespaced a = Namespaced IdeNamespace a
+  deriving (Show, Eq, Ord)
+
+completionFromMatch :: (Match IdeDeclarationAnn, [P.ModuleName]) -> Completion
+completionFromMatch (Match (m, IdeDeclarationAnn ann decl), mns) =
+  Completion {..}
+  where
+    (complIdentifier, complExpandedType) = case decl of
+      IdeDeclValue v -> (v ^. ideValueIdent . identT, v ^. ideValueType & prettyPrintTypeSingleLine)
+      IdeDeclType t -> (t ^. ideTypeName . properNameT, t ^. ideTypeKind & P.prettyPrintKind)
+      IdeDeclTypeSynonym s -> (s ^. ideSynonymName . properNameT, s ^. ideSynonymType & prettyPrintTypeSingleLine)
+      IdeDeclDataConstructor d -> (d ^. ideDtorName . properNameT, d ^. ideDtorType & prettyPrintTypeSingleLine)
+      IdeDeclTypeClass d -> (d ^. ideTCName . properNameT, d ^. ideTCKind & P.prettyPrintKind)
+      IdeDeclValueOperator (IdeValueOperator op ref precedence associativity typeP) ->
+        (P.runOpName op, maybe (showFixity precedence associativity (valueOperatorAliasT ref) op) prettyPrintTypeSingleLine typeP)
+      IdeDeclTypeOperator (IdeTypeOperator op ref precedence associativity kind) ->
+        (P.runOpName op, maybe (showFixity precedence associativity (typeOperatorAliasT ref) op) P.prettyPrintKind kind)
+      IdeDeclKind k -> (P.runProperName k, "kind")
+
+    complExportedFrom = mns
+
+    complModule = P.runModuleName m
+
+    complType = maybe complExpandedType prettyPrintTypeSingleLine (_annTypeAnnotation ann)
+
+    complLocation = _annLocation ann
+
+    complDocumentation = Nothing
+
+    showFixity p a r o =
+      let asso = case a of
+            P.Infix -> "infix"
+            P.Infixl -> "infixl"
+            P.Infixr -> "infixr"
+      in T.unwords [asso, show p, r, "as", P.runOpName o]
+

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -66,9 +66,9 @@ encodeRebuildErrors = toJSON . map encodeRebuildError . P.runMultipleErrors
     insertTSCompletions _ _ _ v = v
 
     identCompletion (P.Qualified mn i, ty) =
-      Completion (maybe "" P.runModuleName mn) i (prettyPrintTypeSingleLine ty) (prettyPrintTypeSingleLine ty) Nothing Nothing
+      Completion (maybe "" P.runModuleName mn) i (prettyPrintTypeSingleLine ty) (prettyPrintTypeSingleLine ty) Nothing Nothing (maybe [] (\x -> [x]) mn)
     fieldCompletion (label, ty) =
-      Completion "" ("_." <> P.prettyPrintLabel label) (prettyPrintTypeSingleLine ty) (prettyPrintTypeSingleLine ty) Nothing Nothing
+      Completion "" ("_." <> P.prettyPrintLabel label) (prettyPrintTypeSingleLine ty) (prettyPrintTypeSingleLine ty) Nothing Nothing []
 
 textError :: IdeError -> Text
 textError (GeneralError msg)          = msg

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -46,16 +46,7 @@ namespaceFilter namespaces =
   mkFilter (filterModuleDecls filterNamespaces)
   where
     filterNamespaces :: IdeDeclaration -> Bool
-    filterNamespaces decl = elem (namespace decl) namespaces
-    namespace :: IdeDeclaration -> IdeNamespace
-    namespace (IdeDeclValue _)           = IdeNSValue
-    namespace (IdeDeclType _)            = IdeNSType
-    namespace (IdeDeclTypeSynonym _)     = IdeNSType
-    namespace (IdeDeclDataConstructor _) = IdeNSValue
-    namespace (IdeDeclTypeClass _)       = IdeNSType
-    namespace (IdeDeclValueOperator _)   = IdeNSValue
-    namespace (IdeDeclTypeOperator _)    = IdeNSType
-    namespace (IdeDeclKind _)            = IdeNSKind
+    filterNamespaces decl = elem (namespaceForDeclaration decl) namespaces
 
 -- | Only keeps the given Modules
 moduleFilter :: [P.ModuleName] -> Filter

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -22,9 +22,9 @@ import           Protolude
 import           Control.Concurrent.STM
 import           Control.Lens.TH
 import           Data.Aeson
-import qualified Data.Map.Lazy                       as M
-import qualified Language.PureScript                 as P
-import qualified Language.PureScript.Errors.JSON     as P
+import qualified Data.Map.Lazy as M
+import qualified Language.PureScript as P
+import qualified Language.PureScript.Errors.JSON as P
 
 type ModuleIdent = Text
 type ModuleMap a = Map P.ModuleName a
@@ -193,6 +193,7 @@ data Completion = Completion
   , complExpandedType  :: Text
   , complLocation      :: Maybe P.SourceSpan
   , complDocumentation :: Maybe Text
+  , complExportedFrom  :: [P.ModuleName]
   } deriving (Show, Eq, Ord)
 
 instance ToJSON Completion where
@@ -203,6 +204,7 @@ instance ToJSON Completion where
            , "expandedType" .= complExpandedType
            , "definedAt" .= complLocation
            , "documentation" .= complDocumentation
+           , "exportedFrom" .= complExportedFrom
            ]
 
 identifierFromDeclarationRef :: P.DeclarationRef -> Text

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -18,6 +18,7 @@ module Language.PureScript.Ide.Util
   , unwrapPositioned
   , unwrapPositionedRef
   , completionFromMatch
+  , namespaceForDeclaration
   , encodeT
   , decodeT
   , discardAnn
@@ -55,6 +56,17 @@ identifierFromIdeDeclaration d = case d of
   IdeDeclValueOperator op -> op ^. ideValueOpName & P.runOpName
   IdeDeclTypeOperator op -> op ^. ideTypeOpName & P.runOpName
   IdeDeclKind name -> P.runProperName name
+
+namespaceForDeclaration :: IdeDeclaration -> IdeNamespace
+namespaceForDeclaration d = case d of
+  IdeDeclValue _ -> IdeNSValue
+  IdeDeclType _ -> IdeNSType
+  IdeDeclTypeSynonym _ -> IdeNSType
+  IdeDeclDataConstructor _ -> IdeNSValue
+  IdeDeclTypeClass _ -> IdeNSType
+  IdeDeclValueOperator _ -> IdeNSValue
+  IdeDeclTypeOperator _ -> IdeNSType
+  IdeDeclKind _ -> IdeNSKind
 
 discardAnn :: IdeDeclarationAnn -> IdeDeclaration
 discardAnn (IdeDeclarationAnn _ d) = d

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -17,7 +17,6 @@ module Language.PureScript.Ide.Util
   , unwrapMatch
   , unwrapPositioned
   , unwrapPositionedRef
-  , completionFromMatch
   , namespaceForDeclaration
   , encodeT
   , decodeT
@@ -41,7 +40,7 @@ import qualified Data.Text                           as T
 import qualified Data.Text.Lazy                      as TL
 import           Data.Text.Lazy.Encoding             as TLE
 import qualified Language.PureScript                 as P
-import           Language.PureScript.Ide.Error       (prettyPrintTypeSingleLine, IdeError(..))
+import           Language.PureScript.Ide.Error       (IdeError(..))
 import           Language.PureScript.Ide.Logging
 import           Language.PureScript.Ide.Types
 import           System.IO.UTF8                      (readUTF8FileT)
@@ -76,37 +75,6 @@ withEmptyAnn = IdeDeclarationAnn emptyAnn
 
 unwrapMatch :: Match a -> a
 unwrapMatch (Match (_, ed)) = ed
-
-completionFromMatch :: Match IdeDeclarationAnn -> Completion
-completionFromMatch (Match (m, IdeDeclarationAnn ann decl)) =
-  Completion {..}
-  where
-    (complIdentifier, complExpandedType) = case decl of
-      IdeDeclValue v -> (v ^. ideValueIdent . identT, v ^. ideValueType & prettyPrintTypeSingleLine)
-      IdeDeclType t -> (t ^. ideTypeName . properNameT, t ^. ideTypeKind & P.prettyPrintKind)
-      IdeDeclTypeSynonym s -> (s ^. ideSynonymName . properNameT, s ^. ideSynonymType & prettyPrintTypeSingleLine)
-      IdeDeclDataConstructor d -> (d ^. ideDtorName . properNameT, d ^. ideDtorType & prettyPrintTypeSingleLine)
-      IdeDeclTypeClass d -> (d ^. ideTCName . properNameT, d ^. ideTCKind & P.prettyPrintKind)
-      IdeDeclValueOperator (IdeValueOperator op ref precedence associativity typeP) ->
-        (P.runOpName op, maybe (showFixity precedence associativity (valueOperatorAliasT ref) op) prettyPrintTypeSingleLine typeP)
-      IdeDeclTypeOperator (IdeTypeOperator op ref precedence associativity kind) ->
-        (P.runOpName op, maybe (showFixity precedence associativity (typeOperatorAliasT ref) op) P.prettyPrintKind kind)
-      IdeDeclKind k -> (P.runProperName k, "kind")
-
-    complModule = P.runModuleName m
-
-    complType = maybe complExpandedType prettyPrintTypeSingleLine (_annTypeAnnotation ann)
-
-    complLocation = _annLocation ann
-
-    complDocumentation = Nothing
-
-    showFixity p a r o =
-      let asso = case a of
-            P.Infix -> "infix"
-            P.Infixl -> "infixl"
-            P.Infixr -> "infixr"
-      in T.unwords [asso, show p, r, "as", P.runOpName o]
 
 valueOperatorAliasT
   :: P.Qualified (Either P.Ident (P.ProperName 'P.ConstructorName)) -> Text

--- a/tests/Language/PureScript/Ide/CompletionSpec.hs
+++ b/tests/Language/PureScript/Ide/CompletionSpec.hs
@@ -4,21 +4,31 @@ module Language.PureScript.Ide.CompletionSpec where
 
 import Protolude
 
+import Language.PureScript as P
 import Language.PureScript.Ide.Completion
 import Language.PureScript.Ide.Test
 import Language.PureScript.Ide.Types
 import Test.Hspec
 
-matches :: [Match IdeDeclarationAnn]
-matches = map (\d -> Match (mn "Main", d)) [ ideKind "Kind", ideType "Type" Nothing ]
+reexportMatches :: [Match IdeDeclarationAnn]
+reexportMatches =
+  map (\d -> Match (mn "A", d)) moduleA
+  ++ map (\d -> Match (mn "B", d)) moduleB
+  where
+    moduleA = [ideKind "Kind"]
+    moduleB = [ideKind "Kind" `annExp` "A"]
+
+matches :: [(Match IdeDeclarationAnn, [P.ModuleName])]
+matches = map (\d -> (Match (mn "Main", d), [mn "Main"])) [ ideKind "Kind", ideType "Type" Nothing ]
 
 spec :: Spec
 spec = describe "Applying completion options" $ do
   it "keeps all matches if maxResults is not specified" $ do
-    applyCompletionOptions (defaultCompletionOptions { coMaxResults = Nothing }) matches
-    `shouldBe`
-      matches
+    applyCompletionOptions (defaultCompletionOptions { coMaxResults = Nothing })
+      (map fst matches) `shouldMatchList` matches
   it "keeps only the specified amount of maxResults" $ do
-    applyCompletionOptions (defaultCompletionOptions { coMaxResults = Just 1 }) matches
-    `shouldBe`
-      take 1 matches
+    applyCompletionOptions (defaultCompletionOptions { coMaxResults = Just 1 })
+      (map fst matches) `shouldMatchList` take 1 matches
+  it "groups reexports for a single identifier" $ do
+    applyCompletionOptions (defaultCompletionOptions { coGroupReexports = True })
+      reexportMatches `shouldBe` [(Match (mn "A", ideKind "Kind"), [mn "A", mn "B"])]


### PR DESCRIPTION
Adds an option to control how reexport should be grouped in the completions.

TODO:

- [x] Actually describe what this does behaviour wise
- [ ] Figure out if this is the desired (default) behaviour
- [x] tests
- [x] Return the list of reexporting modules in the completion format

Fixes #2752, Fixes #2908 