### PR TITLE
trim whitespace in typelevel string extraction

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -1333,7 +1333,7 @@ renderBox = unlines
 
 toTypelevelString :: Type -> Maybe Box.Box
 toTypelevelString (TypeLevelString s) =
-  Just . Box.text $ decodeStringWithReplacement s
+  Just . line . T.strip $ decodeStringWithReplacement s
 toTypelevelString (TypeApp (TypeConstructor f) x)
   | f == primName "TypeString" = Just (typeAsBox x)
 toTypelevelString (TypeApp (TypeApp (TypeConstructor f) x) ret)

--- a/src/Language/PureScript/PSString.hs
+++ b/src/Language/PureScript/PSString.hs
@@ -74,8 +74,8 @@ codePoints = map (either (chr . fromIntegral) id) . decodeStringEither
 -- Decode a PSString as UTF-16 text. Lone surrogates will be replaced with
 -- U+FFFD REPLACEMENT CHARACTER
 --
-decodeStringWithReplacement :: PSString -> String
-decodeStringWithReplacement = map (either (const '\xFFFD') id) . decodeStringEither
+decodeStringWithReplacement :: PSString -> Text
+decodeStringWithReplacement = T.pack . map (either (const '\xFFFD') id) . decodeStringEither
 
 -- |
 -- Decode a PSString as UTF-16. Lone surrogates in the input are represented in


### PR DESCRIPTION
Small cleanup PR for extra spaces in custom error constraints.

![asdasdajsdlkzjxczxc](https://user-images.githubusercontent.com/2396926/27520205-53f9a8ea-5a0e-11e7-8bba-89ad7abad284.PNG)

Left: stripped spaces, Right: original

For me, this is definitely what I want since I write all of my Fail constraints with `"""`, leading to having a newline and spaces before and after my message.