### PR TITLE
Introduce data type for value declarations

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -443,10 +443,6 @@ data ValueDeclarationData a = ValueDeclarationData
   , valdeclExpression :: !a
   } deriving (Show)
 
-  -- |
-  -- A value declaration (name, top-level binders, optional guard, value)
-  --
-
 overValueDeclaration :: (ValueDeclarationData [GuardedExpr] -> ValueDeclarationData [GuardedExpr]) -> Declaration -> Declaration
 overValueDeclaration f d = maybe d (ValueDeclaration . f) (getValueDeclaration d)
 

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -441,7 +441,7 @@ data ValueDeclarationData a = ValueDeclarationData
   -- ^ Whether or not this value is exported/visible
   , valdeclBinders :: ![Binder]
   , valdeclExpression :: !a
-  } deriving (Show)
+  } deriving (Show, Functor, Foldable, Traversable)
 
 overValueDeclaration :: (ValueDeclarationData [GuardedExpr] -> ValueDeclarationData [GuardedExpr]) -> Declaration -> Declaration
 overValueDeclaration f d = maybe d (ValueDeclaration . f) (getValueDeclaration d)

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -428,6 +428,32 @@ getTypeDeclaration _ = Nothing
 unwrapTypeDeclaration :: TypeDeclarationData -> (Ident, Type)
 unwrapTypeDeclaration td = (tydeclIdent td, tydeclType td)
 
+-- | A value declaration assigns a name and potential binders, to an expression (or multiple guarded expressions).
+--
+-- @double x = x + x@
+--
+-- In this example @double@ is the identifier, @x@ is a binder and @x + x@ is the expression.
+data ValueDeclarationData a = ValueDeclarationData
+  { valdeclSourceAnn :: !SourceAnn
+  , valdeclIdent :: !Ident
+  -- ^ The declared value's name
+  , valdeclName :: !NameKind
+  -- ^ Whether or not this value is exported/visible
+  , valdeclBinders :: ![Binder]
+  , valdeclExpression :: !a
+  } deriving (Show)
+
+  -- |
+  -- A value declaration (name, top-level binders, optional guard, value)
+  --
+
+overValueDeclaration :: (ValueDeclarationData [GuardedExpr] -> ValueDeclarationData [GuardedExpr]) -> Declaration -> Declaration
+overValueDeclaration f d = maybe d (ValueDeclaration . f) (getValueDeclaration d)
+
+getValueDeclaration :: Declaration -> Maybe (ValueDeclarationData [GuardedExpr])
+getValueDeclaration (ValueDeclaration d) = Just d
+getValueDeclaration _ = Nothing
+
 -- |
 -- The data type of declarations
 --
@@ -451,7 +477,7 @@ data Declaration
   -- |
   -- A value declaration (name, top-level binders, optional guard, value)
   --
-  | ValueDeclaration SourceAnn Ident NameKind [Binder] [GuardedExpr]
+  | ValueDeclaration {-# UNPACK #-} !(ValueDeclarationData [GuardedExpr])
   -- |
   -- A declaration paired with pattern matching in let-in expression (binder, optional guard, value)
   | BoundValueDeclaration SourceAnn Binder Expr
@@ -528,7 +554,7 @@ declSourceAnn (DataDeclaration sa _ _ _ _) = sa
 declSourceAnn (DataBindingGroupDeclaration ds) = declSourceAnn (NEL.head ds)
 declSourceAnn (TypeSynonymDeclaration sa _ _ _) = sa
 declSourceAnn (TypeDeclaration td) = tydeclSourceAnn td
-declSourceAnn (ValueDeclaration sa _ _ _ _) = sa
+declSourceAnn (ValueDeclaration vd) = valdeclSourceAnn vd
 declSourceAnn (BoundValueDeclaration sa _ _) = sa
 declSourceAnn (BindingGroupDeclaration ds) = let ((sa, _), _, _) = NEL.head ds in sa
 declSourceAnn (ExternDeclaration sa _ _) = sa
@@ -545,7 +571,7 @@ declSourceSpan = fst . declSourceAnn
 declName :: Declaration -> Maybe Name
 declName (DataDeclaration _ _ n _ _) = Just (TyName n)
 declName (TypeSynonymDeclaration _ n _ _) = Just (TyName n)
-declName (ValueDeclaration _ n _ _ _) = Just (IdentName n)
+declName (ValueDeclaration vd) = Just (IdentName (valdeclIdent vd))
 declName (ExternDeclaration _ n _) = Just (IdentName n)
 declName (ExternDataDeclaration _ n _) = Just (TyName n)
 declName (ExternKindDeclaration _ n) = Just (KiName n)

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -63,7 +63,7 @@ moduleToCoreFn env (A.Module modSS coms mn decls (Just exps)) =
       in NonRec (ssA ss) (properToIdent ctor) $ Constructor (ss, com, Nothing, Nothing) tyName ctor fields
   declToCoreFn (A.DataBindingGroupDeclaration ds) =
     concatMap declToCoreFn ds
-  declToCoreFn (A.ValueDeclaration (ss, com) name _ _ [A.MkUnguarded e]) =
+  declToCoreFn (A.ValueDeclaration (A.ValueDeclarationData (ss, com) name _ _ [A.MkUnguarded e])) =
     [NonRec (ssA ss) name (exprToCoreFn ss com Nothing e)]
   declToCoreFn (A.BindingGroupDeclaration ds) =
     [Rec . NEL.toList $ fmap (\(((ss, com), name), _, e) -> ((ssA ss, name), exprToCoreFn ss com Nothing e)) ds]

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -82,7 +82,7 @@ augmentDeclarations (partitionEithers -> (augments, toplevels)) =
     d { declChildren = declChildren d ++ [child] }
 
 getDeclarationTitle :: P.Declaration -> Maybe Text
-getDeclarationTitle (P.ValueDeclaration _ name _ _ _) = Just (P.showIdent name)
+getDeclarationTitle (P.ValueDeclaration vd) = Just (P.showIdent (P.valdeclIdent vd))
 getDeclarationTitle (P.ExternDeclaration _ name _) = Just (P.showIdent name)
 getDeclarationTitle (P.DataDeclaration _ _ name _ _) = Just (P.runProperName name)
 getDeclarationTitle (P.ExternDataDeclaration _ name _) = Just (P.runProperName name)
@@ -108,9 +108,9 @@ basicDeclaration :: P.SourceAnn -> Text -> DeclarationInfo -> Maybe Intermediate
 basicDeclaration sa title = Just . Right . mkDeclaration sa title
 
 convertDeclaration :: P.Declaration -> Text -> Maybe IntermediateDeclaration
-convertDeclaration (P.ValueDeclaration sa _ _ _ [P.MkUnguarded (P.TypedValue _ _ ty)]) title =
+convertDeclaration (P.ValueDeclaration (P.ValueDeclarationData sa _ _ _ [P.MkUnguarded (P.TypedValue _ _ ty)])) title =
   basicDeclaration sa title (ValueDeclaration ty)
-convertDeclaration (P.ValueDeclaration sa _ _ _ _) title =
+convertDeclaration (P.ValueDeclaration (P.ValueDeclarationData sa _ _ _ _)) title =
   -- If no explicit type declaration was provided, insert a wildcard, so that
   -- the actual type will be added during type checking.
   basicDeclaration sa title (ValueDeclaration P.TypeWildcard{})

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -76,7 +76,7 @@ extractSpans
   -> [(IdeNamespaced, P.SourceSpan)]
   -- ^ Declarations and their source locations
 extractSpans d = case d of
-  P.ValueDeclaration (ss, _) i _ _ _ ->
+  P.ValueDeclaration (P.ValueDeclarationData (ss, _) i _ _ _) ->
     [(IdeNamespaced IdeNSValue (P.runIdent i), ss)]
   P.TypeSynonymDeclaration (ss, _) name _ _ ->
     [(IdeNamespaced IdeNSType (P.runProperName name), ss)]

--- a/src/Language/PureScript/Interactive/Completion.hs
+++ b/src/Language/PureScript/Interactive/Completion.hs
@@ -205,7 +205,7 @@ identNames :: P.Module -> [(N.Ident, P.Declaration)]
 identNames = nubOnFst . concatMap getDeclNames . P.exportedDeclarations
   where
   getDeclNames :: P.Declaration -> [(P.Ident, P.Declaration)]
-  getDeclNames d@(P.ValueDeclaration _ ident _ _ _)  = [(ident, d)]
+  getDeclNames d@(P.ValueDeclaration (P.ValueDeclarationData _ ident _ _ _))  = [(ident, d)]
   getDeclNames d@(P.TypeDeclaration td) = [(P.tydeclIdent td, d)]
   getDeclNames d@(P.ExternDeclaration _ ident _) = [(ident, d)]
   getDeclNames d@(P.TypeClassDeclaration _ _ _ _ _ ds) = map (second (const d)) $ concatMap getDeclNames ds

--- a/src/Language/PureScript/Interactive/Module.hs
+++ b/src/Language/PureScript/Interactive/Module.hs
@@ -51,7 +51,7 @@ createTemporaryModule exec PSCiState{psciImportedModules = imports, psciLetBindi
     supportImport = (supportModuleName, P.Implicit, Just (P.ModuleName [P.ProperName "$Support"]))
     eval          = P.Var (P.Qualified (Just (P.ModuleName [P.ProperName "$Support"])) (P.Ident "eval"))
     mainValue     = P.App eval (P.Var (P.Qualified Nothing (P.Ident "it")))
-    itDecl        = P.ValueDeclaration (internalSpan, []) (P.Ident "it") P.Public [] [P.MkUnguarded val]
+    itDecl        = P.ValueDeclaration $ P.ValueDeclarationData (internalSpan, []) (P.Ident "it") P.Public [] [P.MkUnguarded val]
     typeDecl      = P.TypeDeclaration
                       (P.TypeDeclarationData (internalSpan, []) (P.Ident "$main")
                         (P.TypeApp
@@ -60,7 +60,7 @@ createTemporaryModule exec PSCiState{psciImportedModules = imports, psciLetBindi
                               (P.Qualified (Just (P.ModuleName [P.ProperName "$Eff"])) (P.ProperName "Eff")))
                                 (P.TypeWildcard internalSpan))
                                   (P.TypeWildcard internalSpan)))
-    mainDecl      = P.ValueDeclaration (internalSpan, []) (P.Ident "$main") P.Public [] [P.MkUnguarded mainValue]
+    mainDecl      = P.ValueDeclaration $ P.ValueDeclarationData (internalSpan, []) (P.Ident "$main") P.Public [] [P.MkUnguarded mainValue]
     decls         = if exec then [itDecl, typeDecl, mainDecl] else [itDecl]
   in
     P.Module internalSpan

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -32,7 +32,7 @@ lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDecl
   moduleNames = S.fromList (ordNub (mapMaybe getDeclIdent ds))
 
   getDeclIdent :: Declaration -> Maybe Ident
-  getDeclIdent (ValueDeclaration _ ident _ _ _) = Just ident
+  getDeclIdent (ValueDeclaration vd) = Just (valdeclIdent vd)
   getDeclIdent (ExternDeclaration _ ident _) = Just ident
   getDeclIdent (TypeInstanceDeclaration _ ident _ _ _ _) = Just ident
   getDeclIdent BindingGroupDeclaration{} = internalError "lint: binding groups should not be desugared yet."
@@ -48,7 +48,7 @@ lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDecl
     f dec = f' S.empty dec
 
     f' :: S.Set Text -> Declaration -> MultipleErrors
-    f' s dec@(ValueDeclaration _ name _ _ _) = addHint (ErrorInValueDeclaration name) (warningsInDecl moduleNames dec <> checkTypeVarsInDecl s dec)
+    f' s dec@(ValueDeclaration vd) = addHint (ErrorInValueDeclaration (valdeclIdent vd)) (warningsInDecl moduleNames dec <> checkTypeVarsInDecl s dec)
     f' s (TypeDeclaration td) = addHint (ErrorInTypeDeclaration (tydeclIdent td)) (checkTypeVars s (tydeclType td))
     f' s dec = warningsInDecl moduleNames dec <> checkTypeVarsInDecl s dec
 

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -295,7 +295,7 @@ checkExhaustive ss env mn numArgs cas expr = makeResult . first ordNub $ foldl' 
     where
       partial :: Text -> Text -> Declaration
       partial var tyVar =
-        ValueDeclaration (ss, []) (Ident C.__unused) Private [] $
+        ValueDeclaration $ ValueDeclarationData (ss, []) (Ident C.__unused) Private [] $
         [MkUnguarded
           (TypedValue
            True
@@ -331,7 +331,8 @@ checkExhaustiveExpr initSS env mn = onExpr initSS
   where
   onDecl :: Declaration -> m Declaration
   onDecl (BindingGroupDeclaration bs) = BindingGroupDeclaration <$> mapM (\(sai@((ss, _), _), nk, expr) -> (sai, nk,) <$> onExpr ss expr) bs
-  onDecl (ValueDeclaration sa@(ss, _) name x y [MkUnguarded e]) = ValueDeclaration sa name x y . mkUnguardedExpr <$> censor (addHint (ErrorInValueDeclaration name)) (onExpr ss e)
+  onDecl (ValueDeclaration (ValueDeclarationData sa@(ss, _) name x y [MkUnguarded e])) =
+     ValueDeclaration <$> ValueDeclarationData sa name x y . mkUnguardedExpr <$> censor (addHint (ErrorInValueDeclaration name)) (onExpr ss e)
   onDecl decl = return decl
 
   onExpr :: SourceSpan -> Expr -> m Expr

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -87,7 +87,7 @@ parseValueWithIdentAndBinders ident bs = do
                            <*> (indented *> equals
                                          *> withSourceSpan PositionedValue parseValueWithWhereClause))
     )
-  return $ \sa -> ValueDeclaration sa ident Public bs value
+  return $ \sa -> ValueDeclaration (ValueDeclarationData sa ident Public bs value)
 
 parseValueDeclaration :: TokenParser Declaration
 parseValueDeclaration = withSourceAnnF $ do

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -124,12 +124,12 @@ prettyPrintDeclaration :: Int -> Declaration -> Box
 prettyPrintDeclaration d _ | d < 0 = ellipsis
 prettyPrintDeclaration _ (TypeDeclaration td) =
   text (T.unpack (showIdent (tydeclIdent td)) ++ " :: ") <> typeAsBox (tydeclType td)
-prettyPrintDeclaration d (ValueDeclaration _ ident _ [] [GuardedExpr [] val]) =
+prettyPrintDeclaration d (ValueDeclaration (ValueDeclarationData _ ident _ [] [GuardedExpr [] val])) =
   text (T.unpack (showIdent ident) ++ " = ") <> prettyPrintValue (d - 1) val
 prettyPrintDeclaration d (BindingGroupDeclaration ds) =
   vsep 1 left (NEL.toList (fmap (prettyPrintDeclaration (d - 1) . toDecl) ds))
   where
-  toDecl ((sa, nm), t, e) = ValueDeclaration sa nm t [] [GuardedExpr [] e]
+  toDecl ((sa, nm), t, e) = ValueDeclaration (ValueDeclarationData sa nm t [] [GuardedExpr [] e])
 prettyPrintDeclaration _ _ = internalError "Invalid argument to prettyPrintDeclaration"
 
 prettyPrintCaseAlternative :: Int -> CaseAlternative -> Box

--- a/src/Language/PureScript/Sugar/CaseDeclarations.hs
+++ b/src/Language/PureScript/Sugar/CaseDeclarations.hs
@@ -65,7 +65,7 @@ desugarGuardedExprs ss (Case scrut alternatives)
     (scrut', scrut_decls) <- unzip <$> forM scrut (\e -> do
       scrut_id <- freshIdent'
       pure ( Var (Qualified Nothing scrut_id)
-           , ValueDeclaration (ss, []) scrut_id Private [] [MkUnguarded e]
+           , ValueDeclaration (ValueDeclarationData (ss, []) scrut_id Private [] [MkUnguarded e])
            )
       )
     Let scrut_decls <$> desugarGuardedExprs ss (Case scrut' alternatives)
@@ -231,7 +231,7 @@ desugarGuardedExprs ss (Case scrut alternatives) =
           alt_fail = [CaseAlternative [NullBinder] [MkUnguarded goto_rem_case]]
 
         pure $ Let [
-          ValueDeclaration (ss, []) rem_case_id Private []
+          ValueDeclaration $ ValueDeclarationData (ss, []) rem_case_id Private []
             [MkUnguarded (Abs (VarBinder unused_binder) desugared)]
           ] (mk_body alt_fail)
 
@@ -328,10 +328,10 @@ desugarCases = desugarRest <=< fmap join . flip parU toDecls . groupBy inSameGro
     desugarRest :: [Declaration] -> m [Declaration]
     desugarRest (TypeInstanceDeclaration sa name constraints className tys ds : rest) =
       (:) <$> (TypeInstanceDeclaration sa name constraints className tys <$> traverseTypeInstanceBody desugarCases ds) <*> desugarRest rest
-    desugarRest (ValueDeclaration sa name nameKind bs result : rest) =
+    desugarRest (ValueDeclaration (ValueDeclarationData sa name nameKind bs result) : rest) =
       let (_, f, _) = everywhereOnValuesTopDownM return go return
           f' = mapM (\(GuardedExpr gs e) -> GuardedExpr gs <$> f e)
-      in (:) <$> (ValueDeclaration sa name nameKind bs <$> f' result) <*> desugarRest rest
+      in (:) <$> (ValueDeclaration <$> (ValueDeclarationData sa name nameKind bs <$> f' result)) <*> desugarRest rest
       where
       go (Let ds val') = Let <$> desugarCases ds <*> pure val'
       go other = return other
@@ -339,15 +339,15 @@ desugarCases = desugarRest <=< fmap join . flip parU toDecls . groupBy inSameGro
     desugarRest [] = pure []
 
 inSameGroup :: Declaration -> Declaration -> Bool
-inSameGroup (ValueDeclaration _ ident1 _ _ _) (ValueDeclaration _ ident2 _ _ _) = ident1 == ident2
+inSameGroup (ValueDeclaration vd1) (ValueDeclaration vd2) = valdeclIdent vd1 == valdeclIdent vd2
 inSameGroup _ _ = False
 
 toDecls :: forall m. (MonadSupply m, MonadError MultipleErrors m) => [Declaration] -> m [Declaration]
-toDecls [ValueDeclaration sa@(ss, _) ident nameKind bs [MkUnguarded val]] | all isIrrefutable bs = do
+toDecls [ValueDeclaration (ValueDeclarationData sa@(ss, _) ident nameKind bs [MkUnguarded val])] | all isIrrefutable bs = do
   args <- mapM fromVarBinder bs
   let body = foldr (Abs . VarBinder) val args
   guardWith (errorMessage' ss (OverlappingArgNames (Just ident))) $ length (ordNub args) == length args
-  return [ValueDeclaration sa ident nameKind [] [MkUnguarded body]]
+  return [ValueDeclaration (ValueDeclarationData sa ident nameKind [] [MkUnguarded body])]
   where
   fromVarBinder :: Binder -> m Ident
   fromVarBinder NullBinder = freshIdent'
@@ -355,7 +355,7 @@ toDecls [ValueDeclaration sa@(ss, _) ident nameKind bs [MkUnguarded val]] | all 
   fromVarBinder (PositionedBinder _ _ b) = fromVarBinder b
   fromVarBinder (TypedBinder _ b) = fromVarBinder b
   fromVarBinder _ = internalError "fromVarBinder: Invalid argument"
-toDecls ds@(ValueDeclaration (ss, _) ident _ bs (result : _) : _) = do
+toDecls ds@(ValueDeclaration (ValueDeclarationData (ss, _) ident _ bs (result : _)) : _) = do
   let tuples = map toTuple ds
 
       isGuarded (MkUnguarded _) = False
@@ -370,7 +370,7 @@ toDecls ds@(ValueDeclaration (ss, _) ident _ bs (result : _) : _) = do
 toDecls ds = return ds
 
 toTuple :: Declaration -> ([Binder], [GuardedExpr])
-toTuple (ValueDeclaration _ _ _ bs result) = (bs, result)
+toTuple (ValueDeclaration (ValueDeclarationData _ _ _ bs result)) = (bs, result)
 toTuple _ = internalError "Not a value declaration"
 
 makeCaseDeclaration :: forall m. (MonadSupply m) => SourceSpan -> Ident -> [([Binder], [GuardedExpr])] -> m Declaration
@@ -384,7 +384,7 @@ makeCaseDeclaration ss ident alternatives = do
       binders = [ CaseAlternative bs result | (bs, result) <- alternatives ]
   let value = foldr (Abs . VarBinder) (Case vars binders) args
 
-  return $ ValueDeclaration (ss, []) ident Public [] [MkUnguarded value]
+  return $ ValueDeclaration (ValueDeclarationData (ss, []) ident Public [] [MkUnguarded value])
   where
   -- We will construct a table of potential names.
   -- VarBinders will become Just _ which is a potential name.

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -61,7 +61,7 @@ desugarDo d =
   go [DoNotationLet _] = throwError . errorMessage $ InvalidDoLet
   go (DoNotationLet ds : rest) = do
     let checkBind :: Declaration -> m ()
-        checkBind (ValueDeclaration (ss, _) i@(Ident name) _ _ _)
+        checkBind (ValueDeclaration (ValueDeclarationData (ss, _) i@(Ident name) _ _ _))
           | name `elem` [ C.bind, C.discard ] = throwError . errorMessage' ss $ CannotUseBindWithDo i
         checkBind _ = pure ()
     mapM_ checkBind ds

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -303,8 +303,7 @@ renameInModule imports (Module modSS coms mn decls exps) =
         updatePatGuard _                  = []
 
   letBoundVariable :: Declaration -> Maybe Ident
-  letBoundVariable (ValueDeclaration _ ident _ _ _) = Just ident
-  letBoundVariable _ = Nothing
+  letBoundVariable = fmap valdeclIdent . getValueDeclaration
 
   updateKindsEverywhere :: SourceSpan -> Kind -> m Kind
   updateKindsEverywhere pos = everywhereOnKindsM updateKind

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -45,8 +45,8 @@ findExportable (Module _ _ mn ds _) =
     exportType Internal exps tn [] mn
   updateExports exps (ExternDataDeclaration _ tn _) =
     exportType Internal exps tn [] mn
-  updateExports exps (ValueDeclaration _ name _ _ _) =
-    exportValue exps name mn
+  updateExports exps (ValueDeclaration vd) =
+    exportValue exps (valdeclIdent vd) mn
   updateExports exps (ValueFixityDeclaration _ _ _ op) =
     exportValueOp exps op mn
   updateExports exps (TypeFixityDeclaration _ _ _ op) =

--- a/src/Language/PureScript/Sugar/ObjectWildcards.hs
+++ b/src/Language/PureScript/Sugar/ObjectWildcards.hs
@@ -69,7 +69,7 @@ desugarDecl d = rethrowWithPosition (declSourceSpan d) $ fn d
       then Abs (VarBinder val) <$> wrapLambda (buildUpdates valExpr) ps
       else wrapLambda (buildLet val . buildUpdates valExpr) ps
     where
-      buildLet val = Let [ValueDeclaration (declSourceSpan d, []) val Public [] [MkUnguarded obj]]
+      buildLet val = Let [ValueDeclaration (ValueDeclarationData (declSourceSpan d, []) val Public [] [MkUnguarded obj])]
 
       -- recursively build up the nested `ObjectUpdate` expressions
       buildUpdates :: Expr -> PathTree Expr -> Expr

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -289,9 +289,9 @@ deriveGeneric ss mn syns ds tyConNm dargs = do
   toSpine <- mkSpineFunction tyCon
   fromSpine <- mkFromSpineFunction tyCon
   toSignature <- mkSignatureFunction tyCon dargs
-  return [ ValueDeclaration (ss, []) (Ident C.toSpine) Public [] (unguarded toSpine)
-         , ValueDeclaration (ss, []) (Ident C.fromSpine) Public [] (unguarded fromSpine)
-         , ValueDeclaration (ss, []) (Ident C.toSignature) Public [] (unguarded toSignature)
+  return [ ValueDeclaration $ ValueDeclarationData (ss, []) (Ident C.toSpine) Public [] (unguarded toSpine)
+         , ValueDeclaration $ ValueDeclarationData (ss, []) (Ident C.fromSpine) Public [] (unguarded fromSpine)
+         , ValueDeclaration $ ValueDeclarationData (ss, []) (Ident C.toSignature) Public [] (unguarded toSignature)
          ]
   where
     mkSpineFunction :: Declaration -> m Expr
@@ -467,19 +467,19 @@ deriveGenericRep mn syns ds tyConNm tyConArgs repTy = do
       let rep = toRepTy reps
           inst | null reps =
                    -- If there are no cases, spin
-                   [ ValueDeclaration (ss, []) (Ident "to") Public [] $ unguarded $
+                   [ ValueDeclaration $ ValueDeclarationData (ss, []) (Ident "to") Public [] $ unguarded $
                        lamCase x [ CaseAlternative [NullBinder]
                                                    (unguarded (App toName (Var (Qualified Nothing x))))
                                  ]
-                   , ValueDeclaration (ss, []) (Ident "from") Public [] $ unguarded $
+                   , ValueDeclaration $ ValueDeclarationData (ss, []) (Ident "from") Public [] $ unguarded $
                        lamCase x [ CaseAlternative [NullBinder]
                                                    (unguarded (App fromName (Var (Qualified Nothing x))))
                                  ]
                    ]
                | otherwise =
-                   [ ValueDeclaration (ss, []) (Ident "to") Public [] $ unguarded $
+                   [ ValueDeclaration $ ValueDeclarationData (ss, []) (Ident "to") Public [] $ unguarded $
                        lamCase x (zipWith ($) (map underBinder (sumBinders (length dctors))) to)
-                   , ValueDeclaration (ss, []) (Ident "from") Public [] $ unguarded $
+                   , ValueDeclaration $ ValueDeclarationData (ss, []) (Ident "from") Public [] $ unguarded $
                        lamCase x (zipWith ($) (map underExpr (sumExprs (length dctors))) from)
                    ]
 
@@ -649,7 +649,7 @@ deriveEq
 deriveEq ss mn syns ds tyConNm = do
   tyCon <- findTypeDecl tyConNm ds
   eqFun <- mkEqFunction tyCon
-  return [ ValueDeclaration (ss, []) (Ident C.eq) Public [] (unguarded eqFun) ]
+  return [ ValueDeclaration $ ValueDeclarationData (ss, []) (Ident C.eq) Public [] (unguarded eqFun) ]
   where
     mkEqFunction :: Declaration -> m Expr
     mkEqFunction (DataDeclaration _ _ _ _ args) = do
@@ -705,7 +705,7 @@ deriveOrd
 deriveOrd ss mn syns ds tyConNm = do
   tyCon <- findTypeDecl tyConNm ds
   compareFun <- mkCompareFunction tyCon
-  return [ ValueDeclaration (ss, []) (Ident C.compare) Public [] (unguarded compareFun) ]
+  return [ ValueDeclaration $ ValueDeclarationData (ss, []) (Ident C.compare) Public [] (unguarded compareFun) ]
   where
     mkCompareFunction :: Declaration -> m Expr
     mkCompareFunction (DataDeclaration _ _ _ _ args) = do
@@ -806,9 +806,9 @@ deriveNewtype mn syns ds tyConNm tyConArgs unwrappedTy = do
       let (ctorName, [ty]) = head dctors
       ty' <- replaceAllTypeSynonymsM syns ty
       let inst =
-            [ ValueDeclaration (ss, []) (Ident "wrap") Public [] $ unguarded $
+            [ ValueDeclaration $ ValueDeclarationData (ss, []) (Ident "wrap") Public [] $ unguarded $
                 Constructor (Qualified (Just mn) ctorName)
-            , ValueDeclaration (ss, []) (Ident "unwrap") Public [] $ unguarded $
+            , ValueDeclaration $ ValueDeclarationData (ss, []) (Ident "unwrap") Public [] $ unguarded $
                 lamCase wrappedIdent
                   [ CaseAlternative
                       [ConstructorBinder (Qualified (Just mn) ctorName) [VarBinder unwrappedIdent]]
@@ -886,7 +886,7 @@ deriveFunctor
 deriveFunctor ss mn syns ds tyConNm = do
   tyCon <- findTypeDecl tyConNm ds
   mapFun <- mkMapFunction tyCon
-  return [ ValueDeclaration (ss, []) (Ident C.map) Public [] (unguarded mapFun) ]
+  return [ ValueDeclaration $ ValueDeclarationData (ss, []) (Ident C.map) Public [] (unguarded mapFun) ]
   where
     mkMapFunction :: Declaration -> m Expr
     mkMapFunction (DataDeclaration (ss', _) _ _ tys ctors) = case reverse tys of

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -267,14 +267,14 @@ typeCheckAll moduleName _ = traverse go
     return $ TypeSynonymDeclaration sa name args ty
   go TypeDeclaration{} =
     internalError "Type declarations should have been removed before typeCheckAlld"
-  go (ValueDeclaration sa@(ss, _) name nameKind [] [MkUnguarded val]) = do
+  go (ValueDeclaration (ValueDeclarationData sa@(ss, _) name nameKind [] [MkUnguarded val])) = do
     env <- getEnv
     warnAndRethrow (addHint (ErrorInValueDeclaration name) . addHint (PositionedError ss)) $ do
       val' <- checkExhaustiveExpr ss env moduleName val
       valueIsNotDefined moduleName name
       [(_, (val'', ty))] <- typesOf NonRecursiveBindingGroup moduleName [((sa, name), val')]
       addValue moduleName name ty nameKind
-      return $ ValueDeclaration sa name nameKind [] [MkUnguarded val'']
+      return $ ValueDeclaration $ ValueDeclarationData sa name nameKind [] [MkUnguarded val'']
   go ValueDeclaration{} = internalError "Binders were not desugared"
   go BoundValueDeclaration{} = internalError "BoundValueDeclaration should be desugared"
   go (BindingGroupDeclaration vals) = do
@@ -343,7 +343,7 @@ typeCheckAll moduleName _ = traverse go
     return instDecls
     where
     memberName :: Declaration -> Ident
-    memberName (ValueDeclaration _ ident _ _ _) = ident
+    memberName (ValueDeclaration vd) = valdeclIdent vd
     memberName _ = internalError "checkInstanceMembers: Invalid declaration in type instance definition"
 
     firstDuplicate :: (Eq a) => [a] -> Maybe a

--- a/tests/Language/PureScript/Ide/SourceFileSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFileSpec.hs
@@ -23,7 +23,7 @@ ann2 = (span2, [])
 
 typeAnnotation1, value1, synonym1, class1, class2, data1, data2, valueFixity, typeFixity, foreign1, foreign2, foreign3, member1 :: P.Declaration
 typeAnnotation1 = P.TypeDeclaration (P.TypeDeclarationData ann1 (P.Ident "value1") P.REmpty)
-value1 = P.ValueDeclaration ann1 (P.Ident "value1") P.Public [] []
+value1 = P.ValueDeclaration $ P.ValueDeclarationData ann1 (P.Ident "value1") P.Public [] []
 synonym1 = P.TypeSynonymDeclaration ann1 (P.ProperName "Synonym1") [] P.REmpty
 class1 = P.TypeClassDeclaration ann1 (P.ProperName "Class1") [] [] [] []
 class2 = P.TypeClassDeclaration ann1 (P.ProperName "Class2") [] [] [] [member1]


### PR DESCRIPTION
And another one for #3023! I'd like some Feedback and Discussion on this one.

```haskell
-- | A value declaration assigns a name and potential binders, to an expression (or multiple guarded expressions).
--
-- @double x = x + x@
--
-- In this example @double@ is the identifier, @x@ is a binder and @x + x@ is the expression.
data ValueDeclarationData a = ValueDeclarationData
  { valdeclSourceAnn :: !SourceAnn
  , valdeclIdent :: !Ident
  -- ^ The declared value's name
  , valdeclName :: !NameKind
  -- ^ Whether or not this value is exported/visible
  , valdeclBinders :: ![Binder]
  , valdeclExpression :: !a
  } deriving (Show)
```

I parameterized the data type on the type of it's contained Expressions, because from reading the code it seems like during case desugaring all ValueDeclarations go from `ValueDeclarationData [GuardedExpr]` to `ValueDeclarationData Expr`.

In particular, this means that we can turn `BindingGroupDeclaration (NEL.NonEmpty ((SourceAnn, Ident), NameKind, Expr))` into `BindingGroupDeclaration (NEL.NonEmpty (ValueDeclarationData Expr))`

Additionally there's partial pattern matches on `[MkUnguarded expr]` littered through the code, which could also be addressed this way (The whole CaseDeclarations desugaring is a partial desaster imo). I think we should introduce another Declaration constructor `GuardedValueDeclaration (ValueDeclaration [GuardedExpr])` and have our ValueDeclaration constructor only contain a single expression.

The pattern matches and constructions of ValueDeclarations are getting a little noisy in this PR, and I think we can mitigate that by introducing a pattern synonym. I didn't want to do that yet, because implementing my previous suggestions would mean I'd have to change all that again anyway.