### PR TITLE
eliminate redundant whitespace in js output

### DIFF
--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -49,7 +49,7 @@ literals = mkPattern' match'
     , withIndent $ do
         jss <- forM ps $ \(key, value) -> fmap ((objectPropertyToString key <> emit ": ") <>) . prettyPrintJS' $ value
         indentString <- currentIndent
-        return $ intercalate (emit ", \n") $ map (indentString <>) jss
+        return $ intercalate (emit ",\n") $ map (indentString <>) jss
     , return $ emit "\n"
     , currentIndent
     , return $ emit "}"


### PR DESCRIPTION
fixes #3020