### PR TITLE
Prevent browser from treating declTitle and linkToSource as one word

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,6 +85,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@rightfold](https://github.com/rightfold) | rightfold | [MIT license](https://opensource.org/licenses/MIT) |
 | [@robdaemon](https://github.com/robdaemon) | Robert Roland | [MIT license](http://opensource.org/licenses/MIT) |
 | [@RossMeikleham](https://github.com/RossMeikleham) | Ross Meikleham | [MIT license](http://opensource.org/licenses/MIT) |
+| [@Rufflewind](https://github.com/Rufflewind) | Phil Ruffwind | [MIT license](https://opensource.org/licenses/MIT) |
 | [@rvion](https://github.com/rvion) | Rémi Vion | [MIT license](http://opensource.org/licenses/MIT) |
 | [@RyanGlScott](https://github.com/RyanGlScott) | Ryan Scott | [MIT license](http://opensource.org/licenses/MIT) |
 | [@sebastiaanvisser](https://github.com/sebastiaanvisser) | Sebastiaan Visser | MIT license |

--- a/src/Language/PureScript/Docs/AsHtml.hs
+++ b/src/Language/PureScript/Docs/AsHtml.hs
@@ -138,6 +138,8 @@ declAsHtml r d@Declaration{..} = do
     h3 ! A.class_ "decl__title clearfix" $ do
       a ! A.class_ "decl__anchor" ! A.href (v declFragment) $ "#"
       H.span $ text declTitle
+      text " " -- prevent browser from treating
+               -- declTitle + linkToSource as one word
       for_ declSourceSpan (linkToSource r)
 
     H.div ! A.class_ "decl__body" $ do


### PR DESCRIPTION
The lack of space between the identifier and the "Source" link means that if anyone tries to double-click-select the identifier, they will end up selecting the "Source" too. (Curiously, Haddock once had the [same problem](https://github.com/haskell/haddock/issues/224).)