### PR TITLE
Use order given in export list in generated docs

### DIFF
--- a/examples/docs/src/DeclOrder.purs
+++ b/examples/docs/src/DeclOrder.purs
@@ -1,0 +1,17 @@
+module DeclOrder
+  ( class A
+  , x1
+  , X2
+  , x3
+  , X4
+  , class B
+  ) where
+
+x1 = 0
+x3 = 0
+
+data X2
+data X4
+
+class A
+class B

--- a/examples/docs/src/DeclOrderNoExportList.purs
+++ b/examples/docs/src/DeclOrderNoExportList.purs
@@ -1,0 +1,10 @@
+module DeclOrderNoExportList where
+
+x1 = 0
+x3 = 0
+
+data X2
+data X4
+
+class A
+class B

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -528,11 +528,15 @@ declName (ValueDeclaration _ n _ _ _) = Just (IdentName n)
 declName (ExternDeclaration _ n _) = Just (IdentName n)
 declName (ExternDataDeclaration _ n _) = Just (TyName n)
 declName (ExternKindDeclaration _ n) = Just (KiName n)
-declName (ValueFixityDeclaration _ _ _ n) = Just (ValOpName n)
-declName (TypeFixityDeclaration _ _ _ n) = Just (TyOpName n)
+declName (FixityDeclaration _ (Left (ValueFixity _ _ n))) = Just (ValOpName n)
+declName (FixityDeclaration _ (Right (TypeFixity _ _ n))) = Just (TyOpName n)
 declName (TypeClassDeclaration _ n _ _ _ _) = Just (TyClassName n)
 declName (TypeInstanceDeclaration _ n _ _ _ _) = Just (IdentName n)
-declName _ = Nothing
+declName ImportDeclaration{} = Nothing
+declName BindingGroupDeclaration{} = Nothing
+declName DataBindingGroupDeclaration{} = Nothing
+declName BoundValueDeclaration{} = Nothing
+declName TypeDeclaration{} = Nothing
 
 -- |
 -- Test if a declaration is a value declaration

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -342,6 +342,17 @@ declRefSourceSpan (ModuleRef ss _) = ss
 declRefSourceSpan (KindRef ss _) = ss
 declRefSourceSpan (ReExportRef ss _ _) = ss
 
+declRefName :: DeclarationRef -> Name
+declRefName (TypeRef _ n _) = TyName n
+declRefName (TypeOpRef _ n) = TyOpName n
+declRefName (ValueRef _ n) = IdentName n
+declRefName (ValueOpRef _ n) = ValOpName n
+declRefName (TypeClassRef _ n) = TyClassName n
+declRefName (TypeInstanceRef _ n) = IdentName n
+declRefName (ModuleRef _ n) = ModName n
+declRefName (KindRef _ n) = KiName n
+declRefName (ReExportRef _ _ ref) = declRefName ref
+
 getTypeRef :: DeclarationRef -> Maybe (ProperName 'TypeName, Maybe [ProperName 'ConstructorName])
 getTypeRef (TypeRef _ name dctors) = Just (name, dctors)
 getTypeRef _ = Nothing
@@ -509,6 +520,19 @@ declSourceAnn (TypeInstanceDeclaration sa _ _ _ _ _) = sa
 
 declSourceSpan :: Declaration -> SourceSpan
 declSourceSpan = fst . declSourceAnn
+
+declName :: Declaration -> Maybe Name
+declName (DataDeclaration _ _ n _ _) = Just (TyName n)
+declName (TypeSynonymDeclaration _ n _ _) = Just (TyName n)
+declName (ValueDeclaration _ n _ _ _) = Just (IdentName n)
+declName (ExternDeclaration _ n _) = Just (IdentName n)
+declName (ExternDataDeclaration _ n _) = Just (TyName n)
+declName (ExternKindDeclaration _ n) = Just (KiName n)
+declName (ValueFixityDeclaration _ _ _ n) = Just (ValOpName n)
+declName (TypeFixityDeclaration _ _ _ n) = Just (TyOpName n)
+declName (TypeClassDeclaration _ n _ _ _ _) = Just (TyClassName n)
+declName (TypeInstanceDeclaration _ n _ _ _ _) = Just (IdentName n)
+declName _ = Nothing
 
 -- |
 -- Test if a declaration is a value declaration

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -9,7 +9,7 @@ module Language.PureScript.Sugar.Names
   ) where
 
 import Prelude.Compat
-import Protolude (ordNub)
+import Protolude (ordNub, sortBy, on)
 
 import Control.Arrow (first)
 import Control.Monad
@@ -118,13 +118,17 @@ desugarImportsWithEnv externs modules = do
       return m''
 
 -- |
--- Make all exports for a module explicit. This may still effect modules that
+-- Make all exports for a module explicit. This may still affect modules that
 -- have an exports list, as it will also make all data constructor exports
 -- explicit.
 --
+-- The exports will appear in the same order as they do in the existing exports
+-- list, or if there is no export list, declarations are order based on their
+-- order of appearance in the module.
+--
 elaborateExports :: Exports -> Module -> Module
 elaborateExports exps (Module ss coms mn decls refs) =
-  Module ss coms mn decls $ Just
+  Module ss coms mn decls $ Just $ reorderExports decls refs
     $ elaboratedTypeRefs
     ++ go (TypeOpRef ss) exportedTypeOps
     ++ go (TypeClassRef ss) exportedTypeClasses
@@ -144,6 +148,22 @@ elaborateExports exps (Module ss coms mn decls refs) =
   go toRef select =
     flip map (M.toList (select exps)) $ \(export, mn') ->
       if mn == mn' then toRef export else ReExportRef ss mn' (toRef export)
+
+-- |
+-- Given a list of declarations, an original exports list, and an elaborated
+-- exports list, reorder the elaborated list so that it matches the original
+-- order. If there is no original exports list, reorder declarations based on
+-- their order in the source file.
+reorderExports :: [Declaration] -> Maybe [DeclarationRef] -> [DeclarationRef] -> [DeclarationRef]
+reorderExports decls originalRefs =
+  sortBy (compare `on` originalIndex)
+  where
+  names =
+    maybe (mapMaybe declName decls) (map declRefName) originalRefs
+  namesMap =
+    M.fromList $ zip names [(0::Int)..]
+  originalIndex ref =
+    M.lookup (declRefName ref) namesMap
 
 -- |
 -- Replaces all local names with qualified names within a module and checks that all existing

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -279,7 +279,7 @@ typeInstanceDictionaryDeclaration sa name mn deps className tys decls =
     maybe (throwError . errorMessage . UnknownName $ fmap TyClassName className) return $
       M.lookup (qualify mn className) m
 
-  case map fst typeClassMembers \\ mapMaybe declName decls of
+  case map fst typeClassMembers \\ mapMaybe declIdent decls of
     member : _ -> throwError . errorMessage $ MissingClassMember member
     [] -> do
       -- Replace the type arguments with the appropriate types in the member types
@@ -306,10 +306,10 @@ typeInstanceDictionaryDeclaration sa name mn deps className tys decls =
 
   where
 
-  declName :: Declaration -> Maybe Ident
-  declName (ValueDeclaration _ ident _ _ _) = Just ident
-  declName (TypeDeclaration _ ident _) = Just ident
-  declName _ = Nothing
+  declIdent :: Declaration -> Maybe Ident
+  declIdent (ValueDeclaration _ ident _ _ _) = Just ident
+  declIdent (TypeDeclaration _ ident _) = Just ident
+  declIdent _ = Nothing
 
   memberToValue :: [(Ident, Type)] -> Declaration -> Desugar m Expr
   memberToValue tys' (ValueDeclaration _ ident _ [] [MkUnguarded val]) = do

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -12,6 +12,7 @@ import Prelude.Compat
 import Control.Arrow (first)
 import Control.Monad.IO.Class (liftIO)
 
+import Data.List (findIndex)
 import Data.Foldable
 import Safe (headMay)
 import Data.Maybe (fromMaybe, mapMaybe)
@@ -41,9 +42,14 @@ publishOpts = Publish.defaultPublishOptions
   }
   where testVersion = ("v999.0.0", Version [999,0,0] [])
 
+getPackage :: IO (Either Publish.PackageError (Docs.Package Docs.NotYetKnown))
+getPackage =
+  pushd "examples/docs" $
+    Publish.preparePackage "bower.json" "resolutions.json" publishOpts
+
 main :: IO ()
-main = pushd "examples/docs" $ do
-  res <- Publish.preparePackage "bower.json" "resolutions.json" publishOpts
+main = do
+  res <- getPackage
   case res of
     Left e -> Publish.printErrorToStdout e >> exitFailure
     Right pkg@Docs.Package{..} ->
@@ -52,7 +58,6 @@ main = pushd "examples/docs" $ do
                           (find ((==) mn . Docs.modName) pkgModules)
             linksCtx = Docs.getLinksContext pkg
         in forM_ pragmas (\a -> runAssertionIO a linksCtx mdl)
-
 
 takeJust :: String -> Maybe a -> a
 takeJust msg = fromMaybe (error msg)
@@ -93,6 +98,8 @@ data Assertion
   -- declaration title, title of linked declaration, namespace of linked
   -- declaration, destination of link.
   | ShouldHaveLink P.ModuleName Text Text Docs.Namespace Docs.LinkLocation
+  -- | Assert that a given declaration comes before another in the output
+  | ShouldComeBefore P.ModuleName Text Text
   deriving (Show)
 
 newtype ShowFn a = ShowFn a
@@ -141,12 +148,16 @@ data AssertionFailure
   -- declaration, title of the linked declaration, expected location, actual
   -- location.
   | BadLinkLocation P.ModuleName Text Text Docs.LinkLocation Docs.LinkLocation
+  -- | Declarations were in the wrong order
+  | WrongOrder P.ModuleName Text Text
   deriving (Show)
 
 displayAssertionFailure :: AssertionFailure -> Text
 displayAssertionFailure = \case
   DeclarationWrongType mn title actual ->
     P.runModuleName mn <> "." <> title <> " had the wrong type; got " <> T.pack (P.prettyPrintType actual)
+  WrongOrder mn before after ->
+    "In " <> P.runModuleName mn <> ": expected to see " <> before <> " before " <> after
   -- TODO: deal with the other constructors nicely
   other ->
     T.pack (show other)
@@ -277,6 +288,23 @@ runAssertion assertion linksCtx Docs.Module{..} =
                 else Fail (BadLinkLocation mn decl destTitle expectedLoc actualLoc)
             Nothing ->
               Fail (LinkedDeclarationMissing mn decl destTitle)
+
+    ShouldComeBefore mn before after ->
+      let
+        decls = declarationsFor mn
+
+        indexOf :: Text -> Maybe Int
+        indexOf title = findIndex ((==) title . Docs.declTitle) decls
+      in
+        case (indexOf before, indexOf after) of
+          (Just i, Just j) ->
+            if i < j
+              then Pass
+              else Fail (WrongOrder mn before after)
+          (Nothing, _) ->
+            Fail (NotDocumented mn before)
+          (_, Nothing) ->
+            Fail (NotDocumented mn after)
 
   where
   declarationsFor mn =
@@ -451,6 +479,14 @@ testCases =
       [ ShouldBeDocumented (n "ChildDeclOrder") "Two" ["First", "Second", "showTwo", "fooTwo"]
       , ShouldBeDocumented (n "ChildDeclOrder") "Foo" ["foo1", "foo2", "fooTwo", "fooInt"]
       ])
+
+  , ("DeclOrder",
+      shouldBeOrdered (n "DeclOrder")
+        ["A", "x1", "X2", "x3", "X4", "B"])
+
+  , ("DeclOrderNoExportList",
+      shouldBeOrdered (n "DeclOrderNoExportList")
+        [ "x1", "x3", "X2", "X4", "A", "B" ])
   ]
 
   where
@@ -465,3 +501,6 @@ testCases =
 
   renderedType expected =
     ShowFn $ \ty -> codeToString (Docs.renderType ty) == expected
+
+  shouldBeOrdered mn declNames =
+    map (uncurry (ShouldComeBefore mn)) (zip declNames (tail declNames))

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -503,4 +503,4 @@ testCases =
     ShowFn $ \ty -> codeToString (Docs.renderType ty) == expected
 
   shouldBeOrdered mn declNames =
-    map (uncurry (ShouldComeBefore mn)) (zip declNames (tail declNames))
+    zipWith (ShouldComeBefore mn) declNames (tail declNames)


### PR DESCRIPTION
If a module has an explicit export list, the declarations in the
generated docs now appear in the same order as in the export list.
Otherwise, they appear in the same order as they did in the source file.
Fixes #3003