### PR TITLE
Parse support modules from actual test support purs

### DIFF
--- a/tests/TestCompiler.hs
+++ b/tests/TestCompiler.hs
@@ -61,26 +61,23 @@ main = hspec spec
 spec :: Spec
 spec = do
 
-  (supportExterns, supportForeigns, passingTestCases, warningTestCases, failingTestCases) <- runIO $ do
+  (supportModules, supportExterns, supportForeigns, passingTestCases, warningTestCases, failingTestCases) <- runIO $ do
     cwd <- getCurrentDirectory
     let passing = cwd </> "examples" </> "passing"
     let warning = cwd </> "examples" </> "warning"
     let failing = cwd </> "examples" </> "failing"
-    let supportDir = cwd </> "tests" </> "support" </> "bower_components"
-    let supportFiles ext = Glob.globDir1 (Glob.compile ("purescript-*/src/**/*." ++ ext)) supportDir
     passingFiles <- getTestFiles passing <$> testGlob passing
     warningFiles <- getTestFiles warning <$> testGlob warning
     failingFiles <- getTestFiles failing <$> testGlob failing
-    supportPurs <- supportFiles "purs"
-    supportPursFiles <- readInput supportPurs
+    ms <- getSupportModuleTuples
+    let modules = map snd ms
     supportExterns <- runExceptT $ do
-      modules <- ExceptT . return $ P.parseModulesFromFiles id supportPursFiles
-      foreigns <- inferForeignModules modules
-      externs <- ExceptT . fmap fst . runTest $ P.make (makeActions foreigns) (map snd modules)
-      return (zip (map snd modules) externs, foreigns)
+      foreigns <- inferForeignModules ms
+      externs <- ExceptT . fmap fst . runTest $ P.make (makeActions modules foreigns) modules
+      return (externs, foreigns)
     case supportExterns of
       Left errs -> fail (P.prettyPrintMultipleErrors P.defaultPPEOptions errs)
-      Right (externs, foreigns) -> return (externs, foreigns, passingFiles, warningFiles, failingFiles)
+      Right (externs, foreigns) -> return (modules, externs, foreigns, passingFiles, warningFiles, failingFiles)
 
   outputFile <- runIO $ do
     tmp <- getTemporaryDirectory
@@ -90,21 +87,21 @@ spec = do
   context "Passing examples" $
     forM_ passingTestCases $ \testPurs ->
       it ("'" <> takeFileName (getTestMain testPurs) <> "' should compile and run without error") $
-        assertCompiles supportExterns supportForeigns testPurs outputFile
+        assertCompiles supportModules supportExterns supportForeigns testPurs outputFile
 
   context "Warning examples" $
     forM_ warningTestCases $ \testPurs -> do
       let mainPath = getTestMain testPurs
       expectedWarnings <- runIO $ getShouldWarnWith mainPath
       it ("'" <> takeFileName mainPath <> "' should compile with warning(s) '" <> intercalate "', '" expectedWarnings <> "'") $
-        assertCompilesWithWarnings supportExterns supportForeigns testPurs expectedWarnings
+        assertCompilesWithWarnings supportModules supportExterns supportForeigns testPurs expectedWarnings
 
   context "Failing examples" $
     forM_ failingTestCases $ \testPurs -> do
       let mainPath = getTestMain testPurs
       expectedFailures <- runIO $ getShouldFailWith mainPath
       it ("'" <> takeFileName mainPath <> "' should fail with '" <> intercalate "', '" expectedFailures <> "'") $
-        assertDoesNotCompile supportExterns supportForeigns testPurs expectedFailures
+        assertDoesNotCompile supportModules supportExterns supportForeigns testPurs expectedFailures
 
   where
 
@@ -168,18 +165,18 @@ trim = dropWhile isSpace >>> reverse >>> dropWhile isSpace >>> reverse
 modulesDir :: FilePath
 modulesDir = ".test_modules" </> "node_modules"
 
-makeActions :: M.Map P.ModuleName FilePath -> P.MakeActions P.Make
-makeActions foreigns = (P.buildMakeActions modulesDir (P.internalError "makeActions: input file map was read.") foreigns False)
-                         { P.getInputTimestamp = getInputTimestamp
-                         , P.getOutputTimestamp = getOutputTimestamp
-                         }
+makeActions :: [P.Module] -> M.Map P.ModuleName FilePath -> P.MakeActions P.Make
+makeActions modules foreigns = (P.buildMakeActions modulesDir (P.internalError "makeActions: input file map was read.") foreigns False)
+                               { P.getInputTimestamp = getInputTimestamp
+                               , P.getOutputTimestamp = getOutputTimestamp
+                               }
   where
   getInputTimestamp :: P.ModuleName -> P.Make (Either P.RebuildPolicy (Maybe UTCTime))
   getInputTimestamp mn
     | isSupportModule (P.runModuleName mn) = return (Left P.RebuildNever)
     | otherwise = return (Left P.RebuildAlways)
     where
-    isSupportModule = flip elem supportModules
+    isSupportModule = flip elem (map (P.runModuleName . P.getModuleName) modules)
 
   getOutputTimestamp :: P.ModuleName -> P.Make (Maybe UTCTime)
   getOutputTimestamp mn = do
@@ -187,39 +184,36 @@ makeActions foreigns = (P.buildMakeActions modulesDir (P.internalError "makeActi
     exists <- liftIO $ doesDirectoryExist filePath
     return (if exists then Just (P.internalError "getOutputTimestamp: read timestamp") else Nothing)
 
-readInput :: [FilePath] -> IO [(FilePath, T.Text)]
-readInput inputFiles = forM inputFiles $ \inputFile -> do
-  text <- readUTF8FileT inputFile
-  return (inputFile, text)
-
 runTest :: P.Make a -> IO (Either P.MultipleErrors a, P.MultipleErrors)
 runTest = P.runMake P.defaultOptions
 
 compile
-  :: [(P.Module, P.ExternsFile)]
+  :: [P.Module]
+  -> [P.ExternsFile]
   -> M.Map P.ModuleName FilePath
   -> [FilePath]
   -> ([P.Module] -> IO ())
   -> IO (Either P.MultipleErrors [P.ExternsFile], P.MultipleErrors)
-compile supportExterns supportForeigns inputFiles check = silence $ runTest $ do
+compile supportModules supportExterns supportForeigns inputFiles check = silence $ runTest $ do
   fs <- liftIO $ readInput inputFiles
   ms <- P.parseModulesFromFiles id fs
   foreigns <- inferForeignModules ms
   liftIO (check (map snd ms))
-  let actions = makeActions (foreigns `M.union` supportForeigns)
+  let actions = makeActions supportModules (foreigns `M.union` supportForeigns)
   case ms of
-    [singleModule] -> pure <$> P.rebuildModule actions (map snd supportExterns) (snd singleModule)
-    _ -> P.make actions (map fst supportExterns ++ map snd ms)
+    [singleModule] -> pure <$> P.rebuildModule actions supportExterns (snd singleModule)
+    _ -> P.make actions (supportModules ++ map snd ms)
 
 assert
-  :: [(P.Module, P.ExternsFile)]
+  :: [P.Module]
+  -> [P.ExternsFile]
   -> M.Map P.ModuleName FilePath
   -> [FilePath]
   -> ([P.Module] -> IO ())
   -> (Either P.MultipleErrors P.MultipleErrors -> IO (Maybe String))
   -> Expectation
-assert supportExterns supportForeigns inputFiles check f = do
-  (e, w) <- compile supportExterns supportForeigns inputFiles check
+assert supportModules supportExterns supportForeigns inputFiles check f = do
+  (e, w) <- compile supportModules supportExterns supportForeigns inputFiles check
   maybeErr <- f (const w <$> e)
   maybe (return ()) expectationFailure maybeErr
 
@@ -236,13 +230,14 @@ checkShouldFailWith expected errs =
     else Just $ "Expected these errors: " ++ show expected ++ ", but got these: " ++ show actual
 
 assertCompiles
-  :: [(P.Module, P.ExternsFile)]
+  :: [P.Module]
+  -> [P.ExternsFile]
   -> M.Map P.ModuleName FilePath
   -> [FilePath]
   -> Handle
   -> Expectation
-assertCompiles supportExterns supportForeigns inputFiles outputFile =
-  assert supportExterns supportForeigns inputFiles checkMain $ \e ->
+assertCompiles supportModules supportExterns supportForeigns inputFiles outputFile =
+  assert supportModules supportExterns supportForeigns inputFiles checkMain $ \e ->
     case e of
       Left errs -> return . Just . P.prettyPrintMultipleErrors P.defaultPPEOptions $ errs
       Right _ -> do
@@ -262,13 +257,14 @@ assertCompiles supportExterns supportForeigns inputFiles outputFile =
           Nothing -> return $ Just "Couldn't find node.js executable"
 
 assertCompilesWithWarnings
-  :: [(P.Module, P.ExternsFile)]
+  :: [P.Module]
+  -> [P.ExternsFile]
   -> M.Map P.ModuleName FilePath
   -> [FilePath]
   -> [String]
   -> Expectation
-assertCompilesWithWarnings supportExterns supportForeigns inputFiles shouldWarnWith =
-  assert supportExterns supportForeigns inputFiles checkMain $ \e ->
+assertCompilesWithWarnings supportModules supportExterns supportForeigns inputFiles shouldWarnWith =
+  assert supportModules supportExterns supportForeigns inputFiles checkMain $ \e ->
     case e of
       Left errs ->
         return . Just . P.prettyPrintMultipleErrors P.defaultPPEOptions $ errs
@@ -282,13 +278,14 @@ assertCompilesWithWarnings supportExterns supportForeigns inputFiles shouldWarnW
     (<> "\n\n" <> P.prettyPrintMultipleErrors P.defaultPPEOptions warnings)
 
 assertDoesNotCompile
-  :: [(P.Module, P.ExternsFile)]
+  :: [P.Module]
+  -> [P.ExternsFile]
   -> M.Map P.ModuleName FilePath
   -> [FilePath]
   -> [String]
   -> Expectation
-assertDoesNotCompile supportExterns supportForeigns inputFiles shouldFailWith =
-  assert supportExterns supportForeigns inputFiles noPreCheck $ \e ->
+assertDoesNotCompile supportModules supportExterns supportForeigns inputFiles shouldFailWith =
+  assert supportModules supportExterns supportForeigns inputFiles noPreCheck $ \e ->
     case e of
       Left errs ->
         return $ if null shouldFailWith

--- a/tests/TestCompiler.hs
+++ b/tests/TestCompiler.hs
@@ -176,7 +176,7 @@ makeActions foreigns = (P.buildMakeActions modulesDir (P.internalError "makeActi
   where
   getInputTimestamp :: P.ModuleName -> P.Make (Either P.RebuildPolicy (Maybe UTCTime))
   getInputTimestamp mn
-    | isSupportModule (T.unpack (P.runModuleName mn)) = return (Left P.RebuildNever)
+    | isSupportModule (P.runModuleName mn) = return (Left P.RebuildNever)
     | otherwise = return (Left P.RebuildAlways)
     where
     isSupportModule = flip elem supportModules

--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module TestPsci.CompletionTest where
 
 import Prelude ()
@@ -65,7 +66,7 @@ completionTestData =
 
   -- a few other import tests
   , ("impor", ["import"])
-  , ("import ", map ("import " ++) supportModules)
+  , ("import ", map (T.unpack . mappend "import ") supportModules)
   , ("import Prelude ", [])
 
   -- String and number literals should not be completed
@@ -99,10 +100,10 @@ runCM act = do
 getPSCiStateForCompletion :: IO PSCiState
 getPSCiStateForCompletion = do
   (PSCiState _ bs es, _) <- initTestPSCiEnv
-  let imports = [controlMonadSTasST, (P.ModuleName [P.ProperName (T.pack "Prelude")], P.Implicit, Nothing)]
+  let imports = [controlMonadSTasST, (P.ModuleName [P.ProperName "Prelude"], P.Implicit, Nothing)]
   return $ PSCiState imports bs es
 
 controlMonadSTasST :: ImportedModule
 controlMonadSTasST = (s "Control.Monad.ST", P.Implicit, Just (s "ST"))
   where
-  s = P.moduleNameFromString . T.pack
+  s = P.moduleNameFromString

--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -14,17 +14,18 @@ import qualified Language.PureScript as P
 import           Language.PureScript.Interactive
 import           System.Console.Haskeline
 import           TestPsci.TestEnv (initTestPSCiEnv)
-import           TestUtils (supportModules)
+import           TestUtils (getSupportModuleNames)
 
 completionTests :: Spec
-completionTests = context "completionTests" $
-  mapM_ assertCompletedOk completionTestData
+completionTests = context "completionTests" $ do
+  mns <- runIO $ getSupportModuleNames
+  mapM_ assertCompletedOk (completionTestData mns)
 
 -- If the cursor is at the right end of the line, with the 1st element of the
 -- pair as the text in the line, then pressing tab should offer all the
 -- elements of the list (which is the 2nd element) as completions.
-completionTestData :: [(String, [String])]
-completionTestData =
+completionTestData :: [T.Text] -> [(String, [String])]
+completionTestData supportModuleNames =
   -- basic directives
   [ (":h",  [":help"])
   , (":r",  [":reload"])
@@ -66,7 +67,7 @@ completionTestData =
 
   -- a few other import tests
   , ("impor", ["import"])
-  , ("import ", map (T.unpack . mappend "import ") supportModules)
+  , ("import ", map (T.unpack . mappend "import ") supportModuleNames)
   , ("import Prelude ", [])
 
   -- String and number literals should not be completed

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -5,15 +5,23 @@ module TestUtils where
 import Prelude ()
 import Prelude.Compat
 
+import qualified Language.PureScript as P
+
 import Control.Monad
+import Control.Monad.Trans.Except
 import Control.Monad.Trans.Maybe
 import Control.Exception
-
+import Data.List (sort)
+import qualified Data.Text as T
 import System.Process
 import System.Directory
 import System.Info
+import System.IO.UTF8 (readUTF8FileT)
 import System.Exit (exitFailure)
+import System.FilePath ((</>))
+import qualified System.FilePath.Glob as Glob
 import System.IO (stderr, hPutStrLn)
+import System.IO.Unsafe (unsafePerformIO)
 
 findNodeProcess :: IO (Maybe String)
 findNodeProcess = runMaybeT . msum $ map (MaybeT . findExecutable) names
@@ -52,134 +60,18 @@ updateSupportCode = do
 -- excessive rebuilding.
 --
 supportModules :: [String]
-supportModules =
-  [ "Control.Alt"
-  , "Control.Alternative"
-  , "Control.Applicative"
-  , "Control.Apply"
-  , "Control.Biapplicative"
-  , "Control.Biapply"
-  , "Control.Bind"
-  , "Control.Category"
-  , "Control.Comonad"
-  , "Control.Extend"
-  , "Control.Lazy"
-  , "Control.Monad"
-  , "Control.Monad.Eff"
-  , "Control.Monad.Eff.Class"
-  , "Control.Monad.Eff.Console"
-  , "Control.Monad.Eff.Uncurried"
-  , "Control.Monad.Eff.Unsafe"
-  , "Control.Monad.Gen"
-  , "Control.Monad.Gen.Class"
-  , "Control.Monad.Gen.Common"
-  , "Control.Monad.Rec.Class"
-  , "Control.Monad.ST"
-  , "Control.MonadPlus"
-  , "Control.MonadZero"
-  , "Control.Plus"
-  , "Control.Semigroupoid"
-  , "Data.Array"
-  , "Data.Array.Partial"
-  , "Data.Array.ST"
-  , "Data.Array.ST.Iterator"
-  , "Data.Bifoldable"
-  , "Data.Bifunctor"
-  , "Data.Bifunctor.Clown"
-  , "Data.Bifunctor.Flip"
-  , "Data.Bifunctor.Join"
-  , "Data.Bifunctor.Joker"
-  , "Data.Bifunctor.Product"
-  , "Data.Bifunctor.Wrap"
-  , "Data.Bitraversable"
-  , "Data.Boolean"
-  , "Data.BooleanAlgebra"
-  , "Data.Bounded"
-  , "Data.Char"
-  , "Data.Char.Gen"
-  , "Data.CommutativeRing"
-  , "Data.Either"
-  , "Data.Either.Nested"
-  , "Data.Eq"
-  , "Data.EuclideanRing"
-  , "Data.Field"
-  , "Data.Foldable"
-  , "Data.Function"
-  , "Data.Function.Uncurried"
-  , "Data.Functor"
-  , "Data.Functor.Invariant"
-  , "Data.Generic"
-  , "Data.Generic.Rep"
-  , "Data.Generic.Rep.Bounded"
-  , "Data.Generic.Rep.Eq"
-  , "Data.Generic.Rep.Monoid"
-  , "Data.Generic.Rep.Ord"
-  , "Data.Generic.Rep.Semigroup"
-  , "Data.Generic.Rep.Show"
-  , "Data.HeytingAlgebra"
-  , "Data.Identity"
-  , "Data.Int"
-  , "Data.Int.Bits"
-  , "Data.Lazy"
-  , "Data.List"
-  , "Data.List.Lazy"
-  , "Data.List.Lazy.NonEmpty"
-  , "Data.List.Lazy.Types"
-  , "Data.List.NonEmpty"
-  , "Data.List.Partial"
-  , "Data.List.Types"
-  , "Data.List.ZipList"
-  , "Data.Maybe"
-  , "Data.Maybe.First"
-  , "Data.Maybe.Last"
-  , "Data.Monoid"
-  , "Data.Monoid.Additive"
-  , "Data.Monoid.Alternate"
-  , "Data.Monoid.Conj"
-  , "Data.Monoid.Disj"
-  , "Data.Monoid.Dual"
-  , "Data.Monoid.Endo"
-  , "Data.Monoid.Multiplicative"
-  , "Data.NaturalTransformation"
-  , "Data.Newtype"
-  , "Data.NonEmpty"
-  , "Data.Ord"
-  , "Data.Ord.Unsafe"
-  , "Data.Ordering"
-  , "Data.Ring"
-  , "Data.Semigroup"
-  , "Data.Semiring"
-  , "Data.Show"
-  , "Data.String"
-  , "Data.String.CaseInsensitive"
-  , "Data.String.Gen"
-  , "Data.String.Regex"
-  , "Data.String.Regex.Flags"
-  , "Data.String.Regex.Unsafe"
-  , "Data.String.Unsafe"
-  , "Data.Symbol"
-  , "Data.Traversable"
-  , "Data.Tuple"
-  , "Data.Tuple.Nested"
-  , "Data.Unfoldable"
-  , "Data.Unit"
-  , "Data.Void"
-  , "Global"
-  , "Global.Unsafe"
-  , "Math"
-  , "PSCI.Support"
-  , "Partial"
-  , "Partial.Unsafe"
-  , "Prelude"
-  , "Test.Assert"
-  , "Type.Data.Ordering"
-  , "Type.Data.Symbol"
-  , "Type.Equality"
-  , "Type.Row.Effect.Equality"
-  , "Type.Prelude"
-  , "Type.Proxy"
-  , "Unsafe.Coerce"
-  ]
+supportModules = unsafePerformIO $ do
+  cd <- getCurrentDirectory
+  let supportDir = cd </> "tests" </> "support" </> "bower_components"
+  supportPurs <- Glob.globDir1 (Glob.compile "purescript-*/src/**/*.purs") supportDir
+  supportPursFiles <- readInput supportPurs
+  Right modules <- runExceptT $ ExceptT . return $ P.parseModulesFromFiles id supportPursFiles
+  return $ sort $ map (T.unpack . P.runModuleName . P.getModuleName . snd) modules
+  where
+  readInput :: [FilePath] -> IO [(FilePath, T.Text)]
+  readInput inputFiles = forM inputFiles $ \inputFile -> do
+    text <- readUTF8FileT inputFile
+    return (inputFile, text)
 
 pushd :: forall a. FilePath -> IO a -> IO a
 pushd dir act = do

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -59,14 +59,14 @@ updateSupportCode = do
 -- The support modules that should be cached between test cases, to avoid
 -- excessive rebuilding.
 --
-supportModules :: [String]
+supportModules :: [T.Text]
 supportModules = unsafePerformIO $ do
   cd <- getCurrentDirectory
   let supportDir = cd </> "tests" </> "support" </> "bower_components"
   supportPurs <- Glob.globDir1 (Glob.compile "purescript-*/src/**/*.purs") supportDir
   supportPursFiles <- readInput supportPurs
   Right modules <- runExceptT $ ExceptT . return $ P.parseModulesFromFiles id supportPursFiles
-  return $ sort $ map (T.unpack . P.runModuleName . P.getModuleName . snd) modules
+  return $ sort $ map (P.runModuleName . P.getModuleName . snd) modules
   where
   readInput :: [FilePath] -> IO [(FilePath, T.Text)]
   readInput inputFiles = forM inputFiles $ \inputFile -> do


### PR DESCRIPTION
This may be an alternative solution for #2915.

`unsafePerformIO ` is used to make it quickly work without other source changes and memoize the IO result at the same time. I guess it may be okay given it's test code, but please let me know if there is a better way.