### PR TITLE
Allow blaze-html 0.9

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -37,7 +37,7 @@ dependencies:
   - ansi-terminal >=0.6.2 && <0.7
   - base >=4.8 && <5
   - base-compat >=0.6.0
-  - blaze-html >=0.8.1 && <0.9
+  - blaze-html >=0.8.1 && <0.10
   - bower-json >=1.0.0.1 && <1.1
   - boxes >=0.1.4 && <0.2.0
   - bytestring


### PR DESCRIPTION
None of the changelog items were used by us, and the build is successful.