### PR TITLE
Remove ambiguity from TypesDoNotUnify and KindsDoNotUnify errors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,6 +38,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@davidchambers](https://github.com/davidchambers) | David Chambers | [MIT license](http://opensource.org/licenses/MIT) |
 | [@DavidLindbom](https://github.com/DavidLindbom) | David Lindbom | [MIT license](http://opensource.org/licenses/MIT) |
 | [@dckc](https://github.com/dckc) | Dan Connolly | [MIT license](http://opensource.org/licenses/MIT) |
+| [@dwhitney](https://github.com/dwhitney) | Dustin Whitney | [MIT license](http://opensource.org/licenses/MIT) |
 | [@kleeneplus](https://github.com/dgendill) | Dominick Gendill | [MIT license](http://opensource.org/licenses/MIT) |
 | [@eamelink](https://github.com/eamelink) | Erik Bakker | MIT license |
 | [@epost](https://github.com/epost) | Erik Post | MIT license |

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -584,7 +584,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
                      )
         in paras [ line "Found type"
                  , markCodeBox $ indent $ typeAsBox sorted1
-                 , line "But excpected type"
+                 , line "But expected type"
                  , markCodeBox $ indent $ typeAsBox sorted2
                  ]
 

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -582,9 +582,9 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
                   in ( rowFromList (sort unique1 ++ sort common1, r1)
                      , rowFromList (sort unique2 ++ sort common2, r2)
                      )
-        in paras [ line "Could not match type"
+        in paras [ line "But excpected to match type"
                  , markCodeBox $ indent $ typeAsBox sorted1
-                 , line "with type"
+                 , line "Found type"
                  , markCodeBox $ indent $ typeAsBox sorted2
                  ]
 

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -582,16 +582,16 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
                   in ( rowFromList (sort unique1 ++ sort common1, r1)
                      , rowFromList (sort unique2 ++ sort common2, r2)
                      )
-        in paras [ line "But excpected to match type"
+        in paras [ line "Found type"
                  , markCodeBox $ indent $ typeAsBox sorted1
-                 , line "Found type"
+                 , line "But excpected type"
                  , markCodeBox $ indent $ typeAsBox sorted2
                  ]
 
     renderSimpleErrorMessage (KindsDoNotUnify k1 k2) =
-      paras [ line "Could not match kind"
+      paras [ line "Found kind"
             , indent $ line $ markCode $ prettyPrintKind k1
-            , line "with kind"
+            , line "But expected kind"
             , indent $ line $ markCode $ prettyPrintKind k2
             ]
     renderSimpleErrorMessage (ConstrainedTypeUnified t1 t2) =


### PR DESCRIPTION
Updates the wording of the two errors mentioned above. I'll make a GitHub issue with more discussion and post a link to it in the comments once it's done.