### PR TITLE
Desugar Operators during Doc Generation

### DIFF
--- a/examples/docs/src/TypeOpAliases.purs
+++ b/examples/docs/src/TypeOpAliases.purs
@@ -17,16 +17,16 @@ infixl 6 type Tuple as ×
 third ∷ ∀ a b c. a × b × c → c
 third (a × b × c) = c
 
-data Boop a b
-  = Nope a
-  | Welp b
+data BaseType a b
+  = Con1 a
+  | Con2 b
 
-infixr 6 type Boop as </>
+infixr 6 type BaseType as </>
 
-class Narp a where
-  narp :: a -> String
+class TC_A a where
+  tC_AFn :: a -> String
 
-instance narpBoop :: (Narp a, Narp b) => Narp (a </> b) where
-  narp (Nope a) = narp a
-  narp (Welp b) = narp b
+instance tC_ABaseType :: (TC_A a, TC_A b) => TC_A (a </> b) where
+  tC_AFn (Con1 a) = tC_AFn a
+  tC_AFn (Con2 b) = tC_AFn b
 

--- a/examples/docs/src/TypeOpAliases.purs
+++ b/examples/docs/src/TypeOpAliases.purs
@@ -16,3 +16,17 @@ infixl 6 type Tuple as ×
 
 third ∷ ∀ a b c. a × b × c → c
 third (a × b × c) = c
+
+data Boop a b
+  = Nope a
+  | Welp b
+
+infixr 6 type Boop as </>
+
+class Narp a where
+  narp :: a -> String
+
+instance narpBoop :: (Narp a, Narp b) => Narp (a </> b) where
+  narp (Nope a) = narp a
+  narp (Welp b) = narp b
+

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -208,5 +208,6 @@ partiallyDesugar = P.evalSupplyT 0 . desugar'
       >>> traverse P.desugarCasesModule
       >=> traverse P.desugarTypeDeclarationsModule
       >=> ignoreWarnings . P.desugarImportsWithEnv []
+      >=> traverse (P.rebracket [])
 
   ignoreWarnings = fmap fst . runWriterT

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -208,6 +208,9 @@ partiallyDesugar = P.evalSupplyT 0 . desugar'
       >>> traverse P.desugarCasesModule
       >=> traverse P.desugarTypeDeclarationsModule
       >=> ignoreWarnings . P.desugarImportsWithEnv []
-      >=> traverse (P.rebracket [])
+      >>> fmap desugarTypeClassTypeOps
+
+  desugarTypeClassTypeOps (e, ms) =
+    (e, map P.desugarTypeClassTypeOpsForModule ms)
 
   ignoreWarnings = fmap fst . runWriterT

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -388,11 +388,11 @@ testCases =
       ])
 
   , ("TypeOpAliases",
-      [ ValueShouldHaveTypeSignature (n "TypeOpAliases") "test1" (renderedType "forall a b. a ~> b")
-      , ValueShouldHaveTypeSignature (n "TypeOpAliases") "test2" (renderedType "forall a b c. a ~> b ~> c")
-      , ValueShouldHaveTypeSignature (n "TypeOpAliases") "test3" (renderedType "forall a b c d. a ~> (b ~> c) ~> d")
-      , ValueShouldHaveTypeSignature (n "TypeOpAliases") "test4" (renderedType "forall a b c d. ((a ~> b) ~> c) ~> d")
-      , ValueShouldHaveTypeSignature (n "TypeOpAliases") "third" (renderedType "forall a b c. a × b × c -> c")
+      [ ValueShouldHaveTypeSignature (n "TypeOpAliases") "test1" (renderedType "forall a b. AltFn a b")
+      , ValueShouldHaveTypeSignature (n "TypeOpAliases") "test2" (renderedType "forall a b c. AltFn a (AltFn b c)")
+      , ValueShouldHaveTypeSignature (n "TypeOpAliases") "test3" (renderedType "forall a b c d. AltFn a (AltFn (AltFn b c) d)")
+      , ValueShouldHaveTypeSignature (n "TypeOpAliases") "test4" (renderedType "forall a b c d. AltFn (AltFn (AltFn a b) c) d")
+      , ValueShouldHaveTypeSignature (n "TypeOpAliases") "third" (renderedType "forall a b c. Tuple (Tuple a b) c -> c")
       ])
 
   , ("DocComments",

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -391,8 +391,8 @@ testCases =
       , ValueShouldHaveTypeSignature (n "TypeOpAliases") "test3" (renderedType "forall a b c d. a ~> (b ~> c) ~> d")
       , ValueShouldHaveTypeSignature (n "TypeOpAliases") "test4" (renderedType "forall a b c d. ((a ~> b) ~> c) ~> d")
       , ValueShouldHaveTypeSignature (n "TypeOpAliases") "third" (renderedType "forall a b c. a × b × c -> c")
-      , ShouldBeDocumented (n "TypeOpAliases") "Boop" ["Nope","Welp"]
-      , ShouldBeDocumented (n "TypeOpAliases") "Narp" ["narp","narpBoop"]
+      , ShouldBeDocumented (n "TypeOpAliases") "BaseType" ["Con1","Con2","tC_ABaseType"]
+      , ShouldBeDocumented (n "TypeOpAliases") "TC_A" ["tC_AFn","tC_ABaseType"]
       ])
 
   , ("DocComments",


### PR DESCRIPTION
#2872 

Type operators are now desugared during the documentation generation
phase. This leads to some pretty gnarly type signatures (see the
changes in the tests), but does also clear up TypeClass declarations
to use the unaliased type constructor and not the operator.

Some of my ImportSpec tests are failing for an IOException that I have not
yet been able to track down.

Any any all feedback appreciated. :)