### PR TITLE
correctly quote uppercased field labels

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -113,6 +113,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@b123400](https://github.com/b123400) | b123400 | [MIT license](https://opensource.org/licenses/MIT) |
 | [@drets](https://github.com/drets) | Dmytro Rets | [MIT license](http://opensource.org/licenses/MIT) |
 | [@bjornmelgaaard](https://github.com/BjornMelgaard) | Sergey Homa | [MIT license](http://opensource.org/licenses/MIT) |
+| [@thimoteus](https://github.com/Thimoteus) | thimoteus | [MIT license](http://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms
 

--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -13,6 +13,7 @@ import Data.List (elemIndices, intersperse)
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
+import Data.Char (isUpper)
 
 import Language.PureScript.AST (SourcePos(..), SourceSpan(..))
 import Language.PureScript.Parser.Lexer (isUnquotedKey, reservedPsNames)
@@ -148,7 +149,10 @@ prettyPrintMany f xs = do
 
 objectKeyRequiresQuoting :: Text -> Bool
 objectKeyRequiresQuoting s =
-  s `elem` reservedPsNames || not (isUnquotedKey s)
+  s `elem` reservedPsNames || not (isUnquotedKey s) || startsUppercase s where
+    startsUppercase label = case T.uncons label of
+      Just (c, _) -> isUpper c
+      _ -> False
 
 -- | Place a box before another, vertically when the first box takes up multiple lines.
 before :: Box -> Box -> Box


### PR DESCRIPTION
Example:

Source:

```purescript
module Main where

x :: _
x = {"Test": 3}
```

Current master:
```
Warning found:
in module Main
at Main.purs line 3, column 6 - line 3, column 7

  Wildcard type definition has the inferred type
                 
    { Test :: Int
    }            
                 

in value declaration x
```

With this PR:
```
Warning found:
in module Main
at Main.purs line 3, column 6 - line 3, column 7

  Wildcard type definition has the inferred type
                   
    { "Test" :: Int
    }              
                   

in value declaration x
```