### PR TITLE
Run AppendSymbol in reverse

### DIFF
--- a/examples/passing/AppendInReverse.purs
+++ b/examples/passing/AppendInReverse.purs
@@ -1,0 +1,24 @@
+module Main where
+
+import Prelude
+import Type.Data.Symbol (class AppendSymbol, SProxy(..))
+import Control.Monad.Eff.Console (log)
+
+class Balanced (sym :: Symbol)
+
+instance balanced1 :: Balanced ""
+instance balanced2
+  :: ( AppendSymbol "(" sym1 sym
+     , AppendSymbol sym2 ")" sym1
+     , Balanced sym2
+     ) => Balanced sym
+
+balanced :: forall sym. Balanced sym => SProxy sym -> String
+balanced _ = "ok"
+
+main = do
+  log (balanced (SProxy :: SProxy ""))
+  log (balanced (SProxy :: SProxy "()"))
+  log (balanced (SProxy :: SProxy "(())"))
+  log (balanced (SProxy :: SProxy "((()))"))
+  log "Done"

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -27,7 +27,7 @@ import Data.List (minimumBy)
 import Data.Maybe (fromMaybe, maybeToList, mapMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
-import Data.Text (Text)
+import Data.Text (Text, stripPrefix, stripSuffix)
 
 import Language.PureScript.AST
 import Language.PureScript.Crash
@@ -39,7 +39,7 @@ import Language.PureScript.TypeChecker.Unify
 import Language.PureScript.TypeClassDictionaries
 import Language.PureScript.Types
 import Language.PureScript.Label (Label(..))
-import Language.PureScript.PSString (PSString, mkString)
+import Language.PureScript.PSString (PSString, mkString, decodeString)
 import qualified Language.PureScript.Constants as C
 
 -- | Describes what sort of dictionary to generate for type class instances
@@ -162,8 +162,9 @@ entails SolverOptions{..} constraint context hints =
                   GT -> C.orderingGT
           args = [arg0, arg1, TypeConstructor ordering]
       in [TypeClassDictionaryInScope CompareSymbolInstance [] C.CompareSymbol args Nothing]
-    forClassName _ C.AppendSymbol [arg0@(TypeLevelString lhs), arg1@(TypeLevelString rhs), _] =
-      let args = [arg0, arg1, TypeLevelString (lhs <> rhs)]
+    forClassName _ C.AppendSymbol [arg0, arg1, arg2]
+      | Just (arg0', arg1', arg2') <- appendSymbols arg0 arg1 arg2 =
+      let args = [arg0', arg1', arg2']
       in [TypeClassDictionaryInScope AppendSymbolInstance [] C.AppendSymbol args Nothing]
     forClassName _ C.Union [l, r, u]
       | Just (lOut, rOut, uOut, cst) <- unionRows l r u
@@ -352,6 +353,21 @@ entails SolverOptions{..} constraint context hints =
         subclassDictionaryValue :: Expr -> Qualified (ProperName 'ClassName) -> Integer -> Expr
         subclassDictionaryValue dict className index =
           App (Accessor (mkString (superclassName className index)) dict) valUndefined
+
+    -- | Append type level symbols, or, run backwards, strip a prefix or suffix
+    appendSymbols :: Type -> Type -> Type -> Maybe (Type, Type, Type)
+    appendSymbols arg0@(TypeLevelString lhs) arg1@(TypeLevelString rhs) _ = Just (arg0, arg1, TypeLevelString (lhs <> rhs))
+    appendSymbols arg0@(TypeLevelString lhs) _ arg2@(TypeLevelString out) = do
+      lhs' <- decodeString lhs
+      out' <- decodeString out
+      rhs <- stripPrefix lhs' out'
+      pure (arg0, TypeLevelString (mkString rhs), arg2)
+    appendSymbols _ arg1@(TypeLevelString rhs) arg2@(TypeLevelString out) = do
+      rhs' <- decodeString rhs
+      out' <- decodeString out
+      lhs <- stripSuffix rhs' out'
+      pure (TypeLevelString (mkString lhs), arg1, arg2)
+    appendSymbols _ _ _ = Nothing
 
     -- | Left biased union of two row types
     unionRows :: Type -> Type -> Type -> Maybe (Type, Type, Type, Maybe [Constraint])

--- a/tests/support/bower.json
+++ b/tests/support/bower.json
@@ -35,7 +35,7 @@
     "purescript-tailrec": "3.3.0",
     "purescript-tuples": "4.1.0",
     "purescript-type-equality": "2.1.0",
-    "purescript-typelevel-prelude": "2.3.0",
+    "purescript-typelevel-prelude": "#phil/append-symbol",
     "purescript-unfoldable": "3.0.0",
     "purescript-unsafe-coerce": "3.0.0"
   }


### PR DESCRIPTION
Should be merged with https://github.com/purescript/purescript-typelevel-prelude/pull/19

We can run `AppendSymbol` in reverse, stripping a prefix or suffix from a type level string.

This lets us write simple parsers at the type level, which might lead to some interesting applications.

@LiamGoodacre Could you please review this?