### PR TITLE
Option --dump-coreimp

### DIFF
--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -132,11 +132,17 @@ dumpCoreFn = Opts.switch $
      Opts.long "dump-corefn"
   <> Opts.help "Dump the (functional) core representation of the compiled code at output/*/corefn.json"
 
+dumpCoreImp :: Opts.Parser Bool
+dumpCoreImp = Opts.switch $
+     Opts.long "dump-coreimp"
+  <> Opts.help "Dump the (imperative) core representation of the compiled code at output/*/coreimp.json"
+
 options :: Opts.Parser P.Options
 options = P.Options <$> verboseErrors
                     <*> (not <$> comments)
                     <*> sourceMaps
                     <*> dumpCoreFn
+                    <*> dumpCoreImp
 
 pscMakeOptions :: Opts.Parser PSCMakeOptions
 pscMakeOptions = PSCMakeOptions <$> many inputFile

--- a/src/Language/PureScript/CoreImp/AST.hs
+++ b/src/Language/PureScript/CoreImp/AST.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 -- | Data types for the imperative core AST
 module Language.PureScript.CoreImp.AST where
 
@@ -5,7 +6,9 @@ import Prelude.Compat
 
 import Control.Monad ((>=>))
 import Control.Monad.Identity (Identity(..), runIdentity)
+import Data.Aeson
 import Data.Text (Text)
+import GHC.Generics (Generic)
 
 import Language.PureScript.AST (SourceSpan(..))
 import Language.PureScript.Comments
@@ -19,7 +22,7 @@ data UnaryOperator
   | BitwiseNot
   | Positive
   | New
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
 -- | Built-in binary operators
 data BinaryOperator
@@ -42,7 +45,7 @@ data BinaryOperator
   | ShiftLeft
   | ShiftRight
   | ZeroFillShiftRight
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
 -- | Data type for simplified JavaScript expressions
 data AST
@@ -92,7 +95,11 @@ data AST
   -- ^ instanceof check
   | Comment (Maybe SourceSpan) [Comment] AST
   -- ^ Commented JavaScript
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
+
+instance ToJSON UnaryOperator
+instance ToJSON BinaryOperator
+instance ToJSON AST
 
 withSourceSpan :: SourceSpan -> AST -> AST
 withSourceSpan withSpan = go where

--- a/src/Language/PureScript/CoreImp/ToJSON.hs
+++ b/src/Language/PureScript/CoreImp/ToJSON.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE NoOverloadedStrings #-}
+-- |
+-- Dump the core imperative representation in JSON format for consumption
+-- by third-party code generators
+--
+module Language.PureScript.CoreImp.ToJSON
+  ( moduleToJSON
+  ) where
+
+
+import Prelude.Compat
+
+import Data.Aeson
+import Data.Version (Version, showVersion)
+import qualified Data.Text as T
+
+import Language.PureScript.CoreFn
+import Language.PureScript.Names
+
+import Language.PureScript.CoreImp.AST (AST)
+
+
+
+identToJSON :: Ident -> Value
+identToJSON = toJSON . runIdent
+
+moduleNameToJSON :: ModuleName -> Value
+moduleNameToJSON = toJSON . runModuleName
+
+
+astToJSON :: AST -> Value
+astToJSON = toJSON
+
+moduleToJSON :: Version -> Module a -> [AST] -> Value
+moduleToJSON v m a = object [ T.pack "imports"   .= map (moduleNameToJSON . snd) (moduleImports m)
+                            , T.pack "exports"   .= map identToJSON (moduleExports m)
+                            , T.pack "foreign"   .= map (identToJSON . fst) (moduleForeign m)
+                            , T.pack "builtWith" .= toJSON (showVersion v)
+                            , T.pack "ast"       .= map (astToJSON) a
+                            ]

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -339,6 +339,7 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
         coreFnFile = outputDir </> filePath </> "corefn.json"
         coreImpFile = outputDir </> filePath </> "coreimp.json"
         min3 js exts coreFn coreImp
+          | dumpCoreFn && dumpCoreImp = min (min js exts) (min coreFn coreImp)
           | dumpCoreFn = min (min js exts) coreFn
           | dumpCoreImp = min (min js exts) coreImp
           | otherwise = min js exts

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -71,6 +71,7 @@ import           Language.PureScript.CodeGen.JS.Printer
 import qualified Language.PureScript.CoreFn as CF
 import qualified Language.PureScript.CoreFn.ToJSON as CFJ
 import qualified Language.PureScript.CoreImp.AST as Imp
+import qualified Language.PureScript.CoreImp.ToJSON as CIJ
 import qualified Language.PureScript.Parser as PSParser
 import qualified Paths_purescript as Paths
 import           SourceMap
@@ -331,14 +332,17 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
   getOutputTimestamp :: ModuleName -> Make (Maybe UTCTime)
   getOutputTimestamp mn = do
     dumpCoreFn <- asks optionsDumpCoreFn
+    dumpCoreImp <- asks optionsDumpCoreImp
     let filePath = T.unpack (runModuleName mn)
         jsFile = outputDir </> filePath </> "index.js"
         externsFile = outputDir </> filePath </> "externs.json"
         coreFnFile = outputDir </> filePath </> "corefn.json"
-        min3 js exts coreFn
+        coreImpFile = outputDir </> filePath </> "coreimp.json"
+        min3 js exts coreFn coreImp
           | dumpCoreFn = min (min js exts) coreFn
+          | dumpCoreImp = min (min js exts) coreImp
           | otherwise = min js exts
-    min3 <$> getTimestamp jsFile <*> getTimestamp externsFile <*> getTimestamp coreFnFile
+    min3 <$> getTimestamp jsFile <*> getTimestamp externsFile <*> getTimestamp coreFnFile <*> getTimestamp coreImpFile
 
   readExterns :: ModuleName -> Make (FilePath, Externs)
   readExterns mn = do
@@ -376,11 +380,17 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
       writeTextFile externsFile exts
     lift $ when sourceMaps $ genSourceMap dir mapFile (length prefix) mappings
     dumpCoreFn <- lift $ asks optionsDumpCoreFn
+    dumpCoreImp <- lift $ asks optionsDumpCoreImp
     when dumpCoreFn $ do
       let coreFnFile = outputDir </> filePath </> "corefn.json"
       let jsonPayload = CFJ.moduleToJSON Paths.version m
       let json = Aeson.object [  (runModuleName mn, jsonPayload) ]
       lift $ writeTextFile coreFnFile (encode json)
+    when dumpCoreImp $ do
+      let coreImpFile = outputDir </> filePath </> "coreimp.json"
+      let jsonPayload = CIJ.moduleToJSON Paths.version m rawJs
+      let json = Aeson.object [  (runModuleName mn, jsonPayload) ]
+      lift $ writeTextFile coreImpFile (encode json)
 
   genSourceMap :: String -> String -> Int -> [SMap] -> Make ()
   genSourceMap dir mapFile extraLines mappings = do

--- a/src/Language/PureScript/Options.hs
+++ b/src/Language/PureScript/Options.hs
@@ -13,8 +13,10 @@ data Options = Options
   -- ^ Generate source maps
   , optionsDumpCoreFn :: Bool
   -- ^ Dump CoreFn
+  , optionsDumpCoreImp :: Bool
+  -- ^ Dump CoreImp
   } deriving Show
 
 -- Default make options
 defaultOptions :: Options
-defaultOptions = Options False False False False
+defaultOptions = Options False False False False False


### PR DESCRIPTION
New `purs compile` option `--dump-coreimp`, exactly like the existing `--dump-corefn`, to dump the `CoreImp` AST to a `coreimp.json` output file.

Requested in #876 and also in #711 [in the comments](https://github.com/purescript/purescript/issues/711#issuecomment-74744519)

(The results can be seen in the various `coreimp.json` files throughout https://github.com/metaleap/gopure-demos/tree/master/01_hello_stranger/output )

**New modules:**

- `src/Language/PureScript/CoreImp/ToJSON.hs` --- minimalist, modeled after the existing `src/Language/PureScript/CoreFn/ToJSON.hs`, same code conventions AFAICT. (Has duplicated the trivial tiny helper functions `identToJSON` and `moduleNameToJSON` as I didn't want to impress changes on to what the existing original exports.)

**Existing modules:**

1. Merely duplications of the existing `--dump-corefn` option handling in:
  - `app/Command/Compile.hs`
  - `src/Language/PureScript/Make.hs`
  - `src/Language/PureScript/Options.hs`
  (Too small & trivial to generalize into helper funcs for now IMHO --- until a 3rd `--dump-xyz` request comes along in the future at least.)
2. Minimal changes just to `DeriveGeneric` the 3 `ToJSON` instances for `AST`, `UnaryOperator`, `BinaryOperator` in:
  - `src/Language/PureScript/CoreImp/AST.hs`
