### PR TITLE
bump glob dependency

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -52,7 +52,7 @@ dependencies:
   - file-embed
   - filepath
   - fsnotify >=0.2.1
-  - Glob >=0.7 && <0.8
+  - Glob >=0.7 && <0.9
   - haskeline >=0.7.0.0
   - http-client >=0.4.30 && <0.6.0
   - http-types


### PR DESCRIPTION
Allows glob 0.8. The upper bound caused installing purescript@master to fail in nix.