### PR TITLE
[psc-ide] Make `type` command's `filters` param optional to align with doc

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -108,6 +108,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@utkarshkukreti](https://github.com/utkarshkukreti) | Utkarsh Kukreti | [MIT license](http://opensource.org/licenses/MIT) |
 | [@vkorablin](https://github.com/vkorablin) | Vladimir Korablin | MIT license |
 | [@zudov](https://github.com/zudov) | Konstantin Zudov | [MIT license](http://opensource.org/licenses/MIT) |
+| [@b123400](https://github.com/b123400) | b123400 | [MIT license](https://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms
 

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -131,7 +131,7 @@ instance FromJSON Command where
         params <- o .: "params"
         Type
           <$> params .: "search"
-          <*> params .: "filters"
+          <*> params .:? "filters" .!= []
           <*> (fmap P.moduleNameFromString <$> params .:? "currentModule")
       "complete" -> do
         params <- o .: "params"


### PR DESCRIPTION
[The doc](https://github.com/purescript/purescript/blob/master/psc-ide/PROTOCOL.md#type) says type's `filters` param is optional but it is currently not.