### PR TITLE
[purs ide] return documentation comments

### DIFF
--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -1,5 +1,6 @@
 module Language.PureScript.Docs.Convert.Single
   ( convertSingleModule
+  , convertComments
   ) where
 
 import Protolude hiding (moduleName)

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -130,7 +130,7 @@ completionFromMatch (Match (m, IdeDeclarationAnn ann decl), mns) =
 
     complLocation = _annLocation ann
 
-    complDocumentation = Nothing
+    complDocumentation = _annDocumentation ann
 
     showFixity p a r o =
       let asso = case a of

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -114,13 +114,14 @@ data Annotation
   { _annLocation       :: Maybe P.SourceSpan
   , _annExportedFrom   :: Maybe P.ModuleName
   , _annTypeAnnotation :: Maybe P.Type
+  , _annDocumentation  :: Maybe Text
   } deriving (Show, Eq, Ord, Generic, NFData)
 
 makeLenses ''Annotation
 makeLenses ''IdeDeclarationAnn
 
 emptyAnn :: Annotation
-emptyAnn = Annotation Nothing Nothing Nothing
+emptyAnn = Annotation Nothing Nothing Nothing Nothing
 
 type DefinitionSites a = Map IdeNamespaced a
 type TypeAnnotations = Map P.Ident P.Type

--- a/tests/Language/PureScript/Ide/CompletionSpec.hs
+++ b/tests/Language/PureScript/Ide/CompletionSpec.hs
@@ -5,10 +5,12 @@ module Language.PureScript.Ide.CompletionSpec where
 import Protolude
 
 import Language.PureScript as P
+import Language.PureScript.Ide.Test as Test
+import Language.PureScript.Ide.Command as Command
 import Language.PureScript.Ide.Completion
-import Language.PureScript.Ide.Test
 import Language.PureScript.Ide.Types
 import Test.Hspec
+import System.FilePath
 
 reexportMatches :: [Match IdeDeclarationAnn]
 reexportMatches =
@@ -21,6 +23,15 @@ reexportMatches =
 matches :: [(Match IdeDeclarationAnn, [P.ModuleName])]
 matches = map (\d -> (Match (mn "Main", d), [mn "Main"])) [ ideKind "Kind", ideType "Type" Nothing [] ]
 
+typ :: Text -> Command
+typ txt = Type txt [] Nothing
+
+load :: [Text] -> Command
+load = LoadSync . map Test.mn
+
+rebuildSync :: FilePath -> Command
+rebuildSync fp = RebuildSync ("src" </> fp) Nothing
+
 spec :: Spec
 spec = describe "Applying completion options" $ do
   it "keeps all matches if maxResults is not specified" $ do
@@ -32,3 +43,24 @@ spec = describe "Applying completion options" $ do
   it "groups reexports for a single identifier" $ do
     applyCompletionOptions (defaultCompletionOptions { coGroupReexports = True })
       reexportMatches `shouldBe` [(Match (mn "A", ideKind "Kind"), [mn "A", mn "B"])]
+
+  it "gets simple docs on definition itself" $ do
+    ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
+      Test.runIde [ load ["CompletionSpecDocs"]
+                  , typ "something"
+                  ]
+    result `shouldSatisfy` \res -> complDocumentation res == Just "Doc x\n"
+
+  it "gets multiline docs" $ do
+    ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
+      Test.runIde [ load ["CompletionSpecDocs"]
+                  , typ "multiline"
+                  ]
+    result `shouldSatisfy` \res -> complDocumentation res == Just "This is\na multi-line\ncomment\n"
+
+  it "gets simple docs on type annotation" $ do
+    ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
+      Test.runIde [ load ["CompletionSpecDocs"]
+                  , typ "withType"
+                  ]
+    result `shouldSatisfy` \res -> complDocumentation res == Just "Doc *123*\n"

--- a/tests/support/pscide/src/CompletionSpecDocs.purs
+++ b/tests/support/pscide/src/CompletionSpecDocs.purs
@@ -1,0 +1,13 @@
+module CompletionSpecDocs where
+
+-- | Doc x
+something = "something"
+
+-- | Doc *123*
+withType :: Int
+withType = 42
+
+-- | This is
+-- | a multi-line
+-- | comment
+multiline = "multiline"


### PR DESCRIPTION
For #2349.

My first iteration used more docs code but I think this is simpler and works out better.

I'm thinking that markdown, plaintext and html options could be provided since there's already a markdown renderer there.

@kRITZCREEK 