### PR TITLE
Don't use `Show` instance for pretty printing

### DIFF
--- a/app/Command/Hierarchy.hs
+++ b/app/Command/Hierarchy.hs
@@ -34,7 +34,7 @@ import           System.Exit (exitFailure, exitSuccess)
 import           System.IO (hPutStr, stderr)
 import           System.IO.UTF8 (readUTF8FileT)
 import qualified Language.PureScript as P
-import           Language.PureScript.Hierarchy (_unGraph, _unGraphName, typeClasses)
+import           Language.PureScript.Hierarchy (Graph(..), _unDigraph, _unGraphName, typeClasses)
 
 data HierarchyOptions = HierarchyOptions
   { _hierachyInput   :: FilePath
@@ -53,12 +53,12 @@ compile (HierarchyOptions inputGlob mOutput) = do
   case modules of
     Left errs -> hPutStr stderr (P.prettyPrintMultipleErrors P.defaultPPEOptions errs) >> exitFailure
     Right ms -> do
-      for_ (catMaybes $ typeClasses ms) $ \(name, hier) ->
+      for_ (catMaybes $ typeClasses ms) $ \(Graph name graph) ->
         case mOutput of
           Just output -> do
             createDirectoryIfMissing True output
-            T.writeFile (output </> T.unpack (_unGraphName name)) (_unGraph hier)
-          Nothing -> T.putStrLn (_unGraph hier)
+            T.writeFile (output </> T.unpack (_unGraphName name)) (_unDigraph graph)
+          Nothing -> T.putStrLn (_unDigraph graph)
       exitSuccess
 
 inputFile :: Parser FilePath

--- a/app/Command/Hierarchy.hs
+++ b/app/Command/Hierarchy.hs
@@ -18,14 +18,11 @@
 
 module Command.Hierarchy (command) where
 
-import           Protolude (ordNub)
+import           Protolude (catMaybes)
 
 import           Control.Applicative (optional)
-import           Control.Monad (unless)
-import           Data.List (intercalate, sort)
 import           Data.Foldable (for_)
 import           Data.Monoid ((<>))
-import qualified Data.Text as T
 import           Options.Applicative (Parser)
 import qualified Options.Applicative as Opts
 import           System.Directory (createDirectoryIfMissing)
@@ -35,28 +32,12 @@ import           System.Exit (exitFailure, exitSuccess)
 import           System.IO (hPutStr, stderr)
 import           System.IO.UTF8 (readUTF8FileT)
 import qualified Language.PureScript as P
+import           Language.PureScript.Hierarchy (typeClasses)
 
 data HierarchyOptions = HierarchyOptions
   { _hierachyInput   :: FilePath
   , _hierarchyOutput :: Maybe FilePath
   }
-
-newtype SuperMap = SuperMap { _unSuperMap :: Either (P.ProperName 'P.ClassName) (P.ProperName 'P.ClassName, P.ProperName 'P.ClassName) }
-  deriving Eq
-
-instance Ord SuperMap where
-  compare (SuperMap s) (SuperMap s') = getCls s `compare` getCls s'
-    where
-      getCls = either id snd
-
-prettyPrint :: SuperMap -> String
-prettyPrint (SuperMap (Left sub)) =
-  T.unpack (P.runProperName sub)
-prettyPrint (SuperMap (Right (super, sub))) =
-  T.unpack (P.runProperName super) <> " -> " <> T.unpack (P.runProperName sub)
-
-runModuleName :: P.ModuleName -> String
-runModuleName (P.ModuleName pns) = intercalate "_" ((T.unpack . P.runProperName) `map` pns)
 
 readInput :: [FilePath] -> IO (Either P.MultipleErrors [P.Module])
 readInput paths = do
@@ -70,26 +51,13 @@ compile (HierarchyOptions inputGlob mOutput) = do
   case modules of
     Left errs -> hPutStr stderr (P.prettyPrintMultipleErrors P.defaultPPEOptions errs) >> exitFailure
     Right ms -> do
-      for_ ms $ \(P.Module _ _ moduleName decls _) ->
-        let name = runModuleName moduleName
-            tcs = filter P.isTypeClassDeclaration decls
-            supers = sort . ordNub . filter (not . null) $ fmap superClasses tcs
-            prologue = "digraph " ++ name ++ " {\n"
-            body = intercalate "\n" (concatMap (fmap (\s -> "  " ++ prettyPrint s ++ ";")) supers)
-            epilogue = "\n}"
-            hier = prologue ++ body ++ epilogue
-        in unless (null supers) $ case mOutput of
+      for_ (catMaybes $ typeClasses ms) $ \(name, hier) ->
+        case mOutput of
           Just output -> do
             createDirectoryIfMissing True output
             writeFile (output </> name) hier
           Nothing -> putStrLn hier
       exitSuccess
-
-superClasses :: P.Declaration -> [SuperMap]
-superClasses (P.TypeClassDeclaration _ sub _ supers@(_:_) _ _) =
-  fmap (\(P.Constraint (P.Qualified _ super) _ _) -> SuperMap (Right (super, sub))) supers
-superClasses (P.TypeClassDeclaration _ sub _ _ _ _) = [SuperMap (Left sub)]
-superClasses _ = []
 
 inputFile :: Parser FilePath
 inputFile = Opts.strArgument $

--- a/app/Command/Hierarchy.hs
+++ b/app/Command/Hierarchy.hs
@@ -23,6 +23,8 @@ import           Protolude (catMaybes)
 import           Control.Applicative (optional)
 import           Data.Foldable (for_)
 import           Data.Monoid ((<>))
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
 import           Options.Applicative (Parser)
 import qualified Options.Applicative as Opts
 import           System.Directory (createDirectoryIfMissing)
@@ -32,7 +34,7 @@ import           System.Exit (exitFailure, exitSuccess)
 import           System.IO (hPutStr, stderr)
 import           System.IO.UTF8 (readUTF8FileT)
 import qualified Language.PureScript as P
-import           Language.PureScript.Hierarchy (typeClasses)
+import           Language.PureScript.Hierarchy (_unGraph, _unGraphName, typeClasses)
 
 data HierarchyOptions = HierarchyOptions
   { _hierachyInput   :: FilePath
@@ -55,8 +57,8 @@ compile (HierarchyOptions inputGlob mOutput) = do
         case mOutput of
           Just output -> do
             createDirectoryIfMissing True output
-            writeFile (output </> name) hier
-          Nothing -> putStrLn hier
+            T.writeFile (output </> T.unpack (_unGraphName name)) (_unGraph hier)
+          Nothing -> T.putStrLn (_unGraph hier)
       exitSuccess
 
 inputFile :: Parser FilePath

--- a/src/Language/PureScript/Hierarchy.hs
+++ b/src/Language/PureScript/Hierarchy.hs
@@ -1,0 +1,61 @@
+-----------------------------------------------------------------------------
+--
+-- Module      :  Language.PureScript.Hierarchy
+-- Copyright   :  (c) Hardy Jones 2014
+-- License     :  MIT (http://opensource.org/licenses/MIT)
+--
+-- Maintainer  :  Hardy Jones <jones3.hardy@gmail.com>
+-- Stability   :  experimental
+-- Portability :
+--
+-- |
+-- Generate Directed Graphs of PureScript TypeClasses
+--
+-----------------------------------------------------------------------------
+
+module Language.PureScript.Hierarchy (typeClasses) where
+
+import           Prelude.Compat
+import           Protolude (ordNub)
+
+import           Data.List (intercalate, sort)
+import           Data.Monoid ((<>))
+import qualified Data.Text as T
+import qualified Language.PureScript as P
+
+newtype SuperMap = SuperMap
+  { _unSuperMap :: Either (P.ProperName 'P.ClassName) (P.ProperName 'P.ClassName, P.ProperName 'P.ClassName)
+  }
+  deriving Eq
+
+instance Ord SuperMap where
+  compare (SuperMap s) (SuperMap s') = getCls s `compare` getCls s'
+    where
+      getCls = either id snd
+
+prettyPrint :: SuperMap -> String
+prettyPrint (SuperMap (Left sub)) =
+  T.unpack (P.runProperName sub)
+prettyPrint (SuperMap (Right (super, sub))) =
+  T.unpack (P.runProperName super) <> " -> " <> T.unpack (P.runProperName sub)
+
+runModuleName :: P.ModuleName -> String
+runModuleName (P.ModuleName pns) = intercalate "_" ((T.unpack . P.runProperName) `map` pns)
+
+typeClasses :: Functor f => f P.Module -> f (Maybe (String, String))
+typeClasses ms =
+  flip fmap ms $ \(P.Module _ _ moduleName decls _) ->
+    let name = runModuleName moduleName
+        tcs = filter P.isTypeClassDeclaration decls
+        supers = sort . ordNub . filter (not . null) $ fmap superClasses tcs
+        prologue = "digraph " ++ name ++ " {\n"
+        body = intercalate "\n" (concatMap (fmap (\s -> "  " ++ prettyPrint s ++ ";")) supers)
+        epilogue = "\n}"
+        hier = prologue ++ body ++ epilogue
+    in if null supers then Nothing else Just (name, hier)
+
+superClasses :: P.Declaration -> [SuperMap]
+superClasses (P.TypeClassDeclaration _ sub _ supers@(_:_) _ _) =
+  fmap (\(P.Constraint (P.Qualified _ super) _ _) -> SuperMap (Right (super, sub))) supers
+superClasses (P.TypeClassDeclaration _ sub _ _ _ _) = [SuperMap (Left sub)]
+superClasses _ = []

--- a/src/Language/PureScript/Hierarchy.hs
+++ b/src/Language/PureScript/Hierarchy.hs
@@ -13,11 +13,7 @@
 --
 -----------------------------------------------------------------------------
 
-module Language.PureScript.Hierarchy
-       ( Graph(..)
-       , GraphName(..)
-       , typeClasses
-       ) where
+module Language.PureScript.Hierarchy where
 
 import           Prelude.Compat
 import           Protolude (ordNub)
@@ -40,10 +36,12 @@ instance Ord SuperMap where
 newtype Graph = Graph
   { _unGraph :: T.Text
   }
+  deriving (Eq, Show)
 
 newtype GraphName = GraphName
   { _unGraphName :: T.Text
   }
+  deriving (Eq, Show)
 
 prettyPrint :: SuperMap -> T.Text
 prettyPrint (SuperMap (Left sub)) = "  " <> P.runProperName sub <> ";"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -10,10 +10,11 @@ import Prelude.Compat
 
 import qualified TestCompiler
 import qualified TestDocs
+import qualified TestHierarchy
+import qualified TestPrimDocs
 import qualified TestPsci
 import qualified TestPscIde
 import qualified TestPscPublish
-import qualified TestPrimDocs
 import qualified TestUtils
 
 import System.IO (hSetEncoding, stdout, stderr, utf8)
@@ -29,6 +30,9 @@ main = do
   TestCompiler.main
   heading "Documentation test suite"
   TestDocs.main
+  heading "Hierarchy test suite"
+  TestHierarchy.main
+  heading "Prim documentation test suite"
   TestPrimDocs.main
   heading "psc-publish test suite"
   TestPscPublish.main

--- a/tests/TestHierarchy.hs
+++ b/tests/TestHierarchy.hs
@@ -62,4 +62,4 @@ main = hspec $ do
 
         let graph = typeClassGraph mainModule
 
-        graph `shouldBe` Just (GraphName "Main", Graph "digraph Main {\n  A;\n  A -> B;\n}")
+        graph `shouldBe` Just (Graph (GraphName "Main") (Digraph "digraph Main {\n  A;\n  A -> B;\n}"))

--- a/tests/TestHierarchy.hs
+++ b/tests/TestHierarchy.hs
@@ -1,0 +1,26 @@
+module TestHierarchy where
+
+import System.Process (readCreateProcess, shell)
+
+import Test.Hspec (Spec, describe, hspec, it, shouldBe)
+
+import TestUtils (pushd)
+
+main :: IO ()
+main = pushd "tests/support/hierarchy" (hspec spec)
+
+spec :: Spec
+spec = do
+  describe "hierarchy" $ do
+    it "generates usable graphviz graphs" $ do
+      let expected = unlines
+            [ "digraph Main {"
+            , "  A;"
+            , "  A -> B;"
+            , "  C;"
+            , "}"
+            ]
+
+      actual <- readCreateProcess (shell "purs hierarchy src/Main.purs") ""
+
+      actual `shouldBe` expected

--- a/tests/TestHierarchy.hs
+++ b/tests/TestHierarchy.hs
@@ -1,26 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
 module TestHierarchy where
 
-import System.Process (readCreateProcess, shell)
-
-import Test.Hspec (Spec, describe, hspec, it, shouldBe)
-
-import TestUtils (pushd)
+import Language.PureScript.Hierarchy
+import qualified Language.PureScript as P
+import Test.Hspec (describe, hspec, it, shouldBe)
 
 main :: IO ()
-main = pushd "tests/support/hierarchy" (hspec spec)
+main = hspec $ do
+  describe "Language.PureScript.Hierarchy" $ do
+    describe "typeClassGraph" $ do
+      it "generates usable graphviz graphs" $ do
+        let declarations =
+              [ P.TypeClassDeclaration
+                 (P.internalModuleSourceSpan "<A>", [])
+                 (P.ProperName "A")
+                 []
+                 []
+                 []
+                 []
+              , P.TypeClassDeclaration
+                 (P.internalModuleSourceSpan "<B>", [])
+                 (P.ProperName "B")
+                 []
+                 [P.Constraint (P.Qualified Nothing $ P.ProperName "A") [] Nothing]
+                 []
+                 []
+              ]
+        let mainModule = P.Module
+              (P.internalModuleSourceSpan "<hierarchy>")
+              []
+              (P.ModuleName [P.ProperName "Main"])
+              declarations
+              Nothing
 
-spec :: Spec
-spec = do
-  describe "hierarchy" $ do
-    it "generates usable graphviz graphs" $ do
-      let expected = unlines
-            [ "digraph Main {"
-            , "  A;"
-            , "  A -> B;"
-            , "  C;"
-            , "}"
-            ]
+        let graph = typeClassGraph mainModule
 
-      actual <- readCreateProcess (shell "purs hierarchy src/Main.purs") ""
-
-      actual `shouldBe` expected
+        graph `shouldBe` Just (GraphName "Main", Graph "digraph Main {\n  A;\n  A -> B;\n}")

--- a/tests/TestHierarchy.hs
+++ b/tests/TestHierarchy.hs
@@ -8,7 +8,34 @@ import Test.Hspec (describe, hspec, it, shouldBe)
 main :: IO ()
 main = hspec $ do
   describe "Language.PureScript.Hierarchy" $ do
+    describe "prettyPrint" $ do
+      it "creates just the node when there is no relation" $ do
+        let superMap = SuperMap (Left $ P.ProperName "A")
+
+        let prettyPrinted = prettyPrint superMap
+
+        prettyPrinted `shouldBe` "  A;"
+
+      it "creates a relation when there is one" $ do
+        let superMap = SuperMap (Right $ (P.ProperName "A", P.ProperName "B"))
+
+        let prettyPrinted = prettyPrint superMap
+
+        prettyPrinted `shouldBe` "  A -> B;"
+
     describe "typeClassGraph" $ do
+      it "doesn't generate a graph if there are no type classes" $ do
+        let mainModule = P.Module
+              (P.internalModuleSourceSpan "<hierarchy>")
+              []
+              (P.ModuleName [P.ProperName "Main"])
+              []
+              Nothing
+
+        let graph = typeClassGraph mainModule
+
+        graph `shouldBe` Nothing
+
       it "generates usable graphviz graphs" $ do
         let declarations =
               [ P.TypeClassDeclaration

--- a/tests/support/hierarchy/src/Main.purs
+++ b/tests/support/hierarchy/src/Main.purs
@@ -1,5 +1,0 @@
-module Main where
-
-class A
-class A <= B
-class C

--- a/tests/support/hierarchy/src/Main.purs
+++ b/tests/support/hierarchy/src/Main.purs
@@ -1,0 +1,5 @@
+module Main where
+
+class A
+class A <= B
+class C


### PR DESCRIPTION
This is a fix for https://github.com/purescript/purescript/issues/3012

The output looks like this now:

```dot
➜  purescript git:(hierarchy-fix) ✗ stack exec purs -- hierarchy ../purescript-prelude/src/Control/Monad.purs
digraph Control_Monad {
  Applicative -> Monad;
  Bind -> Monad;
}
```

And produces this image if run through `dot`.

![control_monad](https://user-images.githubusercontent.com/1356417/28758133-c6f4655c-7547-11e7-8d2b-f21529cb875a.png)

---

This feels like it should be verified/checked in some way so it is less likely to break in the future. Should it be added to the test suite somehow? I'm not familiar enough with it to know if that's possible or a huge amount of work.