### PR TITLE
Require single-method instance declarations to be indented

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,6 +85,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@phiggins](https://github.com/phiggins) | Pete Higgins | [MIT license](http://opensource.org/licenses/MIT) |
 | [@philopon](https://github.com/philopon) | Hirotomo Moriwaki | [MIT license](http://opensource.org/licenses/MIT) |
 | [@pseudonom](https://github.com/pseudonom) | Eric Easley | [MIT license](http://opensource.org/licenses/MIT) |
+| [@quesebifurcan](https://github.com/quesebifurcan) | Fredrik Wallberg | [MIT license](http://opensource.org/licenses/MIT) |
 | [@rightfold](https://github.com/rightfold) | rightfold | [MIT license](https://opensource.org/licenses/MIT) |
 | [@robdaemon](https://github.com/robdaemon) | Robert Roland | [MIT license](http://opensource.org/licenses/MIT) |
 | [@RossMeikleham](https://github.com/RossMeikleham) | Ross Meikleham | [MIT license](http://opensource.org/licenses/MIT) |

--- a/examples/failing/2947.purs
+++ b/examples/failing/2947.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith ErrorParsingModule
+
+module Main where
+
+import Prelude
+
+data Foo = Foo
+
+instance eqFoo :: Eq Foo where
+eq _ _ = true

--- a/examples/passing/2947.purs
+++ b/examples/passing/2947.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console (log)
+
+data Foo = Foo
+
+instance eqFoo :: Eq Foo where
+  eq _ _ = true
+
+main = log "Done"

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -228,7 +228,7 @@ parseTypeInstanceDeclaration = do
   instanceDecl <- parseInstanceDeclaration
   members <- P.option [] $ do
     indented *> reserved "where"
-    mark (P.many (same *> declsInInstance))
+    indented *> mark (P.many (same *> declsInInstance))
   return $ instanceDecl (ExplicitInstance members)
   where
     declsInInstance :: TokenParser Declaration


### PR DESCRIPTION
Resolves https://github.com/purescript/purescript/issues/2947

Note: this fix was previously merged and later reverted -- it turned out to contain a breaking change. See https://github.com/purescript/purescript/pull/2965 for context.