### PR TITLE
Added pre-built installers to INSTALL.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,6 +65,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@lukerandall](https://github.com/lukerandall) | Luke Randall | [MIT license](http://opensource.org/licenses/MIT) |
 | [@matthewleon](https://github.com/matthewleon) | Matthew Leon | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mcoffin](https://github.com/mcoffin) | Matt Coffin | [MIT license](http://opensource.org/licenses/MIT) |
+| [@MiracleBlue](https://github.com/MiracleBlue) | Nicholas Kircher | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mrkgnao](https://github.com/mrkgnao) | Soham Chowdhury | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mgmeier](https://github.com/mgmeier) | Michael Gilliland | [MIT license](http://opensource.org/licenses/MIT) |
 | [@michaelficarra](https://github.com/michaelficarra) | Michael Ficarra | [MIT license](http://opensource.org/licenses/MIT) |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
 # Installation information
 
 If you are having difficulty installing the PureScript compiler, feel free to
-ask for help! A good place is the #purescript IRC channel on Freenode, or
+ask for help! A good place is the #purescript IRC channel on Freenode, the #purescript channel on [FPChat Slack](https://fpchat-invite.herokuapp.com/), or
 alternatively Stack Overflow.
 
 ## Using prebuilt binaries
@@ -19,6 +19,17 @@ from source; see below.
 
 Other prebuilt distributions (eg, Homebrew, AUR, npm) will probably have the
 same requirements.
+
+## Installing a pre-built distribution
+
+There are several options available for aquiring a pre-built binary of the PureScript compiler.  This is by no means an exhaustive list, and is presented in no particular order. Each example is expected to install the latest available compiler version at the time of running the command. Many of these are provided and maintained by the community, and may not be immediately up to date.
+
+* NPM: `npm install -g purescript`
+* Homebrew (for OS X): `brew install purescript`
+* [PSVM](https://github.com/ThomasCrevoisier/psvm-js) (PS Version Manager): 
+  1) `psvm install-latest` will install the latest version available
+  2) `psvm latest` will print the latest version number available
+  3) `psvm use <latest version number>` will enable the version we just installed. For example, if the version is `v0.11.7`, you'd run `psvm use v0.11.7`
 
 ## Compiling from source
 


### PR DESCRIPTION
Added 3 examples of installing the latest pre-built PureScript compiler binary, for Homebrew, NPM and PSVM.  Also added reference to FPChat Slack channel for getting help with PureScript.