### PR TITLE
Instantiate abstraction body during inference

### DIFF
--- a/examples/passing/3125.purs
+++ b/examples/passing/3125.purs
@@ -1,0 +1,16 @@
+module Main where
+
+import Prelude
+import Data.Monoid (class Monoid, mempty)
+import Control.Monad.Eff.Console (log, logShow)
+
+data B a = B a a
+
+memptyB :: forall a b. Monoid b => B (a -> b)
+memptyB = B l r where
+  l _ = mempty
+  r _ = mempty
+
+main = do
+  logShow $ case (memptyB :: B (Int -> Array Unit)) of B l r -> l 0 == r 0
+  log "Done"

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -357,7 +357,8 @@ infer' (Abs binder ret)
       ty <- freshType
       withBindingGroupVisible $ bindLocalVariables [(arg, ty, Defined)] $ do
         body@(TypedValue _ _ bodyTy) <- infer' ret
-        return $ TypedValue True (Abs (VarBinder arg) body) $ function ty bodyTy
+        (body', bodyTy') <- instantiatePolyTypeWithUnknowns body bodyTy
+        return $ TypedValue True (Abs (VarBinder arg) body') (function ty bodyTy')
   | otherwise = internalError "Binder was not desugared"
 infer' (App f arg) = do
   f'@(TypedValue _ _ ft) <- infer f


### PR DESCRIPTION
Fixes #3125 

Currently there is an issue with shadowed type vars in the shifted `forall` - see my comment on #3125.

Does this seem like a good approach?