### PR TITLE
Improves ExternsFile parse errors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -53,6 +53,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@izgzhen](https://github.com/izgzhen) | Zhen Zhang | [MIT license](http://opensource.org/licenses/MIT) |
 | [@jacereda](https://github.com/jacereda) | Jorge Acereda | [MIT license](http://opensource.org/licenses/MIT) |
 | [@japesinator](https://github.com/japesinator) | JP Smith | [MIT license](http://opensource.org/licenses/MIT) |
+| [@jkachmar](https://github.com/jkachmar) | Joe Kachmar | MIT license |
 | [@joneshf](https://github.com/joneshf) | Hardy Jones | MIT license |
 | [@kika](https://github.com/kika) | Kirill Pertsev | MIT license |
 | [@kRITZCREEK](https://github.com/kRITZCREEK) | Christoph Hegemann | MIT license |

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -24,6 +24,7 @@ import           Protolude hiding (to, from, (&))
 import           Control.Lens
 import           "monad-logger" Control.Monad.Logger
 import           Data.Aeson (decodeStrict)
+import           Data.Aeson.Types (withObject, parseMaybe, (.:))
 import qualified Data.ByteString as BS
 import           Data.Version (showVersion)
 import           Language.PureScript.Ide.Error (IdeError (..))
@@ -36,16 +37,19 @@ readExternFile
   => FilePath
   -> m P.ExternsFile
 readExternFile fp = do
-   parseResult <- liftIO (decodeStrict <$> BS.readFile fp)
-   case parseResult of
+   externsFile <- liftIO (BS.readFile fp)
+   case (decodeStrict externsFile) of
      Nothing ->
-       throwError (GeneralError
-                   ("Parsing the extern at: " <> toS fp <> " failed"))
-     Just externs
-       | P.efVersion externs /= version -> do
+       let parser = withObject "ExternsFileVersion" $ \o -> o .: "efVersion"
+           maybeEFVersion = parseMaybe parser =<< decodeStrict externsFile
+       in case maybeEFVersion of
+         Nothing ->
+            throwError (GeneralError
+                        ("Parsing the extern at: " <> toS fp <> " failed"))
+         Just efVersion -> do
            let errMsg = "Version mismatch for the externs at: " <> toS fp
                         <> " Expected: " <> version
-                        <> " Found: " <> P.efVersion externs
+                        <> " Found: " <> efVersion
            logErrorN errMsg
            throwError (GeneralError errMsg)
      Just externs -> pure externs

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -38,7 +38,7 @@ readExternFile
   -> m P.ExternsFile
 readExternFile fp = do
    externsFile <- liftIO (BS.readFile fp)
-   case (decodeStrict externsFile) of
+   case decodeStrict externsFile of
      Nothing ->
        let parser = withObject "ExternsFileVersion" $ \o -> o .: "efVersion"
            maybeEFVersion = parseMaybe parser =<< decodeStrict externsFile


### PR DESCRIPTION
Took a quick pass at this, behavior's pretty much unchanged except that it parses the `efVersion` field directly so we can get better errors even if the entire `externs.json` doesn't successfully parse.

Tests pass, and it looks good from poking at it in the REPL.

Addresses #3036 