### PR TITLE
Warn for type constructor aliases w/ suggestions

### DIFF
--- a/examples/warning/TypeConstructorAlias.purs
+++ b/examples/warning/TypeConstructorAlias.purs
@@ -1,0 +1,4 @@
+-- @shouldWarnWith TypeConstructorAlias
+module Main where
+
+type TypeConstructorAlias = String

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -616,6 +616,7 @@ extra-source-files:
       examples/warning/ShadowedBinderPatternGuard.purs
       examples/warning/ShadowedNameParens.purs
       examples/warning/ShadowedTypeVar.purs
+      examples/warning/TypeConstructorAlias.purs
       examples/warning/UnnecessaryFFIModule.js
       examples/warning/UnnecessaryFFIModule.purs
       examples/warning/UnusedDctorExplicitImport.purs

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -70,6 +70,7 @@ data SimpleErrorMessage
   | CannotGetFileInfo FilePath
   | CannotReadFile FilePath
   | CannotWriteFile FilePath
+  | TypeConstructorAlias (ProperName 'TypeName) [(Text, Maybe Kind)] Type
   | InfiniteType Type
   | InfiniteKind Kind
   | MultipleValueOpFixities (OpName 'ValueOpName)

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -84,6 +84,7 @@ errorCode em = case unwrapErrorMessage em of
   CannotGetFileInfo{} -> "CannotGetFileInfo"
   CannotReadFile{} -> "CannotReadFile"
   CannotWriteFile{} -> "CannotWriteFile"
+  TypeConstructorAlias{} -> "TypeConstructorAlias"
   InfiniteType{} -> "InfiniteType"
   InfiniteKind{} -> "InfiniteKind"
   MultipleValueOpFixities{} -> "MultipleValueOpFixities"
@@ -304,6 +305,7 @@ errorSuggestion err =
       HidingImport mn refs -> suggest $ importSuggestion mn refs Nothing
       MissingTypeDeclaration ident ty -> suggest $ showIdent ident <> " :: " <> T.pack (prettyPrintSuggestedType ty)
       WildcardInferredType ty _ -> suggest $ T.pack (prettyPrintSuggestedType ty)
+      TypeConstructorAlias name args ty -> suggest $ T.pack (prettyPrintNewtypeForType name args ty)
       _ -> Nothing
   where
     emptySuggestion = Just $ ErrorSuggestion ""
@@ -481,6 +483,8 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       line "The last statement in a 'do' block must be an expression, but this block ends with a let binding."
     renderSimpleErrorMessage OverlappingNamesInLet =
       line "The same name was used more than once in a let binding."
+    renderSimpleErrorMessage (TypeConstructorAlias _ _ _) =
+      line "This type synonym aliases a type constructor. Consider using a newtype or using the original type instead."
     renderSimpleErrorMessage (InfiniteType ty) =
       paras [ line "An infinite type was inferred for an expression: "
             , markCodeBox $ indent $ typeAsBox ty

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -7,6 +7,7 @@ module Language.PureScript.Pretty.Types
   , prettyPrintType
   , prettyPrintTypeWithUnicode
   , prettyPrintSuggestedType
+  , prettyPrintNewtypeForType
   , typeAtomAsBox
   , prettyPrintTypeAtom
   , prettyPrintRow
@@ -217,6 +218,17 @@ prettyPrintTypeWithUnicode = prettyPrintType' unicodeOptions
 -- | Generate a pretty-printed string representing a suggested 'Type'
 prettyPrintSuggestedType :: Type -> String
 prettyPrintSuggestedType = prettyPrintType' suggestingOptions
+
+-- | Generate a pretty-printed string newtype
+prettyPrintNewtypeForType :: ProperName 'TypeName -> [(Text, Maybe Kind)] -> Type -> String
+prettyPrintNewtypeForType (ProperName name) args ty =
+  "newtype " ++ name' ++ args' ++ " = " ++ name' ++ " " ++ ctr
+  where
+    name' = T.unpack name
+    args' = (" " ++) . T.unpack . fst =<< args
+    ctr = case ty of
+      TypeConstructor (Qualified _ (ProperName tn)) -> T.unpack tn
+      _ -> error "Type constructor was expected here."
 
 prettyPrintType' :: TypeRenderOptions -> Type -> String
 prettyPrintType' tro = render . typeAsBoxImpl tro


### PR DESCRIPTION
This is a PR for the slightly crazy idea I had to ban simple* type aliases. I chose to just make a warning for now with a suggestion that writes out a newtype form.

\* In this case just meaning "is a type constructor on its own"

In screenshots:

<img width="513" alt="screen shot 2017-06-10 at 2 56 49 pm" src="https://user-images.githubusercontent.com/2396926/27003417-9417ddc6-4df6-11e7-9c29-adcba448cfee.png">
<img width="523" alt="screen shot 2017-06-10 at 2 56 55 pm" src="https://user-images.githubusercontent.com/2396926/27003416-93fb6876-4df6-11e7-9bbb-dbe9a307bc8d.png">
<img width="448" alt="screen shot 2017-06-10 at 2 57 03 pm" src="https://user-images.githubusercontent.com/2396926/27003415-93c888b6-4df6-11e7-8b1a-3537fa71f4c7.png">