### PR TITLE
Add position to type class declaration error

### DIFF
--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -316,9 +316,10 @@ typeCheckAll moduleName _ = traverse go
     return d
   go d@FixityDeclaration{} = return d
   go d@ImportDeclaration{} = return d
-  go d@(TypeClassDeclaration _ pn args implies deps tys) = do
-    addTypeClass moduleName pn args implies deps tys
-    return d
+  go d@(TypeClassDeclaration (ss, _) pn args implies deps tys) = do
+    warnAndRethrow (addHint (ErrorInTypeClassDeclaration pn) . addHint (PositionedError ss)) $ do
+      addTypeClass moduleName pn args implies deps tys
+      return d
   go (d@(TypeInstanceDeclaration (ss, _) ch idx dictName deps className tys body)) =
     rethrow (addHint (ErrorInInstance className tys) . addHint (PositionedError ss)) $ do
       env <- getEnv


### PR DESCRIPTION
This PR adds position information to TypeClassDeclaration error so IDE can take advantage of it.

Related: https://github.com/purescript/purescript/pull/3088