### PR TITLE
Add source span annotations to DeclarationRef

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -229,7 +229,6 @@ getModuleSourceSpan (Module ss _ _ _ _) = ss
 --
 addDefaultImport :: ModuleName -> Module -> Module
 addDefaultImport toImport m@(Module ss coms mn decls exps) =
-  -- TODO: probably not the best annotation to use on ss here?
   if isExistingImport `any` decls || mn == toImport then m
   else Module ss coms mn (ImportDeclaration (ss, []) toImport Implicit Nothing : decls) exps
   where

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -228,11 +228,12 @@ getModuleSourceSpan (Module ss _ _ _ _) = ss
 -- Add an import declaration for a module if it does not already explicitly import it.
 --
 addDefaultImport :: ModuleName -> Module -> Module
-addDefaultImport toImport m@(Module ss coms mn decls exps)  =
+addDefaultImport toImport m@(Module ss coms mn decls exps) =
+  -- TODO: probably not the best annotation to use on ss here?
   if isExistingImport `any` decls || mn == toImport then m
-  else Module ss coms mn (ImportDeclaration toImport Implicit Nothing : decls) exps
+  else Module ss coms mn (ImportDeclaration (ss, []) toImport Implicit Nothing : decls) exps
   where
-  isExistingImport (ImportDeclaration mn' _ _) | mn' == toImport = True
+  isExistingImport (ImportDeclaration _ mn' _ _) | mn' == toImport = True
   isExistingImport (PositionedDeclaration _ _ d) = isExistingImport d
   isExistingImport _ = False
 
@@ -243,120 +244,116 @@ data DeclarationRef
   -- |
   -- A type constructor with data constructors
   --
-  = TypeRef (ProperName 'TypeName) (Maybe [ProperName 'ConstructorName])
+  = TypeRef SourceSpan (ProperName 'TypeName) (Maybe [ProperName 'ConstructorName])
   -- |
   -- A type operator
   --
-  | TypeOpRef (OpName 'TypeOpName)
+  | TypeOpRef SourceSpan (OpName 'TypeOpName)
   -- |
   -- A value
   --
-  | ValueRef Ident
+  | ValueRef SourceSpan Ident
   -- |
   -- A value-level operator
   --
-  | ValueOpRef (OpName 'ValueOpName)
+  | ValueOpRef SourceSpan (OpName 'ValueOpName)
   -- |
   -- A type class
   --
-  | TypeClassRef (ProperName 'ClassName)
+  | TypeClassRef SourceSpan (ProperName 'ClassName)
   -- |
   -- A type class instance, created during typeclass desugaring (name, class name, instance types)
   --
-  | TypeInstanceRef Ident
+  | TypeInstanceRef SourceSpan Ident
   -- |
   -- A module, in its entirety
   --
-  | ModuleRef ModuleName
+  | ModuleRef SourceSpan ModuleName
   -- |
   -- A named kind
   --
-  | KindRef (ProperName 'KindName)
+  | KindRef SourceSpan (ProperName 'KindName)
   -- |
   -- A value re-exported from another module. These will be inserted during
   -- elaboration in name desugaring.
   --
-  | ReExportRef ModuleName DeclarationRef
-  -- |
-  -- A declaration reference with source position information
-  --
-  | PositionedDeclarationRef SourceSpan [Comment] DeclarationRef
+  | ReExportRef SourceSpan ModuleName DeclarationRef
   deriving (Show)
 
 instance Eq DeclarationRef where
-  (TypeRef name dctors) == (TypeRef name' dctors') = name == name' && dctors == dctors'
-  (TypeOpRef name) == (TypeOpRef name') = name == name'
-  (ValueRef name) == (ValueRef name') = name == name'
-  (ValueOpRef name) == (ValueOpRef name') = name == name'
-  (TypeClassRef name) == (TypeClassRef name') = name == name'
-  (TypeInstanceRef name) == (TypeInstanceRef name') = name == name'
-  (ModuleRef name) == (ModuleRef name') = name == name'
-  (KindRef name) == (KindRef name') = name == name'
-  (ReExportRef mn ref) == (ReExportRef mn' ref') = mn == mn' && ref == ref'
-  (PositionedDeclarationRef _ _ r) == r' = r == r'
-  r == (PositionedDeclarationRef _ _ r') = r == r'
+  (TypeRef _ name dctors) == (TypeRef _ name' dctors') = name == name' && dctors == dctors'
+  (TypeOpRef _ name) == (TypeOpRef _ name') = name == name'
+  (ValueRef _ name) == (ValueRef _ name') = name == name'
+  (ValueOpRef _ name) == (ValueOpRef _ name') = name == name'
+  (TypeClassRef _ name) == (TypeClassRef _ name') = name == name'
+  (TypeInstanceRef _ name) == (TypeInstanceRef _ name') = name == name'
+  (ModuleRef _ name) == (ModuleRef _ name') = name == name'
+  (KindRef _ name) == (KindRef _ name') = name == name'
+  (ReExportRef _ mn ref) == (ReExportRef _ mn' ref') = mn == mn' && ref == ref'
   _ == _ = False
 
 -- enable sorting lists of explicitly imported refs when suggesting imports in linting, IDE, etc.
 -- not an Ord because this implementation is not consistent with its Eq instance.
 -- think of it as a notion of contextual, not inherent, ordering.
 compDecRef :: DeclarationRef -> DeclarationRef -> Ordering
-compDecRef (TypeRef name _) (TypeRef name' _) = compare name name'
-compDecRef (TypeOpRef name) (TypeOpRef name') = compare name name'
-compDecRef (ValueRef ident) (ValueRef ident') = compare ident ident'
-compDecRef (ValueOpRef name) (ValueOpRef name') = compare name name'
-compDecRef (TypeClassRef name) (TypeClassRef name') = compare name name'
-compDecRef (TypeInstanceRef ident) (TypeInstanceRef ident') = compare ident ident'
-compDecRef (ModuleRef name) (ModuleRef name') = compare name name'
-compDecRef (KindRef name) (KindRef name') = compare name name'
-compDecRef (ReExportRef name _) (ReExportRef name' _) = compare name name'
-compDecRef (PositionedDeclarationRef _ _ ref) ref' = compDecRef ref ref'
-compDecRef ref (PositionedDeclarationRef _ _ ref') = compDecRef ref ref'
+compDecRef (TypeRef _ name _) (TypeRef _ name' _) = compare name name'
+compDecRef (TypeOpRef _ name) (TypeOpRef _ name') = compare name name'
+compDecRef (ValueRef _ ident) (ValueRef _ ident') = compare ident ident'
+compDecRef (ValueOpRef _ name) (ValueOpRef _ name') = compare name name'
+compDecRef (TypeClassRef _ name) (TypeClassRef _ name') = compare name name'
+compDecRef (TypeInstanceRef _ ident) (TypeInstanceRef _ ident') = compare ident ident'
+compDecRef (ModuleRef _ name) (ModuleRef _ name') = compare name name'
+compDecRef (KindRef _ name) (KindRef _ name') = compare name name'
+compDecRef (ReExportRef _ name _) (ReExportRef _ name' _) = compare name name'
 compDecRef ref ref' = compare
   (orderOf ref) (orderOf ref')
     where
       orderOf :: DeclarationRef -> Int
-      orderOf (TypeClassRef _) = 0
-      orderOf (TypeOpRef _) = 1
-      orderOf (TypeRef _ _) = 2
-      orderOf (ValueRef _) = 3
-      orderOf (ValueOpRef _) = 4
-      orderOf (KindRef _) = 5
+      orderOf TypeClassRef{} = 0
+      orderOf TypeOpRef{} = 1
+      orderOf TypeRef{} = 2
+      orderOf ValueRef{} = 3
+      orderOf ValueOpRef{} = 4
+      orderOf KindRef{} = 5
       orderOf _ = 6
 
+declRefSourceSpan :: DeclarationRef -> SourceSpan
+declRefSourceSpan (TypeRef ss _ _) = ss
+declRefSourceSpan (TypeOpRef ss _) = ss
+declRefSourceSpan (ValueRef ss _) = ss
+declRefSourceSpan (ValueOpRef ss _) = ss
+declRefSourceSpan (TypeClassRef ss _) = ss
+declRefSourceSpan (TypeInstanceRef ss _) = ss
+declRefSourceSpan (ModuleRef ss _) = ss
+declRefSourceSpan (KindRef ss _) = ss
+declRefSourceSpan (ReExportRef ss _ _) = ss
+
 getTypeRef :: DeclarationRef -> Maybe (ProperName 'TypeName, Maybe [ProperName 'ConstructorName])
-getTypeRef (TypeRef name dctors) = Just (name, dctors)
-getTypeRef (PositionedDeclarationRef _ _ r) = getTypeRef r
+getTypeRef (TypeRef _ name dctors) = Just (name, dctors)
 getTypeRef _ = Nothing
 
 getTypeOpRef :: DeclarationRef -> Maybe (OpName 'TypeOpName)
-getTypeOpRef (TypeOpRef op) = Just op
-getTypeOpRef (PositionedDeclarationRef _ _ r) = getTypeOpRef r
+getTypeOpRef (TypeOpRef _ op) = Just op
 getTypeOpRef _ = Nothing
 
 getValueRef :: DeclarationRef -> Maybe Ident
-getValueRef (ValueRef name) = Just name
-getValueRef (PositionedDeclarationRef _ _ r) = getValueRef r
+getValueRef (ValueRef _ name) = Just name
 getValueRef _ = Nothing
 
 getValueOpRef :: DeclarationRef -> Maybe (OpName 'ValueOpName)
-getValueOpRef (ValueOpRef op) = Just op
-getValueOpRef (PositionedDeclarationRef _ _ r) = getValueOpRef r
+getValueOpRef (ValueOpRef _ op) = Just op
 getValueOpRef _ = Nothing
 
 getTypeClassRef :: DeclarationRef -> Maybe (ProperName 'ClassName)
-getTypeClassRef (TypeClassRef name) = Just name
-getTypeClassRef (PositionedDeclarationRef _ _ r) = getTypeClassRef r
+getTypeClassRef (TypeClassRef _ name) = Just name
 getTypeClassRef _ = Nothing
 
 getKindRef :: DeclarationRef -> Maybe (ProperName 'KindName)
-getKindRef (KindRef name) = Just name
-getKindRef (PositionedDeclarationRef _ _ r) = getKindRef r
+getKindRef (KindRef _ name) = Just name
 getKindRef _ = Nothing
 
 isModuleRef :: DeclarationRef -> Bool
-isModuleRef (PositionedDeclarationRef _ _ r) = isModuleRef r
-isModuleRef (ModuleRef _) = True
+isModuleRef ModuleRef{} = True
 isModuleRef _ = False
 
 -- |
@@ -435,7 +432,7 @@ data Declaration
   -- |
   -- A module import (module name, qualified/unqualified/hiding, optional "qualified as" name)
   --
-  | ImportDeclaration ModuleName ImportDeclarationType (Maybe ModuleName)
+  | ImportDeclaration SourceAnn ModuleName ImportDeclarationType (Maybe ModuleName)
   -- |
   -- A type class declaration (name, argument, implies, member declarations)
   --

--- a/src/Language/PureScript/AST/Exported.hs
+++ b/src/Language/PureScript/AST/Exported.hs
@@ -85,13 +85,11 @@ filterInstances mn (Just exps) =
   checkQual q = isQualified q && not (isQualifiedWith mn q)
 
   typeName :: DeclarationRef -> Maybe (ProperName 'TypeName)
-  typeName (TypeRef n _) = Just n
-  typeName (PositionedDeclarationRef _ _ r) = typeName r
+  typeName (TypeRef _ n _) = Just n
   typeName _ = Nothing
 
   typeClassName :: DeclarationRef -> Maybe (ProperName 'ClassName)
-  typeClassName (TypeClassRef n) = Just n
-  typeClassName (PositionedDeclarationRef _ _ r) = typeClassName r
+  typeClassName (TypeClassRef _ n) = Just n
   typeClassName _ = Nothing
 
 -- |
@@ -127,18 +125,17 @@ isExported _ TypeInstanceDeclaration{} = True
 isExported exps (PositionedDeclaration _ _ d) = isExported exps d
 isExported (Just exps) decl = any (matches decl) exps
   where
-  matches (TypeDeclaration ident _) (ValueRef ident') = ident == ident'
-  matches (ValueDeclaration ident _ _ _) (ValueRef ident') = ident == ident'
-  matches (ExternDeclaration ident _) (ValueRef ident') = ident == ident'
-  matches (DataDeclaration _ ident _ _) (TypeRef ident' _) = ident == ident'
-  matches (ExternDataDeclaration ident _) (TypeRef ident' _) = ident == ident'
-  matches (ExternKindDeclaration ident) (KindRef ident') = ident == ident'
-  matches (TypeSynonymDeclaration ident _ _) (TypeRef ident' _) = ident == ident'
-  matches (TypeClassDeclaration ident _ _ _ _) (TypeClassRef ident') = ident == ident'
-  matches (ValueFixityDeclaration _ _ op) (ValueOpRef op') = op == op'
-  matches (TypeFixityDeclaration _ _ op) (TypeOpRef op') = op == op'
+  matches (TypeDeclaration ident _) (ValueRef _ ident') = ident == ident'
+  matches (ValueDeclaration ident _ _ _) (ValueRef _ ident') = ident == ident'
+  matches (ExternDeclaration ident _) (ValueRef _ ident') = ident == ident'
+  matches (DataDeclaration _ ident _ _) (TypeRef _ ident' _) = ident == ident'
+  matches (ExternDataDeclaration ident _) (TypeRef _ ident' _) = ident == ident'
+  matches (ExternKindDeclaration ident) (KindRef _ ident') = ident == ident'
+  matches (TypeSynonymDeclaration ident _ _) (TypeRef _ ident' _) = ident == ident'
+  matches (TypeClassDeclaration ident _ _ _ _) (TypeClassRef _ ident') = ident == ident'
+  matches (ValueFixityDeclaration _ _ op) (ValueOpRef _ op') = op == op'
+  matches (TypeFixityDeclaration _ _ op) (TypeOpRef _ op') = op == op'
   matches (PositionedDeclaration _ _ d) r = d `matches` r
-  matches d (PositionedDeclarationRef _ _ r) = d `matches` r
   matches _ _ = False
 
 -- |
@@ -149,7 +146,6 @@ isDctorExported :: ProperName 'TypeName -> Maybe [DeclarationRef] -> ProperName 
 isDctorExported _ Nothing _ = True
 isDctorExported ident (Just exps) ctor = test `any` exps
   where
-  test (PositionedDeclarationRef _ _ d) = test d
-  test (TypeRef ident' Nothing) = ident == ident'
-  test (TypeRef ident' (Just ctors)) = ident == ident' && ctor `elem` ctors
+  test (TypeRef _ ident' Nothing) = ident == ident'
+  test (TypeRef _ ident' (Just ctors)) = ident == ident' && ctor `elem` ctors
   test _ = False

--- a/src/Language/PureScript/AST/SourcePos.hs
+++ b/src/Language/PureScript/AST/SourcePos.hs
@@ -6,27 +6,25 @@ module Language.PureScript.AST.SourcePos where
 
 import Prelude.Compat
 
-import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 import Data.Aeson ((.=), (.:))
-import qualified Data.Aeson as A
 import Data.Monoid
-import qualified Data.Text as T
 import Data.Text (Text)
+import GHC.Generics (Generic)
+import Language.PureScript.Comments
+import qualified Data.Aeson as A
+import qualified Data.Text as T
 import System.FilePath (makeRelative)
 
--- |
--- Source position information
---
+-- | Source annotation - position information and comments.
+type SourceAnn = (SourceSpan, [Comment])
+
+-- | Source position information
 data SourcePos = SourcePos
-  { -- |
-    -- Line number
-    --
-    sourcePosLine :: Int
-    -- |
-    -- Column number
-    --
+  { sourcePosLine :: Int
+    -- ^ Line number
   , sourcePosColumn :: Int
+    -- ^ Column number
   } deriving (Show, Eq, Ord, Generic)
 
 instance NFData SourcePos
@@ -46,17 +44,12 @@ instance A.FromJSON SourcePos where
     return $ SourcePos line col
 
 data SourceSpan = SourceSpan
-  { -- |
-    -- Source name
-    --
-    spanName :: String
-    -- |
-    -- Start of the span
-    --
+  { spanName :: String
+    -- ^ Source name
   , spanStart :: SourcePos
-    -- End of the span
-    --
+    -- ^ Start of the span
   , spanEnd :: SourcePos
+    -- ^ End of the span
   } deriving (Show, Eq, Ord, Generic)
 
 instance NFData SourceSpan

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -225,7 +225,7 @@ findQualModules decls =
 
 -- | Desugars import declarations from AST to CoreFn representation.
 importToCoreFn :: A.Declaration -> Maybe (Ann, ModuleName)
-importToCoreFn (A.ImportDeclaration name _ _) = Just (nullAnn, name)
+importToCoreFn (A.ImportDeclaration _ name _ _) = Just (nullAnn, name)
 importToCoreFn (A.PositionedDeclaration ss _ d) =
   ((,) (Just ss, [], Nothing, Nothing) . snd) <$> importToCoreFn d
 importToCoreFn _ = Nothing
@@ -240,11 +240,10 @@ externToCoreFn _ = Nothing
 -- CoreFn modules only export values, so all data constructors, class
 -- constructor, instances and values are flattened into one list.
 exportToCoreFn :: A.DeclarationRef -> [Ident]
-exportToCoreFn (A.TypeRef _ (Just dctors)) = map properToIdent dctors
-exportToCoreFn (A.ValueRef name) = [name]
-exportToCoreFn (A.TypeClassRef name) = [properToIdent name]
-exportToCoreFn (A.TypeInstanceRef name) = [name]
-exportToCoreFn (A.PositionedDeclarationRef _ _ d) = exportToCoreFn d
+exportToCoreFn (A.TypeRef _ _ (Just dctors)) = map properToIdent dctors
+exportToCoreFn (A.ValueRef _ name) = [name]
+exportToCoreFn (A.TypeClassRef _ name) = [properToIdent name]
+exportToCoreFn (A.TypeInstanceRef _ name) = [name]
 exportToCoreFn _ = []
 
 -- | Makes a typeclass dictionary constructor function. The returned expression

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -191,7 +191,7 @@ errorMessage err = MultipleErrors [ErrorMessage [] err]
 
 -- | Create an error set from a single simple error message and source annotation
 errorMessage' :: SourceSpan -> SimpleErrorMessage -> MultipleErrors
-errorMessage' ss err = MultipleErrors [ErrorMessage [] err]
+errorMessage' ss err = MultipleErrors [ErrorMessage [PositionedError ss] err]
 
 -- | Create an error set from a single error message
 singleError :: ErrorMessage -> MultipleErrors

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -189,6 +189,10 @@ nonEmpty = not . null . runMultipleErrors
 errorMessage :: SimpleErrorMessage -> MultipleErrors
 errorMessage err = MultipleErrors [ErrorMessage [] err]
 
+-- | Create an error set from a single simple error message and source annotation
+errorMessage' :: SourceSpan -> SimpleErrorMessage -> MultipleErrors
+errorMessage' ss err = MultipleErrors [ErrorMessage [] err]
+
 -- | Create an error set from a single error message
 singleError :: ErrorMessage -> MultipleErrors
 singleError = MultipleErrors . pure
@@ -1190,7 +1194,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
 
 -- Pretty print and export declaration
 prettyPrintExport :: DeclarationRef -> Text
-prettyPrintExport (TypeRef pn _) = runProperName pn
+prettyPrintExport (TypeRef _ pn _) = runProperName pn
 prettyPrintExport ref =
   fromMaybe
     (internalError "prettyPrintRef returned Nothing in prettyPrintExport")
@@ -1205,30 +1209,28 @@ prettyPrintImport mn idt qual =
   in i <> maybe "" (\q -> " as " <> runModuleName q) qual
 
 prettyPrintRef :: DeclarationRef -> Maybe Text
-prettyPrintRef (TypeRef pn Nothing) =
+prettyPrintRef (TypeRef _ pn Nothing) =
   Just $ runProperName pn <> "(..)"
-prettyPrintRef (TypeRef pn (Just [])) =
+prettyPrintRef (TypeRef _ pn (Just [])) =
   Just $ runProperName pn
-prettyPrintRef (TypeRef pn (Just dctors)) =
+prettyPrintRef (TypeRef _ pn (Just dctors)) =
   Just $ runProperName pn <> "(" <> T.intercalate ", " (map runProperName dctors) <> ")"
-prettyPrintRef (TypeOpRef op) =
+prettyPrintRef (TypeOpRef _ op) =
   Just $ "type " <> showOp op
-prettyPrintRef (ValueRef ident) =
+prettyPrintRef (ValueRef _ ident) =
   Just $ showIdent ident
-prettyPrintRef (ValueOpRef op) =
+prettyPrintRef (ValueOpRef _ op) =
   Just $ showOp op
-prettyPrintRef (TypeClassRef pn) =
+prettyPrintRef (TypeClassRef _ pn) =
   Just $ "class " <> runProperName pn
-prettyPrintRef (TypeInstanceRef ident) =
+prettyPrintRef (TypeInstanceRef _ ident) =
   Just $ showIdent ident
-prettyPrintRef (ModuleRef name) =
+prettyPrintRef (ModuleRef _ name) =
   Just $ "module " <> runModuleName name
-prettyPrintRef (KindRef pn) =
+prettyPrintRef (KindRef _ pn) =
   Just $ "kind " <> runProperName pn
-prettyPrintRef (ReExportRef _ _) =
+prettyPrintRef ReExportRef{} =
   Nothing
-prettyPrintRef (PositionedDeclarationRef _ _ ref) =
-  prettyPrintRef ref
 
 -- | Pretty print multiple errors
 prettyPrintMultipleErrors :: PPEOptions -> MultipleErrors -> String

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -193,13 +193,12 @@ moduleToExternsFile (Module ss _ mn ds (Just exps)) env = ExternsFile{..}
   findOp g op = maybe False (== op) . g
 
   importDecl :: Declaration -> Maybe ExternsImport
-  importDecl (ImportDeclaration m mt qmn) = Just (ExternsImport m mt qmn)
+  importDecl (ImportDeclaration _ m mt qmn) = Just (ExternsImport m mt qmn)
   importDecl (PositionedDeclaration _ _ d) = importDecl d
   importDecl _ = Nothing
 
   toExternsDeclaration :: DeclarationRef -> [ExternsDeclaration]
-  toExternsDeclaration (PositionedDeclarationRef _ _ r) = toExternsDeclaration r
-  toExternsDeclaration (TypeRef pn dctors) =
+  toExternsDeclaration (TypeRef _ pn dctors) =
     case Qualified (Just mn) pn `M.lookup` types env of
       Nothing -> internalError "toExternsDeclaration: no kind in toExternsDeclaration"
       Just (kind, TypeSynonym)
@@ -211,10 +210,10 @@ moduleToExternsFile (Module ss _ mn ds (Just exps)) env = ExternsFile{..}
                             , (dty, _, ty, args) <- maybeToList (Qualified (Just mn) dctor `M.lookup` dataConstructors env)
                             ]
       _ -> internalError "toExternsDeclaration: Invalid input"
-  toExternsDeclaration (ValueRef ident)
+  toExternsDeclaration (ValueRef _ ident)
     | Just (ty, _, _) <- Qualified (Just mn) ident `M.lookup` names env
     = [ EDValue ident ty ]
-  toExternsDeclaration (TypeClassRef className)
+  toExternsDeclaration (TypeClassRef _ className)
     | Just TypeClassData{..} <- Qualified (Just mn) className `M.lookup` typeClasses env
     , Just (kind, TypeSynonym) <- Qualified (Just mn) (coerceProperName className) `M.lookup` types env
     , Just (_, synTy) <- Qualified (Just mn) (coerceProperName className) `M.lookup` typeSynonyms env
@@ -222,13 +221,13 @@ moduleToExternsFile (Module ss _ mn ds (Just exps)) env = ExternsFile{..}
       , EDTypeSynonym (coerceProperName className) typeClassArguments synTy
       , EDClass className typeClassArguments typeClassMembers typeClassSuperclasses typeClassDependencies
       ]
-  toExternsDeclaration (TypeInstanceRef ident)
+  toExternsDeclaration (TypeInstanceRef _ ident)
     = [ EDInstance tcdClassName ident tcdInstanceTypes tcdDependencies
       | m1 <- maybeToList (M.lookup (Just mn) (typeClassDictionaries env))
       , m2 <- M.elems m1
       , TypeClassDictionaryInScope{..} <- maybeToList (M.lookup (Qualified (Just mn) ident) m2)
       ]
-  toExternsDeclaration (KindRef pn)
+  toExternsDeclaration (KindRef _ pn)
     | Qualified (Just mn) pn `S.member` kinds env
     = [ EDKind pn ]
   toExternsDeclaration _ = []

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -28,7 +28,6 @@ import qualified Data.ByteString as BS
 import           Data.Version (showVersion)
 import           Language.PureScript.Ide.Error (IdeError (..))
 import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util
 
 import qualified Language.PureScript as P
 
@@ -59,7 +58,7 @@ convertExterns ef =
     decls = map
       (IdeDeclarationAnn emptyAnn)
       (resolvedDeclarations ++ operatorDecls ++ tyOperatorDecls)
-    exportDecls = mapMaybe (convertExport . unwrapPositionedRef) (P.efExports ef)
+    exportDecls = mapMaybe convertExport (P.efExports ef)
     operatorDecls = convertOperator <$> P.efFixities ef
     tyOperatorDecls = convertTypeOperator <$> P.efTypeFixities ef
     (toResolve, declarations) =
@@ -114,7 +113,7 @@ data ToResolve
   | SynonymToResolve (P.ProperName 'P.TypeName) P.Type
 
 convertExport :: P.DeclarationRef -> Maybe (P.ModuleName, P.DeclarationRef)
-convertExport (P.ReExportRef m r) = Just (m, r)
+convertExport (P.ReExportRef _ m r) = Just (m, r)
 convertExport _ = Nothing
 
 convertDecl :: P.ExternsDeclaration -> Either ToResolve (Maybe IdeDeclaration)

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -222,7 +222,7 @@ addExplicitImport' decl moduleName imports =
         refs
     insertDeclIntoRefs dr refs = nubBy ((==) `on` P.prettyPrintRef) (refFromDeclaration dr : refs)
 
-    insertDtor _ (P.TypeRef sa tn' _) = P.TypeRef sa tn' Nothing
+    insertDtor _ (P.TypeRef ss tn' _) = P.TypeRef ss tn' Nothing
     insertDtor _ refs = refs
 
     matchType :: P.ProperName 'P.TypeName -> P.DeclarationRef -> Bool

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -93,7 +93,7 @@ parseModuleHeader = do
     (P.mark (Parsec.many (P.same *> P.parseImportDeclaration')))
   pure (ImportParse mn ipStart ipEnd (map mkImport decls))
   where
-    mkImport (mn, (P.Explicit refs), qual) = Import mn (P.Explicit (unwrapPositionedRef <$> refs)) qual
+    mkImport (mn, (P.Explicit refs), qual) = Import mn (P.Explicit refs) qual
     mkImport (mn, it, qual) = Import mn it qual
 
 sliceImportSection :: [Text] -> Either Text (P.ModuleName, [Text], [Import], [Text])
@@ -192,19 +192,19 @@ addExplicitImport' decl moduleName imports =
     else updateAtFirstOrPrepend matches (insertDeclIntoImport decl) freshImport imports
   where
     refFromDeclaration (IdeDeclTypeClass tc) =
-      P.TypeClassRef (tc ^. ideTCName)
+      P.TypeClassRef ideSpan (tc ^. ideTCName)
     refFromDeclaration (IdeDeclDataConstructor dtor) =
-      P.TypeRef (dtor ^. ideDtorTypeName) Nothing
+      P.TypeRef ideSpan (dtor ^. ideDtorTypeName) Nothing
     refFromDeclaration (IdeDeclType t) =
-      P.TypeRef (t ^. ideTypeName) (Just [])
+      P.TypeRef ideSpan (t ^. ideTypeName) (Just [])
     refFromDeclaration (IdeDeclValueOperator op) =
-      P.ValueOpRef (op ^. ideValueOpName)
+      P.ValueOpRef ideSpan (op ^. ideValueOpName)
     refFromDeclaration (IdeDeclTypeOperator op) =
-      P.TypeOpRef (op ^. ideTypeOpName)
+      P.TypeOpRef ideSpan (op ^. ideTypeOpName)
     refFromDeclaration (IdeDeclKind kn) =
-      P.KindRef kn
+      P.KindRef ideSpan kn
     refFromDeclaration d =
-      P.ValueRef (P.Ident (identifierFromIdeDeclaration d))
+      P.ValueRef ideSpan (P.Ident (identifierFromIdeDeclaration d))
 
     -- | Adds a declaration to an import:
     -- TypeDeclaration "Maybe" + Data.Maybe (maybe) -> Data.Maybe(Maybe, maybe)
@@ -222,12 +222,15 @@ addExplicitImport' decl moduleName imports =
         refs
     insertDeclIntoRefs dr refs = nubBy ((==) `on` P.prettyPrintRef) (refFromDeclaration dr : refs)
 
-    insertDtor _ (P.TypeRef tn' _) = P.TypeRef tn' Nothing
+    insertDtor _ (P.TypeRef sa tn' _) = P.TypeRef sa tn' Nothing
     insertDtor _ refs = refs
 
     matchType :: P.ProperName 'P.TypeName -> P.DeclarationRef -> Bool
-    matchType tn (P.TypeRef n _) = tn == n
+    matchType tn (P.TypeRef _ n _) = tn == n
     matchType _ _ = False
+
+ideSpan :: P.SourceSpan
+ideSpan = P.internalModuleSourceSpan "<psc-ide>"
 
 updateAtFirstOrPrepend :: (a -> Bool) -> (a -> a) -> a -> [a] -> [a]
 updateAtFirstOrPrepend p t d l =
@@ -336,6 +339,6 @@ parseImport t =
   case P.lex "<psc-ide>" t
        >>= P.runTokenParser "<psc-ide>" P.parseImportDeclaration' of
     Right (mn, P.Explicit refs, mmn) ->
-      Just (Import mn (P.Explicit (unwrapPositionedRef <$> refs)) mmn)
+      Just (Import mn (P.Explicit refs) mmn)
     Right (mn, idt, mmn) -> Just (Import mn idt mmn)
     Left _ -> Nothing

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -176,7 +176,7 @@ sortExterns m ex = do
     mkShallowModule P.ExternsFile{..} =
       P.Module (P.internalModuleSourceSpan "<rebuild>") [] efModuleName (map mkImport efImports) Nothing
     mkImport (P.ExternsImport mn it iq) =
-      P.ImportDeclaration mn it iq
+      P.ImportDeclaration (P.internalModuleSourceSpan "<rebuild>", []) mn it iq
     getExtern mn = M.lookup mn ex
     -- Sort a list so its elements appear in the same order as in another list.
     inOrderOf :: (Ord a) => [a] -> [a] -> [a]

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -92,7 +92,7 @@ resolveRef
   -> P.DeclarationRef
   -> Either P.DeclarationRef [IdeDeclarationAnn]
 resolveRef decls ref = case ref of
-  P.TypeRef tn mdtors ->
+  P.TypeRef _ tn mdtors ->
     case findRef (anyOf (_IdeDeclType . ideTypeName) (== tn))
          <|> findRef (anyOf (_IdeDeclTypeSynonym . ideSynonymName) (== tn)) of
       Nothing ->
@@ -104,15 +104,15 @@ resolveRef decls ref = case ref of
             -- those up ourselfes
             findDtors tn
           Just dtors -> mapMaybe lookupDtor dtors
-  P.ValueRef i ->
+  P.ValueRef _ i ->
     findWrapped (anyOf (_IdeDeclValue . ideValueIdent) (== i))
-  P.ValueOpRef name ->
+  P.ValueOpRef _ name ->
     findWrapped (anyOf (_IdeDeclValueOperator . ideValueOpName) (== name))
-  P.TypeOpRef name ->
+  P.TypeOpRef _ name ->
     findWrapped (anyOf (_IdeDeclTypeOperator . ideTypeOpName) (== name))
-  P.TypeClassRef name ->
+  P.TypeClassRef _ name ->
     findWrapped (anyOf (_IdeDeclTypeClass . ideTCName) (== name))
-  P.KindRef name ->
+  P.KindRef _ name ->
     findWrapped (anyOf _IdeDeclKind (== name))
   _ ->
     Left ref

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -208,12 +208,12 @@ instance ToJSON Completion where
            ]
 
 identifierFromDeclarationRef :: P.DeclarationRef -> Text
-identifierFromDeclarationRef (P.TypeRef name _) = P.runProperName name
-identifierFromDeclarationRef (P.ValueRef ident) = P.runIdent ident
-identifierFromDeclarationRef (P.TypeClassRef name) = P.runProperName name
-identifierFromDeclarationRef (P.KindRef name) = P.runProperName name
-identifierFromDeclarationRef (P.ValueOpRef op) = P.showOp op
-identifierFromDeclarationRef (P.TypeOpRef op) = P.showOp op
+identifierFromDeclarationRef (P.TypeRef _ name _) = P.runProperName name
+identifierFromDeclarationRef (P.ValueRef _ ident) = P.runIdent ident
+identifierFromDeclarationRef (P.TypeClassRef _ name) = P.runProperName name
+identifierFromDeclarationRef (P.KindRef _ name) = P.runProperName name
+identifierFromDeclarationRef (P.ValueOpRef _ op) = P.showOp op
+identifierFromDeclarationRef (P.TypeOpRef _ op) = P.showOp op
 identifierFromDeclarationRef _ = ""
 
 data Success =

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -16,7 +16,6 @@ module Language.PureScript.Ide.Util
   ( identifierFromIdeDeclaration
   , unwrapMatch
   , unwrapPositioned
-  , unwrapPositionedRef
   , namespaceForDeclaration
   , encodeT
   , decodeT
@@ -95,10 +94,6 @@ decodeT = decode . TLE.encodeUtf8 . TL.fromStrict
 unwrapPositioned :: P.Declaration -> P.Declaration
 unwrapPositioned (P.PositionedDeclaration _ _ x) = unwrapPositioned x
 unwrapPositioned x = x
-
-unwrapPositionedRef :: P.DeclarationRef -> P.DeclarationRef
-unwrapPositionedRef (P.PositionedDeclarationRef _ _ x) = unwrapPositionedRef x
-unwrapPositionedRef x = x
 
 properNameT :: Iso' (P.ProperName a) Text
 properNameT = iso P.runProperName P.ProperName

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -202,26 +202,24 @@ handleShowImportedModules print' = do
   refsList refs = " (" <> commaList (mapMaybe showRef refs) <> ")"
 
   showRef :: P.DeclarationRef -> Maybe Text
-  showRef (P.TypeRef pn dctors) =
+  showRef (P.TypeRef _ pn dctors) =
     Just $ N.runProperName pn <> "(" <> maybe ".." (commaList . map N.runProperName) dctors <> ")"
-  showRef (P.TypeOpRef op) =
+  showRef (P.TypeOpRef _ op) =
     Just $ "type " <> N.showOp op
-  showRef (P.ValueRef ident) =
+  showRef (P.ValueRef _ ident) =
     Just $ N.runIdent ident
-  showRef (P.ValueOpRef op) =
+  showRef (P.ValueOpRef _ op) =
     Just $ N.showOp op
-  showRef (P.TypeClassRef pn) =
+  showRef (P.TypeClassRef _ pn) =
     Just $ "class " <> N.runProperName pn
-  showRef (P.TypeInstanceRef ident) =
+  showRef (P.TypeInstanceRef _ ident) =
     Just $ N.runIdent ident
-  showRef (P.ModuleRef name) =
+  showRef (P.ModuleRef _ name) =
     Just $ "module " <> N.runModuleName name
-  showRef (P.KindRef pn) =
+  showRef (P.KindRef _ pn) =
     Just $ "kind " <> N.runProperName pn
-  showRef (P.ReExportRef _ _) =
+  showRef (P.ReExportRef _ _ _) =
     Nothing
-  showRef (P.PositionedDeclarationRef _ _ ref) =
-    showRef ref
 
   commaList :: [Text] -> Text
   commaList = T.intercalate ", "

--- a/src/Language/PureScript/Interactive/Module.hs
+++ b/src/Language/PureScript/Interactive/Module.hs
@@ -61,7 +61,6 @@ createTemporaryModule exec PSCiState{psciImportedModules = imports, psciLetBindi
                                 (P.TypeWildcard internalSpan))
     mainDecl      = P.ValueDeclaration (P.Ident "$main") P.Public [] [P.MkUnguarded mainValue]
     decls         = if exec then [itDecl, typeDecl, mainDecl] else [itDecl]
-    internalSpan  = P.internalModuleSourceSpan "<internal>"
   in
     P.Module internalSpan
              [] moduleName
@@ -78,7 +77,7 @@ createTemporaryModuleForKind PSCiState{psciImportedModules = imports, psciLetBin
     moduleName = P.ModuleName [P.ProperName "$PSCI"]
     itDecl = P.TypeSynonymDeclaration (P.ProperName "IT") [] typ
   in
-    P.Module (P.internalModuleSourceSpan "<internal>") [] moduleName ((importDecl `map` imports) ++ lets ++ [itDecl]) Nothing
+    P.Module internalSpan [] moduleName ((importDecl `map` imports) ++ lets ++ [itDecl]) Nothing
 
 -- |
 -- Makes a volatile module to execute the current imports.
@@ -88,13 +87,16 @@ createTemporaryModuleForImports PSCiState{psciImportedModules = imports} =
   let
     moduleName = P.ModuleName [P.ProperName "$PSCI"]
   in
-    P.Module (P.internalModuleSourceSpan "<internal>") [] moduleName (importDecl `map` imports) Nothing
+    P.Module internalSpan [] moduleName (importDecl `map` imports) Nothing
 
 importDecl :: ImportedModule -> P.Declaration
-importDecl (mn, declType, asQ) = P.ImportDeclaration mn declType asQ
+importDecl (mn, declType, asQ) = P.ImportDeclaration (internalSpan, []) mn declType asQ
 
 indexFile :: FilePath
 indexFile = ".psci_modules" ++ pathSeparator : "index.js"
 
 modulesDir :: FilePath
 modulesDir = ".psci_modules" ++ pathSeparator : "node_modules"
+
+internalSpan :: P.SourceSpan
+internalSpan = P.internalModuleSourceSpan "<internal>"

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -13,7 +13,7 @@ import Control.Monad.Writer.Class
 import Data.Function (on)
 import Data.Foldable (for_)
 import Data.List (find, intersect, groupBy, sortBy, (\\))
-import Data.Maybe (mapMaybe, fromMaybe)
+import Data.Maybe (mapMaybe)
 import Data.Monoid (Sum(..))
 import Data.Traversable (forM)
 import qualified Data.Text as T
@@ -58,7 +58,7 @@ lintImports
   -> m ()
 lintImports (Module _ _ _ _ Nothing) _ _ =
   internalError "lintImports needs desugared exports"
-lintImports (Module ss _ mn mdecls (Just mexports)) env usedImps = do
+lintImports (Module _ _ mn mdecls (Just mexports)) env usedImps = do
 
   -- TODO: this needs some work to be easier to understand
 
@@ -70,15 +70,15 @@ lintImports (Module ss _ mn mdecls (Just mexports)) env usedImps = do
 
   for_ imports $ \(mni, decls) ->
     unless (isPrim mni) .
-      for_ decls $ \(ss', declType, qualifierName) -> do
+      for_ decls $ \(ss, declType, qualifierName) -> do
         let names = ordNub $ M.findWithDefault [] mni usedImps'
-        lintImportDecl env mni qualifierName names ss' declType allowImplicit
+        lintImportDecl env mni qualifierName names ss declType allowImplicit
 
   for_ (M.toAscList (byQual imports)) $ \(mnq, entries) -> do
     let mnis = ordNub $ map (\(_, _, mni) -> mni) entries
     unless (length mnis == 1) $ do
       let implicits = filter (\(_, declType, _) -> not $ isExplicit declType) entries
-      for_ implicits $ \(ss', _, mni) -> do
+      for_ implicits $ \(ss, _, mni) -> do
         let names = ordNub $ M.findWithDefault [] mni usedImps'
             usedRefs = findUsedRefs env mni (Just mnq) names
         unless (null usedRefs) .

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -221,8 +221,8 @@ lintImportDecl env mni qualifierName names ss declType allowImplicit =
     -- used constructors explicity `T(X, Y, [...])` to `T(..)` for suggestion
     -- message.
     simplifyTypeRef :: DeclarationRef -> DeclarationRef
-    simplifyTypeRef (TypeRef sa name (Just dctors))
-      | not (null dctors) = TypeRef sa name Nothing
+    simplifyTypeRef (TypeRef ss' name (Just dctors))
+      | not (null dctors) = TypeRef ss' name Nothing
     simplifyTypeRef other = other
 
   checkExplicit

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -69,22 +69,20 @@ lintImports (Module ss _ mn mdecls (Just mexports)) env usedImps = do
       imports = M.toAscList (findImports mdecls)
 
   for_ imports $ \(mni, decls) ->
-    unless (isPrim mni) $
-      for_ decls $ \(ss', declType, qualifierName) ->
-        maybe id warnWithPosition ss' $ do
-          let names = ordNub $ M.findWithDefault [] mni usedImps'
-          lintImportDecl env mni qualifierName names declType allowImplicit
+    unless (isPrim mni) .
+      for_ decls $ \(ss', declType, qualifierName) -> do
+        let names = ordNub $ M.findWithDefault [] mni usedImps'
+        lintImportDecl env mni qualifierName names ss' declType allowImplicit
 
   for_ (M.toAscList (byQual imports)) $ \(mnq, entries) -> do
     let mnis = ordNub $ map (\(_, _, mni) -> mni) entries
     unless (length mnis == 1) $ do
       let implicits = filter (\(_, declType, _) -> not $ isExplicit declType) entries
-      for_ implicits $ \(ss', _, mni) ->
-        maybe id warnWithPosition ss' $ do
-          let names = ordNub $ M.findWithDefault [] mni usedImps'
-              usedRefs = findUsedRefs env mni (Just mnq) names
-          unless (null usedRefs) $
-            tell $ errorMessage $ ImplicitQualifiedImport mni mnq usedRefs
+      for_ implicits $ \(ss', _, mni) -> do
+        let names = ordNub $ M.findWithDefault [] mni usedImps'
+            usedRefs = findUsedRefs env mni (Just mnq) names
+        unless (null usedRefs) .
+          tell . errorMessage' ss $ ImplicitQualifiedImport mni mnq usedRefs
 
   for_ imports $ \(mnq, imps) -> do
 
@@ -100,11 +98,10 @@ lintImports (Module ss _ mn mdecls (Just mexports)) env usedImps = do
           $ unwarned
 
     for_ duplicates $ \(pos, _, _) ->
-      maybe id warnWithPosition pos $
-        tell $ errorMessage $ DuplicateSelectiveImport mnq
+      tell . errorMessage' pos $ DuplicateSelectiveImport mnq
 
     for_ (imps \\ (warned ++ duplicates)) $ \(pos, typ, _) ->
-      warnDuplicateRefs (fromMaybe ss pos) DuplicateImportRef $ case typ of
+      warnDuplicateRefs pos DuplicateImportRef $ case typ of
         Explicit refs -> refs
         Hiding refs -> refs
         _ -> []
@@ -120,9 +117,9 @@ lintImports (Module ss _ mn mdecls (Just mexports)) env usedImps = do
 
   countOpenImports :: Declaration -> Int
   countOpenImports (PositionedDeclaration _ _ d) = countOpenImports d
-  countOpenImports (ImportDeclaration mn' Implicit Nothing)
+  countOpenImports (ImportDeclaration _ mn' Implicit Nothing)
     | not (isPrim mn' || mn == mn') = 1
-  countOpenImports (ImportDeclaration mn' (Hiding _) Nothing)
+  countOpenImports (ImportDeclaration _ mn' (Hiding _) Nothing)
     | not (isPrim mn' || mn == mn') = 1
   countOpenImports _ = 0
 
@@ -135,8 +132,8 @@ lintImports (Module ss _ mn mdecls (Just mexports)) env usedImps = do
   -- import to that module, with the corresponding source span, import type,
   -- and module being imported
   byQual
-    :: [(ModuleName, [(Maybe SourceSpan, ImportDeclarationType, Maybe ModuleName)])]
-    -> M.Map ModuleName [(Maybe SourceSpan, ImportDeclarationType, ModuleName)]
+    :: [(ModuleName, [(SourceSpan, ImportDeclarationType, Maybe ModuleName)])]
+    -> M.Map ModuleName [(SourceSpan, ImportDeclarationType, ModuleName)]
   byQual = foldr goImp M.empty
     where
     goImp (mni, xs) acc = foldr (goDecl mni) acc xs
@@ -150,8 +147,7 @@ lintImports (Module ss _ mn mdecls (Just mexports)) env usedImps = do
   exportedModules :: [ModuleName]
   exportedModules = ordNub $ mapMaybe extractModule mexports
     where
-    extractModule (PositionedDeclarationRef _ _ r) = extractModule r
-    extractModule (ModuleRef mne) = Just mne
+    extractModule (ModuleRef _ mne) = Just mne
     extractModule _ = Nothing
 
   -- Elaborates the UsedImports to include values from modules that are being
@@ -195,10 +191,11 @@ lintImportDecl
   -> ModuleName
   -> Maybe ModuleName
   -> [Qualified Name]
+  -> SourceSpan
   -> ImportDeclarationType
   -> Bool
   -> m Bool
-lintImportDecl env mni qualifierName names declType allowImplicit =
+lintImportDecl env mni qualifierName names ss declType allowImplicit =
   case declType of
     Implicit -> case qualifierName of
       Nothing ->
@@ -224,8 +221,8 @@ lintImportDecl env mni qualifierName names declType allowImplicit =
     -- used constructors explicity `T(X, Y, [...])` to `T(..)` for suggestion
     -- message.
     simplifyTypeRef :: DeclarationRef -> DeclarationRef
-    simplifyTypeRef (TypeRef name (Just dctors))
-      | not (null dctors) = TypeRef name Nothing
+    simplifyTypeRef (TypeRef sa name (Just dctors))
+      | not (null dctors) = TypeRef sa name Nothing
     simplifyTypeRef other = other
 
   checkExplicit
@@ -250,7 +247,7 @@ lintImportDecl env mni qualifierName names declType allowImplicit =
           (_, []) | c /= Just [] -> warn (UnusedDctorImport mni tn qualifierName allRefs)
           (Just ctors, dctors') ->
             let ddiff = ctors \\ dctors'
-            in unless' (null ddiff) $ warn $ UnusedDctorExplicitImport mni tn ddiff qualifierName allRefs
+            in unless' (null ddiff) . warn $ UnusedDctorExplicitImport mni tn ddiff qualifierName allRefs
           _ -> return False
 
     return (didWarn || or didWarn')
@@ -259,7 +256,7 @@ lintImportDecl env mni qualifierName names declType allowImplicit =
   unused = warn (UnusedImport mni)
 
   warn :: SimpleErrorMessage -> m Bool
-  warn err = tell (errorMessage err) >> return True
+  warn err = tell (errorMessage' ss err) >> return True
 
   -- Unless the boolean is true, run the action. Return false when the action is
   -- not run, otherwise return whatever the action does.
@@ -299,17 +296,17 @@ findUsedRefs
   -> [DeclarationRef]
 findUsedRefs env mni qn names =
   let
-    classRefs = TypeClassRef <$> mapMaybe (getClassName <=< disqualifyFor qn) names
-    valueRefs = ValueRef <$> mapMaybe (getIdentName <=< disqualifyFor qn) names
-    valueOpRefs = ValueOpRef <$> mapMaybe (getValOpName <=< disqualifyFor qn) names
-    typeOpRefs = TypeOpRef <$> mapMaybe (getTypeOpName <=< disqualifyFor qn) names
+    classRefs = TypeClassRef (internalModuleSourceSpan "<TODO>") <$> mapMaybe (getClassName <=< disqualifyFor qn) names
+    valueRefs = ValueRef (internalModuleSourceSpan "<TODO>") <$> mapMaybe (getIdentName <=< disqualifyFor qn) names
+    valueOpRefs = ValueOpRef (internalModuleSourceSpan "<TODO>") <$> mapMaybe (getValOpName <=< disqualifyFor qn) names
+    typeOpRefs = TypeOpRef (internalModuleSourceSpan "<TODO>") <$> mapMaybe (getTypeOpName <=< disqualifyFor qn) names
     types = mapMaybe (getTypeName <=< disqualifyFor qn) names
     dctors = mapMaybe (getDctorName <=< disqualifyFor qn) names
     typesWithDctors = reconstructTypeRefs dctors
     typesWithoutDctors = filter (`M.notMember` typesWithDctors) types
     typesRefs
-      = map (flip TypeRef (Just [])) typesWithoutDctors
-      ++ map (\(ty, ds) -> TypeRef ty (Just ds)) (M.toList typesWithDctors)
+      = map (flip (TypeRef (internalModuleSourceSpan "<TODO>")) (Just [])) typesWithoutDctors
+      ++ map (\(ty, ds) -> TypeRef (internalModuleSourceSpan "<TODO>") ty (Just ds)) (M.toList typesWithDctors)
   in sortBy compDecRef $ classRefs ++ typeOpRefs ++ typesRefs ++ valueRefs ++ valueOpRefs
 
   where
@@ -343,12 +340,11 @@ matchName _ ModName{} = Nothing
 matchName _ name = Just name
 
 runDeclRef :: DeclarationRef -> Maybe Name
-runDeclRef (PositionedDeclarationRef _ _ ref) = runDeclRef ref
-runDeclRef (ValueRef ident) = Just $ IdentName ident
-runDeclRef (ValueOpRef op) = Just $ ValOpName op
-runDeclRef (TypeRef pn _) = Just $ TyName pn
-runDeclRef (TypeOpRef op) = Just $ TyOpName op
-runDeclRef (TypeClassRef pn) = Just $ TyClassName pn
+runDeclRef (ValueRef _ ident) = Just $ IdentName ident
+runDeclRef (ValueOpRef _ op) = Just $ ValOpName op
+runDeclRef (TypeRef _ pn _) = Just $ TyName pn
+runDeclRef (TypeOpRef _ op) = Just $ TyOpName op
+runDeclRef (TypeClassRef _ pn) = Just $ TyClassName pn
 runDeclRef _ = Nothing
 
 checkDuplicateImports
@@ -360,7 +356,6 @@ checkDuplicateImports
 checkDuplicateImports mn xs ((_, t1, q1), (pos, t2, q2)) =
   if t1 == t2 && q1 == q2
   then do
-    maybe id warnWithPosition pos $
-      tell $ errorMessage $ DuplicateImport mn t2 q2
+    tell . errorMessage' pos $ DuplicateImport mn t2 q2
     return $ (pos, t2, q2) : xs
   else return xs

--- a/src/Language/PureScript/ModuleDependencies.hs
+++ b/src/Language/PureScript/ModuleDependencies.hs
@@ -53,7 +53,7 @@ sortModules ms = do
 usedModules :: Declaration -> Maybe (ModuleName, Maybe SourceSpan)
 -- Regardless of whether an imported module is qualified we still need to
 -- take into account its import to build an accurate list of dependencies.
-usedModules (ImportDeclaration mn _ _) = pure (mn, Nothing)
+usedModules (ImportDeclaration _ mn _ _) = pure (mn, Nothing)
 usedModules (PositionedDeclaration ss _ d) = fmap (second (const (Just ss))) (usedModules d)
 usedModules _ = Nothing
 

--- a/src/Language/PureScript/Parser/Common.hs
+++ b/src/Language/PureScript/Parser/Common.hs
@@ -143,3 +143,15 @@ withSourceSpan f p = do
         _ -> Nothing
   let sp = SourceSpan (P.sourceName start) (toSourcePos start) (toSourcePos $ fromMaybe end end')
   return $ f sp comments x
+
+withSourceAnn
+  :: (SourceAnn -> a -> b)
+  -> P.Parsec [PositionedToken] u a
+  -> P.Parsec [PositionedToken] u b
+withSourceAnn = withSourceSpan . curry
+
+withSourceSpan'
+  :: (SourceSpan -> a -> b)
+  -> P.Parsec [PositionedToken] u a
+  -> P.Parsec [PositionedToken] u b
+withSourceSpan' f = withSourceSpan (\ss _ -> f ss)

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -84,9 +84,7 @@ resolveExports env ss mn imps exps refs =
   -- `DeclarationRef` for an explicit export. When the ref refers to another
   -- module, export anything from the imports that matches for that module.
   elaborateModuleExports :: Exports -> DeclarationRef -> m Exports
-  elaborateModuleExports result (PositionedDeclarationRef pos _ r) =
-    warnAndRethrowWithPosition pos $ elaborateModuleExports result r
-  elaborateModuleExports result (ModuleRef name) | name == mn = do
+  elaborateModuleExports result (ModuleRef _ name) | name == mn = do
     let types' = exportedTypes result `M.union` exportedTypes exps
     let typeOps' = exportedTypeOps result `M.union` exportedTypeOps exps
     let classes' = exportedTypeClasses result `M.union` exportedTypeClasses exps
@@ -101,10 +99,10 @@ resolveExports env ss mn imps exps refs =
       , exportedValueOps = valueOps'
       , exportedKinds = kinds'
       }
-  elaborateModuleExports result (ModuleRef name) = do
+  elaborateModuleExports result (ModuleRef ss name) = do
     let isPseudo = isPseudoModule name
     when (not isPseudo && not (isImportedModule name))
-      . throwError . errorMessage . UnknownExport $ ModName name
+      . throwError . errorMessage' ss . UnknownExport $ ModName name
     reTypes <- extract isPseudo name TyName (importedTypes imps)
     reTypeOps <- extract isPseudo name TyOpName (importedTypeOps imps)
     reDctors <- extract isPseudo name DctorName (importedDataConstructors imps)
@@ -270,21 +268,20 @@ filterModule mn exps refs = do
   -- listing for the last ref would be used.
   combineTypeRefs :: [DeclarationRef] -> [DeclarationRef]
   combineTypeRefs
-    = fmap (uncurry TypeRef)
-    . map (foldr1 $ \(tc, dcs1) (_, dcs2) -> (tc, liftM2 (++) dcs1 dcs2))
-    . groupBy ((==) `on` fst)
-    . sortBy (compare `on` fst)
-    . mapMaybe getTypeRef
+    -- = fmap (uncurry TypeRef)
+    -- . map (foldr1 $ \(tc, dcs1) (_, dcs2) -> (tc, liftM2 (++) dcs1 dcs2))
+    -- . groupBy ((==) `on` fst)
+    -- . sortBy (compare `on` fst)
+    -- . mapMaybe getTypeRef
+    = id
 
   filterTypes
     :: M.Map (ProperName 'TypeName) ([ProperName 'ConstructorName], ModuleName)
     -> DeclarationRef
     -> m (M.Map (ProperName 'TypeName) ([ProperName 'ConstructorName], ModuleName))
-  filterTypes result (PositionedDeclarationRef pos _ r) =
-    rethrowWithPosition pos $ filterTypes result r
-  filterTypes result (TypeRef name expDcons) =
+  filterTypes result (TypeRef ss name expDcons) =
     case name `M.lookup` exportedTypes exps of
-      Nothing -> throwError . errorMessage . UnknownExport $ TyName name
+      Nothing -> throwError . errorMessage' ss . UnknownExport $ TyName name
       Just (dcons, _) -> do
         let expDcons' = fromMaybe dcons expDcons
         traverse_ (checkDcon name dcons) expDcons'
@@ -299,8 +296,8 @@ filterModule mn exps refs = do
       -> ProperName 'ConstructorName
       -> m ()
     checkDcon tcon dcons dcon =
-      unless (dcon `elem` dcons) $
-        throwError . errorMessage $ UnknownExportDataConstructor tcon dcon
+      unless (dcon `elem` dcons) .
+        throwError . errorMessage' ss $ UnknownExportDataConstructor tcon dcon
   filterTypes result _ = return result
 
   filterExport
@@ -311,12 +308,10 @@ filterModule mn exps refs = do
     -> M.Map a ModuleName
     -> DeclarationRef
     -> m (M.Map a ModuleName)
-  filterExport toName get fromExps result (PositionedDeclarationRef pos _ r) =
-    rethrowWithPosition pos $ filterExport toName get fromExps result r
   filterExport toName get fromExps result ref
     | Just name <- get ref =
         case name `M.lookup` fromExps exps of
           -- TODO: I'm not sure if we actually need to check mn == mn' here -gb
           Just mn' | mn == mn' -> return $ M.insert name mn result
-          _ -> throwError . errorMessage . UnknownExport $ toName name
+          _ -> throwError . errorMessage' (declRefSourceSpan ref) . UnknownExport $ toName name
   filterExport _ _ _ result _ = return result

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -99,10 +99,10 @@ resolveExports env ss mn imps exps refs =
       , exportedValueOps = valueOps'
       , exportedKinds = kinds'
       }
-  elaborateModuleExports result (ModuleRef ss name) = do
+  elaborateModuleExports result (ModuleRef ss' name) = do
     let isPseudo = isPseudoModule name
     when (not isPseudo && not (isImportedModule name))
-      . throwError . errorMessage' ss . UnknownExport $ ModName name
+      . throwError . errorMessage' ss' . UnknownExport $ ModName name
     reTypes <- extract isPseudo name TyName (importedTypes imps)
     reTypeOps <- extract isPseudo name TyOpName (importedTypeOps imps)
     reDctors <- extract isPseudo name DctorName (importedDataConstructors imps)

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -268,12 +268,11 @@ filterModule mn exps refs = do
   -- listing for the last ref would be used.
   combineTypeRefs :: [DeclarationRef] -> [DeclarationRef]
   combineTypeRefs
-    -- = fmap (uncurry TypeRef)
-    -- . map (foldr1 $ \(tc, dcs1) (_, dcs2) -> (tc, liftM2 (++) dcs1 dcs2))
-    -- . groupBy ((==) `on` fst)
-    -- . sortBy (compare `on` fst)
-    -- . mapMaybe getTypeRef
-    = id
+    = fmap (\(ss', (tc, dcs)) -> TypeRef ss' tc dcs)
+    . fmap (foldr1 $ \(ss, (tc, dcs1)) (_, (_, dcs2)) -> (ss, (tc, liftM2 (++) dcs1 dcs2)))
+    . groupBy ((==) `on` (fst . snd))
+    . sortBy (compare `on` (fst . snd))
+    . mapMaybe (\ref -> (declRefSourceSpan ref,) <$> getTypeRef ref)
 
   filterTypes
     :: M.Map (ProperName 'TypeName) ([ProperName 'ConstructorName], ModuleName)

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -367,23 +367,21 @@ checkFixityExports m@(Module ss _ mn ds (Just exps)) =
   where
 
   checkRef :: DeclarationRef -> m ()
-  checkRef (PositionedDeclarationRef pos _ d) =
-    rethrowWithPosition pos $ checkRef d
-  checkRef dr@(ValueOpRef op) =
+  checkRef dr@(ValueOpRef ss' op) =
     for_ (getValueOpAlias op) $ \case
       Left ident ->
-        unless (ValueRef ident `elem` exps)
-          . throwError . errorMessage
-          $ TransitiveExportError dr [ValueRef ident]
+        unless (ValueRef ss' ident `elem` exps)
+          . throwError . errorMessage' ss'
+          $ TransitiveExportError dr [ValueRef ss' ident]
       Right ctor ->
         unless (anyTypeRef (maybe False (elem ctor) . snd))
-          . throwError . errorMessage
+          . throwError . errorMessage' ss
           $ TransitiveDctorExportError dr ctor
-  checkRef dr@(TypeOpRef op) =
+  checkRef dr@(TypeOpRef ss' op) =
     for_ (getTypeOpAlias op) $ \ty ->
       unless (anyTypeRef ((== ty) . fst))
-        . throwError . errorMessage
-        $ TransitiveExportError dr [TypeRef ty Nothing]
+        . throwError . errorMessage' ss'
+        $ TransitiveExportError dr [TypeRef ss' ty Nothing]
   checkRef _ = return ()
 
   -- Finds the name associated with a type operator when that type is also

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -195,11 +195,11 @@ desugarDecl mn exps = go
 
   expRef :: Ident -> Qualified (ProperName 'ClassName) -> [Type] -> Maybe DeclarationRef
   expRef name className tys
-    | isExportedClass className && all isExportedType (getConstructors `concatMap` tys) = Just $ TypeInstanceRef name
+    | isExportedClass className && all isExportedType (getConstructors `concatMap` tys) = Just $ TypeInstanceRef genSpan name
     | otherwise = Nothing
 
   isExportedClass :: Qualified (ProperName 'ClassName) -> Bool
-  isExportedClass = isExported (elem . TypeClassRef)
+  isExportedClass = isExported (elem . TypeClassRef genSpan)
 
   isExportedType :: Qualified (ProperName 'TypeName) -> Bool
   isExportedType = isExported $ \pn -> isJust . find (matchesTypeRef pn)
@@ -212,7 +212,7 @@ desugarDecl mn exps = go
   isExported _ _ = internalError "Names should have been qualified in name desugaring"
 
   matchesTypeRef :: ProperName 'TypeName -> DeclarationRef -> Bool
-  matchesTypeRef pn (TypeRef pn' _) = pn == pn'
+  matchesTypeRef pn (TypeRef _ pn' _) = pn == pn'
   matchesTypeRef _ _ = False
 
   getConstructors :: Type -> [Qualified (ProperName 'TypeName)]
@@ -220,6 +220,9 @@ desugarDecl mn exps = go
     where
     getConstructor (TypeConstructor tcname) = [tcname]
     getConstructor _ = []
+
+  genSpan :: SourceSpan
+  genSpan = internalModuleSourceSpan "<generated>"
 
 memberToNameAndType :: Declaration -> (Ident, Type)
 memberToNameAndType (TypeDeclaration ident ty) = (ident, ty)

--- a/tests/Language/PureScript/Ide/ReexportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ReexportsSpec.hs
@@ -27,24 +27,27 @@ env = Map.fromList
 
 type Refs = [(P.ModuleName, P.DeclarationRef)]
 
+testSpan :: P.SourceSpan
+testSpan = P.internalModuleSourceSpan "<test>"
+
 succTestCases :: [(Text, Refs, [IdeDeclarationAnn])]
 succTestCases =
-  [ ("resolves a value reexport", [(mn "A", P.ValueRef (P.Ident "valueA"))], [valueA `annExp` "A"])
+  [ ("resolves a value reexport", [(mn "A", P.ValueRef testSpan (P.Ident "valueA"))], [valueA `annExp` "A"])
   , ("resolves a type reexport with explicit data constructors"
-    , [(mn "A", P.TypeRef (P.ProperName "TypeA") (Just [P.ProperName "DtorA1"]))], [typeA `annExp` "A", dtorA1 `annExp` "A"])
+    , [(mn "A", P.TypeRef testSpan (P.ProperName "TypeA") (Just [P.ProperName "DtorA1"]))], [typeA `annExp` "A", dtorA1 `annExp` "A"])
   , ("resolves a type reexport with implicit data constructors"
-    , [(mn "A", P.TypeRef (P.ProperName "TypeA") Nothing)], map (`annExp` "A") [typeA, dtorA1, dtorA2])
+    , [(mn "A", P.TypeRef testSpan (P.ProperName "TypeA") Nothing)], map (`annExp` "A") [typeA, dtorA1, dtorA2])
   , ("resolves a synonym reexport"
-    , [(mn "A", P.TypeRef (P.ProperName "SynonymA") Nothing)], [synonymA `annExp` "A"])
-  , ("resolves a class reexport", [(mn "A", P.TypeClassRef (P.ProperName "ClassA"))], [classA `annExp` "A"])
-  , ("resolves a kind reexport", [(mn "A", P.KindRef (P.ProperName "KindA"))], [kindA `annExp` "A"])
+    , [(mn "A", P.TypeRef testSpan (P.ProperName "SynonymA") Nothing)], [synonymA `annExp` "A"])
+  , ("resolves a class reexport", [(mn "A", P.TypeClassRef testSpan (P.ProperName "ClassA"))], [classA `annExp` "A"])
+  , ("resolves a kind reexport", [(mn "A", P.KindRef testSpan (P.ProperName "KindA"))], [kindA `annExp` "A"])
   ]
 
 failTestCases :: [(Text, Refs)]
 failTestCases =
-  [ ("fails to resolve a non existing value", [(mn "A", P.ValueRef (P.Ident "valueB"))])
-  , ("fails to resolve a non existing type reexport" , [(mn "A", P.TypeRef (P.ProperName "TypeB") Nothing)])
-  , ("fails to resolve a non existing class reexport", [(mn "A", P.TypeClassRef (P.ProperName "ClassB"))])
+  [ ("fails to resolve a non existing value", [(mn "A", P.ValueRef testSpan (P.Ident "valueB"))])
+  , ("fails to resolve a non existing type reexport" , [(mn "A", P.TypeRef testSpan (P.ProperName "TypeB") Nothing)])
+  , ("fails to resolve a non existing class reexport", [(mn "A", P.TypeClassRef testSpan (P.ProperName "ClassB"))])
   ]
 
 spec :: Spec


### PR DESCRIPTION
There's a couple of things I need to finish up in here, but it's mostly there.

This isn't general purpose annotations, but I think given previous discussions we may as well have add source position info to the ASTs, since we always want that, and don't want to have to deal with partiality in extracting it from annotations an whatnot. Also means we won't have to deal with the precarious `PositionedN` constructors anymore.

I chose `DeclarationRef` to start with as it's "easy"... turned out, not so much. But at least now this sets up a bunch of stuff for the way forward. Ideally in time we won't have the old `errorMessage` function at all, and it will only be possible to throw with a `SourceSpan`.

One thing I don't love is how I dealt with the annotations in parsing though, any ideas there would be welcome.