### PR TITLE
Fix entailment issues with skolems and matches

### DIFF
--- a/examples/failing/InstanceChainBothUnknownAndMatch.purs
+++ b/examples/failing/InstanceChainBothUnknownAndMatch.purs
@@ -1,0 +1,14 @@
+-- @shouldFailWith NoInstanceFound
+module InstanceChains.BothUnknownAndMatch where
+
+class Same l r o | l r -> o
+instance sameY :: Same t t @"Y" else instance sameN :: Same l r @"N"
+same :: forall l r o. Same l r o => l -> r -> @o
+same _ _ = @o
+
+-- for label `u`, `t ~ Int` should be Unknown
+-- for label `m`, `Int ~ Int` should be a match
+-- together they should be Unknown
+example :: forall t. @t -> @_
+example _ = same @(u :: t, m :: Int) @(u :: Int, m :: Int)
+

--- a/examples/failing/InstanceChainSkolemUnknownMatch.purs
+++ b/examples/failing/InstanceChainSkolemUnknownMatch.purs
@@ -1,0 +1,12 @@
+-- @shouldFailWith NoInstanceFound
+module InstanceChainSkolemUnknownMatch where
+
+class Same l r o | l r -> o
+instance sameY :: Same t t @"Y" else instance sameN :: Same l r @"N"
+same :: forall l r o. Same l r o => l -> r -> @o
+same _ _ = @o
+
+-- shouldn't discard sameY as Apart
+example :: forall t. @t -> @_
+example _ = same @t @Int
+


### PR DESCRIPTION
When verifying a substitution, if we see a skolem (that hasn't been
matched with itself) then it is unknown whether or not we might have a
match or be apart.

Combining a match with an unknown should be an unknown not a match.
I.e: knowing that one of two things match doesn't make the other one now
a match.

Added failing examples to catch these cases.