### PR TITLE
Use dot accessors/setters in purs bundle if possible

### DIFF
--- a/src/Language/PureScript/Bundle.hs
+++ b/src/Language/PureScript/Bundle.hs
@@ -512,7 +512,7 @@ codeGen optionsMainModule optionsNamespace ms outFileOpt = (fmap sourceMapping o
   rendered = renderToString (JSAstProgram (prelude : concatMap fst modulesJS ++ maybe [] runMain optionsMainModule) JSNoAnnot)
 
   isValidJavaScriptIdentifier :: String -> Bool
-  isValidJavaScriptIdentifier str = case parse str mempty of
+  isValidJavaScriptIdentifier string = case parse string mempty of
     Right (JSAstProgram [JSExpressionStatement (JSIdentifier _ _) _] _)  -> True
     Right _ -> False
     Left _ -> False

--- a/src/Language/PureScript/Bundle.hs
+++ b/src/Language/PureScript/Bundle.hs
@@ -511,6 +511,12 @@ codeGen optionsMainModule optionsNamespace ms outFileOpt = (fmap sourceMapping o
   where
   rendered = renderToString (JSAstProgram (prelude : concatMap fst modulesJS ++ maybe [] runMain optionsMainModule) JSNoAnnot)
 
+  isValidJavaScriptIdentifier :: String -> Bool
+  isValidJavaScriptIdentifier str = case parse str mempty of
+    Right (JSAstProgram [JSExpressionStatement (JSIdentifier _ _) _] _)  -> True
+    Right _ -> False
+    Left _ -> False
+
   sourceMapping :: String -> SourceMapping
   sourceMapping outFile = SourceMapping {
       smFile = outFile,
@@ -574,9 +580,16 @@ codeGen optionsMainModule optionsNamespace ms outFileOpt = (fmap sourceMapping o
 
       toExport :: (ExportType, String, JSExpression, [Key]) -> JSStatement
       toExport (_, nm, val, _) =
+        let jsMemberExpression = if isValidJavaScriptIdentifier nm
+            then
+              JSMemberDot (JSIdentifier lfsp "exports") JSNoAnnot
+                (JSIdentifier JSNoAnnot nm)
+            else
+              JSMemberSquare (JSIdentifier lfsp "exports") JSNoAnnot
+                (str nm) JSNoAnnot
+        in
         JSAssignStatement
-          (JSMemberSquare (JSIdentifier lfsp "exports") JSNoAnnot
-            (str nm) JSNoAnnot)
+          jsMemberExpression
           (JSAssign sp)
           val
           (JSSemi JSNoAnnot)
@@ -617,9 +630,14 @@ codeGen optionsMainModule optionsNamespace ms outFileOpt = (fmap sourceMapping o
     JSMemberExpression (JSIdentifier JSNoAnnot "require") JSNoAnnot (cList [ str mn ]) JSNoAnnot
 
   moduleReference :: JSAnnot -> String -> JSExpression
-  moduleReference a mn =
-    JSMemberSquare (JSIdentifier a optionsNamespace) JSNoAnnot
-      (str mn) JSNoAnnot
+  moduleReference a mn = if isValidJavaScriptIdentifier mn
+    then
+      JSMemberDot (JSIdentifier a optionsNamespace) JSNoAnnot
+        (JSIdentifier JSNoAnnot mn)
+    else
+      JSMemberSquare (JSIdentifier a optionsNamespace) JSNoAnnot
+        (str mn) JSNoAnnot
+
 
   str :: String -> JSExpression
   str s = JSStringLiteral JSNoAnnot $ "\"" ++ s ++ "\""


### PR DESCRIPTION
Output code from purs bundle includes a fair amount of redundant string accesses to objects when getting and setting properties. This is seen quite often in output code such as `exports["main"] = main` when `exports.main = main` would have worked just as well because `main` is a valid JavaScript identifier. This change will save 3 bytes everywhere it can be applied which is a not a significant saving in itself but will appear quite often in a large codebase. It also can be argued that accessing using the dot notation is more idiomatic output JavaScript than using string literals.

As an example the hello world pulp project compiled to this before at 999 bytes:
```
// Generated by psc-bundle 0.11.6
var PS = {};
(function(exports) {
    "use strict";

  exports.log = function (s) {
    return function () {
      console.log(s);
      return {};
    };
  };
})(PS["Control.Monad.Eff.Console"] = PS["Control.Monad.Eff.Console"] || {});
(function(exports) {
  // Generated by purs version 0.11.6
  "use strict";
  var $foreign = PS["Control.Monad.Eff.Console"];
  var Control_Monad_Eff = PS["Control.Monad.Eff"];
  var Data_Show = PS["Data.Show"];
  var Data_Unit = PS["Data.Unit"];
  exports["log"] = $foreign.log;
})(PS["Control.Monad.Eff.Console"] = PS["Control.Monad.Eff.Console"] || {});
(function(exports) {
  // Generated by purs version 0.11.6
  "use strict";
  var Control_Monad_Eff = PS["Control.Monad.Eff"];
  var Control_Monad_Eff_Console = PS["Control.Monad.Eff.Console"];
  var Prelude = PS["Prelude"];        
  var main = Control_Monad_Eff_Console.log("Hello sailor!");
  exports["main"] = main;
})(PS["Main"] = PS["Main"] || {});
PS["Main"].main();
```
And after at 985 bytes:
```
// Generated by purs bundle 0.11.6
var PS = {};
(function(exports) {
    "use strict";

  exports.log = function (s) {
    return function () {
      console.log(s);
      return {};
    };
  };
})(PS["Control.Monad.Eff.Console"] = PS["Control.Monad.Eff.Console"] || {});
(function(exports) {
  // Generated by purs version 0.11.6
  "use strict";
  var $foreign = PS["Control.Monad.Eff.Console"];
  var Control_Monad_Eff = PS["Control.Monad.Eff"];
  var Data_Show = PS["Data.Show"];
  var Data_Unit = PS["Data.Unit"];
  exports.log = $foreign.log;
})(PS["Control.Monad.Eff.Console"] = PS["Control.Monad.Eff.Console"] || {});
(function(exports) {
  // Generated by purs version 0.11.6
  "use strict";
  var Control_Monad_Eff = PS["Control.Monad.Eff"];
  var Control_Monad_Eff_Console = PS["Control.Monad.Eff.Console"];
  var Prelude = PS.Prelude;           
  var main = Control_Monad_Eff_Console.log("Hello sailor!");
  exports.main = main;
})(PS.Main = PS.Main || {});
PS.Main.main();
```
On a larger example project this change reduced purs bundle output size from 399253 bytes to 397378 bytes.