### PR TITLE
Update Glob library, fixes #3055

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -52,7 +52,7 @@ dependencies:
   - file-embed
   - filepath
   - fsnotify >=0.2.1
-  - Glob >=0.7 && <0.9
+  - Glob >=0.9 && <0.10
   - haskeline >=0.7.0.0
   - http-client >=0.4.30 && <0.6.0
   - http-types

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2017-09-10
+resolver: nightly-2017-11-20
 packages:
 - '.'
 extra-deps:

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -5,7 +5,7 @@ STACK="stack --no-terminal --jobs=1"
 
 # Setup & install dependencies or abort
 ret=0
-$TIMEOUT 40m $STACK --install-ghc build \
+$TIMEOUT 30m $STACK --install-ghc build \
   --only-dependencies --test --haddock \
   || ret=$?
 case "$ret" in


### PR DESCRIPTION
Also update the Stackage snapshot so that we get the latest version of
Glob, which includes memory usage and performance fixes.