### PR TITLE
Expand error message for UnusableDeclaration

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,6 +51,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@houli](https://github.com/houli) | Eoin Houlihan | [MIT license](http://opensource.org/licenses/MIT) |
 | [@ianbollinger](https://github.com/ianbollinger) | Ian D. Bollinger | [MIT license](http://opensource.org/licenses/MIT) |
 | [@ilovezfs](https://github.com/ilovezfs) | ilovezfs | MIT license |
+| [@i-am-tom](https://github.com/i-am-tom) | i-am-tom | [MIT license](http://opensource.org/licenses/MIT)  |
 | [@izgzhen](https://github.com/izgzhen) | Zhen Zhang | [MIT license](http://opensource.org/licenses/MIT) |
 | [@jacereda](https://github.com/jacereda) | Jorge Acereda | [MIT license](http://opensource.org/licenses/MIT) |
 | [@japesinator](https://github.com/japesinator) | JP Smith | [MIT license](http://opensource.org/licenses/MIT) |

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -168,9 +168,8 @@ data SimpleErrorMessage
   | ClassInstanceArityMismatch Ident (Qualified (ProperName 'ClassName)) Int Int
   -- | a user-defined warning raised by using the Warn type class
   | UserDefinedWarning Type
-  -- | a declaration couldn't be used because there wouldn't be enough information
-  -- | to choose an instance
-  | UnusableDeclaration Ident
+  -- | a declaration couldn't be used because it contained free variables
+  | UnusableDeclaration Ident [[Text]]
   deriving (Show)
 
 -- | Error message hints, providing more detailed information about failure.

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -950,9 +950,20 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             , indent msg
             ]
 
-    renderSimpleErrorMessage (UnusableDeclaration ident) =
-      paras [ line $ "The declaration " <> markCode (showIdent ident) <> " is unusable."
-            , line $ "This happens when a constraint couldn't possibly have enough information to work out which instance is required."
+    renderSimpleErrorMessage (UnusableDeclaration ident unexplained) =
+      paras $
+        [ line $ "The declaration " <> markCode (showIdent ident) <> " contains arguments that couldn't be determined."
+        ] <>
+
+        case unexplained of
+          [required] ->
+            [ line $ "These arguments are: { " <> T.intercalate "," required <> "}"
+            ]
+
+          options  ->
+            [ line "To fix this, one of the following sets of variables must be determined:"
+            , Box.moveRight 2 . Box.vsep 0 Box.top $
+                map (\set -> line $ "{ " <> T.intercalate ", " set <> " }") options
             ]
 
     renderHint :: ErrorMessageHint -> Box.Box -> Box.Box


### PR DESCRIPTION
Previously, the error message made no mention of a solution to the error. This update adds possible solutions to the error message in the form of the remaining covering sets. In other words, the remaining variables that need to be determined in order to satisfy the typechecker.

I think a couple of these changes look a bit ugly, so please do leave opinions :)