### PR TITLE
Option --dump-coreimp to output imperative-core to JSON

### DIFF
--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -132,11 +132,17 @@ dumpCoreFn = Opts.switch $
      Opts.long "dump-corefn"
   <> Opts.help "Dump the (functional) core representation of the compiled code at output/*/corefn.json"
 
+dumpCoreImp :: Opts.Parser Bool
+dumpCoreImp = Opts.switch $
+     Opts.long "dump-coreimp"
+  <> Opts.help "Dump the (imperative) core representation of the compiled code at output/*/coreimp.json"
+
 options :: Opts.Parser P.Options
 options = P.Options <$> verboseErrors
                     <*> (not <$> comments)
                     <*> sourceMaps
                     <*> dumpCoreFn
+                    <*> dumpCoreImp
 
 pscMakeOptions :: Opts.Parser PSCMakeOptions
 pscMakeOptions = PSCMakeOptions <$> many inputFile

--- a/src/Language/PureScript/CoreFn/Meta.hs
+++ b/src/Language/PureScript/CoreFn/Meta.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TemplateHaskell #-}
 -- |
 -- Metadata annotations for core functional representation
 --
@@ -6,6 +7,8 @@ module Language.PureScript.CoreFn.Meta where
 import Prelude.Compat
 
 import Language.PureScript.Names
+
+import Data.Aeson.TH
 
 -- |
 -- Metadata annotations
@@ -40,3 +43,8 @@ data ConstructorType
   -- The constructor is for a type with multiple construcors
   --
   | SumType deriving (Show, Eq, Ord)
+
+
+$(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''ConstructorType)
+
+$(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''Meta)

--- a/src/Language/PureScript/CoreImp/ToJSON.hs
+++ b/src/Language/PureScript/CoreImp/ToJSON.hs
@@ -1,0 +1,283 @@
+{-# LANGUAGE NoOverloadedStrings #-}
+-- |
+-- Dump the core imperative representation in JSON format for consumption
+-- by third-party code generators
+--
+module Language.PureScript.CoreImp.ToJSON
+  ( moduleToJSON
+  ) where
+
+
+import Prelude.Compat
+
+import Data.Aeson
+import Data.Maybe
+import qualified Data.Text as T
+import Data.Version (Version, showVersion)
+
+import Language.PureScript.AST (SourceSpan)
+import qualified Language.PureScript.AST.Literals as ASTL
+import Language.PureScript.CoreFn (Module, moduleDecls, moduleExports, moduleImports, moduleForeign)
+import Language.PureScript.CoreFn.Binders
+import qualified Language.PureScript.CoreFn.Expr as CoreFnExpr
+import Language.PureScript.CoreImp.AST
+import Language.PureScript.Names
+import Language.PureScript.PSString
+
+
+moduleNameToJSON :: ModuleName -> Value
+moduleNameToJSON = toJSON . runModuleName
+
+literalToJSON :: (a -> Value) -> ASTL.Literal a -> Value
+literalToJSON _ (ASTL.NumericLiteral (Left n)) = toJSON ("IntLiteral", n)
+literalToJSON _ (ASTL.NumericLiteral (Right n)) = toJSON ("NumberLiteral", n)
+literalToJSON _ (ASTL.StringLiteral s) = toJSON ("StringLiteral", s)
+literalToJSON _ (ASTL.CharLiteral c) = toJSON ("CharLiteral", c)
+literalToJSON _ (ASTL.BooleanLiteral b) = toJSON ("BooleanLiteral", b)
+literalToJSON t (ASTL.ArrayLiteral xs) = toJSON ("ArrayLiteral", map t xs)
+literalToJSON t (ASTL.ObjectLiteral xs) = toJSON ("ObjectLiteral", recordToJSON t xs)
+
+identToJSON :: Ident -> Value
+identToJSON = toJSON . runIdent
+
+properNameToJSON :: ProperName a -> Value
+properNameToJSON = toJSON . runProperName
+
+qualifiedToJSON :: (a -> T.Text) -> Qualified a -> Value
+qualifiedToJSON f = toJSON . showQualified f
+
+moduleToJSON :: (ToJSON a) => Version -> Module a -> [AST] -> Value
+moduleToJSON v m ast = object [ T.pack "imports"   .= map (moduleNameToJSON . snd) (moduleImports m)
+                              , T.pack "exports"   .= map identToJSON (moduleExports m)
+                              , T.pack "foreign"   .= map identToJSON (moduleForeign m)
+                              , T.pack "builtWith" .= toJSON (showVersion v)
+                              , T.pack "decls"     .= map bindToJSON (moduleDecls m) -- unlike the `decls` in --dump-corefn, here we only dump annotations (types & meta)
+                              , T.pack "body"      .= map (astToJSON) ast
+                              ]
+
+bindToJSON :: (ToJSON a) => CoreFnExpr.Bind a -> Value
+bindToJSON (CoreFnExpr.NonRec _ n e) = object [ runIdent n .= exprToJSON e ]
+bindToJSON (CoreFnExpr.Rec bs) = object $ map (\((_, n), e) -> runIdent n .= exprToJSON e) bs
+
+recordToJSON :: (a -> Value) -> [(PSString, a)] -> Value
+recordToJSON f rec = fromMaybe (asArrayOfPairs rec) (asObject rec)
+  where
+  asObject = fmap object . traverse (uncurry maybePair)
+  maybePair label a = fmap (\l -> l .= f a) (decodeString label)
+
+  asArrayOfPairs = toJSON . map (\(label, a) -> (toJSON label, f a))
+
+exprToJSON :: (ToJSON a) => CoreFnExpr.Expr a -> Value
+exprToJSON (CoreFnExpr.Var ann i)              = toJSON ( "Var"
+                                               , qualifiedToJSON runIdent i
+                                               , ann
+                                               )
+exprToJSON (CoreFnExpr.Literal ann l)          = toJSON ( "Literal"
+                                               , literalToJSON (exprToJSON) l
+                                               , ann
+                                               )
+exprToJSON (CoreFnExpr.Constructor ann d c is) = toJSON ( "Constructor"
+                                               , properNameToJSON d
+                                               , properNameToJSON c
+                                               , map identToJSON is
+                                               , ann
+                                               )
+exprToJSON (CoreFnExpr.Accessor ann f r)       = toJSON ( "Accessor"
+                                               , f
+                                               , exprToJSON r
+                                               , ann
+                                               )
+exprToJSON (CoreFnExpr.ObjectUpdate ann r fs)  = toJSON ( "ObjectUpdate"
+                                               , exprToJSON r
+                                               , recordToJSON exprToJSON fs
+                                               , ann
+                                               )
+exprToJSON (CoreFnExpr.Abs ann p b)            = toJSON ( "Abs"
+                                               , identToJSON p
+                                               , exprToJSON b
+                                               , ann
+                                               )
+exprToJSON (CoreFnExpr.App ann f x)            = toJSON ( "App"
+                                               , exprToJSON f
+                                               , exprToJSON x
+                                               , ann
+                                               )
+exprToJSON (CoreFnExpr.Case ann ss cs)         = toJSON ( "Case"
+                                               , map exprToJSON ss
+                                               , map caseAlternativeToJSON cs
+                                               , ann
+                                               )
+exprToJSON (CoreFnExpr.Let ann bs e)           = toJSON ( "Let"
+                                               , map bindToJSON bs
+                                               , exprToJSON e
+                                               , ann
+                                               )
+
+caseAlternativeToJSON :: (ToJSON a) => CoreFnExpr.CaseAlternative a -> Value
+caseAlternativeToJSON (CoreFnExpr.CaseAlternative bs r') =
+  toJSON [ toJSON (map binderToJSON bs)
+         , case r' of
+             Left rs -> toJSON $ map (\(g, e) -> (exprToJSON g, exprToJSON e)) rs
+             Right r -> exprToJSON r
+         ]
+
+binderToJSON :: (ToJSON a) => Binder a -> Value
+binderToJSON (VarBinder ann v)              = toJSON ( "VarBinder"
+                                                     , identToJSON v
+                                                     , ann
+                                                     )
+binderToJSON (NullBinder ann)               = toJSON ( "NullBinder"
+                                                     , ann
+                                                     )
+binderToJSON (LiteralBinder ann l)          = toJSON ( "LiteralBinder"
+                                                     , literalToJSON binderToJSON l
+                                                     , ann
+                                                     )
+binderToJSON (ConstructorBinder ann d c bs) = toJSON ( "ConstructorBinder"
+                                                     , qualifiedToJSON runProperName d
+                                                     , qualifiedToJSON runProperName c
+                                                     , map binderToJSON bs
+                                                     , ann
+                                                     )
+binderToJSON (NamedBinder ann n b)          = toJSON ( "NamedBinder"
+                                                     , identToJSON n
+                                                     , binderToJSON b
+                                                     , ann
+                                                     )
+
+
+
+
+
+astToJSON :: AST -> Value
+astToJSON (StringLiteral maybeSrcSpan psStr) =
+    object [T.pack "sourceSpan"    .= toJSON maybeSrcSpan,
+            T.pack "tag"           .= "StringLiteral",
+            T.pack "StringLiteral" .= toJSON psStr ]
+astToJSON (BooleanLiteral maybeSrcSpan bool) =
+    object [T.pack "sourceSpan"     .= toJSON maybeSrcSpan,
+            T.pack "tag"            .= "BooleanLiteral",
+            T.pack "BooleanLiteral" .= toJSON bool ]
+astToJSON (NumericLiteral maybeSrcSpan (Left num)) =
+    object [T.pack "sourceSpan"             .= toJSON maybeSrcSpan,
+            T.pack "tag"                    .= "NumericLiteral_Integer",
+            T.pack "NumericLiteral_Integer" .= toJSON num ]
+astToJSON (NumericLiteral maybeSrcSpan (Right num)) =
+    object [T.pack "sourceSpan"            .= toJSON maybeSrcSpan,
+            T.pack "tag"                   .= "NumericLiteral_Double",
+            T.pack "NumericLiteral_Double" .= toJSON num ]
+astToJSON (Var maybeSrcSpan text) =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= "Var",
+            T.pack "Var"        .= toJSON text ]
+astToJSON (Block maybeSrcSpan asts) =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= "Block",
+            T.pack "Block"      .= map astToJSON asts ]
+astToJSON (While maybeSrcSpan astCond astBody) =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= "While",
+            T.pack "While"      .= astToJSON astCond,
+            T.pack "body"       .= astToJSON astBody ]
+astToJSON (App maybeSrcSpan astFuncExpr astArgs) =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= "App",
+            T.pack "App"        .= astToJSON astFuncExpr,
+            T.pack "args"       .= map astToJSON astArgs ]
+astToJSON (Unary maybeSrcSpan unOp ast) =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= "Unary",
+            T.pack "Unary"      .= astToJSON ast,
+            T.pack "op"         .= show unOp ]
+astToJSON (Comment maybeSrcSpan comments ast) =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= "Comment",
+            T.pack "Comment"    .= map toJSON comments,
+            T.pack "decl"       .= astToJSON ast ]
+astToJSON (Function maybeSrcSpan maybeText texts ast) =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= "Function",
+            T.pack "Function"   .= toJSON maybeText,
+            T.pack "params"     .= toJSON texts,
+            T.pack "body"       .= astToJSON ast ]
+astToJSON (Binary maybeSrcSpan binOp astLeft astRight) =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= "Binary",
+            T.pack "Binary"     .= astToJSON astLeft,
+            T.pack "op"         .= show binOp,
+            T.pack "rhs"        .= astToJSON astRight ]
+astToJSON (ForIn maybeSrcSpan forname astInExpr astBody) =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= "ForIn",
+            T.pack "ForIn"      .= forname,
+            T.pack "for1"       .= astToJSON astInExpr,
+            T.pack "body"       .= astToJSON astBody ]
+astToJSON (For maybeSrcSpan forname astInitial astCmpLT astBody) =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= "For",
+            T.pack "For"        .= forname,
+            T.pack "for1"       .= astToJSON astInitial,
+            T.pack "for2"       .= astToJSON astCmpLT,
+            T.pack "body"       .= astToJSON astBody ]
+astToJSON (IfElse maybeSrcSpan astIf astThen astElse) =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= "IfElse",
+            T.pack "IfElse"     .= astToJSON astIf,
+            T.pack "then"       .= astToJSON astThen,
+            T.pack "else"       .= subAstToJSON astElse ]
+astToJSON (VariableIntroduction maybeSrcSpan text maybeAST) =
+    object [T.pack "sourceSpan"           .= toJSON maybeSrcSpan,
+            T.pack "tag"                  .= "VariableIntroduction",
+            T.pack "VariableIntroduction" .= toJSON text,
+            T.pack "rhs"                  .= subAstToJSON maybeAST ]
+astToJSON (ObjectLiteral maybeSrcSpan psStrASTs) =
+    object [T.pack "sourceSpan"    .= toJSON maybeSrcSpan,
+            T.pack "tag"           .= "ObjectLiteral",
+            T.pack "ObjectLiteral" .= map psStrASTToJson psStrASTs ]
+astToJSON (ReturnNoResult maybeSrcSpan) =
+    object [T.pack "sourceSpan"     .= toJSON maybeSrcSpan,
+            T.pack "tag"            .= "ReturnNoResult" ]
+astToJSON (Return maybeSrcSpan ast) =
+    subASTSingleToJSON "Return" maybeSrcSpan ast
+astToJSON (Throw maybeSrcSpan ast) =
+    subASTSingleToJSON "Throw" maybeSrcSpan ast
+astToJSON (ArrayLiteral maybeSrcSpan asts) =
+    subASTsListToJSON "ArrayLiteral" maybeSrcSpan asts
+astToJSON (Assignment maybeSrcSpan astLeft astRight) =
+    subASTsLeftRightToJSON "Assignment" maybeSrcSpan astLeft astRight
+astToJSON (Indexer maybeSrcSpan astInner astOuter) =
+    subASTsLeftRightToJSON "Indexer" maybeSrcSpan astOuter astInner
+astToJSON (InstanceOf maybeSrcSpan astLeft astRight) =
+    subASTsLeftRightToJSON "InstanceOf" maybeSrcSpan astLeft astRight
+
+psStrASTToJson :: (PSString, AST) -> Value
+psStrASTToJson (psStr, ast) =
+    object [T.pack (decodeStringWithReplacement psStr) .= astToJSON ast]
+
+subAstToJSON :: Maybe AST -> Value
+subAstToJSON (Just ast) =
+    astToJSON ast
+subAstToJSON Nothing =
+    Null
+
+subASTSingleToJSON :: String -> Maybe SourceSpan -> AST -> Value
+subASTSingleToJSON tag maybeSrcSpan ast =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= tag,
+            T.pack tag          .= astToJSON ast
+            ]
+
+subASTsListToJSON :: String -> Maybe SourceSpan -> [AST] -> Value
+subASTsListToJSON tag maybeSrcSpan asts =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= tag,
+            T.pack tag          .= map astToJSON asts
+            ]
+
+subASTsLeftRightToJSON :: String -> Maybe SourceSpan -> AST -> AST -> Value
+subASTsLeftRightToJSON tag maybeSrcSpan astLeft astRight =
+    object [T.pack "sourceSpan" .= toJSON maybeSrcSpan,
+            T.pack "tag"        .= tag,
+            T.pack tag          .= astToJSON astLeft,
+            T.pack "rhs"        .= astToJSON astRight
+            ]

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -70,6 +70,7 @@ import           Language.PureScript.CodeGen.JS.Printer
 import qualified Language.PureScript.CoreFn as CF
 import qualified Language.PureScript.CoreFn.ToJSON as CFJ
 import qualified Language.PureScript.CoreImp.AST as Imp
+import qualified Language.PureScript.CoreImp.ToJSON as CIJ
 import qualified Language.PureScript.Parser as PSParser
 import qualified Paths_purescript as Paths
 import           SourceMap
@@ -330,14 +331,18 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
   getOutputTimestamp :: ModuleName -> Make (Maybe UTCTime)
   getOutputTimestamp mn = do
     dumpCoreFn <- asks optionsDumpCoreFn
+    dumpCoreImp <- asks optionsDumpCoreImp
     let filePath = T.unpack (runModuleName mn)
         jsFile = outputDir </> filePath </> "index.js"
         externsFile = outputDir </> filePath </> "externs.json"
         coreFnFile = outputDir </> filePath </> "corefn.json"
-        min3 js exts coreFn
+        coreImpFile = outputDir </> filePath </> "coreimp.json"
+        min4 js exts coreFn coreImp
+          | dumpCoreFn && dumpCoreImp = min (min js exts) (min coreFn coreImp)
           | dumpCoreFn = min (min js exts) coreFn
+          | dumpCoreImp = min (min js exts) coreImp
           | otherwise = min js exts
-    min3 <$> getTimestamp jsFile <*> getTimestamp externsFile <*> getTimestamp coreFnFile
+    min4 <$> getTimestamp jsFile <*> getTimestamp externsFile <*> getTimestamp coreFnFile <*> getTimestamp coreImpFile
 
   readExterns :: ModuleName -> Make (FilePath, Externs)
   readExterns mn = do
@@ -375,10 +380,15 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
       writeTextFile externsFile exts
     lift $ when sourceMaps $ genSourceMap dir mapFile (length prefix) mappings
     dumpCoreFn <- lift $ asks optionsDumpCoreFn
+    dumpCoreImp <- lift $ asks optionsDumpCoreImp
     when dumpCoreFn $ do
       let coreFnFile = outputDir </> filePath </> "corefn.json"
       let json = CFJ.moduleToJSON Paths.version m
       lift $ writeTextFile coreFnFile (encode json)
+    when dumpCoreImp $ do
+      let coreImpFile = outputDir </> filePath </> "coreimp.json"
+      let json = CIJ.moduleToJSON Paths.version m rawJs
+      lift $ writeTextFile coreImpFile (encode json)
 
   genSourceMap :: String -> String -> Int -> [SMap] -> Make ()
   genSourceMap dir mapFile extraLines mappings = do

--- a/src/Language/PureScript/Options.hs
+++ b/src/Language/PureScript/Options.hs
@@ -13,8 +13,10 @@ data Options = Options
   -- ^ Generate source maps
   , optionsDumpCoreFn :: Bool
   -- ^ Dump CoreFn
+  , optionsDumpCoreImp :: Bool
+  -- ^ Dump CoreImp
   } deriving Show
 
 -- Default make options
 defaultOptions :: Options
-defaultOptions = Options False False False False
+defaultOptions = Options False False False False False


### PR DESCRIPTION
_(I sent this before in #3097 but retracted back then, but *now* it's in a state where it's solidified (keeping the recommendations from reviewers back then) and I'd ask for another review on this PR.. I don't foresee any changes to this feature set from the uses I can think of. Mostly the below is a verbatim copy of then.)_

New `purs compile` option `--dump-coreimp`, exactly like the existing `--dump-corefn`, to dump the `CoreImp` AST to a `coreimp.json` output file.

Requested in #876 and also in #711 [in the comments](https://github.com/purescript/purescript/issues/711#issuecomment-74744519)

(The results can be seen in the various `coreimp.json` files throughout [this directory](https://github.com/metaleap/gonad-demos/tree/master/output) )

**New modules:**

- `src/Language/PureScript/CoreImp/ToJSON.hs` --- modeled after the existing `src/Language/PureScript/CoreFn/ToJSON.hs`. (Has duplicated the trivial tiny helper functions `identToJSON` and `moduleNameToJSON` as I didn't want to impress changes on to what the existing original exports.)

**Existing modules:**

Mostly, merely duplications of the existing `--dump-corefn` option handling in:
- `app/Command/Compile.hs`
- `src/Language/PureScript/Make.hs`
- `src/Language/PureScript/Options.hs`
(Too small & trivial to generalize into helper funcs for now IMHO --- until a 3rd `--dump-xyz` request comes along in the future at least.)

Plus, `src/Language/PureScript/CoreFn/Meta.hs` added `deriveJSON` for `ConstructorType` and `Meta` --- part of this `--dump-coreimp` use-case as currently devised here is to indeed dump the various meta annotations and type information already "in-flight". In my currently-baking PureScript-to-Golang backend I'll need it on-top-of what `externs.json` has. I expect other future `coreimp` uses may as well. (When not needed, the consumer can obviously just ignore the stuff in the JSON's `decls` entry.)