### PR TITLE
Improve instance ordering in HTML docs

### DIFF
--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -79,7 +79,7 @@ augmentDeclarations (partitionEithers -> (augments, toplevels)) =
   matches d (name, AugmentClass) = isTypeClass d && declTitle d == name
 
   augmentWith (AugmentChild child) d =
-    d { declChildren = declChildren d ++ [child] }
+    d { declChildren = child : declChildren d }
 
 getDeclarationTitle :: P.Declaration -> Maybe Text
 getDeclarationTitle (P.ValueDeclaration _ name _ _ _) = Just (P.showIdent name)


### PR DESCRIPTION
Instances now appear in the same order as in the source file, which is
in general likely to be the most sensible option.

Fixes https://github.com/purescript/pursuit/issues/125