### PR TITLE
Add Match class

### DIFF
--- a/examples/failing/Match.purs
+++ b/examples/failing/Match.purs
@@ -1,3 +1,4 @@
+-- @shouldFailWith NoInstanceFound
 module Main where
 
 import Prelude
@@ -12,6 +13,5 @@ lit = Lowercase <<< reflectSymbol
 
 main :: Eff (console :: CONSOLE) Unit
 main = do
-  _ <- pure <<< lit $ SProxy :: SProxy ""
-  _ <- pure <<< lit $ SProxy :: SProxy "foo bar baz"
+  _ <- pure <<< lit $ SProxy :: SProxy "foo BAR baz"
   log "Done"

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -205,6 +205,7 @@ extra-source-files:
       examples/failing/LetPatterns2.purs
       examples/failing/LetPatterns3.purs
       examples/failing/LetPatterns4.purs
+      examples/failing/Match.purs
       examples/failing/MissingClassExport.purs
       examples/failing/MissingClassMemberExport.purs
       examples/failing/MissingRecordField.purs

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -387,6 +387,9 @@ pattern Union = Qualified (Just Prim) (ProperName "Union")
 pattern RowCons :: Qualified (ProperName 'ClassName)
 pattern RowCons = Qualified (Just Prim) (ProperName "RowCons")
 
+pattern Match :: Qualified (ProperName 'ClassName)
+pattern Match = Qualified (Just Prim) (ProperName "Match")
+
 typ :: forall a. (IsString a) => a
 typ = "Type"
 

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -27,6 +27,7 @@ primDocsModule = Module
       , warn
       , union
       , rowCons
+      , match
       , typeConcat
       , typeString
       , kindType
@@ -243,6 +244,11 @@ rowCons = primClass "RowCons" $ T.unlines
   [ "The RowCons type class is a 4-way relation which asserts that one row of"
   , "types can be obtained from another by inserting a new label/type pair on"
   , "the left."
+  ]
+
+match :: Declaration
+match = primClass "Match" $ T.unlines
+  [ "The Match type class is used to match a symbol against a regex."
   ]
 
 typeConcat :: Declaration

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -350,6 +350,7 @@ primTypes =
     , (primName "Warn",       (FunKind kindSymbol kindType, ExternData))
     , (primName "TypeString", (FunKind kindType kindSymbol, ExternData))
     , (primName "TypeConcat", (FunKind kindSymbol (FunKind kindSymbol kindSymbol), ExternData))
+    , (primName "Match",      (FunKind kindSymbol (FunKind kindSymbol kindType), ExternData))
     ]
 
 -- | The primitive class map. This just contains the `Fail`, `Warn`, and `Partial`
@@ -384,6 +385,12 @@ primClasses =
                              [ FunctionalDependency [0, 1, 2] [3]
                              , FunctionalDependency [0, 3] [1, 2]
                              ]))
+    -- class Match (p :: Symbol) (a :: Symbol)
+    , (primName "Match",   (makeTypeClassData
+                             [ ("p", Just kindSymbol)
+                             , ("s", Just kindSymbol)
+                             ] [] []
+                             []))
     ]
 
 -- | Finds information about data constructors from the current environment.


### PR DESCRIPTION
Provides the `Prim.Match` type class, constraints of which are only satisfied when a symbol matches a regex in another symbol. This is useful for the pattern where you have an abstract newtype with a smart constructor, but want to allow the construction of literals without `unsafePartial fromJust`.

For example:

```purescript
module Data.Positive
  ( Positive
  , fromInt
  , lit
  ) where

import Data.Int as Int
import Data.Maybe (fromJust)
import Data.Symbol (class IsSymbol, reflectSymbol)
import Partial.Unsafe (unsafePartial)
import Prelude

newtype Positive = Positive Int

fromInt :: Int -> Maybe Positive
fromInt n | n < 1 = Nothing
          | otherwise = Just (Positive n)

lit :: forall s. IsSymbol s => Match "^[1-9][0-9]{0,8}$" s => @s -> Positive
lit = unsafePartial fromJust <<< fromInt <=< Int.fromString <<< reflectSymbol
```

Compare:

```purescript
import Data.Maybe (fromJust)
import Data.Positive (fromInt, lit)
import Partial.Unsafe (unsafePartial)
import Prelude

example1 :: Positive
-- example1 = unsafePartial fromJust $ fromInt 0 -- ugly and unsafe
example1 = unsafePartial fromJust $ fromInt 1 -- ugly but ok

example2 :: Positive
-- example2 = lit @"0" -- type error
example2 = lit @"1" -- 😍
```
