### PR TITLE
Allow type signatures in instances

### DIFF
--- a/examples/failing/InstanceSigsBodyIncorrect.purs
+++ b/examples/failing/InstanceSigsBodyIncorrect.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith TypesDoNotUnify
+
+module Main where
+
+class Foo a where
+  foo :: a
+
+instance fooNumber :: Foo Number where
+  foo :: Number
+  foo = true

--- a/examples/failing/InstanceSigsDifferentTypes.purs
+++ b/examples/failing/InstanceSigsDifferentTypes.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith TypesDoNotUnify
+
+module Main where
+
+class Foo a where
+  foo :: a
+
+instance fooNumber :: Foo Number where
+  foo :: Int
+  foo = 0.0

--- a/examples/failing/InstanceSigsIncorrectType.purs
+++ b/examples/failing/InstanceSigsIncorrectType.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith TypesDoNotUnify
+
+module Main where
+
+class Foo a where
+  foo :: a
+
+instance fooNumber :: Foo Number where
+  foo :: Boolean
+  foo = true

--- a/examples/failing/InstanceSigsOrphanTypeDeclaration.purs
+++ b/examples/failing/InstanceSigsOrphanTypeDeclaration.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith OrphanTypeDeclaration
+
+module Main where
+
+class Foo a where
+  foo :: a
+
+instance fooNumber :: Foo Number where
+  bar :: Int
+  foo = 0.0

--- a/examples/failing/InstanceSigsTypeTooGeneral.purs
+++ b/examples/failing/InstanceSigsTypeTooGeneral.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith TypesDoNotUnify
+
+module Main where
+
+class Eq a where
+  eq :: a -> a -> Boolean
+
+instance eqNumber :: Eq Number where
+  eq :: forall x y. x -> y -> Boolean
+  eq _ _ = true

--- a/examples/passing/InstanceSigs.purs
+++ b/examples/passing/InstanceSigs.purs
@@ -1,0 +1,12 @@
+module Main where
+
+import Control.Monad.Eff.Console (log)
+
+class Foo a where
+  foo :: a
+
+instance fooNumber :: Foo Number where
+  foo :: Number
+  foo = 0.0
+
+main = log "Done"

--- a/examples/passing/InstanceSigsGeneral.purs
+++ b/examples/passing/InstanceSigsGeneral.purs
@@ -1,6 +1,6 @@
--- @shouldFailWith TypesDoNotUnify
-
 module Main where
+
+import Control.Monad.Eff.Console (log)
 
 class Eq a where
   eq :: a -> a -> Boolean
@@ -8,3 +8,5 @@ class Eq a where
 instance eqNumber :: Eq Number where
   eq :: forall x y. x -> y -> Boolean
   eq _ _ = true
+
+main = log "Done"

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -185,9 +185,10 @@ extra-source-files:
       examples/failing/InfiniteType.purs
       examples/failing/InstanceExport.purs
       examples/failing/InstanceExport/InstanceExport.purs
+      examples/failing/InstanceSigsBodyIncorrect.purs
       examples/failing/InstanceSigsDifferentTypes.purs
+      examples/failing/InstanceSigsIncorrectType.purs
       examples/failing/InstanceSigsOrphanTypeDeclaration.purs
-      examples/failing/InstanceSigsTypeTooGeneral.purs
       examples/failing/IntOutOfRange.purs
       examples/failing/InvalidDerivedInstance.purs
       examples/failing/InvalidDerivedInstance2.purs
@@ -403,6 +404,7 @@ extra-source-files:
       examples/passing/InferRecFunWithConstrainedArgument.purs
       examples/passing/InstanceBeforeClass.purs
       examples/passing/InstanceSigs.purs
+      examples/passing/InstanceSigsGeneral.purs
       examples/passing/IntAndChar.purs
       examples/passing/iota.purs
       examples/passing/JSReserved.purs

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -185,6 +185,9 @@ extra-source-files:
       examples/failing/InfiniteType.purs
       examples/failing/InstanceExport.purs
       examples/failing/InstanceExport/InstanceExport.purs
+      examples/failing/InstanceSigsDifferentTypes.purs
+      examples/failing/InstanceSigsOrphanTypeDeclaration.purs
+      examples/failing/InstanceSigsTypeTooGeneral.purs
       examples/failing/IntOutOfRange.purs
       examples/failing/InvalidDerivedInstance.purs
       examples/failing/InvalidDerivedInstance2.purs
@@ -399,6 +402,7 @@ extra-source-files:
       examples/passing/ImportQualified/M1.purs
       examples/passing/InferRecFunWithConstrainedArgument.purs
       examples/passing/InstanceBeforeClass.purs
+      examples/passing/InstanceSigs.purs
       examples/passing/IntAndChar.purs
       examples/passing/iota.purs
       examples/passing/JSReserved.purs

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -216,8 +216,14 @@ parseTypeInstanceDeclaration = do
   instanceDecl <- parseInstanceDeclaration
   members <- P.option [] $ do
     indented *> reserved "where"
-    mark (P.many (same *> positioned parseValueDeclaration))
+    mark (P.many (same *> positioned declsInInstance))
   return $ instanceDecl (ExplicitInstance members)
+  where
+    declsInInstance :: TokenParser Declaration
+    declsInInstance = P.choice
+      [ parseTypeDeclaration
+      , parseValueDeclaration
+      ] P.<?> "type declaration or value declaration in instance"
 
 parseDerivingInstanceDeclaration :: TokenParser Declaration
 parseDerivingInstanceDeclaration = do


### PR DESCRIPTION
This is a WIP PR for implenting InstanceSigs in PureScript.  

Closes #2902.

Commit 6768e35 changes the parser to allow type signatures inside of type class instances.

Commit c56c615 adds some example files.

This is mostly working except for one thing.   Instance members are allowed to have signatures that are more general than the signature declared in the type class.

The PureScript file is able to be compiled successfully:

```purescript
module Main where

class Eq a where
  eq :: a -> a -> Boolean

instance eqNumber :: Eq Number where
  eq :: forall x y. x -> y -> Boolean
  eq _ _ = true
```

In #2902, @paf31 made the following [comment](https://github.com/purescript/purescript/issues/2902#issuecomment-303142729):

>> 
>> Should instance signatures be allowed to be more general than the definition in the type class?
> 
> No, I don't think so. Instance members already have an implicit type signature, so I think this should just optionally replace that.

I was trying to figure out where to make a change to disallow more general instance signatures.  However, I couldn't figure out where it would make the most sense.

Here are the three potential places I found, ordered by code flow (so, for instance, (1) happens first in the compilation process, etc):

1.  [Language.PureScript.Sugar.TypeDeclarations.desugarTypeDeclarationsModule](https://github.com/purescript/purescript/blob/0a6de6ec9431df0b01d00e9dd10aaade0aee043a/src/Language/PureScript/Sugar/TypeDeclarations.hs#L57): This function changes `TypeDeclaration`s to `ValueDeclaration`s.  

    This feels like a good place to do the check, but  we don't have access to the environment with all the available type classes.
2.  [Language.PureScript.Sugar.TypeClasses.typeInstanceDictionaryDeclaration](https://github.com/purescript/purescript/blob/0a6de6ec9431df0b01d00e9dd10aaade0aee043a/src/Language/PureScript/Sugar/TypeClasses.hs#L274): This function changes a `TypeInstanceDeclaration` into a `ValueDeclaration` wrapped around a `TypeClassDictionaryConstructorApp`.

    This also feels like it might be a good place to do the check, but we've sort-of lost the type information in (1).  I imagine it would be possible to try to inspect the `ValueDeclaration`s created in (1) and figure out which ones are wrapping around a `GuardedExpr [] (TypedValue True val ty)`.  But this seems like it would be slightly hacky?
3.  Somewhere in the type checker.  Not knowing anything about the compiler, originally I thought this sort of check would happen in the type checker.  However, I wasn't sure if there would be a good place for it here.  Just like with (2), we've sort-of lost the type definition in (1), so the solution would be somewhat hacky.

    Maybe a function like [Language.PureScript.TypeChecker.Types.checkTypedBindingGroupElement](https://github.com/purescript/purescript/blob/0a6de6ec9431df0b01d00e9dd10aaade0aee043a/src/Language/PureScript/TypeChecker/Types.hs#L225) would be a good place to start?



I can think of two possible ways to continue from here.

1.  Merge this PR (after changing the one test from "failing" to "passing").  It's not completely horrible to accept instance members that are too general.  It's how Haskell handles it.
2.  Maybe someone could take a look at this PR and give me some ideas on where this sort of check should go.  A high-level overview of how it might be implemented would also be helpful :-)