### PR TITLE
Add `:complete` directive to psci

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@ If you would prefer to use different terms, please use the section below instead
 | Username | Name | License |
 | :------- | :--- | :------ |
 | [@5outh](https://github.com/5outh) | Benjamin Kovach | MIT license |
+| [@actionshrimp](https://github.com/actionshrimp) | David Aitken | [MIT license](http://opensource.org/licenses/MIT) |
 | [@alexbiehl](https://github.com/alexbiehl) | Alexander Biehl | [MIT license](http://opensource.org/licenses/MIT) |
 | [@andreypopp](https://github.com/andreypopp) | Andrey Popp | MIT license |
 | [@andyarvanitis](https://github.com/andyarvanitis) | Andy Arvanitis | [MIT license](http://opensource.org/licenses/MIT) |

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -110,7 +110,7 @@ handleCommand _ _ p (KindOf typ)              = handleKindOf p typ
 handleCommand _ _ p (BrowseModule moduleName) = handleBrowse p moduleName
 handleCommand _ _ p (ShowInfo QueryLoaded)    = handleShowLoadedModules p
 handleCommand _ _ p (ShowInfo QueryImport)    = handleShowImportedModules p
-handleCommand _ _ p (CompleteStr semiExpr)    = handleComplete p semiExpr
+handleCommand _ _ p (CompleteStr prefix)      = handleComplete p prefix
 handleCommand _ _ _ _                         = P.internalError "handleCommand: unexpected command"
 
 -- | Reload the application state
@@ -315,8 +315,8 @@ handleComplete
   => (String -> m ())
   -> String
   -> m ()
-handleComplete print' semiExpr = do
+handleComplete print' prefix = do
   st <- get
-  let act = liftCompletionM (completion' (reverse semiExpr, ""))
+  let act = liftCompletionM (completion' (reverse prefix, ""))
   results <- evalStateT act st
   print' $ unlines (formatCompletions results)

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -24,7 +24,7 @@ import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.State.Class
 import           Control.Monad.Reader.Class
 import           Control.Monad.Trans.Except (ExceptT(..), runExceptT)
-import           Control.Monad.Trans.State.Strict (StateT, runStateT)
+import           Control.Monad.Trans.State.Strict (StateT, runStateT, evalStateT)
 import           Control.Monad.Writer.Strict (Writer(), runWriter)
 
 import qualified Language.PureScript as P
@@ -110,6 +110,7 @@ handleCommand _ _ p (KindOf typ)              = handleKindOf p typ
 handleCommand _ _ p (BrowseModule moduleName) = handleBrowse p moduleName
 handleCommand _ _ p (ShowInfo QueryLoaded)    = handleShowLoadedModules p
 handleCommand _ _ p (ShowInfo QueryImport)    = handleShowImportedModules p
+handleCommand _ _ p (CompleteStr semiExpr)    = handleComplete p semiExpr
 handleCommand _ _ _ _                         = P.internalError "handleCommand: unexpected command"
 
 -- | Reload the application state
@@ -307,3 +308,17 @@ handleBrowse print' moduleName = do
         print' $ T.unpack $ "Module '" <> N.runModuleName modName <> "' is not valid."
     lookupUnQualifiedModName quaModName st =
         (\(modName,_,_) -> modName) <$> find ( \(_, _, mayQuaName) -> mayQuaName == Just quaModName) (psciImportedModules st)
+
+-- | Return output as would be returned by tab completion, for tools integration etc.
+handleComplete
+  :: (MonadState PSCiState m, MonadIO m)
+  => (String -> m ())
+  -> String
+  -> m ()
+handleComplete print' semiExpr = do
+  st <- get
+  let act = liftCompletionM (completion' (reverse semiExpr, ""))
+  (unusedR, completions) <- evalStateT act st
+  let unused = reverse unusedR
+  let actuals = map ((unused ++) . replacement) completions
+  print' $ unlines actuals

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -318,7 +318,5 @@ handleComplete
 handleComplete print' semiExpr = do
   st <- get
   let act = liftCompletionM (completion' (reverse semiExpr, ""))
-  (unusedR, completions) <- evalStateT act st
-  let unused = reverse unusedR
-  let actuals = map ((unused ++) . replacement) completions
-  print' $ unlines actuals
+  results <- evalStateT act st
+  print' $ unlines (formatCompletions results)

--- a/src/Language/PureScript/Interactive/Completion.hs
+++ b/src/Language/PureScript/Interactive/Completion.hs
@@ -3,6 +3,7 @@ module Language.PureScript.Interactive.Completion
   , liftCompletionM
   , completion
   , completion'
+  , replacement
   ) where
 
 import Prelude.Compat
@@ -128,6 +129,7 @@ directiveArg _ Paste       = []
 directiveArg _ Show        = map CtxFixed replQueryStrings
 directiveArg _ Type        = [CtxIdentifier]
 directiveArg _ Kind        = [CtxType]
+directiveArg _ Complete    = []
 
 completeImport :: [String] -> String -> [CompletionContext]
 completeImport ws w' =

--- a/src/Language/PureScript/Interactive/Completion.hs
+++ b/src/Language/PureScript/Interactive/Completion.hs
@@ -3,7 +3,7 @@ module Language.PureScript.Interactive.Completion
   , liftCompletionM
   , completion
   , completion'
-  , replacement
+  , formatCompletions
   ) where
 
 import Prelude.Compat
@@ -85,6 +85,14 @@ findCompletions prev word = do
       go (':' : _) _ = LT
       go _ (':' : _) = GT
       go xs ys = compare xs ys
+
+-- |
+-- Convert Haskeline completion result to results as they would be displayed
+formatCompletions :: (String, [Completion]) -> [String]
+formatCompletions (unusedR, completions) = actuals
+  where
+    unused = reverse unusedR
+    actuals = map ((unused ++) . replacement) completions
 
 data CompletionContext
   = CtxDirective String

--- a/src/Language/PureScript/Interactive/Directive.hs
+++ b/src/Language/PureScript/Interactive/Directive.hs
@@ -23,15 +23,16 @@ directives = map fst directiveStrings
 --
 directiveStrings :: [(Directive, [String])]
 directiveStrings =
-    [ (Help   , ["?", "help"])
-    , (Quit   , ["quit"])
-    , (Reload , ["reload"])
-    , (Clear  , ["clear"])
-    , (Browse , ["browse"])
-    , (Type   , ["type"])
-    , (Kind   , ["kind"])
-    , (Show   , ["show"])
-    , (Paste  , ["paste"])
+    [ (Help      , ["?", "help"])
+    , (Quit      , ["quit"])
+    , (Reload    , ["reload"])
+    , (Clear     , ["clear"])
+    , (Browse    , ["browse"])
+    , (Type      , ["type"])
+    , (Kind      , ["kind"])
+    , (Show      , ["show"])
+    , (Paste     , ["paste"])
+    , (Complete  , ["complete"])
     ]
 
 -- |
@@ -93,14 +94,16 @@ hasArgument _ = True
 --
 help :: [(Directive, String, String)]
 help =
-  [ (Help,    "",         "Show this help menu")
-  , (Quit,    "",         "Quit PSCi")
-  , (Reload,  "",         "Reload all imported modules while discarding bindings")
-  , (Clear,   "",         "Discard all imported modules and declared bindings")
-  , (Browse,  "<module>", "See all functions in <module>")
-  , (Type,    "<expr>",   "Show the type of <expr>")
-  , (Kind,    "<type>",   "Show the kind of <type>")
-  , (Show,    "import",   "Show all imported modules")
-  , (Show,    "loaded",   "Show all loaded modules")
-  , (Paste,   "paste",    "Enter multiple lines, terminated by ^D")
+  [ (Help,     "",          "Show this help menu")
+  , (Quit,     "",          "Quit PSCi")
+  , (Reload,   "",          "Reload all imported modules while discarding bindings")
+  , (Clear,    "",          "Discard all imported modules and declared bindings")
+  , (Browse,   "<module>",  "See all functions in <module>")
+  , (Type,     "<expr>",    "Show the type of <expr>")
+  , (Kind,     "<type>",    "Show the kind of <type>")
+  , (Show,     "import",    "Show all imported modules")
+  , (Show,     "loaded",    "Show all loaded modules")
+  , (Paste,    "paste",     "Enter multiple lines, terminated by ^D")
+  , (Complete, "<(expr?)>", "Show completion output as if pressing tab")
   ]
+

--- a/src/Language/PureScript/Interactive/Directive.hs
+++ b/src/Language/PureScript/Interactive/Directive.hs
@@ -104,6 +104,6 @@ help =
   , (Show,     "import",    "Show all imported modules")
   , (Show,     "loaded",    "Show all loaded modules")
   , (Paste,    "paste",     "Enter multiple lines, terminated by ^D")
-  , (Complete, "<(expr?)>", "Show completion output as if pressing tab")
+  , (Complete, "<prefix>",  "Show completions for <prefix> as if pressing tab")
   ]
 

--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -58,7 +58,7 @@ parseDirective cmd =
     ds       -> Left ("Ambiguous directive. Possible matches: " ++
                   intercalate ", " (map snd ds) ++ ". Type :? for help.")
   where
-  (dstr, arg) = break isSpace cmd
+  (dstr, arg) = trim <$> break isSpace cmd
 
   commandFor d = case d of
     Help     -> return ShowHelp
@@ -67,10 +67,10 @@ parseDirective cmd =
     Clear    -> return ClearState
     Paste    -> return PasteLines
     Browse   -> BrowseModule <$> parseRest P.moduleName arg
-    Show     -> ShowInfo <$> parseReplQuery' (trim arg)
+    Show     -> ShowInfo <$> parseReplQuery' arg
     Type     -> TypeOf <$> parseRest P.parseValue arg
     Kind     -> KindOf <$> parseRest P.parseType arg
-    Complete -> CompleteStr <$> Right (trim arg)
+    Complete -> return (CompleteStr arg)
 -- |
 -- Parses expressions entered at the PSCI repl.
 --

--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -61,16 +61,16 @@ parseDirective cmd =
   (dstr, arg) = break isSpace cmd
 
   commandFor d = case d of
-    Help    -> return ShowHelp
-    Quit    -> return QuitPSCi
-    Reload  -> return ReloadState
-    Clear   -> return ClearState
-    Paste   -> return PasteLines
-    Browse  -> BrowseModule <$> parseRest P.moduleName arg
-    Show    -> ShowInfo <$> parseReplQuery' (trim arg)
-    Type    -> TypeOf <$> parseRest P.parseValue arg
-    Kind    -> KindOf <$> parseRest P.parseType arg
-
+    Help     -> return ShowHelp
+    Quit     -> return QuitPSCi
+    Reload   -> return ReloadState
+    Clear    -> return ClearState
+    Paste    -> return PasteLines
+    Browse   -> BrowseModule <$> parseRest P.moduleName arg
+    Show     -> ShowInfo <$> parseReplQuery' (trim arg)
+    Type     -> TypeOf <$> parseRest P.parseValue arg
+    Kind     -> KindOf <$> parseRest P.parseType arg
+    Complete -> CompleteStr <$> Right arg
 -- |
 -- Parses expressions entered at the PSCI repl.
 --

--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -70,7 +70,7 @@ parseDirective cmd =
     Show     -> ShowInfo <$> parseReplQuery' (trim arg)
     Type     -> TypeOf <$> parseRest P.parseValue arg
     Kind     -> KindOf <$> parseRest P.parseType arg
-    Complete -> CompleteStr <$> Right arg
+    Complete -> CompleteStr <$> Right (trim arg)
 -- |
 -- Parses expressions entered at the PSCI repl.
 --

--- a/src/Language/PureScript/Interactive/Types.hs
+++ b/src/Language/PureScript/Interactive/Types.hs
@@ -96,6 +96,8 @@ data Command
   | ShowInfo ReplQuery
   -- | Paste multiple lines
   | PasteLines
+  -- | Return auto-completion output as if pressing <tab>
+  | CompleteStr String
   deriving Show
 
 data ReplQuery
@@ -129,4 +131,5 @@ data Directive
   | Kind
   | Show
   | Paste
+  | Complete
   deriving (Eq, Show)

--- a/tests/TestPsci/CommandTest.hs
+++ b/tests/TestPsci/CommandTest.hs
@@ -32,3 +32,9 @@ commandTests = context "commandTests" $ do
     run ":reload"
     ms' <- psciImportedModules <$> get
     length ms' `equalsTo` 3
+
+  specPSCi ":complete" $ do
+    ":complete ma" `prints` []
+    ":complete Data.Functor.ma" `prints` (map ("Data.Functor." ++ ) ["map", "mapFlipped"])
+    run "import Data.Functor"
+    ":complete ma" `prints` ["map", "mapFlipped"]

--- a/tests/TestPsci/CommandTest.hs
+++ b/tests/TestPsci/CommandTest.hs
@@ -35,6 +35,6 @@ commandTests = context "commandTests" $ do
 
   specPSCi ":complete" $ do
     ":complete ma" `prints` []
-    ":complete Data.Functor.ma" `prints` (map ("Data.Functor." ++ ) ["map", "mapFlipped"])
+    ":complete Data.Functor.ma" `prints` (unlines (map ("Data.Functor." ++ ) ["map", "mapFlipped"]))
     run "import Data.Functor"
-    ":complete ma" `prints` ["map", "mapFlipped"]
+    ":complete ma" `prints` (unlines ["map", "mapFlipped"])

--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -12,7 +12,6 @@ import           Data.List (sort)
 import qualified Data.Text as T
 import qualified Language.PureScript as P
 import           Language.PureScript.Interactive
-import           System.Console.Haskeline
 import           TestPsci.TestEnv (initTestPSCiEnv)
 import           TestUtils (getSupportModuleNames)
 
@@ -29,7 +28,7 @@ completionTestData supportModuleNames =
   -- basic directives
   [ (":h",  [":help"])
   , (":r",  [":reload"])
-  , (":c",  [":clear"])
+  , (":c",  [":clear", ":complete"])
   , (":q",  [":quit"])
   , (":b",  [":browse"])
 

--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -87,9 +87,8 @@ completionTestData supportModuleNames =
 
 assertCompletedOk :: (String, [String]) -> Spec
 assertCompletedOk (line, expecteds) = specify line $ do
-  (unusedR, completions) <- runCM (completion' (reverse line, ""))
-  let unused = reverse unusedR
-  let actuals = map ((unused ++) . replacement) completions
+  results <- runCM (completion' (reverse line, ""))
+  let actuals = formatCompletions results
   sort expecteds `shouldBe` sort actuals
 
 runCM :: CompletionM a -> IO a

--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -89,7 +89,7 @@ assertCompletedOk :: (String, [String]) -> Spec
 assertCompletedOk (line, expecteds) = specify line $ do
   results <- runCM (completion' (reverse line, ""))
   let actuals = formatCompletions results
-  sort expecteds `shouldBe` sort actuals
+  sort actuals `shouldBe` sort expecteds
 
 runCM :: CompletionM a -> IO a
 runCM act = do

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -86,9 +86,9 @@ evaluatesTo command expected = runAndEval command eval evalPrinted
       actual `equalsTo` (expected ++ "\n")
     evalPrinted _ = return ()
 
-prints :: String -> [String] -> TestPSCi ()
+prints :: String -> String -> TestPSCi ()
 prints command expected = runAndEval command eval evalPrinted
   where
     eval = return ()
-    evalPrinted s = s `equalsTo` (unlines (map (" " ++) expected))
+    evalPrinted s = s `equalsTo` expected
 

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -90,7 +90,7 @@ evaluatesTo command expected = runAndEval command evalJsAndCompare ignorePrinted
 
 -- | An assertion to check command PSCi printed output against a given string
 prints :: String -> String -> TestPSCi ()
-prints command expected = runAndEval command skipEval evalPrinted
+prints command expected = runAndEval command evalJsAndIgnore evalPrinted
   where
-    skipEval = return ()
+    evalJsAndIgnore = jsEval *> return ()
     evalPrinted s = s `equalsTo` expected

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -56,7 +56,8 @@ jsEval = liftIO $ do
     Just (ExitFailure _, _, err) -> putStrLn err >> exitFailure
     Nothing                      -> putStrLn "Couldn't find node.js" >> exitFailure
 
--- | Run a PSCi command and evaluate the output with 'eval'.
+-- | Run a PSCi command and evaluate the output with 'eval', and the
+-- printed-to-console output with 'evalPrinted'
 runAndEval :: String -> TestPSCi () -> (String -> TestPSCi ()) -> TestPSCi ()
 runAndEval comm eval evalPrinted =
   case parseCommand comm of


### PR DESCRIPTION
Some wrappers around psci (such as [emacs-psci](https://github.com/ardumont/emacs-psci)) are [unable to hook into the tab-complete functionality](https://stackoverflow.com/questions/20396698/get-tab-completion-in-custom-comint-mode) provided by psci. There is some basic tab completion in emacs-psci but it currently seems to work only on filenames as far as I'm able to work out.

This exposes the completions produced usually by hitting tab to the normal eval/print mechanism via a `:complete` directive so they can be accessed by these kinds of tools (inspired by https://github.com/commercialhaskell/intero/blob/master/elisp/intero.el#L819).

I have a feeling there might be a plan afoot to have psc-ide take over more of these responsibilities in the future? Hopefully this will be able to serve as a stop-gap as the functionality is already tucked away inside psci 😃