### PR TITLE
Add docs for duplicate labels in record types

### DIFF
--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -150,7 +150,7 @@ record = primType "Record" $ T.unlines
   , "    type Person = { name :: String, age :: Number }"
   , ""
   , "The row associates a type to each label which appears in the record."
-  , """
+  , ""
   , "_Technical note_: PureScript allows duplicate labels in rows, and the"
   , "meaning of `Record r` is based on the _first_ occurrence of each label in"
   , "the row `r`."

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -148,6 +148,12 @@ record = primType "Record" $ T.unlines
   , "The syntactic sugar with curly braces `{ }` is generally preferred, though:"
   , ""
   , "    type Person = { name :: String, age :: Number }"
+  , ""
+  , "The row associates a type to each label which appears in the record."
+  , """
+  , "_Technical note_: PureScript allows duplicate labels in rows, and the"
+  , "meaning of `Record r` is based on the _first_ occurrence of each label in"
+  , "the row `r`."
   ]
 
 number :: Declaration


### PR DESCRIPTION
This came up on Slack and it seemed worth documenting.