### PR TITLE
Desugar nested parentheses

### DIFF
--- a/examples/passing/ParensInType.purs
+++ b/examples/passing/ParensInType.purs
@@ -1,0 +1,20 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, log)
+
+class Foo a where
+  foo :: forall eff. (String -> a (( console :: CONSOLE | eff)) ((Unit)))
+
+instance fooLogEff :: Foo Eff where
+  foo = log
+
+main :: 
+    forall eff.
+      Eff
+        ( console :: CONSOLE
+        | eff
+        )
+        Unit
+main = foo "Done"

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -230,15 +230,15 @@ removeParens = f
   (goDecl, goExpr', goBinder') = updateTypes (\_ -> return . goType)
 
   goExpr :: Expr -> Expr
-  goExpr (Parens val) = val
+  goExpr (Parens val) = goExpr val
   goExpr val = val
 
   goBinder :: Binder -> Binder
-  goBinder (ParensInBinder b) = b
+  goBinder (ParensInBinder b) = goBinder b
   goBinder b = b
 
   goType :: Type -> Type
-  goType (ParensInType t) = t
+  goType (ParensInType t) = goType t
   goType t = t
 
   decontextify


### PR DESCRIPTION
Doubly-nested parentheses (as in `((Unit))`) caused an issue in inferring kinds (Invalid argument to `infer`, i.e. `ParensInType`) then in unifying types (Could not match type `Unit` with `Unit`), but desugaring it earlier fixes both of those problems.