### PR TITLE
Add empty case expressions

### DIFF
--- a/examples/failing/EmptyCase.purs
+++ b/examples/failing/EmptyCase.purs
@@ -1,4 +1,7 @@
--- @shouldFailWith ErrorParsingModule
+-- @shouldFailWith NoInstanceFound
 module Main where
 
-error err = case err of \_ -> 1
+data Unit = Unit
+
+f :: ∀ a. Unit -> a
+f = case _

--- a/examples/passing/EmptyCase.purs
+++ b/examples/passing/EmptyCase.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Control.Monad.Eff.Console (log)
+
+data Void
+
+absurd :: ∀ a. Void -> a
+absurd = case _
+
+absurd' :: ∀ a. Void -> Void -> a
+absurd' a b = case a, b
+
+main = log "Done"

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -361,6 +361,7 @@ extra-source-files:
       examples/passing/Dollar.purs
       examples/passing/DuplicateProperties.purs
       examples/passing/Eff.purs
+      examples/passing/EmptyCase.purs
       examples/passing/EmptyDataDecls.purs
       examples/passing/EmptyRow.purs
       examples/passing/EmptyTypeClass.purs

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -369,8 +369,12 @@ parseConstructor :: TokenParser Expr
 parseConstructor = Constructor <$> parseQualified dataConstructorName
 
 parseCase :: TokenParser Expr
-parseCase = Case <$> P.between (reserved "case") (indented *> reserved "of") (commaSep1 parseValue)
-                 <*> (indented *> mark (P.many1 (same *> mark parseCaseAlternative)))
+parseCase = do
+  values <- reserved "case" *> commaSep1 parseValue
+  binders <- P.optionMaybe (indented *> reserved "of") >>= \case
+    Just _ -> indented *> mark (P.many1 (same *> mark parseCaseAlternative))
+    Nothing -> pure []
+  pure $ Case values binders
 
 parseCaseAlternative :: TokenParser CaseAlternative
 parseCaseAlternative = CaseAlternative <$> commaSep1 parseBinder

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -69,6 +69,8 @@ prettyPrintValue d (App val arg) = prettyPrintValueAtom (d - 1) val `beforeWithS
 prettyPrintValue d (Abs arg val) = text ('\\' : T.unpack (prettyPrintBinder arg) ++ " -> ") // moveRight 2 (prettyPrintValue (d - 1) val)
 prettyPrintValue d (TypeClassDictionaryConstructorApp className ps) =
   text (T.unpack (runProperName (disqualify className)) ++ " ") <> prettyPrintValueAtom (d - 1) ps
+prettyPrintValue d (Case values []) =
+  text "case " <> foldr1 beforeWithSpace (map (prettyPrintValueAtom (d - 1)) values)
 prettyPrintValue d (Case values binders) =
   (text "case " <> foldr beforeWithSpace (text "of") (map (prettyPrintValueAtom (d - 1)) values)) //
     moveRight 2 (vcat left (map (prettyPrintCaseAlternative (d - 1)) binders))


### PR DESCRIPTION
Fixes #2922.

WIP:

 - [ ] Exhaustivity checker now accepts all empty case expressions. Check that at least one of the arguments is of an empty type.