### PR TITLE
Include comments in child declarations in HTML docs

### DIFF
--- a/app/static/pursuit.css
+++ b/app/static/pursuit.css
@@ -413,6 +413,10 @@ ol li {
 .decl__body .syntax {
   color: #0B71B4;
 }
+.decl__child_comments {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
 /* Component: Dependency Link
  * -------------------------------------------------------------------------- */
 .deplink {

--- a/src/Language/PureScript/Docs/AsHtml.hs
+++ b/src/Language/PureScript/Docs/AsHtml.hs
@@ -163,11 +163,16 @@ declAsHtml r d@Declaration{..} = do
 
 renderChildren :: HtmlRenderContext -> [ChildDeclaration] -> Html
 renderChildren _ [] = return ()
-renderChildren r xs = ul $ mapM_ go xs
+renderChildren r xs = ul $ mapM_ item xs
   where
-  go decl = item decl . code . codeAsHtml r . Render.renderChildDeclaration $ decl
-  item decl = let fragment = makeFragment (childDeclInfoNamespace (cdeclInfo decl)) (cdeclTitle decl)
-              in  li ! A.id (v (T.drop 1 fragment))
+  item decl =
+    li ! A.id (v (T.drop 1 (fragment decl))) $ do
+      renderCode decl
+      for_ (cdeclComments decl) $ \coms ->
+        H.div ! A.class_ "decl__child_comments" $ renderMarkdown coms
+
+  fragment decl = makeFragment (childDeclInfoNamespace (cdeclInfo decl)) (cdeclTitle decl)
+  renderCode = code . codeAsHtml r . Render.renderChildDeclaration
 
 codeAsHtml :: HtmlRenderContext -> RenderedCode -> Html
 codeAsHtml r = outputWith elemAsHtml


### PR DESCRIPTION
That is, if doc-comments are provided in a source file for any of the
following:

- type class members
- instance declarations
- data constructors

they will now be included in the HTML.

Fixes https://github.com/purescript/pursuit/issues/159.