### PR TITLE
Only add newline before initial group of comment lines in codegen

### DIFF
--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -116,20 +116,19 @@ literals = mkPattern' match'
     , prettyPrintJS' value
     ]
   match (Comment _ com js) = mconcat <$> sequence
-    [ mconcat <$> forM com comment
+    [ return $ emit "\n"
+    , mconcat <$> forM com comment
     , prettyPrintJS' js
     ]
   match _ = mzero
 
   comment :: (Emit gen) => Comment -> StateT PrinterState Maybe gen
   comment (LineComment com) = fmap mconcat $ sequence $
-    [ return $ emit "\n"
-    , currentIndent
+    [ currentIndent
     , return $ emit "//" <> emit com <> emit "\n"
     ]
   comment (BlockComment com) = fmap mconcat $ sequence $
-    [ return $ emit "\n"
-    , currentIndent
+    [ currentIndent
     , return $ emit "/**\n"
     ] ++
     map asLine (T.lines com) ++


### PR DESCRIPTION
Fixes #3096.

Most Purescript code tends to be commented using multiple Line comments rather than block comments. This change removes the current behaviour of adding additional newlines between each line comment, producing more readable javascript comments when compiling with comments.

I am not really sure how to implement a test for this change?