### PR TITLE
CoreFn Module type

### DIFF
--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -45,9 +45,9 @@ import System.FilePath.Posix ((</>))
 -- | Generate code in the simplified JavaScript intermediate representation for all declarations in a
 -- module.
 moduleToJs
-  :: forall m t
+  :: forall m
    . (Monad m, MonadReader Options m, MonadSupply m, MonadError MultipleErrors m)
-  => ModuleT t Ann
+  => Module Ann
   -> Maybe AST
   -> m [AST]
 moduleToJs (Module coms mn _ imps exps foreigns decls) foreign_ =
@@ -64,7 +64,7 @@ moduleToJs (Module coms mn _ imps exps foreigns decls) foreign_ =
     let header = if comments && not (null coms) then AST.Comment Nothing coms strict else strict
     let foreign' = [AST.VariableIntroduction Nothing "$foreign" foreign_ | not $ null foreigns || isNothing foreign_]
     let moduleBody = header : foreign' ++ jsImports ++ concat optimized
-    let foreignExps = exps `intersect` (fst `map` foreigns)
+    let foreignExps = exps `intersect` foreigns
     let standardExps = exps \\ foreignExps
     let exps' = AST.ObjectLiteral Nothing $ map (mkString . runIdent &&& AST.Var Nothing . identToJs) standardExps
                                ++ map (mkString . runIdent &&& foreignIdent) foreignExps

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -221,8 +221,8 @@ importToCoreFn (A.ImportDeclaration (ss, com) name _ _) = Just ((ss, com, Nothin
 importToCoreFn _ = Nothing
 
 -- | Desugars foreign declarations from AST to CoreFn representation.
-externToCoreFn :: A.Declaration -> Maybe ForeignDecl
-externToCoreFn (A.ExternDeclaration _ name ty) = Just (name, ty)
+externToCoreFn :: A.Declaration -> Maybe Ident
+externToCoreFn (A.ExternDeclaration _ name _) = Just name
 externToCoreFn _ = Nothing
 
 -- | Desugars export declarations references from AST to CoreFn representation.

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -104,7 +104,7 @@ qualifiedFromJSON f = withObject "Qualified" qualifiedFromObj
 moduleNameFromJSON :: Value -> Parser ModuleName
 moduleNameFromJSON v = ModuleName <$> listParser properNameFromJSON v
 
-moduleFromJSON :: Value -> Parser (Version, ModuleT () Ann)
+moduleFromJSON :: Value -> Parser (Version, Module Ann)
 moduleFromJSON = withObject "Module" moduleFromObj
   where
   moduleFromObj o = do
@@ -114,7 +114,7 @@ moduleFromJSON = withObject "Module" moduleFromObj
     moduleImports <- o .: "imports" >>= listParser (importFromJSON modulePath)
     moduleExports <- o .: "exports" >>= listParser identFromJSON
     moduleDecls <- o .: "decls" >>= listParser (bindFromJSON modulePath)
-    moduleForeign <- o .: "foreign" >>= listParser (fmap (flip (,) ()) . identFromJSON)
+    moduleForeign <- o .: "foreign" >>= listParser identFromJSON
     moduleComments <- o .: "comments" >>= listParser parseJSON
     return (version, Module {..})
 

--- a/src/Language/PureScript/CoreFn/Module.hs
+++ b/src/Language/PureScript/CoreFn/Module.hs
@@ -5,7 +5,6 @@ import Prelude.Compat
 import Language.PureScript.Comments
 import Language.PureScript.CoreFn.Expr
 import Language.PureScript.Names
-import Language.PureScript.Types
 
 -- |
 -- The CoreFn module representation
@@ -13,18 +12,12 @@ import Language.PureScript.Types
 -- The json CoreFn representation does not contain type information.  When
 -- parsing it one gets back `ModuleT () Ann` rathern than `ModuleT Type Ann`,
 -- which is enough for `moduleToJs`.
-data ModuleT t a = Module
+data Module a = Module
   { moduleComments :: [Comment]
   , moduleName :: ModuleName
   , modulePath :: FilePath
   , moduleImports :: [(a, ModuleName)]
   , moduleExports :: [Ident]
-  , moduleForeign :: [ForeignDeclT t]
+  , moduleForeign :: [Ident]
   , moduleDecls :: [Bind a]
   } deriving (Show)
-
-type Module a = ModuleT Type a
-
-type ForeignDeclT t = (Ident, t)
-
-type ForeignDecl = ForeignDeclT Type

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -101,13 +101,13 @@ qualifiedToJSON f (Qualified mn a) = object
 moduleNameToJSON :: ModuleName -> Value
 moduleNameToJSON (ModuleName pns) = toJSON $ properNameToJSON `map` pns
 
-moduleToJSON :: Version -> ModuleT a Ann -> Value
+moduleToJSON :: Version -> Module Ann -> Value
 moduleToJSON v m = object
   [ T.pack "moduleName" .= moduleNameToJSON (moduleName m)
   , T.pack "modulePath" .= toJSON (modulePath m)
   , T.pack "imports"    .= map importToJSON (moduleImports m)
   , T.pack "exports"    .= map identToJSON (moduleExports m)
-  , T.pack "foreign"    .= map (identToJSON . fst) (moduleForeign m)
+  , T.pack "foreign"    .= map identToJSON (moduleForeign m)
   , T.pack "decls"      .= map bindToJSON (moduleDecls m)
   , T.pack "builtWith"  .= toJSON (showVersion v)
   , T.pack "comments"   .= map toJSON (moduleComments m)

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -435,7 +435,7 @@ checkForeignDecls m path = do
                      errorInvalidForeignIdentifiers
                      (pure . S.fromList)
                      (parseIdents foreignIdentsStrs)
-  let importedIdents = S.fromList $ map fst (CF.moduleForeign m)
+  let importedIdents = S.fromList (CF.moduleForeign m)
 
   let unusedFFI = foreignIdents S.\\ importedIdents
   unless (null unusedFFI) $

--- a/tests/TestCoreFn.hs
+++ b/tests/TestCoreFn.hs
@@ -19,7 +19,6 @@ import Language.PureScript.CoreFn
 import Language.PureScript.CoreFn.FromJSON
 import Language.PureScript.CoreFn.ToJSON
 import Language.PureScript.Names
-import Language.PureScript.Types
 import Language.PureScript.PSString
 
 import Test.Hspec
@@ -27,11 +26,11 @@ import Test.Hspec
 main :: IO ()
 main = hspec spec
 
-parseModule :: Value -> Result (Version, ModuleT () Ann)
+parseModule :: Value -> Result (Version, Module Ann)
 parseModule = parse moduleFromJSON
 
 -- convert a module to its json CoreFn representation and back
-parseMod :: Module Ann -> Result (ModuleT () Ann)
+parseMod :: Module Ann -> Result (Module Ann)
 parseMod m =
   let v = Version [0] []
   in snd <$> parseModule (moduleToJSON v m)
@@ -76,11 +75,11 @@ spec = context "CoreFnFromJsonTest" $ do
       Success m -> moduleExports m `shouldBe` [Ident "exp"]
 
   specify "should parse foreign" $ do
-    let r = parseMod $ Module [] mn mp [] [] [(Ident "exp", TUnknown 0)] []
+    let r = parseMod $ Module [] mn mp [] [] [Ident "exp"] []
     r `shouldSatisfy` isSuccess
     case r of
       Error _   -> return ()
-      Success m -> moduleForeign m `shouldBe` [(Ident "exp", ())]
+      Success m -> moduleForeign m `shouldBe` [Ident "exp"]
 
   context "Expr" $ do
     specify "should parse literals" $ do


### PR DESCRIPTION
@paf31 this clears the `CoreFn.Module` type.