### PR TITLE
[purs ide] Editor mode

### DIFF
--- a/psc-ide/README.md
+++ b/psc-ide/README.md
@@ -1,17 +1,18 @@
-psc-ide
+purs ide
 ===
 
-A tool which provides editor support for the PureScript programming language.
+Editor and tooling support for the PureScript programming language.
 
-## Editor Integration
-* [@epost](https://github.com/epost) wrote a plugin to integrate psc-ide with Emacs at https://github.com/epost/psc-ide-emacs.
-* Atom integration is available with https://github.com/nwolverson/atom-ide-purescript.
-* Visual Studio Code integration is available with https://github.com/nwolverson/vscode-ide-purescript.
-* Vim integration is available here: https://github.com/FrigoEU/psc-ide-vim.
+## Setting up your editor
+
+This document will describe how to run `purs ide` as an editor plugin creator.
+If you're looking to set up your PureScript development environment consult
+the
+[documentation repository](https://github.com/purescript/documentation/blob/master/ecosystem/Editor-and-tool-support.md) instead.
 
 ## Running the Server
 
-Start the server by running the `psc-ide-server [SOURCEGLOBS]` executable, where
+Start the server by running the `purs ide server [SOURCEGLOBS]` executable, where
 `SOURCEGLOBS` are (optional) globs that match your PureScript sourcefiles.
 
 It supports the following options:
@@ -26,21 +27,22 @@ It supports the following options:
   files. This flag is reversed on Windows and polling is the default.
 - `--log-level`: Can be set to one of "all", "none", "debug" and "perf"
 - `--no-watch`: Disables the filewatcher
+- `--editor-mode`: Only reload on source file changes reported by the editor
 - `--version`: Output psc-ide version
 
 ## Issuing queries
 
 After you started the server you can start issuing requests using
-`psc-ide-client`. Make sure you start by loading the modules before you try to
+`purs ide client`. Make sure you start by loading the modules before you try to
 query them.
 
-`psc-ide-server` expects the build externs.purs inside the `output/` folder of
-your project after running `pulp build` or `psc-make` respectively.
+`purs ide` expects the built externs.json inside the output folder of your
+project after running `pulp build` or `purs compile` respectively.
 
 (If you changed the port of the server you can change the port for
-`psc-ide-client` by using the -p option accordingly)
+`purs ide client` by using the -p option accordingly)
 
 ## Protocol
 
-For documentation about the protocol have a look at:
-[PROTOCOL.md](PROTOCOL.md)
+If you want to know how to send commands/queries to `purs ide` take a look
+at [PROTOCOL.md](PROTOCOL.md)

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DeriveAnyClass #-}
 
 -- |
 -- Data types for modules and declarations
@@ -9,12 +11,14 @@ module Language.PureScript.AST.Declarations where
 
 import Prelude.Compat
 
+import Control.DeepSeq (NFData)
 import Control.Monad.Identity
 
 import Data.Aeson.TH
 import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Data.List.NonEmpty as NEL
+import GHC.Generics (Generic)
 
 import Language.PureScript.AST.Binders
 import Language.PureScript.AST.Literals
@@ -288,7 +292,7 @@ data DeclarationRef
   -- elaboration in name desugaring.
   --
   | ReExportRef SourceSpan ModuleName DeclarationRef
-  deriving (Show)
+  deriving (Show, Generic, NFData)
 
 instance Eq DeclarationRef where
   (TypeRef _ name dctors) == (TypeRef _ name' dctors') = name == name' && dctors == dctors'

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -187,14 +187,7 @@ loadModulesAsync
   -> m Success
 loadModulesAsync moduleNames = do
   tr <- loadModules moduleNames
-
-  -- Finally we kick off the worker with @async@ and return the number of
-  -- successfully parsed modules.
-  env <- ask
-  let ll = confLogLevel (ideConfiguration env)
-  -- populateVolatileState return Unit for now, so it's fine to discard this
-  -- result. We might want to block on this in a benchmarking situation.
-  _ <- liftIO (async (runLogger ll (runReaderT populateVolatileState env)))
+  _ <- populateVolatileState
   pure tr
 
 loadModulesSync
@@ -203,7 +196,7 @@ loadModulesSync
   -> m Success
 loadModulesSync moduleNames = do
   tr <- loadModules moduleNames
-  populateVolatileState
+  populateVolatileStateSync
   pure tr
 
 loadModules

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 -----------------------------------------------------------------------------
 --
 -- Module      : Language.PureScript.Ide.Reexports
@@ -35,7 +36,9 @@ data ReexportResult a
   = ReexportResult
   { reResolved :: a
   , reFailed   :: [(P.ModuleName, P.DeclarationRef)]
-  } deriving (Show, Eq, Functor)
+  } deriving (Show, Eq, Functor, Generic)
+
+instance NFData a => NFData (ReexportResult a)
 
 -- | Uses the passed formatter to format the resolved module, and adds possible
 -- failures

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -12,6 +12,8 @@
 -- Type definitions for psc-ide
 -----------------------------------------------------------------------------
 
+{-# LANGUAGE DeriveGeneric   #-}
+{-# LANGUAGE DeriveAnyClass  #-}
 {-# LANGUAGE DeriveFoldable  #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -38,43 +40,43 @@ data IdeDeclaration
   | IdeDeclValueOperator IdeValueOperator
   | IdeDeclTypeOperator IdeTypeOperator
   | IdeDeclKind (P.ProperName 'P.KindName)
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic, NFData)
 
 data IdeValue = IdeValue
   { _ideValueIdent :: P.Ident
   , _ideValueType  :: P.Type
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic, NFData)
 
 data IdeType = IdeType
  { _ideTypeName :: P.ProperName 'P.TypeName
  , _ideTypeKind :: P.Kind
  , _ideTypeDtors :: [(P.ProperName 'P.ConstructorName, P.Type)]
- } deriving (Show, Eq, Ord)
+ } deriving (Show, Eq, Ord, Generic, NFData)
 
 data IdeTypeSynonym = IdeTypeSynonym
   { _ideSynonymName :: P.ProperName 'P.TypeName
   , _ideSynonymType :: P.Type
   , _ideSynonymKind :: P.Kind
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic, NFData)
 
 data IdeDataConstructor = IdeDataConstructor
   { _ideDtorName     :: P.ProperName 'P.ConstructorName
   , _ideDtorTypeName :: P.ProperName 'P.TypeName
   , _ideDtorType     :: P.Type
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic, NFData)
 
 data IdeTypeClass = IdeTypeClass
   { _ideTCName :: P.ProperName 'P.ClassName
   , _ideTCKind :: P.Kind
   , _ideTCInstances :: [IdeInstance]
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic, NFData)
 
 data IdeInstance = IdeInstance
   { _ideInstanceModule      :: P.ModuleName
   , _ideInstanceName        :: P.Ident
   , _ideInstanceTypes       :: [P.Type]
   , _ideInstanceConstraints :: Maybe [P.Constraint]
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic, NFData)
 
 data IdeValueOperator = IdeValueOperator
   { _ideValueOpName          :: P.OpName 'P.ValueOpName
@@ -82,7 +84,7 @@ data IdeValueOperator = IdeValueOperator
   , _ideValueOpPrecedence    :: P.Precedence
   , _ideValueOpAssociativity :: P.Associativity
   , _ideValueOpType          :: Maybe P.Type
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic, NFData)
 
 data IdeTypeOperator = IdeTypeOperator
   { _ideTypeOpName          :: P.OpName 'P.TypeOpName
@@ -90,7 +92,7 @@ data IdeTypeOperator = IdeTypeOperator
   , _ideTypeOpPrecedence    :: P.Precedence
   , _ideTypeOpAssociativity :: P.Associativity
   , _ideTypeOpKind          :: Maybe P.Kind
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic, NFData)
 
 makePrisms ''IdeDeclaration
 makeLenses ''IdeValue
@@ -105,14 +107,14 @@ makeLenses ''IdeTypeOperator
 data IdeDeclarationAnn = IdeDeclarationAnn
   { _idaAnnotation  :: Annotation
   , _idaDeclaration :: IdeDeclaration
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic, NFData)
 
 data Annotation
   = Annotation
   { _annLocation       :: Maybe P.SourceSpan
   , _annExportedFrom   :: Maybe P.ModuleName
   , _annTypeAnnotation :: Maybe P.Type
-  } deriving (Show, Eq, Ord)
+  } deriving (Show, Eq, Ord, Generic, NFData)
 
 makeLenses ''Annotation
 makeLenses ''IdeDeclarationAnn
@@ -125,7 +127,7 @@ type TypeAnnotations = Map P.Ident P.Type
 newtype AstData a = AstData (ModuleMap (DefinitionSites a, TypeAnnotations))
   -- ^ SourceSpans for the definition sites of values and types as well as type
   -- annotations found in a module
-  deriving (Show, Eq, Ord, Functor, Foldable)
+  deriving (Show, Eq, Ord, Generic, NFData, Functor, Foldable)
 
 data IdeLogLevel = LogDebug | LogPerf | LogAll | LogDefault | LogNone
   deriving (Show, Eq)
@@ -317,7 +319,7 @@ instance ToJSON PursuitResponse where
 
 -- | Denotes the different namespaces a name in PureScript can reside in.
 data IdeNamespace = IdeNSValue | IdeNSType | IdeNSKind
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic, NFData)
 
 instance FromJSON IdeNamespace where
   parseJSON (String s) = case s of
@@ -329,4 +331,4 @@ instance FromJSON IdeNamespace where
 
 -- | A name tagged with a namespace
 data IdeNamespaced = IdeNamespaced IdeNamespace Text
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic, NFData)

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -135,6 +135,7 @@ data IdeConfiguration =
   { confOutputPath :: FilePath
   , confLogLevel   :: IdeLogLevel
   , confGlobs      :: [FilePath]
+  , confEditorMode :: Bool
   }
 
 data IdeEnvironment =

--- a/tests/Language/PureScript/Ide/Test.hs
+++ b/tests/Language/PureScript/Ide/Test.hs
@@ -20,10 +20,12 @@ import qualified Language.PureScript             as P
 
 defConfig :: IdeConfiguration
 defConfig =
-  IdeConfiguration { confLogLevel = LogNone
-                , confOutputPath = "output/"
-                , confGlobs = ["src/*.purs"]
-                }
+  IdeConfiguration
+    { confLogLevel = LogNone
+    , confOutputPath = "output/"
+    , confGlobs = ["src/*.purs"]
+    , confEditorMode = False
+    }
 
 runIde' :: IdeConfiguration -> IdeState -> [Command] -> IO ([Either IdeError Success], IdeState)
 runIde' conf s cs = do


### PR DESCRIPTION
Adds a new flag to the server invocation: `--editor-mode`

When the editor-mode flag is specified at startup the server will not start a file watcher process anymore. Instead it only reloads after successful rebuild commands. This is a lot less fragile than relying on the file system APIs, but will mean that a manual load needs to be triggered after builds that didn't go through purs ide.

Looking forward to get Feedback :) After using psc-ide more intensively the last months it seems like the file watcher is the most fragile part of the system so I'm looking for ways to circumvent that problem.