### PR TITLE
Instance signatures don't bring type variables into scope

### DIFF
--- a/examples/passing/ScopedTypesInInstance.purs
+++ b/examples/passing/ScopedTypesInInstance.purs
@@ -1,0 +1,15 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console (log)
+
+class Test t where
+  test :: forall a. t -> a -> a
+
+instance testUnit :: Test Unit where
+  test :: forall a. Unit -> a -> a
+  test = go where
+    go :: Unit -> a -> a
+    go _ a = a
+
+main = log "Done"


### PR DESCRIPTION
Fixes #2941

This uses a `let`, as discussed before.