### PR TITLE
Fix compatibility with protolude 0.2

### DIFF
--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -9,7 +9,7 @@ module Language.PureScript.Ide.Completion
        , applyCompletionOptions
        ) where
 
-import           Protolude
+import           Protolude hiding ((<&>))
 
 import           Control.Lens hiding ((&), op)
 import           Data.Aeson


### PR DESCRIPTION
protolude 0.2 exports <&> which will conflict the one imported from Control.Lens. This patch fixes it.

```
[128 of 147] Compiling Language.PureScript.Ide.Completion ( src/Language/PureScript/Ide/Completion.hs, dist/build/Language/PureScript/Ide/Completion.o )

src/Language/PureScript/Ide/Completion.hs:41:3: error:
    Ambiguous occurrence ‘<&>’
    It could refer to either ‘Protolude.<&>’,
                             imported from ‘Protolude’ at src/Language/PureScript/Ide/Completion.hs:12:1-26
                          or ‘Control.Lens.<&>’,
                             imported from ‘Control.Lens’ at src/Language/PureScript/Ide/Completion.hs:14:1-46
                             (and originally defined in ‘Control.Lens.Lens’)

src/Language/PureScript/Ide/Completion.hs:53:3: error:
    Ambiguous occurrence ‘<&>’
    It could refer to either ‘Protolude.<&>’,
                             imported from ‘Protolude’ at src/Language/PureScript/Ide/Completion.hs:12:1-26
                          or ‘Control.Lens.<&>’,
                             imported from ‘Control.Lens’ at src/Language/PureScript/Ide/Completion.hs:14:1-46
                             (and originally defined in ‘Control.Lens.Lens’)

src/Language/PureScript/Ide/Completion.hs:54:3: error:
    Ambiguous occurrence ‘<&>’
    It could refer to either ‘Protolude.<&>’,
                             imported from ‘Protolude’ at src/Language/PureScript/Ide/Completion.hs:12:1-26
                          or ‘Control.Lens.<&>’,
                             imported from ‘Control.Lens’ at src/Language/PureScript/Ide/Completion.hs:14:1-46
                             (and originally defined in ‘Control.Lens.Lens’)
```