### PR TITLE
Remove stack 7.10 yaml file

### DIFF
--- a/stack-ghc-7.10.yaml
+++ b/stack-ghc-7.10.yaml
@@ -1,7 +1,0 @@
-resolver: lts-6.25
-packages:
-- '.'
-extra-deps:
-- aeson-better-errors-0.9.1.0
-- bower-json-1.0.0.1
-- optparse-applicative-0.13.0.0


### PR DESCRIPTION
This file is quite out of date and after asking on Slack GHC 7.10 support isn't needed anymore.