### PR TITLE
Introduces a type for type declarations

### DIFF
--- a/app/Command/Docs/Tags.hs
+++ b/app/Command/Docs/Tags.hs
@@ -10,7 +10,7 @@ tags = map (first T.unpack) . concatMap dtags . P.exportedDeclarations
     dtags :: P.Declaration -> [(P.Text, Int)]
     dtags (P.DataDeclaration (ss, _) _ name _ dcons) = (P.runProperName name, pos ss) : consNames
       where consNames = map (\(cname, _) -> (P.runProperName cname, pos ss)) dcons
-    dtags (P.TypeDeclaration (ss, _) ident _) = [(P.showIdent ident, pos ss)]
+    dtags (P.TypeDeclaration (P.TypeDeclarationData (ss, _) ident _)) = [(P.showIdent ident, pos ss)]
     dtags (P.ExternDeclaration (ss, _) ident _) = [(P.showIdent ident, pos ss)]
     dtags (P.TypeSynonymDeclaration (ss, _) name _ _) = [(P.runProperName name, pos ss)]
     dtags (P.TypeClassDeclaration (ss, _) name _ _ _ _) = [(P.runProperName name, pos ss)]

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -407,6 +407,19 @@ isExplicit :: ImportDeclarationType -> Bool
 isExplicit (Explicit _) = True
 isExplicit _ = False
 
+data TypeDeclarationData = TypeDeclarationData
+  { tydeclSourceAnn :: !SourceAnn
+  , tydeclIdent :: !Ident
+  , tydeclType :: !Type
+  } deriving (Show, Eq)
+
+onTypeDeclaration :: (TypeDeclarationData -> TypeDeclarationData) -> Declaration -> Declaration
+onTypeDeclaration f d = maybe d (TypeDeclaration . f) (getTypeDeclaration d)
+
+getTypeDeclaration :: Declaration -> Maybe TypeDeclarationData
+getTypeDeclaration (TypeDeclaration d) = Just d
+getTypeDeclaration _ = Nothing
+
 -- |
 -- The data type of declarations
 --
@@ -426,7 +439,7 @@ data Declaration
   -- |
   -- A type declaration for a value (name, ty)
   --
-  | TypeDeclaration SourceAnn Ident Type
+  | TypeDeclaration {-# UNPACK #-} !TypeDeclarationData
   -- |
   -- A value declaration (name, top-level binders, optional guard, value)
   --
@@ -506,7 +519,7 @@ declSourceAnn :: Declaration -> SourceAnn
 declSourceAnn (DataDeclaration sa _ _ _ _) = sa
 declSourceAnn (DataBindingGroupDeclaration ds) = declSourceAnn (NEL.head ds)
 declSourceAnn (TypeSynonymDeclaration sa _ _ _) = sa
-declSourceAnn (TypeDeclaration sa _ _) = sa
+declSourceAnn (TypeDeclaration td) = tydeclSourceAnn td
 declSourceAnn (ValueDeclaration sa _ _ _ _) = sa
 declSourceAnn (BoundValueDeclaration sa _ _) = sa
 declSourceAnn (BindingGroupDeclaration ds) = let ((sa, _), _, _) = NEL.head ds in sa

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -420,6 +420,9 @@ getTypeDeclaration :: Declaration -> Maybe TypeDeclarationData
 getTypeDeclaration (TypeDeclaration d) = Just d
 getTypeDeclaration _ = Nothing
 
+unwrapTypeDeclaration :: TypeDeclarationData -> (Ident, Type)
+unwrapTypeDeclaration td = (tydeclIdent td, tydeclType td)
+
 -- |
 -- The data type of declarations
 --

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -407,14 +407,19 @@ isExplicit :: ImportDeclarationType -> Bool
 isExplicit (Explicit _) = True
 isExplicit _ = False
 
+-- | A type declaration assigns a type to an identifier, eg:
+--
+-- @identity :: forall a. a -> a@
+--
+-- In this example @identity@ is the identifier and @forall a. a -> a@ the type.
 data TypeDeclarationData = TypeDeclarationData
   { tydeclSourceAnn :: !SourceAnn
   , tydeclIdent :: !Ident
   , tydeclType :: !Type
   } deriving (Show, Eq)
 
-onTypeDeclaration :: (TypeDeclarationData -> TypeDeclarationData) -> Declaration -> Declaration
-onTypeDeclaration f d = maybe d (TypeDeclaration . f) (getTypeDeclaration d)
+overTypeDeclaration :: (TypeDeclarationData -> TypeDeclarationData) -> Declaration -> Declaration
+overTypeDeclaration f d = maybe d (TypeDeclaration . f) (getTypeDeclaration d)
 
 getTypeDeclaration :: Declaration -> Maybe TypeDeclarationData
 getTypeDeclaration (TypeDeclaration d) = Just d

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -597,7 +597,7 @@ everythingWithScope f g h i j = (f'', g'', h'', i'', \s -> snd . j'' s)
 
   getDeclIdent :: Declaration -> Maybe Ident
   getDeclIdent (ValueDeclaration _ ident _ _ _) = Just ident
-  getDeclIdent (TypeDeclaration _ ident _) = Just ident
+  getDeclIdent (TypeDeclaration td) = Just (tydeclIdent td)
   getDeclIdent _ = Nothing
 
 accumTypes
@@ -616,7 +616,7 @@ accumTypes f = everythingOnValues mappend forDecls forValues (const mempty) (con
   forDecls (TypeClassDeclaration _ _ _ implies _ _) = mconcat (concatMap (fmap f . constraintArgs) implies)
   forDecls (TypeInstanceDeclaration _ _ cs _ tys _) = mconcat (concatMap (fmap f . constraintArgs) cs) `mappend` mconcat (fmap f tys)
   forDecls (TypeSynonymDeclaration _ _ _ ty) = f ty
-  forDecls (TypeDeclaration _ _ ty) = f ty
+  forDecls (TypeDeclaration td) = f (tydeclType td)
   forDecls _ = mempty
 
   forValues (TypeClassDictionary c _ _) = mconcat (fmap f (constraintArgs c))
@@ -647,7 +647,7 @@ accumKinds f = everythingOnValues mappend forDecls forValues (const mempty) (con
   forDecls (TypeSynonymDeclaration _ _ args ty) =
     foldMap (foldMap f . snd) args `mappend`
     forTypes ty
-  forDecls (TypeDeclaration _ _ ty) = forTypes ty
+  forDecls (TypeDeclaration td) = forTypes (tydeclType td)
   forDecls (ExternDeclaration _ _ ty) = forTypes ty
   forDecls (ExternDataDeclaration _ _ kn) = f kn
   forDecls _ = mempty

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -134,7 +134,7 @@ convertDeclaration (P.TypeClassDeclaration sa _ args implies fundeps ds) title =
   where
   info = TypeClassDeclaration args implies (convertFundepsToStrings args fundeps)
   children = map convertClassMember ds
-  convertClassMember (P.TypeDeclaration (ss, com) ident' ty) =
+  convertClassMember (P.TypeDeclaration (P.TypeDeclarationData (ss, com) ident' ty)) =
     ChildDeclaration (P.showIdent ident') (convertComments com) (Just ss) (ChildTypeClassMember ty)
   convertClassMember _ =
     P.internalError "convertDeclaration: Invalid argument to convertClassMember."

--- a/src/Language/PureScript/Ide/CaseSplit.hs
+++ b/src/Language/PureScript/Ide/CaseSplit.hs
@@ -131,7 +131,7 @@ parseTypeDeclaration' s =
         P.runTokenParser "" (P.parseDeclaration <* Parsec.eof) ts
   in
     case x of
-      Right (P.TypeDeclaration _ i t) -> pure (i, t)
+      Right (P.TypeDeclaration td) -> pure (P.tydeclIdent td, P.tydeclType td)
       Right _ -> throwError (GeneralError "Found a non-type-declaration")
       Left err ->
         throwError (GeneralError ("Parsing the type signature failed with: "

--- a/src/Language/PureScript/Ide/CaseSplit.hs
+++ b/src/Language/PureScript/Ide/CaseSplit.hs
@@ -131,7 +131,7 @@ parseTypeDeclaration' s =
         P.runTokenParser "" (P.parseDeclaration <* Parsec.eof) ts
   in
     case x of
-      Right (P.TypeDeclaration td) -> pure (P.tydeclIdent td, P.tydeclType td)
+      Right (P.TypeDeclaration td) -> pure (P.unwrapTypeDeclaration td)
       Right _ -> throwError (GeneralError "Found a non-type-declaration")
       Left err ->
         throwError (GeneralError ("Parsing the type signature failed with: "

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -65,12 +65,8 @@ extractAstInformation (P.Module _ _ _ decls _) =
   in (definitions, typeAnnotations)
 
 -- | Extracts type annotations for functions from a given Module
-extractTypeAnnotations
-  :: [P.Declaration]
-  -> [(P.Ident, P.Type)]
-extractTypeAnnotations = mapMaybe extract
-  where
-    extract = map (\td -> (P.tydeclIdent td, P.tydeclType td)) . P.getTypeDeclaration
+extractTypeAnnotations :: [P.Declaration] -> [(P.Ident, P.Type)]
+extractTypeAnnotations = mapMaybe (map P.unwrapTypeDeclaration . P.getTypeDeclaration)
 
 -- | Given a surrounding Sourcespan and a Declaration from the PS AST, extracts
 -- definition sites inside that Declaration.

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -70,8 +70,7 @@ extractTypeAnnotations
   -> [(P.Ident, P.Type)]
 extractTypeAnnotations = mapMaybe extract
   where
-    extract (P.TypeDeclaration _ ident ty) = Just (ident, ty)
-    extract _ = Nothing
+    extract = map (\td -> (P.tydeclIdent td, P.tydeclType td)) . P.getTypeDeclaration
 
 -- | Given a surrounding Sourcespan and a Declaration from the PS AST, extracts
 -- definition sites inside that Declaration.
@@ -107,6 +106,6 @@ extractSpans d = case d of
     -- declarations for non-typeclass members, which is why we can't handle them
     -- in extractSpans.
     extractSpans' dP = case dP of
-      P.TypeDeclaration (ss', _) ident _ ->
+      P.TypeDeclaration (P.TypeDeclarationData (ss', _) ident _) ->
         [(IdeNamespaced IdeNSValue (P.runIdent ident), ss')]
       _ -> []

--- a/src/Language/PureScript/Interactive/Completion.hs
+++ b/src/Language/PureScript/Interactive/Completion.hs
@@ -206,7 +206,7 @@ identNames = nubOnFst . concatMap getDeclNames . P.exportedDeclarations
   where
   getDeclNames :: P.Declaration -> [(P.Ident, P.Declaration)]
   getDeclNames d@(P.ValueDeclaration _ ident _ _ _)  = [(ident, d)]
-  getDeclNames d@(P.TypeDeclaration _ ident _ ) = [(ident, d)]
+  getDeclNames d@(P.TypeDeclaration td) = [(P.tydeclIdent td, d)]
   getDeclNames d@(P.ExternDeclaration _ ident _) = [(ident, d)]
   getDeclNames d@(P.TypeClassDeclaration _ _ _ _ _ ds) = map (second (const d)) $ concatMap getDeclNames ds
   getDeclNames _ = []

--- a/src/Language/PureScript/Interactive/Module.hs
+++ b/src/Language/PureScript/Interactive/Module.hs
@@ -52,13 +52,14 @@ createTemporaryModule exec PSCiState{psciImportedModules = imports, psciLetBindi
     eval          = P.Var (P.Qualified (Just (P.ModuleName [P.ProperName "$Support"])) (P.Ident "eval"))
     mainValue     = P.App eval (P.Var (P.Qualified Nothing (P.Ident "it")))
     itDecl        = P.ValueDeclaration (internalSpan, []) (P.Ident "it") P.Public [] [P.MkUnguarded val]
-    typeDecl      = P.TypeDeclaration (internalSpan, []) (P.Ident "$main")
-                      (P.TypeApp
+    typeDecl      = P.TypeDeclaration
+                      (P.TypeDeclarationData (internalSpan, []) (P.Ident "$main")
                         (P.TypeApp
-                          (P.TypeConstructor
-                            (P.Qualified (Just (P.ModuleName [P.ProperName "$Eff"])) (P.ProperName "Eff")))
-                              (P.TypeWildcard internalSpan))
+                          (P.TypeApp
+                            (P.TypeConstructor
+                              (P.Qualified (Just (P.ModuleName [P.ProperName "$Eff"])) (P.ProperName "Eff")))
                                 (P.TypeWildcard internalSpan))
+                                  (P.TypeWildcard internalSpan)))
     mainDecl      = P.ValueDeclaration (internalSpan, []) (P.Ident "$main") P.Public [] [P.MkUnguarded mainValue]
     decls         = if exec then [itDecl, typeDecl, mainDecl] else [itDecl]
   in

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -49,7 +49,7 @@ lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDecl
 
     f' :: S.Set Text -> Declaration -> MultipleErrors
     f' s dec@(ValueDeclaration _ name _ _ _) = addHint (ErrorInValueDeclaration name) (warningsInDecl moduleNames dec <> checkTypeVarsInDecl s dec)
-    f' s (TypeDeclaration _ name ty) = addHint (ErrorInTypeDeclaration name) (checkTypeVars s ty)
+    f' s (TypeDeclaration td) = addHint (ErrorInTypeDeclaration (tydeclIdent td)) (checkTypeVars s (tydeclType td))
     f' s dec = warningsInDecl moduleNames dec <> checkTypeVarsInDecl s dec
 
     stepE :: S.Set Ident -> Expr -> MultipleErrors

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -59,7 +59,7 @@ parseTypeDeclaration :: TokenParser Declaration
 parseTypeDeclaration = withSourceAnnF $ do
   name <- P.try (parseIdent <* indented <* doubleColon)
   ty <- parsePolyType
-  return $ \sa -> TypeDeclaration sa name ty
+  return $ \sa -> TypeDeclaration (TypeDeclarationData sa name ty)
 
 parseTypeSynonymDeclaration :: TokenParser Declaration
 parseTypeSynonymDeclaration = withSourceAnnF $ do

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -122,8 +122,8 @@ prettyPrintLiteralValue d (ObjectLiteral ps) = prettyPrintObject (d - 1) $ secon
 
 prettyPrintDeclaration :: Int -> Declaration -> Box
 prettyPrintDeclaration d _ | d < 0 = ellipsis
-prettyPrintDeclaration _ (TypeDeclaration _ ident ty) =
-  text (T.unpack (showIdent ident) ++ " :: ") <> typeAsBox ty
+prettyPrintDeclaration _ (TypeDeclaration td) =
+  text (T.unpack (showIdent (tydeclIdent td)) ++ " :: ") <> typeAsBox (tydeclType td)
 prettyPrintDeclaration d (ValueDeclaration _ ident _ [] [GuardedExpr [] val]) =
   text (T.unpack (showIdent ident) ++ " = ") <> prettyPrintValue (d - 1) val
 prettyPrintDeclaration d (BindingGroupDeclaration ds) =

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -216,9 +216,9 @@ renameInModule imports (Module modSS coms mn decls exps) =
         <*> updateClassName cn ss
         <*> traverse (updateTypesEverywhere ss) ts
         <*> pure ds
-  updateDecl bound (TypeDeclaration sa@(ss, _) name ty) =
+  updateDecl bound (TypeDeclaration (TypeDeclarationData sa@(ss, _) name ty)) =
     fmap (bound,) $
-      TypeDeclaration sa name
+      TypeDeclaration . TypeDeclarationData sa name
         <$> updateTypesEverywhere ss ty
   updateDecl bound (ExternDeclaration sa@(ss, _) name ty) =
     fmap (name : bound,) $

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -37,7 +37,7 @@ findExportable (Module _ _ mn ds _) =
     exps' <- rethrowWithPosition ss $ exportTypeClass Internal exps tcn mn
     foldM go exps' ds'
     where
-    go exps'' (TypeDeclaration (ss', _) name _) = rethrowWithPosition ss' $ exportValue exps'' name mn
+    go exps'' (TypeDeclaration (TypeDeclarationData (ss', _) name _)) = rethrowWithPosition ss' $ exportValue exps'' name mn
     go _ _ = internalError "Invalid declaration in TypeClassDeclaration"
   updateExports exps (DataDeclaration _ _ tn _ dcs) =
     exportType Internal exps tn (map fst dcs) mn

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -340,8 +340,8 @@ updateTypes goType = (goDecl, goExpr, goBinder)
     return $ TypeInstanceDeclaration sa name cs' className tys' impls
   goDecl (TypeSynonymDeclaration sa@(ss, _) name args ty) =
     TypeSynonymDeclaration sa name args <$> goType'' ss ty
-  goDecl (TypeDeclaration sa@(ss, _) expr ty) =
-    TypeDeclaration sa expr <$> goType'' ss ty
+  goDecl (TypeDeclaration (TypeDeclarationData sa@(ss, _) expr ty)) =
+    TypeDeclaration . TypeDeclarationData sa expr <$> goType'' ss ty
   goDecl other =
     return other
 

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -222,7 +222,7 @@ desugarDecl mn exps = go
   genSpan = internalModuleSourceSpan "<generated>"
 
 memberToNameAndType :: Declaration -> (Ident, Type)
-memberToNameAndType (TypeDeclaration td) = (tydeclIdent td, tydeclType td)
+memberToNameAndType (TypeDeclaration td) = unwrapTypeDeclaration td
 memberToNameAndType _ = internalError "Invalid declaration in type class definition"
 
 typeClassDictionaryDeclaration

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -16,7 +16,7 @@ import           Control.Monad.State
 import           Control.Monad.Supply.Class
 import           Data.List ((\\), find, sortBy)
 import qualified Data.Map as M
-import           Data.Maybe (catMaybes, mapMaybe, isJust)
+import           Data.Maybe (catMaybes, mapMaybe, isJust, fromMaybe)
 import           Data.Text (Text)
 import qualified Language.PureScript.Constants as C
 import           Language.PureScript.Crash
@@ -222,7 +222,7 @@ desugarDecl mn exps = go
   genSpan = internalModuleSourceSpan "<generated>"
 
 memberToNameAndType :: Declaration -> (Ident, Type)
-memberToNameAndType (TypeDeclaration _ ident ty) = (ident, ty)
+memberToNameAndType (TypeDeclaration td) = (tydeclIdent td, tydeclType td)
 memberToNameAndType _ = internalError "Invalid declaration in type class definition"
 
 typeClassDictionaryDeclaration
@@ -247,7 +247,7 @@ typeClassMemberToDictionaryAccessor
   -> [(Text, Maybe Kind)]
   -> Declaration
   -> Declaration
-typeClassMemberToDictionaryAccessor mn name args (TypeDeclaration sa ident ty) =
+typeClassMemberToDictionaryAccessor mn name args (TypeDeclaration (TypeDeclarationData sa ident ty)) =
   let className = Qualified (Just mn) name
   in ValueDeclaration sa ident Private [] $
     [MkUnguarded (
@@ -306,21 +306,19 @@ typeInstanceDictionaryDeclaration sa name mn deps className tys decls =
 
   where
 
-  declIdent :: Declaration -> Maybe Ident
-  declIdent (ValueDeclaration _ ident _ _ _) = Just ident
-  declIdent (TypeDeclaration _ ident _) = Just ident
-  declIdent _ = Nothing
-
   memberToValue :: [(Ident, Type)] -> Declaration -> Desugar m Expr
   memberToValue tys' (ValueDeclaration _ ident _ [] [MkUnguarded val]) = do
     _ <- maybe (throwError . errorMessage $ ExtraneousClassMember ident className) return $ lookup ident tys'
     return val
   memberToValue _ _ = internalError "Invalid declaration in type instance definition"
 
+declIdent :: Declaration -> Maybe Ident
+declIdent (ValueDeclaration _ ident _ _ _) = Just ident
+declIdent (TypeDeclaration td) = Just (tydeclIdent td)
+declIdent _ = Nothing
+
 typeClassMemberName :: Declaration -> Text
-typeClassMemberName (TypeDeclaration _ ident _) = runIdent ident
-typeClassMemberName (ValueDeclaration _ ident _ _ _) = runIdent ident
-typeClassMemberName _ = internalError "typeClassMemberName: Invalid declaration in type class definition"
+typeClassMemberName = fromMaybe (internalError "typeClassMemberName: Invalid declaration in type class definition") . fmap runIdent . declIdent
 
 superClassDictionaryNames :: [Constraint] -> [Text]
 superClassDictionaryNames supers =

--- a/src/Language/PureScript/Sugar/TypeDeclarations.hs
+++ b/src/Language/PureScript/Sugar/TypeDeclarations.hs
@@ -29,7 +29,7 @@ desugarTypeDeclarationsModule (Module modSS coms name ds exps) =
   where
 
   desugarTypeDeclarations :: [Declaration] -> m [Declaration]
-  desugarTypeDeclarations (TypeDeclaration sa name' ty : d : rest) = do
+  desugarTypeDeclarations (TypeDeclaration (TypeDeclarationData sa name' ty) : d : rest) = do
     (_, nameKind, val) <- fromValueDeclaration d
     desugarTypeDeclarations (ValueDeclaration sa name' nameKind [] [MkUnguarded (TypedValue True val ty)] : rest)
     where
@@ -38,7 +38,7 @@ desugarTypeDeclarationsModule (Module modSS coms name ds exps) =
       | name' == name'' = return (name'', nameKind, val)
     fromValueDeclaration d' =
       throwError . errorMessage' (declSourceSpan d') $ OrphanTypeDeclaration name'
-  desugarTypeDeclarations [TypeDeclaration (ss, _) name' _] =
+  desugarTypeDeclarations [TypeDeclaration (TypeDeclarationData (ss, _) name' _)] =
     throwError . errorMessage' ss $ OrphanTypeDeclaration name'
   desugarTypeDeclarations (ValueDeclaration sa name' nameKind bs val : rest) = do
     let (_, f, _) = everywhereOnValuesTopDownM return go return

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -140,7 +140,7 @@ addTypeClass moduleName pn args implies dependencies ds = do
     argToIndex :: Text -> Maybe Int
     argToIndex = flip M.lookup $ M.fromList (zipWith ((,) . fst) args [0..])
 
-    toPair (TypeDeclaration _ ident ty) = (ident, ty)
+    toPair (TypeDeclaration (TypeDeclarationData _ ident ty)) = (ident, ty)
     toPair _ = internalError "Invalid declaration in TypeClassDeclaration"
 
     -- Currently we are only checking usability based on the type class currently
@@ -493,6 +493,6 @@ typeCheckModule (Module ss coms mn decls (Just exps)) =
     findClassMembers (TypeClassDeclaration _ name' _ _ _ ds) | name == name' = Just $ map extractMemberName ds
     findClassMembers _ = Nothing
     extractMemberName :: Declaration -> Ident
-    extractMemberName (TypeDeclaration _ memberName _) = memberName
+    extractMemberName (TypeDeclaration td) = tydeclIdent td
     extractMemberName _ = internalError "Unexpected declaration in typeclass member list"
   checkClassMembersAreExported _ = return ()

--- a/tests/Language/PureScript/Ide/SourceFileSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFileSpec.hs
@@ -22,7 +22,7 @@ ann1 = (span1, [])
 ann2 = (span2, [])
 
 typeAnnotation1, value1, synonym1, class1, class2, data1, data2, valueFixity, typeFixity, foreign1, foreign2, foreign3, member1 :: P.Declaration
-typeAnnotation1 = P.TypeDeclaration ann1 (P.Ident "value1") P.REmpty
+typeAnnotation1 = P.TypeDeclaration (P.TypeDeclarationData ann1 (P.Ident "value1") P.REmpty)
 value1 = P.ValueDeclaration ann1 (P.Ident "value1") P.Public [] []
 synonym1 = P.TypeSynonymDeclaration ann1 (P.ProperName "Synonym1") [] P.REmpty
 class1 = P.TypeClassDeclaration ann1 (P.ProperName "Class1") [] [] [] []
@@ -44,7 +44,7 @@ typeFixity =
 foreign1 = P.ExternDeclaration ann1 (P.Ident "foreign1") P.REmpty
 foreign2 = P.ExternDataDeclaration ann1 (P.ProperName "Foreign2") P.kindType
 foreign3 = P.ExternKindDeclaration ann1 (P.ProperName "Foreign3")
-member1 = P.TypeDeclaration ann2 (P.Ident "member1") P.REmpty
+member1 = P.TypeDeclaration (P.TypeDeclarationData ann2 (P.Ident "member1") P.REmpty)
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
This is a first foray into one of the changes suggested in #3023. I just picked TypeDeclarations, because they seemed like a simple enough data type. We'll have to decide if it's worth doing this for all the constructors and if we can improve the ergonomics around it with patterns. While doing this change I already spotted some opportunities for decreasing partiality around type class declarations.