### PR TITLE
Only build master and semver tags in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: c
 dist: trusty # because of perf issues
 sudo: required
+branches:
+  # Only build master and tagged versions, i.e. not feature branches; feature
+  # branches already get built after opening a pull request.
+  only:
+    - master
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 matrix:
   include:
     # We use trusty boxes because they seem to be a bit faster.


### PR DESCRIPTION
Currently, for PRs from branches in this repository, we have to wait for
4 CI builds: 2 Travis and 2 appveyor, one for the branch and one for the
PR. As far as I can see, the branch builds don't achieve anything beyond
making us wait longer for CI to finish. This change to .travis.yml
should hopefully disable the branch ones but leave the builds we want
intact.

I'll see if I can make a similar change for AppVeyor.