### PR TITLE
[purs ide] Collect usages

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -232,6 +232,10 @@ getModuleName (Module _ _ name _ _) = name
 getModuleSourceSpan :: Module -> SourceSpan
 getModuleSourceSpan (Module ss _ _ _ _) = ss
 
+-- | Return a module's declarations
+getModuleDeclarations :: Module -> [Declaration]
+getModuleDeclarations (Module _ _ _ decls _) = decls
+
 -- |
 -- Add an import declaration for a module if it does not already explicitly import it.
 --

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -57,12 +57,10 @@ handleCommand c = case c of
     findAvailableExterns >>= loadModulesSync
   LoadSync modules ->
     loadModulesSync modules
-  Info id -> do
-    getAtDeclarationId id >>= \case
-      Nothing ->
-        throwError (NotFound ("Couldn't find declaration for id: " <> printIdeDeclarationId id))
-      Just decl ->
-        pure (InfoResult decl)
+  Query filters currentModule -> do
+    modules <- getAllModules currentModule
+    let decls = applyFilters filters modules
+    pure (QueryResult decls)
   Type search filters currentModule ->
     findType search filters currentModule
   Complete filters matcher currentModule complOptions ->

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -57,6 +57,12 @@ handleCommand c = case c of
     findAvailableExterns >>= loadModulesSync
   LoadSync modules ->
     loadModulesSync modules
+  Info id -> do
+    getAtDeclarationId id >>= \case
+      Nothing ->
+        throwError (NotFound ("Couldn't find declaration for id: " <> printIdeDeclarationId id))
+      Just decl ->
+        pure (InfoResult decl)
   Type search filters currentModule ->
     findType search filters currentModule
   Complete filters matcher currentModule complOptions ->

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -57,9 +57,15 @@ handleCommand c = case c of
     findAvailableExterns >>= loadModulesSync
   LoadSync modules ->
     loadModulesSync modules
-  Query filters currentModule -> do
-    modules <- getAllModules currentModule
-    pure (QueryResult (applyFilters filters modules))
+  Usages declarationId _currentModule -> do
+    -- TODO(Christoph): currentModule is unused here, see if we can make
+    -- findUsages work with the rebuild cache
+    decl <- lookupDeclarationId declarationId
+    case decl of
+      Nothing -> throwError (NotFound ("Couldn't find a declaration for " <> show declarationId))
+      Just d -> case d & _idaAnnotation & _annUsages of
+        Nothing -> throwError (GeneralError ("Usages have not been resolved"))
+        Just usages -> pure (UsagesResult usages)
   Type search filters currentModule ->
     findType search filters currentModule
   Complete filters matcher currentModule complOptions ->

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -59,8 +59,7 @@ handleCommand c = case c of
     loadModulesSync modules
   Query filters currentModule -> do
     modules <- getAllModules currentModule
-    let decls = applyFilters filters modules
-    pure (QueryResult decls)
+    pure (QueryResult (applyFilters filters modules))
   Type search filters currentModule ->
     findType search filters currentModule
   Complete filters matcher currentModule complOptions ->

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -68,6 +68,7 @@ commandName c = case c of
   Load{} -> "Load"
   LoadSync{} -> "LoadSync"
   Type{} -> "Type"
+  Info{} -> "Info"
   Complete{} -> "Complete"
   Pursuit{} -> "Pursuit"
   CaseSplit{} -> "CaseSplit"

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -32,6 +32,7 @@ data Command
       , typeFilters       :: [Filter]
       , typeCurrentModule :: Maybe P.ModuleName
       }
+    | Info IdeDeclarationId
     | Complete
       { completeFilters       :: [Filter]
       , completeMatcher       :: Matcher IdeDeclarationAnn
@@ -127,6 +128,12 @@ instance FromJSON Command where
           Nothing -> pure (Load [])
           Just params ->
             Load <$> (map P.moduleNameFromString <$> params .:? "modules" .!= [])
+      "info" -> do
+        params <- o .: "params"
+        id <- params .:  "id"
+        case parseIdeDeclarationId id of
+          Nothing -> mzero
+          Just declarationId -> pure (Info declarationId)
       "type" -> do
         params <- o .: "params"
         Type

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -32,7 +32,10 @@ data Command
       , typeFilters       :: [Filter]
       , typeCurrentModule :: Maybe P.ModuleName
       }
-    | Info IdeDeclarationId
+    | Query
+      { queryFilters :: [Filter]
+      , queryCurrentModule :: Maybe P.ModuleName
+      }
     | Complete
       { completeFilters       :: [Filter]
       , completeMatcher       :: Matcher IdeDeclarationAnn
@@ -68,7 +71,7 @@ commandName c = case c of
   Load{} -> "Load"
   LoadSync{} -> "LoadSync"
   Type{} -> "Type"
-  Info{} -> "Info"
+  Query{} -> "Query"
   Complete{} -> "Complete"
   Pursuit{} -> "Pursuit"
   CaseSplit{} -> "CaseSplit"
@@ -129,12 +132,11 @@ instance FromJSON Command where
           Nothing -> pure (Load [])
           Just params ->
             Load <$> (map P.moduleNameFromString <$> params .:? "modules" .!= [])
-      "info" -> do
+      "query" -> do
         params <- o .: "params"
-        id <- params .:  "id"
-        case parseIdeDeclarationId id of
-          Nothing -> mzero
-          Just declarationId -> pure (Info declarationId)
+        filters <- params .:? "filters" .!= []
+        currentModule <- params .:?  "currentModule"
+        pure (Query filters currentModule)
       "type" -> do
         params <- o .: "params"
         Type

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -26,13 +26,13 @@ module Language.PureScript.Ide.Imports
        , addExplicitImport'
        , sliceImportSection
        , prettyPrintImport'
-       , Import(Import)
+       , Import(..)
        )
        where
 
 import           Protolude hiding (moduleName)
 
-import           Control.Lens                       ((^.), (%~), ix)
+import           Control.Lens                       ((^.))
 import           Data.List                          (findIndex, nubBy, partition)
 import qualified Data.Text                          as T
 import qualified Language.PureScript                as P
@@ -42,86 +42,8 @@ import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
+import           Language.PureScript.Ide.Imports.Helpers
 import           System.IO.UTF8                     (writeUTF8FileT)
-import qualified Text.Parsec as Parsec
-
-data Import = Import P.ModuleName P.ImportDeclarationType (Maybe P.ModuleName)
-              deriving (Eq, Show)
-
--- | Reads a file and returns the parsed modulename as well as the parsed
--- imports, while ignoring eventual parse errors that aren't relevant to the
--- import section
-parseImportsFromFile
-  :: (MonadIO m, MonadError IdeError m)
-  => FilePath
-  -> m (P.ModuleName, [(P.ModuleName, P.ImportDeclarationType, Maybe P.ModuleName)])
-parseImportsFromFile file = do
-  (mn, _, imports, _) <- parseImportsFromFile' file
-  pure (mn, unwrapImport <$> imports)
-  where
-    unwrapImport (Import a b c) = (a, b, c)
-
--- | Reads a file and returns the (lines before the imports, the imports, the
--- lines after the imports)
-parseImportsFromFile' :: (MonadIO m, MonadError IdeError m) =>
-                        FilePath -> m (P.ModuleName, [Text], [Import], [Text])
-parseImportsFromFile' fp = do
-  file <- ideReadFile fp
-  case sliceImportSection (T.lines file) of
-    Right res -> pure res
-    Left err -> throwError (GeneralError err)
-
--- | @ImportParse@ holds the data we extract out of a partial parse of the
--- sourcefile
-data ImportParse = ImportParse
-  { ipModuleName :: P.ModuleName
-  -- ^ the module name we parse
-  , ipStart :: P.SourcePos
-  -- ^ the beginning of the import section. If `import Prelude` was the first
-  -- import, this would point at `i`
-  , ipEnd :: P.SourcePos
-  -- ^ the end of the import section
-  , ipImports :: [Import]
-  -- ^ the extracted import declarations
-  }
-
-parseModuleHeader :: P.TokenParser ImportParse
-parseModuleHeader = do
-  _ <- P.readComments
-  (mn, _) <- P.parseModuleDeclaration
-  (ipStart, ipEnd, decls) <- P.withSourceSpan (\(P.SourceSpan _ start end) _ -> (start, end,))
-    (P.mark (Parsec.many (P.same *> P.parseImportDeclaration')))
-  pure (ImportParse mn ipStart ipEnd (map mkImport decls))
-  where
-    mkImport (mn, (P.Explicit refs), qual) = Import mn (P.Explicit refs) qual
-    mkImport (mn, it, qual) = Import mn it qual
-
-sliceImportSection :: [Text] -> Either Text (P.ModuleName, [Text], [Import], [Text])
-sliceImportSection fileLines = first show $ do
-  tokens <- P.lexLenient "<psc-ide>" file
-  ImportParse{..} <- P.runTokenParser "<psc-ide>" parseModuleHeader tokens
-  pure ( ipModuleName
-       , sliceFile (P.SourcePos 1 1) (prevPos ipStart)
-       , ipImports
-       -- Not sure why I need to drop 1 here, but it makes the tests pass
-       , drop 1 (sliceFile (nextPos ipEnd) (P.SourcePos (length fileLines) (lineLength (length fileLines))))
-       )
-  where
-    prevPos (P.SourcePos l c)
-      | l == 1 && c == 1 = P.SourcePos l c
-      | c == 1 = P.SourcePos (l - 1) (lineLength (l - 1))
-      | otherwise = P.SourcePos l (c - 1)
-    nextPos (P.SourcePos l c)
-      | c == lineLength l = P.SourcePos (l + 1) 1
-      | otherwise = P.SourcePos l (c + 1)
-    file = T.unlines fileLines
-    lineLength l = T.length (fileLines ^. ix (l - 1))
-    sliceFile (P.SourcePos l1 c1) (P.SourcePos l2 c2) =
-      fileLines
-      & drop (l1 - 1)
-      & take (l2 - l1 + 1)
-      & ix 0 %~ T.drop (c1 - 1)
-      & ix (l2 - l1) %~ T.take c2
 
 -- | Adds an implicit import like @import Prelude@ to a Sourcefile.
 addImplicitImport
@@ -327,7 +249,6 @@ prettyPrintImportSection imports =
       Import _ P.Implicit Nothing -> True
       Import _ (P.Hiding _) Nothing -> True
       _ -> False
-
 
 -- | Writes a list of lines to @Just filepath@ and responds with a @TextResult@,
 -- or returns the lines as a @MultilineTextResult@ if @Nothing@ was given as the

--- a/src/Language/PureScript/Ide/Imports/Helpers.hs
+++ b/src/Language/PureScript/Ide/Imports/Helpers.hs
@@ -1,0 +1,88 @@
+module Language.PureScript.Ide.Imports.Helpers where
+
+import           Protolude hiding (moduleName)
+
+import           Control.Lens                       ((^.), (%~), ix)
+import qualified Data.Text                          as T
+import qualified Language.PureScript                as P
+import           Language.PureScript.Ide.Error
+import           Language.PureScript.Ide.Util
+import qualified Text.Parsec as Parsec
+
+data Import = Import P.ModuleName P.ImportDeclarationType (Maybe P.ModuleName)
+              deriving (Eq, Show)
+
+-- | Reads a file and returns the parsed modulename as well as the parsed
+-- imports, while ignoring eventual parse errors that aren't relevant to the
+-- import section
+parseImportsFromFile
+  :: (MonadIO m, MonadError IdeError m)
+  => FilePath
+  -> m (P.ModuleName, [(P.ModuleName, P.ImportDeclarationType, Maybe P.ModuleName)])
+parseImportsFromFile file = do
+  (mn, _, imports, _) <- parseImportsFromFile' file
+  pure (mn, unwrapImport <$> imports)
+  where
+    unwrapImport (Import a b c) = (a, b, c)
+
+-- | Reads a file and returns the (lines before the imports, the imports, the
+-- lines after the imports)
+parseImportsFromFile' :: (MonadIO m, MonadError IdeError m) =>
+                        FilePath -> m (P.ModuleName, [Text], [Import], [Text])
+parseImportsFromFile' fp = do
+  file <- ideReadFile fp
+  case sliceImportSection (T.lines file) of
+    Right res -> pure res
+    Left err -> throwError (GeneralError err)
+
+-- | @ImportParse@ holds the data we extract out of a partial parse of the
+-- sourcefile
+data ImportParse = ImportParse
+  { ipModuleName :: P.ModuleName
+  -- ^ the module name we parse
+  , ipStart :: P.SourcePos
+  -- ^ the beginning of the import section. If `import Prelude` was the first
+  -- import, this would point at `i`
+  , ipEnd :: P.SourcePos
+  -- ^ the end of the import section
+  , ipImports :: [Import]
+  -- ^ the extracted import declarations
+  }
+
+parseModuleHeader :: P.TokenParser ImportParse
+parseModuleHeader = do
+  _ <- P.readComments
+  (mn, _) <- P.parseModuleDeclaration
+  (ipStart, ipEnd, decls) <- P.withSourceSpan (\(P.SourceSpan _ start end) _ -> (start, end,))
+    (P.mark (Parsec.many (P.same *> P.parseImportDeclaration')))
+  pure (ImportParse mn ipStart ipEnd (map mkImport decls))
+  where
+    mkImport (mn, (P.Explicit refs), qual) = Import mn (P.Explicit refs) qual
+    mkImport (mn, it, qual) = Import mn it qual
+
+sliceImportSection :: [Text] -> Either Text (P.ModuleName, [Text], [Import], [Text])
+sliceImportSection fileLines = first show $ do
+  tokens <- P.lexLenient "<psc-ide>" file
+  ImportParse{..} <- P.runTokenParser "<psc-ide>" parseModuleHeader tokens
+  pure ( ipModuleName
+       , sliceFile (P.SourcePos 1 1) (prevPos ipStart)
+       , ipImports
+       -- Not sure why I need to drop 1 here, but it makes the tests pass
+       , drop 1 (sliceFile (nextPos ipEnd) (P.SourcePos (length fileLines) (lineLength (length fileLines))))
+       )
+  where
+    prevPos (P.SourcePos l c)
+      | l == 1 && c == 1 = P.SourcePos l c
+      | c == 1 = P.SourcePos (l - 1) (lineLength (l - 1))
+      | otherwise = P.SourcePos l (c - 1)
+    nextPos (P.SourcePos l c)
+      | c == lineLength l = P.SourcePos (l + 1) 1
+      | otherwise = P.SourcePos l (c + 1)
+    file = T.unlines fileLines
+    lineLength l = T.length (fileLines ^. ix (l - 1))
+    sliceFile (P.SourcePos l1 c1) (P.SourcePos l2 c2) =
+      fileLines
+      & drop (l1 - 1)
+      & take (l2 - l1 + 1)
+      & ix 0 %~ T.drop (c1 - 1)
+      & ix (l2 - l1) %~ T.take c2

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -206,10 +206,11 @@ populateVolatileStateSync :: (Ide m, MonadLogger m) => m ()
 populateVolatileStateSync = do
   st <- ideStateVar <$> ask
   let message duration = "Finished populating volatile state in: " <> displayTimeSpec duration
+  let usageMessage duration = "Finished populating usages in: " <> displayTimeSpec duration
   results <- logPerf message $ do
     !r <- liftIO (atomically (populateVolatileStateSTM st))
     pure r
-  logPerf message resolveUsages
+  logPerf usageMessage (resolveUsages *> forceVolatile)
   void $ Map.traverseWithKey
     (\mn -> logWarnN . prettyPrintReexportResult (const (P.runModuleName mn)))
     (Map.filter reexportHasFailures results)

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -244,7 +244,7 @@ identifierFromDeclarationRef _ = ""
 data Success =
   CompletionResult [Completion]
   | TextResult Text
-  | InfoResult IdeDeclarationAnn
+  | QueryResult [(P.ModuleName, [IdeDeclarationAnn])]
   | MultilineTextResult [Text]
   | PursuitResult [PursuitResponse]
   | ImportList (P.ModuleName, [(P.ModuleName, P.ImportDeclarationType, Maybe P.ModuleName)])
@@ -258,8 +258,11 @@ encodeSuccess res =
 
 instance ToJSON Success where
   toJSON (CompletionResult cs) = encodeSuccess cs
-  toJSON (InfoResult d) =
-    object ["resultType" .= ("success" :: Text), "result" .= encodeDeclarationAnn d]
+  toJSON (QueryResult r) =
+    object
+      [ "resultType" .= ("success" :: Text)
+      , "result" .= map (bimap P.runModuleName (map encodeDeclarationAnn)) r
+      ]
   toJSON (TextResult t) = encodeSuccess t
   toJSON (MultilineTextResult ts) = encodeSuccess ts
   toJSON (PursuitResult resp) = encodeSuccess resp

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -335,8 +335,7 @@ encodeDeclaration = \case
     , "params" .= object
       [ "name" .= P.runProperName (_ideTCName typeclass)
       , "kind" .= _ideTCKind typeclass
-      -- TODO(Christoph): A proper encoder for instances
-      , "instances" .= (map show (_ideTCInstances typeclass) :: [Text])
+      , "instances" .= map encodeIdeInstance (_ideTCInstances typeclass)
       ]
     ]
   IdeDeclValueOperator operator -> object
@@ -364,6 +363,17 @@ encodeDeclaration = \case
     , "params" .= object
       [ "name" .= P.runProperName kind ]
     ]
+
+encodeIdeInstance :: IdeInstance -> Value
+encodeIdeInstance IdeInstance{..} = object
+  [ "tag" .= ("instance" :: Text)
+  , "params" .= object
+    [ "module" .= P.runModuleName _ideInstanceModule
+    , "name" .= P.runIdent _ideInstanceName
+    , "types" .= _ideInstanceTypes
+    , "constraints" .= _ideInstanceConstraints
+    ]
+  ]
 
 newtype PursuitQuery = PursuitQuery Text
                      deriving (Show, Eq)

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -24,7 +24,6 @@ import           Protolude hiding (moduleName)
 import           Control.Concurrent.STM
 import           Control.Lens.TH
 import           Data.Aeson
-import qualified Data.Text as T
 import qualified Data.Map.Lazy as M
 import qualified Language.PureScript as P
 import qualified Language.PureScript.Errors.JSON as P
@@ -38,30 +37,6 @@ data IdeDeclarationId = IdeDeclarationId
   , _ididNamespace  :: !IdeNamespace
   , _ididIdentifier :: !Text
   } deriving (Show, Eq, Ord)
-
-printIdeDeclarationId :: IdeDeclarationId -> Text
-printIdeDeclarationId IdeDeclarationId{..} =
-  P.runModuleName _ididModule <> ":" <> printNS _ididNamespace <> ":" <> _ididIdentifier
-  where
-    printNS ns = case ns of
-      IdeNSValue -> "V"
-      IdeNSType -> "T"
-      IdeNSKind -> "K"
-
--- | Parses DeclarationId strings of the form:
--- "Module.Name:Namespace:identifier" where Namespace is one of V, T, or K.
-parseIdeDeclarationId :: Text -> Maybe IdeDeclarationId
-parseIdeDeclarationId t = do
-  guard (t /= "")
-  let (mn, rest) = bimap P.moduleNameFromString T.tail (T.breakOn ":" t)
-  let (ns, ident) = bimap parseNS T.tail (T.breakOn ":" rest)
-  IdeDeclarationId mn <$> ns <*> pure ident
-  where
-    parseNS c = case c of
-      "V" -> Just IdeNSValue
-      "T" -> Just IdeNSType
-      "K" -> Just IdeNSKind
-      _ -> Nothing
 
 data IdeDeclaration
   = IdeDeclValue IdeValue

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -236,7 +236,7 @@ instance ToJSON Success where
   toJSON (UsagesResult usages) =
     object
       [ "resultType" .= ("success" :: Text)
-      , "result" .= usages
+      , "result" .= map (first P.runModuleName) usages
       ]
   toJSON (TextResult t) = encodeSuccess t
   toJSON (MultilineTextResult ts) = encodeSuccess ts

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -31,6 +31,13 @@ import qualified Language.PureScript.Errors.JSON as P
 type ModuleIdent = Text
 type ModuleMap a = Map P.ModuleName a
 
+-- | This datatype can be used to uniquely identify a declaration in our State
+data IdeDeclarationId = IdeDeclarationId
+  { _ididModule     :: !P.ModuleName
+  , _ididNamespace  :: !IdeNamespace
+  , _ididIdentifier :: !Text
+  } deriving (Show, Eq, Ord)
+
 data IdeDeclaration
   = IdeDeclValue IdeValue
   | IdeDeclType IdeType
@@ -48,8 +55,8 @@ data IdeValue = IdeValue
   } deriving (Show, Eq, Ord, Generic, NFData)
 
 data IdeType = IdeType
- { _ideTypeName :: P.ProperName 'P.TypeName
- , _ideTypeKind :: P.Kind
+ { _ideTypeName  :: P.ProperName 'P.TypeName
+ , _ideTypeKind  :: P.Kind
  , _ideTypeDtors :: [(P.ProperName 'P.ConstructorName, P.Type)]
  } deriving (Show, Eq, Ord, Generic, NFData)
 
@@ -94,16 +101,6 @@ data IdeTypeOperator = IdeTypeOperator
   , _ideTypeOpKind          :: Maybe P.Kind
   } deriving (Show, Eq, Ord, Generic, NFData)
 
-makePrisms ''IdeDeclaration
-makeLenses ''IdeValue
-makeLenses ''IdeType
-makeLenses ''IdeTypeSynonym
-makeLenses ''IdeDataConstructor
-makeLenses ''IdeTypeClass
-makeLenses ''IdeInstance
-makeLenses ''IdeValueOperator
-makeLenses ''IdeTypeOperator
-
 data IdeDeclarationAnn = IdeDeclarationAnn
   { _idaAnnotation  :: Annotation
   , _idaDeclaration :: IdeDeclaration
@@ -115,10 +112,8 @@ data Annotation
   , _annExportedFrom   :: Maybe P.ModuleName
   , _annTypeAnnotation :: Maybe P.Type
   , _annDocumentation  :: Maybe Text
+  , _annUsages         :: Maybe [(P.ModuleName, P.SourceSpan)]
   } deriving (Show, Eq, Ord, Generic, NFData)
-
-makeLenses ''Annotation
-makeLenses ''IdeDeclarationAnn
 
 emptyAnn :: Annotation
 emptyAnn = Annotation Nothing Nothing Nothing Nothing
@@ -333,3 +328,17 @@ instance FromJSON IdeNamespace where
 -- | A name tagged with a namespace
 data IdeNamespaced = IdeNamespaced IdeNamespace Text
   deriving (Show, Eq, Ord, Generic, NFData)
+
+makePrisms ''IdeDeclaration
+makeLenses ''IdeValue
+makeLenses ''IdeType
+makeLenses ''IdeTypeSynonym
+makeLenses ''IdeDataConstructor
+makeLenses ''IdeTypeClass
+makeLenses ''IdeInstance
+makeLenses ''IdeValueOperator
+makeLenses ''IdeTypeOperator
+
+makeLenses ''Annotation
+makeLenses ''IdeDeclarationAnn
+makeLenses ''IdeDeclarationId

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -335,6 +335,7 @@ encodeDeclaration = \case
     , "params" .= object
       [ "name" .= P.runProperName (_ideTCName typeclass)
       , "kind" .= _ideTCKind typeclass
+      -- TODO(Christoph): A proper encoder for instances
       , "instances" .= (map show (_ideTCInstances typeclass) :: [Text])
       ]
     ]
@@ -343,11 +344,26 @@ encodeDeclaration = \case
     , "params" .= object
       [ "name" .= P.runOpName (_ideValueOpName operator)
       , "alias" .= _ideValueOpAlias operator
-      , "kind" .= _ideTCKind typeclass
-      , "instances" .= (map show (_ideTCInstances typeclass) :: [Text])
+      , "precedence" .= _ideValueOpPrecedence operator
+      , "associativity" .= _ideValueOpAssociativity operator
+      , "type" .= _ideValueOpType operator
       ]
     ]
-  _ -> object [ "tag" .= ("NotImplemented" :: Text) ]
+  IdeDeclTypeOperator operator -> object
+    [ "tag" .= ("typeoperator" :: Text)
+    , "params" .= object
+      [ "name" .= P.runOpName (_ideTypeOpName operator)
+      , "alias" .= _ideTypeOpAlias operator
+      , "precedence" .= _ideTypeOpPrecedence operator
+      , "associativity" .= _ideTypeOpAssociativity operator
+      , "kind" .= _ideTypeOpKind operator
+      ]
+    ]
+  IdeDeclKind kind -> object
+    [ "tag" .= ("kind" :: Text)
+    , "params" .= object
+      [ "name" .= P.runProperName kind ]
+    ]
 
 newtype PursuitQuery = PursuitQuery Text
                      deriving (Show, Eq)

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -48,6 +48,8 @@ printIdeDeclarationId IdeDeclarationId{..} =
       IdeNSType -> "T"
       IdeNSKind -> "K"
 
+-- | Parses DeclarationId strings of the form:
+-- "Module.Name:Namespace:identifier" where Namespace is one of V, T, or K.
 parseIdeDeclarationId :: Text -> Maybe IdeDeclarationId
 parseIdeDeclarationId t = do
   guard (t /= "")

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -141,7 +141,7 @@ data Annotation
   } deriving (Show, Eq, Ord, Generic, NFData)
 
 emptyAnn :: Annotation
-emptyAnn = Annotation Nothing Nothing Nothing Nothing
+emptyAnn = Annotation Nothing Nothing Nothing Nothing Nothing
 
 type DefinitionSites a = Map IdeNamespaced a
 type TypeAnnotations = Map P.Ident P.Type

--- a/src/Language/PureScript/Ide/Usages.hs
+++ b/src/Language/PureScript/Ide/Usages.hs
@@ -8,21 +8,6 @@ import qualified Language.PureScript as P
 import           Language.PureScript.Ide.Imports.Helpers
 import           Language.PureScript.Ide.Types
 
-testModule :: P.Module
-testModule =
-  either (panic "") snd $ P.parseModuleFromFile (const "") $ ("" :: [Char], ) $ T.unlines
-    [ "module Test where"
-    , ""
-    , "import Prelude"
-    , ""
-    , "import Data.Array (filter)"
-    , "import Globals (globalList)"
-    , ""
-    , "id x = x"
-    , "killer y = filter isEven y"
-    , "rofl = map killer globalList"
-    ]
-
 -- | The usage of an identifier inside some other declaration
 data Usage = Usage
   { usageSiteModule :: P.ModuleName

--- a/src/Language/PureScript/Ide/Usages.hs
+++ b/src/Language/PureScript/Ide/Usages.hs
@@ -31,7 +31,6 @@ collectUsages m@(P.Module _ _ mn decls _) =
     freeNames = foldMap collectFreeNames decls
     topLevelNames = collectTopLevelValues m
     imports = mapMaybe toIdeImport decls
-    importUsages :: [Usage]
     importUsages = foldMap (getUsagesFromImport mn) imports
   in
     importUsages <> (flip mapMaybe freeNames $ \n@(ns, ident, ss) -> do

--- a/src/Language/PureScript/Ide/Usages.hs
+++ b/src/Language/PureScript/Ide/Usages.hs
@@ -1,0 +1,121 @@
+module Language.PureScript.Ide.Usages where
+
+import           Protolude
+
+import           Control.Lens ((^.))
+import qualified Data.Text as T
+import qualified Language.PureScript as P
+import           Language.PureScript.Ide.Imports.Helpers
+import           Language.PureScript.Ide.Types
+
+testModule :: P.Module
+testModule =
+  either (panic "") snd $ P.parseModuleFromFile (const "") $ ("" :: [Char], ) $ T.unlines
+    [ "module Test where"
+    , ""
+    , "import Prelude"
+    , ""
+    , "import Data.Array (filter)"
+    , "import Globals (globalList)"
+    , ""
+    , "id x = x"
+    , "killer y = filter isEven y"
+    , "rofl = map killer globalList"
+    ]
+
+-- | The usage of an identifier inside some other declaration
+data Usage = Usage
+  { usageSiteModule :: P.ModuleName
+  , usageSiteLocation :: P.SourceSpan
+  , usageOriginId :: IdeDeclarationId
+  } deriving (Show)
+
+showUsage :: Usage -> Text
+showUsage Usage{..} =
+  P.runModuleName (usageOriginId ^. ididModule)
+  <> "."
+  <> usageOriginId ^. ididIdentifier
+  <> " used in: "
+  <> P.runModuleName usageSiteModule
+  <> " "
+  <> P.displaySourceSpan "." usageSiteLocation
+
+-- | Collects all usages of names for a given module
+collectUsages :: P.Module -> [Usage]
+collectUsages m@(P.Module _ _ mn decls _) =
+  let
+    freeNames = foldMap collectFreeNames decls
+    topLevelNames = collectTopLevelValues m
+    imports = mapMaybe toIdeImport decls
+  in
+    flip mapMaybe freeNames $ \n@(ns, ident, ss) -> do
+      resolvedModule <- resolveFreeName imports topLevelNames mn n
+      pure $ Usage mn ss $ IdeDeclarationId resolvedModule ns $ P.runIdent (P.disqualify ident)
+
+resolveFreeName
+  :: [Import]
+  -> [P.Ident]
+  -> P.ModuleName
+  -> (IdeNamespace, P.Qualified P.Ident, P.SourceSpan)
+  -> Maybe P.ModuleName
+resolveFreeName imports topLevelNames currentModule name = case name of
+  -- Non-qualified values
+  (IdeNSValue, P.Qualified Nothing i, _) ->
+    -- Is the value defined in this module?
+    (guard (elem i topLevelNames) $> currentModule)
+    -- Is the value imported explicitly?
+    <|> head (mapMaybe (resolveAgainstExplicitImport i) imports)
+    -- Falling back to implicit imports
+    <|> resolveAgainstSingleImplicitImport imports
+  _ ->
+    -- TODO(Christoph): Handle more cases
+    Nothing
+
+resolveAgainstSingleImplicitImport :: [Import] -> Maybe P.ModuleName
+resolveAgainstSingleImplicitImport imports = case mapMaybe isImplicit imports of
+  [implicit] -> Just implicit
+  _ -> Nothing
+  where
+    isImplicit = \case
+      Import mn P.Implicit Nothing -> Just mn
+      Import mn (P.Hiding _) Nothing -> Just mn
+      _ -> Nothing
+
+resolveAgainstExplicitImport :: P.Ident -> Import -> Maybe P.ModuleName
+resolveAgainstExplicitImport ident i = case i of
+  Import mn (P.Explicit refs) Nothing ->
+    guard (any refMatchesIdent refs) $> mn
+  _ -> Nothing
+  where
+    refMatchesIdent = \case
+      P.ValueRef _ refIdent -> refIdent == ident
+      _ -> False
+
+toIdeImport :: P.Declaration -> Maybe Import
+toIdeImport d = case d of
+  P.ImportDeclaration _ mn idt qualifier ->
+    Just (Import mn idt qualifier)
+  _ -> Nothing
+
+collectTopLevelValues :: P.Module -> [P.Ident]
+collectTopLevelValues =
+  mapMaybe (map P.valdeclIdent . P.getValueDeclaration) . P.getModuleDeclarations
+
+collectFreeNames :: P.Declaration -> [(IdeNamespace, P.Qualified P.Ident, P.SourceSpan)]
+collectFreeNames =
+  let
+    (extractor, _, _, _, _) =
+      P.everythingWithScope
+        mempty
+        exprs
+        mempty
+        mempty
+        mempty
+  in extractor mempty
+  where
+    exprs scope expr = case expr of
+      P.PositionedValue ss _ (P.Var v)
+        | P.Qualified Nothing i <- v
+        , not (i `elem` scope) -> [(IdeNSValue, v, ss)]
+        -- TODO(Christoph): Handle qualified identifiers
+      _ -> []

--- a/tests/Language/PureScript/Ide/UsagesSpec.hs
+++ b/tests/Language/PureScript/Ide/UsagesSpec.hs
@@ -28,10 +28,12 @@ testModule =
 
 shouldFindUsage :: [Usage] -> (IdeDeclarationId, P.SourcePos, P.SourcePos) -> Expectation
 shouldFindUsage us (id, start, end) =
-  shouldSatisfy us
+  let
+    matchingIds = filter (\u -> id == usageOriginId u) us
+  in
+    shouldSatisfy matchingIds
     (any (\u ->
-      id == usageOriginId u
-      && start == P.spanStart (usageSiteLocation u)
+      start == P.spanStart (usageSiteLocation u)
       && end == P.spanEnd (usageSiteLocation u)))
 
 spec :: Spec
@@ -53,3 +55,8 @@ spec = do
         ( IdeDeclarationId (Test.mn "Test") IdeNSValue "localFn"
         , P.SourcePos 10 12
         , P.SourcePos 10 19)
+    it "should find a usage in the import section" $
+      usages `shouldFindUsage`
+        ( IdeDeclarationId (Test.mn "Data.Array") IdeNSValue "filter"
+        , P.SourcePos 5 20
+        , P.SourcePos 5 26)

--- a/tests/Language/PureScript/Ide/UsagesSpec.hs
+++ b/tests/Language/PureScript/Ide/UsagesSpec.hs
@@ -19,11 +19,13 @@ testModule =
     , "import Prelude"
     , ""
     , "import Data.Array (filter)"
+    , "import Data.List as List"
     , "import Globals (globalList)"
     , ""
     , "id x = x"
     , "localFn y = filter isEven y"
     , "rofl = map localFn globalList"
+    , "anotherTest = List.map localFn globalList"
     ]
 
 shouldFindUsage :: [Usage] -> (IdeDeclarationId, P.SourcePos, P.SourcePos) -> Expectation
@@ -43,18 +45,23 @@ spec = do
     it "should find an explicitly imported value" $
       usages `shouldFindUsage`
         ( IdeDeclarationId (Test.mn "Data.Array") IdeNSValue "filter"
-        , P.SourcePos 9 13
-        , P.SourcePos 9 19)
+        , P.SourcePos 10 13
+        , P.SourcePos 10 19)
     it "should find an implicitly imported value" $
       usages `shouldFindUsage`
         ( IdeDeclarationId (Test.mn "Prelude") IdeNSValue "map"
-        , P.SourcePos 10 8
-        , P.SourcePos 10 11)
+        , P.SourcePos 11 8
+        , P.SourcePos 11 11)
+    it "should find a qualified usage" $
+      usages `shouldFindUsage`
+        ( IdeDeclarationId (Test.mn "Data.List") IdeNSValue "map"
+        , P.SourcePos 12 15
+        , P.SourcePos 12 23)
     it "should find a locally defined value" $
       usages `shouldFindUsage`
         ( IdeDeclarationId (Test.mn "Test") IdeNSValue "localFn"
-        , P.SourcePos 10 12
-        , P.SourcePos 10 19)
+        , P.SourcePos 11 12
+        , P.SourcePos 11 19)
     it "should find a usage in the import section" $
       usages `shouldFindUsage`
         ( IdeDeclarationId (Test.mn "Data.Array") IdeNSValue "filter"

--- a/tests/Language/PureScript/Ide/UsagesSpec.hs
+++ b/tests/Language/PureScript/Ide/UsagesSpec.hs
@@ -95,5 +95,5 @@ spec = do
       ([_, Right (InfoResult da)], _) <- Test.inProject $
         Test.runIde [Command.LoadSync [], Command.Info (IdeDeclarationId (Test.mn "RebuildSpecDep") IdeNSValue "dep")]
       let Just usages = da ^. idaAnnotation . annUsages
-      let cases = zip ["RebuildSpecWithDeps-5:5-5:5", "RebuildSpecWithDeps-3:24-3:27"] usages
+      let cases = zip ["RebuildSpecWithDeps-3:24-3:27", "RebuildSpecWithDeps-5:5-5:5"] usages
       for_ cases (uncurry shouldBeUsage)

--- a/tests/Language/PureScript/Ide/UsagesSpec.hs
+++ b/tests/Language/PureScript/Ide/UsagesSpec.hs
@@ -5,7 +5,9 @@ module Language.PureScript.Ide.UsagesSpec where
 
 import           Protolude
 import qualified Data.Text as T
+import           Control.Lens ((^.))
 import           Language.PureScript.Ide.Usages (Usage(..), collectUsages)
+import qualified Language.PureScript.Ide.Command as Command
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Test as Test
 import qualified Language.PureScript as P
@@ -67,3 +69,8 @@ spec = do
         ( IdeDeclarationId (Test.mn "Data.Array") IdeNSValue "filter"
         , P.SourcePos 5 20
         , P.SourcePos 5 26)
+  describe "retrieving usages" $ do
+    it "returns a simple value usage" $ do
+      ([_, Right (InfoResult da)], _) <- Test.inProject $
+        Test.runIde [Command.LoadSync [], Command.Info (IdeDeclarationId (Test.mn "RebuildSpecDep") IdeNSValue "dep")]
+      print (da ^. idaAnnotation . annUsages)

--- a/tests/Language/PureScript/Ide/UsagesSpec.hs
+++ b/tests/Language/PureScript/Ide/UsagesSpec.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TupleSections     #-}
+module Language.PureScript.Ide.UsagesSpec where
+
+import           Protolude
+import qualified Data.Text as T
+import           Language.PureScript.Ide.Usages (Usage(..), collectUsages)
+import           Language.PureScript.Ide.Types
+import           Language.PureScript.Ide.Test as Test
+import qualified Language.PureScript as P
+import           Test.Hspec
+
+testModule :: P.Module
+testModule =
+  either (panic "") snd $ P.parseModuleFromFile (const "") $ ("" :: [Char], ) $ T.unlines
+    [ "module Test where"
+    , ""
+    , "import Prelude"
+    , ""
+    , "import Data.Array (filter)"
+    , "import Globals (globalList)"
+    , ""
+    , "id x = x"
+    , "localFn y = filter isEven y"
+    , "rofl = map localFn globalList"
+    ]
+
+shouldFindUsage :: [Usage] -> (IdeDeclarationId, P.SourcePos, P.SourcePos) -> Expectation
+shouldFindUsage us (id, start, end) =
+  shouldSatisfy us
+    (any (\u ->
+      id == usageOriginId u
+      && start == P.spanStart (usageSiteLocation u)
+      && end == P.spanEnd (usageSiteLocation u)))
+
+spec :: Spec
+spec = do
+  describe "collect usages" $ do
+    let usages = collectUsages testModule
+    it "should find an explicitly imported value" $
+      usages `shouldFindUsage`
+        ( IdeDeclarationId (Test.mn "Data.Array") IdeNSValue "filter"
+        , P.SourcePos 9 13
+        , P.SourcePos 9 19)
+    it "should find an implicitly imported value" $
+      usages `shouldFindUsage`
+        ( IdeDeclarationId (Test.mn "Prelude") IdeNSValue "map"
+        , P.SourcePos 10 8
+        , P.SourcePos 10 11)
+    it "should find a locally defined value" $
+      usages `shouldFindUsage`
+        ( IdeDeclarationId (Test.mn "Test") IdeNSValue "localFn"
+        , P.SourcePos 10 12
+        , P.SourcePos 10 19)


### PR DESCRIPTION
I figured I'd put this out, even though it's not finished, because I'm starting to hit a few design questions that might benefit from input. This will need extensive benchmarking, because in my current observations populating the usages takes about twice as long as all the other resolutions (That's still way faster than parsing, but something to keep an eye on, especially the memory usage). I also need to find a bigger codebase that compiles under current master.

For now, this only collects usages of values (no data constructors yet). Usages of types, classes, operators, and kinds can be added in following PRs.

I've added a new `query` command which returns all the information `ide` stores about a given declaration.

## Restrictions of the current implementation/design:

- It does not resolve ambiguous identifiers in the presence of multiple implicit imports

## Example usage:

Given this file:
https://gist.github.com/kRITZCREEK/02b3f49f6e4db01a939e9e188699b170

and this command (I hope you can see what's going on event hough it's elisp. I need to get jq to work on this machine...):
```elisp
(defun psc-ide-command-info (declarationId)
  (json-encode
   (list :command "info"
         :params (list
                  :id declarationId))))

(let-alist (psc-ide-unwrap-result
            (psc-ide-send-sync
             (psc-ide-command-info "Control.Monad.Eff.Console:V:log")))
  (print .ann.usages))
```

I get the following result:

```
[
[["Main"] ((start . [36 3]) (name . "C:\\Users\\creek\\code\\variant-experiments\\src\\Main.purs") (end . [36 6]))] 
[["Main"] ((start . [35 3]) (name . "C:\\Users\\creek\\code\\variant-experiments\\src\\Main.purs") (end . [35 6]))] 
[["Main"] ((start . [6 44]) (name . "C:\\Users\\creek\\code\\variant-experiments\\src\\Main.purs") (end . [6 47]))]
]
```

Running the find usage command for Prelude's `id`: https://gist.github.com/kRITZCREEK/be0a8c3ed38596a74aa1736f6be795e9

## TODO:

- [x] Make `resolveUsages` operate in STM
- [x] Figure out how to handle re-exports
  I see two options here:
  1. When inserting the found usages, follow the `exportedFrom` annotations, to add usages to the original declaration
  2. Store which modules reexport a given value in the annotation for that value and have the caller track them down at query time.
- [x] ~Find constructor usages~
- [x] Make the `info` command also take `filters` as arguments, and either turn the `IdeDeclarationId` into a filter, or build it by combining the `module`, `namespace`, `exact` filters. I think we might need to spot that combination on the server side and optimize it.