### PR TITLE
Update installation doc [ci skip]

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,10 +6,10 @@ alternatively Stack Overflow.
 
 ## Using prebuilt binaries
 
-The prebuilt binaries are compiled with GHC 7.10.3, and therefore they should
-run on any operating system supported by GHC 7.10.3, such as:
+The prebuilt binaries are compiled with GHC 8.0.2 and therefore they should
+run on any operating system supported by GHC 8.0.2, such as:
 
-* Windows 2000 or later,
+* Windows Vista or later,
 * OS X 10.7 or later,
 * Linux ??? (we're not sure what the minimum version is).
 
@@ -17,20 +17,18 @@ This list is not exhaustive. If your OS is too old or not listed, or if the
 binaries fail to run, you may be able to install the compiler by building it
 from source; see below.
 
-It's probably safe to assume that other prebuilt distributions (eg, Homebrew,
-Chocolatey, AUR, npm) use the same binaries, and therefore have the same
-requirements.
+Other prebuilt distributions (eg, Homebrew, AUR, npm) will probably have the
+same requirements.
 
 ## Compiling from source
 
-GHC 7.10.1 or newer is required to compile from source. The easiest way is to
-use stack:
+The easiest way is to use stack:
 
 ```
 $ stack update
 $ stack unpack purescript
 $ cd purescript-x.y.z  # (replace x.y.z with whichever version you just downloaded)
-$ stack install
+$ stack install --flag purescript:RELEASE
 ```
 
 This will then copy the compiler and utilities into `~/.local/bin`.
@@ -39,14 +37,14 @@ This will then copy the compiler and utilities into `~/.local/bin`.
 If you don't have stack installed, there are install instructions
 [here](https://github.com/commercialhaskell/stack/blob/master/doc/install_and_upgrade.md).
 
-If you don't have ghc installed, stack will prompt you to run `stack setup`
-which will install ghc for you.
+If you don't have GHC installed, stack will prompt you to run `stack setup`
+which will install the correct version of GHC for you.
 
 ## The "curses" library
 
-`psci` depends on the `curses` library (via the Haskell package `terminfo`). If
-you are having difficulty running the compiler, it may be because the `curses`
-library is missing.
+The PureScript REPL depends on the `curses` library (via the Haskell package
+`terminfo`). If you are having difficulty running the compiler, it may be
+because the `curses` library is missing.
 
 On Linux, you will probably need to install `ncurses` manually. On Ubuntu, for
 example, this can be done by running:


### PR DESCRIPTION
- The lts-8.5 resolver uses GHC 8.0.2 so update INSTALL.md to reflect
  that
- Homebrew compiles purescript from source, so don't suggest that it
  uses the prebuilt binaries
- Remove Chocolatey since the Chocolatey distribution does not appear to
  be maintained any more