### PR TITLE
[purs ide] Adds an `actualFile` parameter to the rebuild command

### DIFF
--- a/psc-ide/PROTOCOL.md
+++ b/psc-ide/PROTOCOL.md
@@ -326,12 +326,16 @@ identifiers.
 
 Arguments:
   - `file :: String` the path to the module to rebuild
+  - `actualFile :: Maybe String` Specifies the path to be used for location
+    information and parse errors. This is useful in case a temp file is used as
+    the source for a rebuild.
 
 ```json
 {
   "command": "rebuild",
   "params": {
     "file": "/path/to/file.purs"
+    "actualFile": "/path/to/actualFile.purs"
   }
 }
 ```

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -87,10 +87,10 @@ handleCommand c = case c of
       Right rs' -> answerRequest outfp rs'
       Left question ->
         pure (CompletionResult (map (completionFromMatch . simpleExport . map withEmptyAnn) question))
-  Rebuild file ->
-    rebuildFileAsync file
-  RebuildSync file ->
-    rebuildFileSync file
+  Rebuild file actualFile ->
+    rebuildFileAsync file actualFile
+  RebuildSync file actualFile ->
+    rebuildFileSync file actualFile
   Cwd ->
     TextResult . toS <$> liftIO getCurrentDirectory
   Reset ->

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -56,8 +56,8 @@ data Command
       -- Import InputFile OutputFile
     | Import FilePath (Maybe FilePath) [Filter] ImportCommand
     | List { listType :: ListType }
-    | Rebuild FilePath -- ^ Rebuild the specified file using the loaded externs
-    | RebuildSync FilePath -- ^ Rebuild the specified file using the loaded externs
+    | Rebuild FilePath (Maybe FilePath)
+    | RebuildSync FilePath (Maybe FilePath)
     | Cwd
     | Reset
     | Quit
@@ -169,6 +169,7 @@ instance FromJSON Command where
         params <- o .: "params"
         Rebuild
           <$> params .: "file"
+          <*> params .:? "actualFile"
       _ -> mzero
     where
       mkAnnotations True = explicitAnnotations

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -40,14 +40,16 @@ rebuildFile
   :: (Ide m, MonadLogger m, MonadError IdeError m)
   => FilePath
   -- ^ The file to rebuild
+  -> Maybe FilePath
+  -- ^ The file to use as the location for parsing and errors
   -> (ReaderT IdeEnvironment (LoggingT IO) () -> m ())
   -- ^ A runner for the second build with open exports
   -> m Success
-rebuildFile path runOpenBuild = do
+rebuildFile path actualPath runOpenBuild = do
 
   input <- ideReadFile path
 
-  m <- case snd <$> P.parseModuleFromFile identity (path, input) of
+  m <- case snd <$> P.parseModuleFromFile (maybe identity const actualPath) (path, input) of
     Left parseError ->
       throwError (RebuildError (P.MultipleErrors [P.toPositionedError parseError]))
     Right m -> pure m
@@ -74,7 +76,7 @@ rebuildFile path runOpenBuild = do
     Left errors -> throwError (RebuildError errors)
     Right newExterns -> do
       whenM isEditorMode $ do
-        insertModule (path, m)
+        insertModule (fromMaybe path actualPath, m)
         insertExterns newExterns
         void populateVolatileState
       runOpenBuild (rebuildModuleOpen makeEnv externs m)
@@ -85,8 +87,8 @@ isEditorMode = asks (confEditorMode . ideConfiguration)
 
 rebuildFileAsync
   :: forall m. (Ide m, MonadLogger m, MonadError IdeError m)
-  => FilePath -> m Success
-rebuildFileAsync fp = rebuildFile fp asyncRun
+  => FilePath -> Maybe FilePath -> m Success
+rebuildFileAsync fp fp' = rebuildFile fp fp' asyncRun
   where
     asyncRun :: ReaderT IdeEnvironment (LoggingT IO) () -> m ()
     asyncRun action = do
@@ -96,8 +98,8 @@ rebuildFileAsync fp = rebuildFile fp asyncRun
 
 rebuildFileSync
   :: forall m. (Ide m, MonadLogger m, MonadError IdeError m)
-  => FilePath -> m Success
-rebuildFileSync fp = rebuildFile fp syncRun
+  => FilePath -> Maybe FilePath -> m Success
+rebuildFileSync fp fp' = rebuildFile fp fp' syncRun
   where
     syncRun :: ReaderT IdeEnvironment (LoggingT IO) () -> m ()
     syncRun action = do

--- a/tests/Language/PureScript/Ide/RebuildSpec.hs
+++ b/tests/Language/PureScript/Ide/RebuildSpec.hs
@@ -4,6 +4,7 @@ module Language.PureScript.Ide.RebuildSpec where
 
 import           Protolude
 
+import           Language.PureScript.AST.SourcePos (spanName)
 import           Language.PureScript.Ide.Command
 import           Language.PureScript.Ide.Completion
 import           Language.PureScript.Ide.Matcher
@@ -16,10 +17,10 @@ load :: [Text] -> Command
 load = LoadSync . map Test.mn
 
 rebuild :: FilePath -> Command
-rebuild fp = Rebuild ("src" </> fp)
+rebuild fp = Rebuild ("src" </> fp) Nothing
 
 rebuildSync :: FilePath -> Command
-rebuildSync fp = RebuildSync ("src" </> fp)
+rebuildSync fp = RebuildSync ("src" </> fp) Nothing
 
 spec :: Spec
 spec = describe "Rebuilding single modules" $ do
@@ -60,3 +61,12 @@ spec = describe "Rebuilding single modules" $ do
         Test.runIde [ rebuildSync "RebuildSpecWithHiddenIdent.purs"
                     , Complete [] (flexMatcher "hid") (Just (Test.mn "RebuildSpecWithHiddenIdent")) defaultCompletionOptions]
       complIdentifier result `shouldBe` "hidden"
+    it "uses the specified `actualPath` for location information (in editor mode)" $ do
+      let editorConfig = Test.defConfig { confEditorMode = True }
+      ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
+        Test.runIde'
+          editorConfig
+          emptyIdeState
+          [ RebuildSync ("src" </> "RebuildSpecWithHiddenIdent.purs") (Just "actualPath")
+          , Complete [] (flexMatcher "hid") (Just (Test.mn "RebuildSpecWithHiddenIdent")) defaultCompletionOptions]
+      map spanName (complLocation result) `shouldBe` Just "actualPath"

--- a/tests/Language/PureScript/Ide/RebuildSpec.hs
+++ b/tests/Language/PureScript/Ide/RebuildSpec.hs
@@ -61,12 +61,12 @@ spec = describe "Rebuilding single modules" $ do
         Test.runIde [ rebuildSync "RebuildSpecWithHiddenIdent.purs"
                     , Complete [] (flexMatcher "hid") (Just (Test.mn "RebuildSpecWithHiddenIdent")) defaultCompletionOptions]
       complIdentifier result `shouldBe` "hidden"
-    it "uses the specified `actualPath` for location information (in editor mode)" $ do
+    it "uses the specified `actualFile` for location information (in editor mode)" $ do
       let editorConfig = Test.defConfig { confEditorMode = True }
       ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
         Test.runIde'
           editorConfig
           emptyIdeState
-          [ RebuildSync ("src" </> "RebuildSpecWithHiddenIdent.purs") (Just "actualPath")
+          [ RebuildSync ("src" </> "RebuildSpecWithHiddenIdent.purs") (Just "actualFile")
           , Complete [] (flexMatcher "hid") (Just (Test.mn "RebuildSpecWithHiddenIdent")) defaultCompletionOptions]
-      map spanName (complLocation result) `shouldBe` Just "actualPath"
+      map spanName (complLocation result) `shouldBe` Just "actualFile"


### PR DESCRIPTION
This allows us to specify the actual path of the source file (important for
declaration location information as well as correct parse error locations), in
case we are using a temp file for rebuilding.


Fixes #3033