### PR TITLE
[purs ide] improve reexport bundling

### DIFF
--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -76,11 +76,11 @@ defaultCompletionOptions :: CompletionOptions
 defaultCompletionOptions = CompletionOptions { coMaxResults = Nothing, coGroupReexports = False }
 
 applyCompletionOptions :: CompletionOptions -> [Match IdeDeclarationAnn] -> [(Match IdeDeclarationAnn, [P.ModuleName])]
-applyCompletionOptions co decls =
-  maybe identity take (coMaxResults co) decls
-  & if coGroupReexports co
-    then groupCompletionReexports
-    else map simpleExport
+applyCompletionOptions co decls =  decls
+  & (if coGroupReexports co
+      then groupCompletionReexports
+      else map simpleExport)
+  & maybe identity take (coMaxResults co)
 
 simpleExport :: Match a -> (Match a, [P.ModuleName])
 simpleExport match@(Match (moduleName, _)) = (match, [moduleName])

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -204,7 +204,7 @@ instance ToJSON Completion where
            , "expandedType" .= complExpandedType
            , "definedAt" .= complLocation
            , "documentation" .= complDocumentation
-           , "exportedFrom" .= complExportedFrom
+           , "exportedFrom" .= map P.runModuleName complExportedFrom
            ]
 
 identifierFromDeclarationRef :: P.DeclarationRef -> Text


### PR DESCRIPTION
- Fix encoding of exportedFrom field
  It used the derived json encoding for module names before, which is not what we
  want for the editors

- run reexportGrouping before applying maxResults

/cc @nwolverson 