### PR TITLE
Bump to ghc8 2

### DIFF
--- a/app/Command/Ide.hs
+++ b/app/Command/Ide.hs
@@ -147,6 +147,7 @@ command = Opts.helper <*> subcommands where
             `mappend` Opts.help "One of \"debug\", \"perf\", \"all\" or \"none\""))
       <*> Opts.switch (Opts.long "editor-mode")
 
+  parseLogLevel :: Text -> IdeLogLevel
   parseLogLevel s = case s of
     "debug" -> LogDebug
     "perf" -> LogPerf

--- a/package.yaml
+++ b/package.yaml
@@ -116,6 +116,21 @@ executables:
     main: Main.hs
     source-dirs: app
     ghc-options: -Wall -O2 -fno-warn-unused-do-bind -threaded -rtsopts -with-rtsopts=-N
+    other-modules:
+      - Command.Bundle
+      - Command.Compile
+      - Command.Docs
+      - Command.Docs.Ctags
+      - Command.Docs.Etags
+      - Command.Docs.Html
+      - Command.Docs.Tags
+      - Command.Hierarchy
+      - Command.Ide
+      - Command.Publish
+      - Command.REPL
+      - Paths_purescript
+      - Version
+
     dependencies:
       - ansi-wl-pprint
       - file-embed

--- a/package.yaml
+++ b/package.yaml
@@ -32,7 +32,7 @@ extra-source-files:
   - CONTRIBUTORS.md
   - CONTRIBUTING.md
 dependencies:
-  - aeson >=1.0 && <1.2
+  - aeson >=1.0 && <1.3
   - aeson-better-errors >=0.8
   - ansi-terminal >=0.6.2 && <0.7
   - base >=4.8 && <5
@@ -67,7 +67,7 @@ dependencies:
   - pattern-arrows >=0.0.2 && <0.1
   - pipes >=4.0.0 && <4.4.0
   - pipes-http
-  - process >=1.2.0 && <1.5
+  - process >=1.2.0 && <1.7
   - protolude >=0.1.6
   - regex-tdfa
   - safe >=0.3.9 && <0.4
@@ -140,14 +140,14 @@ executables:
       - wai ==3.*
       - wai-websockets ==3.*
       - warp ==3.*
-      - websockets >=0.9 && <0.11
+      - websockets >=0.9 && <0.13
     when:
     - condition: flag(release)
       then:
         cpp-options: -DRELEASE
       else:
         dependencies:
-        - gitrev >=1.2.0 && <1.3
+        - gitrev >=1.2.0 && <1.4
 
 tests:
   tests:

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -2,7 +2,7 @@ module Language.PureScript.Docs.Convert.Single
   ( convertSingleModule
   ) where
 
-import Protolude
+import Protolude hiding (moduleName)
 
 import Control.Category ((>>>))
 

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -9,7 +9,7 @@ module Language.PureScript.Ide.Completion
        , applyCompletionOptions
        ) where
 
-import           Protolude
+import           Protolude hiding ((<&>), moduleName)
 
 import           Control.Lens hiding ((&), op)
 import           Data.Aeson

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -30,7 +30,7 @@ module Language.PureScript.Ide.Imports
        )
        where
 
-import           Protolude
+import           Protolude hiding (moduleName)
 
 import           Control.Lens                       ((^.), (%~), ix)
 import           Data.List                          (findIndex, nubBy, partition)

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -23,7 +23,7 @@ module Language.PureScript.Ide.Reexports
   , resolveReexports'
   ) where
 
-import           Protolude
+import           Protolude hiding (moduleName)
 
 import           Control.Lens                  hiding ((&))
 import qualified Data.Map                      as Map

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -36,7 +36,7 @@ module Language.PureScript.Ide.State
   , resolveDataConstructorsForModule
   ) where
 
-import           Protolude
+import           Protolude hiding (moduleName)
 
 import           Control.Arrow
 import           Control.Concurrent.STM

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -19,7 +19,7 @@
 
 module Language.PureScript.Ide.Types where
 
-import           Protolude
+import           Protolude hiding (moduleName)
 
 import           Control.Concurrent.STM
 import           Control.Lens.TH

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,6 @@
-resolver: lts-8.5
+resolver: nightly-2017-09-10
 packages:
 - '.'
 extra-deps:
 - pipes-http-1.0.5
+- Win32-notify-0.3.0.3

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 module Language.PureScript.Ide.ImportsSpec where
 
-import           Protolude
+import           Protolude hiding (moduleName)
 import           Data.Maybe                      (fromJust)
 
 import qualified Language.PureScript             as P


### PR DESCRIPTION
Fixes #3065 

I bumped the resolver to point at the current nightly, and relaxed all the blocking bounds. I also checked the changelogs and didn't find anything that directly affects us. I'd totally encourage someone else to do the same though.

I haven't paid attention to retaining backwards compatibility with GHC 8.0.2. I don't really like that Protolude exports `moduleName` now, and I'm wondering if it would be a good idea to build our own project specific Prelude. We could still use protolude as a baseline, but a lot of the exported names from the Generics modules conflict with things a in compiler project.