### PR TITLE
Add valid location list to orphan instance error

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -16,6 +16,7 @@ import Control.Monad.Identity
 
 import Data.Aeson.TH
 import qualified Data.Map as M
+import Data.Set (Set)
 import Data.Text (Text)
 import qualified Data.List.NonEmpty as NEL
 import GHC.Generics (Generic)
@@ -130,7 +131,7 @@ data SimpleErrorMessage
   | PropertyIsMissing Label
   | AdditionalProperty Label
   | TypeSynonymInstance
-  | OrphanInstance Ident (Qualified (ProperName 'ClassName)) [Type]
+  | OrphanInstance Ident (Qualified (ProperName 'ClassName)) (Set ModuleName) [Type]
   | InvalidNewtype (ProperName 'TypeName)
   | InvalidInstanceHead Type
   | TransitiveExportError DeclarationRef [DeclarationRef]

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -774,9 +774,9 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
                 [] -> [ line "There is nowhere this instance can be placed without being an orphan."
                       , line "A newtype wrapper can be used to avoid this problem."
                       ]
-                _  -> [ Box.text $ "This instance must be declared in "
+                _  -> [ Box.text $ "This problem can be resolved by declaring the instance in "
                           <> T.unpack formattedModules
-                          <> ", or be defined for a newtype wrapper."
+                          <> ", or by defining the instance on a newtype wrapper."
                       ]
                 ]
       where

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -771,12 +771,16 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
                 , Box.vcat Box.left (map typeAtomAsBox ts)
                 ]
             , line "is an orphan instance."
-            , line "To avoid this error, declare the instance in one of the following modules if possible:"
-            , markCodeBox $ indent $ Box.hsep 1 Box.left $ (line . runModuleName) <$> nonOrphans
-            , line "Otherwise, consider adding a newtype wrapper."
+            , suggestion
             ]
       where
-        nonOrphans = S.toList $ S.delete (moduleNameFromString "Prim") nonOrphanModules
+        suggestion = Box.vcat Box.left $
+          case S.toList $ S.delete (moduleNameFromString "Prim") nonOrphanModules of
+            [] -> [ line "There is nowhere this instance can be placed without being an orphan. A newtype wrapper can be used to avoid this problem." ]
+            xs -> [ line "This instance must be declared in one of the following modules:"
+                  , Box.vcat Box.left $ (line . runModuleName) <$> xs
+                  , line "Otherwise, a newtype wrapper can be used to solve this problem."
+                  ]
     renderSimpleErrorMessage (InvalidNewtype name) =
       paras [ line $ "Newtype " <> markCode (runProperName name) <> " is invalid."
             , line "Newtypes must define a single constructor with a single argument."

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -22,6 +22,7 @@ import           Data.List (transpose, nubBy, sort, partition, dropWhileEnd)
 import qualified Data.List.NonEmpty as NEL
 import           Data.Maybe (maybeToList, fromMaybe, mapMaybe)
 import qualified Data.Map as M
+import qualified Data.Set as S
 import qualified Data.Text as T
 import           Data.Text (Text)
 import           Language.PureScript.AST
@@ -274,7 +275,7 @@ onTypesInErrorMessageM f (ErrorMessage hints simple) = ErrorMessage <$> traverse
   gSimple (InvalidDerivedInstance cl ts n) = InvalidDerivedInstance cl <$> traverse f ts <*> pure n
   gSimple (ExpectedTypeConstructor cl ts ty) = ExpectedTypeConstructor cl <$> traverse f ts <*> f ty
   gSimple (ExpectedType ty k) = ExpectedType <$> f ty <*> pure k
-  gSimple (OrphanInstance nm cl ts) = OrphanInstance nm cl <$> traverse f ts
+  gSimple (OrphanInstance nm cl noms ts) = OrphanInstance nm cl noms <$> traverse f ts
   gSimple (WildcardInferredType ty ctx) = WildcardInferredType <$> f ty <*> traverse (sndM f) ctx
   gSimple (HoleInferredType name ty ctx env) = HoleInferredType name <$> f ty <*> traverse (sndM f) ctx  <*> onTypeSearchTypesM f env
   gSimple (MissingTypeDeclaration nm ty) = MissingTypeDeclaration nm <$> f ty
@@ -763,16 +764,19 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       line $ "Type of expression contains additional label " <> markCode (prettyPrintLabel prop) <> "."
     renderSimpleErrorMessage TypeSynonymInstance =
       line "Type class instances for type synonyms are disallowed."
-    renderSimpleErrorMessage (OrphanInstance nm cnm ts) =
+    renderSimpleErrorMessage (OrphanInstance nm cnm nonOrphanModules ts) =
       paras [ line $ "Type class instance " <> markCode (showIdent nm) <> " for "
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName cnm)
                 , Box.vcat Box.left (map typeAtomAsBox ts)
                 ]
             , line "is an orphan instance."
-            , line "An orphan instance is one which is defined in a module that is unrelated to either the class or the collection of data types that the instance is defined for."
-            , line "Consider moving the instance, if possible, or using a newtype wrapper."
+            , line "To avoid this error, declare the instance in one of the following modules if possible:"
+            , markCodeBox $ indent $ Box.hsep 1 Box.left $ (line . runModuleName) <$> nonOrphans
+            , line "Otherwise, consider adding a newtype wrapper."
             ]
+      where
+        nonOrphans = S.toList $ S.delete (moduleNameFromString "Prim") nonOrphanModules
     renderSimpleErrorMessage (InvalidNewtype name) =
       paras [ line $ "Newtype " <> markCode (runProperName name) <> " is invalid."
             , line "Newtypes must define a single constructor with a single argument."

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -372,6 +372,7 @@ typeCheckAll moduleName _ = traverse go
     typeModule (TypeConstructor (Qualified (Just mn'') _)) = Just mn''
     typeModule (TypeConstructor (Qualified Nothing _)) = internalError "Unqualified type name in checkOrphanInstance"
     typeModule (TypeApp t1 _) = typeModule t1
+    typeModule (ProxyType _) = Nothing
     typeModule _ = internalError "Invalid type in instance in checkOrphanInstance"
 
     modulesByTypeIndex :: M.Map Int (Maybe ModuleName)

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -360,9 +360,12 @@ typeCheckAll moduleName _ = traverse go
 
   checkOrphanInstance :: Ident -> Qualified (ProperName 'ClassName) -> TypeClassData -> [Type] -> m ()
   checkOrphanInstance dictName className@(Qualified (Just mn') _) typeClass tys'
-    | moduleName == mn' || moduleName `S.member` nonOrphanModules = return ()
-    | otherwise = throwError . errorMessage $ OrphanInstance dictName className tys'
+    | moduleName `S.member` nonOrphanModules' = return ()
+    | otherwise = throwError . errorMessage $ OrphanInstance dictName className nonOrphanModules' tys'
     where
+    nonOrphanModules' :: S.Set ModuleName
+    nonOrphanModules' = S.insert mn' nonOrphanModules
+
     typeModule :: Type -> Maybe ModuleName
     typeModule (TypeVar _) = Nothing
     typeModule (TypeLevelString _) = Nothing


### PR DESCRIPTION
Previously, the orphan instance simply said to consider a newtype. Now, it lists all the places in the project that would be considered valid locations for the instance as well. This hopefully closes #3063, and looks a little something like:

```
Error found:
in module $PSCI
at  line 1, column 1 - line 1, column 35

  Type class instance showFn for

    Data.Show.Show (a -> b)

  is an orphan instance.
  To avoid this error, declare the instance in one of the following modules if possible:

    Data.Show

  Otherwise, consider adding a newtype wrapper.
```