### PR TITLE
Instance signatures scoped type variables

### DIFF
--- a/examples/passing/InstanceSigsScopedTypeVariables.purs
+++ b/examples/passing/InstanceSigsScopedTypeVariables.purs
@@ -1,0 +1,23 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console (log)
+
+class Foo t where
+  foo :: forall a. a -> t
+
+instance fooUnit :: Foo Unit where
+  foo :: forall a. a -> Unit
+  foo = go
+    where
+      go :: a -> Unit
+      go = \_ -> unit
+
+instance fooNumber :: Foo Int where
+  foo :: forall b. b -> Int
+  foo = go
+    where
+      go :: b -> Int
+      go = \_ -> 0
+
+main = log "Done"

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -408,6 +408,7 @@ extra-source-files:
       examples/passing/InstanceBeforeClass.purs
       examples/passing/InstanceSigs.purs
       examples/passing/InstanceSigsGeneral.purs
+      examples/passing/InstanceSigsScopedTypeVariables.purs
       examples/passing/IntAndChar.purs
       examples/passing/iota.purs
       examples/passing/JSReserved.purs


### PR DESCRIPTION
Addresses https://github.com/purescript/purescript/issues/2941

Typeclass instances are desugared into records. When an instance is provided with a type signature, that creates a `TypedValue` property. This pull request detects such creatures, and brings the corresponding type variables into scope.