### PR TITLE
Fix links to type operators in HTML docs

### DIFF
--- a/src/Language/PureScript/Docs/AsHtml.hs
+++ b/src/Language/PureScript/Docs/AsHtml.hs
@@ -184,8 +184,9 @@ codeAsHtml r = outputWith elemAsHtml
         Link mn ->
           let
             class_ = if startsWithUpper name then "ctor" else "ident"
+            target = if ns == TypeLevel then "type (" <> name <> ")" else name
           in
-            linkToDecl ns name mn (withClass class_ (text name))
+            linkToDecl ns target mn (withClass class_ (text name))
         NoLink ->
           text name
 


### PR DESCRIPTION
Fixes https://github.com/purescript/pursuit/issues/312

Unfortunately this is difficult to test with the way the tests are set
up right now, so I have omitted tests.