### PR TITLE
Support unsigned integers

### DIFF
--- a/examples/failing/UIntNegative.purs
+++ b/examples/failing/UIntNegative.purs
@@ -1,4 +1,4 @@
--- @shouldFailWith UIntOutOfRange
+-- @shouldFailWith NegativeUInt
 
 module Main where
 

--- a/examples/failing/UIntNegative.purs
+++ b/examples/failing/UIntNegative.purs
@@ -1,6 +1,8 @@
--- @shouldFailWith NegativeUInt
+-- @shouldFailWith NoInstanceFound
 
 module Main where
 
+import Prelude (negate)
+
 n :: UInt
-n =  -1234u
+n = -1u

--- a/examples/failing/UIntNegative.purs
+++ b/examples/failing/UIntNegative.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith UIntOutOfRange
+
+module Main where
+
+n :: UInt
+n =  -1234u

--- a/examples/failing/UIntNegative.purs
+++ b/examples/failing/UIntNegative.purs
@@ -4,5 +4,8 @@ module Main where
 
 import Prelude (negate)
 
+-- Currently this is failing with "Unable to find instance Ring UInt", which is
+-- correct, but it'd be nicer if it could fail with "Can't have negative UInt
+-- literals"
 n :: UInt
 n = -1u

--- a/examples/failing/UIntNegative.purs
+++ b/examples/failing/UIntNegative.purs
@@ -1,11 +1,12 @@
--- @shouldFailWith NoInstanceFound
+-- @shouldFailWith NegativeUInt
 
 module Main where
 
-import Prelude (negate)
+import Prelude
+import Data.Ring
 
--- Currently this is failing with "Unable to find instance Ring UInt", which is
--- correct, but it'd be nicer if it could fail with "Can't have negative UInt
--- literals"
+-- This is failing with a NoInstanceFound error instead of NegativeUInt. I have
+-- no idea why. I can load `pulp psci` in the directory and it works with UInts
+-- just fine.
 n :: UInt
 n = -1u

--- a/examples/failing/UIntOutOfRange.purs
+++ b/examples/failing/UIntOutOfRange.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith UIntOutOfRange
+
+module Main where
+
+n :: UInt
+n = 4294967296u

--- a/examples/failing/UIntOutOfRange.purs
+++ b/examples/failing/UIntOutOfRange.purs
@@ -1,4 +1,4 @@
--- @shouldFailWith UIntOutOfRange
+-- @shouldFailWith IntOutOfRange
 
 module Main where
 

--- a/examples/passing/UInt.purs
+++ b/examples/passing/UInt.purs
@@ -9,5 +9,5 @@ main = do
   let -- uint :: UInt -- TODO: make UInt a type that shows up
       uint = 1u
   -- TODO: actually print the UInt
-  logShow "Done"
+  log "Done"
 

--- a/examples/passing/UInt.purs
+++ b/examples/passing/UInt.purs
@@ -6,7 +6,7 @@ import Control.Monad.ST
 import Control.Monad.Eff.Console (log, logShow)
 
 main = do
-  let uint :: UInt
+  let -- uint :: UInt -- TODO: make UInt a type that shows up
       uint = 1u
   -- TODO: actually print the UInt
   logShow "hello"

--- a/examples/passing/UInt.purs
+++ b/examples/passing/UInt.purs
@@ -6,8 +6,8 @@ import Control.Monad.ST
 import Control.Monad.Eff.Console (log, logShow)
 
 main = do
-  let -- uint :: UInt -- TODO: make UInt a type that shows up
+  let uint :: UInt
       uint = 1u
-  -- TODO: actually print the UInt
+  -- TODO: Use the version of Prelude that includes the Show instance
+  -- logShow uint
   log "Done"
-

--- a/examples/passing/UInt.purs
+++ b/examples/passing/UInt.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff
+import Control.Monad.ST
+import Control.Monad.Eff.Console (log, logShow)
+
+main = do
+  let uint :: UInt
+      uint = 1u
+  -- TODO: actually print the UInt
+  logShow "hello"
+

--- a/examples/passing/UInt.purs
+++ b/examples/passing/UInt.purs
@@ -9,5 +9,5 @@ main = do
   let -- uint :: UInt -- TODO: make UInt a type that shows up
       uint = 1u
   -- TODO: actually print the UInt
-  logShow "hello"
+  logShow "Done"
 

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -157,7 +157,7 @@ data SimpleErrorMessage
   | DuplicateImportRef Name
   | DuplicateExportRef Name
   | IntOutOfRange Integer Text Integer Integer
-  | NegativeUInt Integer Text Integer Integer
+  | NegativeUInt Integer Text Integer
   | ImplicitQualifiedImport ModuleName ModuleName [DeclarationRef]
   | ImplicitImport ModuleName [DeclarationRef]
   | HidingImport ModuleName [DeclarationRef]

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -157,6 +157,7 @@ data SimpleErrorMessage
   | DuplicateImportRef Name
   | DuplicateExportRef Name
   | IntOutOfRange Integer Text Integer Integer
+  | NegativeUInt Integer Text Integer Integer
   | ImplicitQualifiedImport ModuleName ModuleName [DeclarationRef]
   | ImplicitImport ModuleName [DeclarationRef]
   | HidingImport ModuleName [DeclarationRef]

--- a/src/Language/PureScript/AST/Literals.hs
+++ b/src/Language/PureScript/AST/Literals.hs
@@ -38,13 +38,27 @@ data Literal a
   | ObjectLiteral [(PSString, a)]
   deriving (Eq, Ord, Show, Functor)
 
+-- | The various numeric literals in PureScript.
 data NumericLiteral
+  -- | 
+  -- 32 bit signed integer literals
+  -- > 32 :: Int
   = LitInt Integer
+  -- | 
+  -- 64 bit signed floating point literals
+  -- > 32.2 :: Number
   | LitNumber Double
+  -- | 
+  -- 32 bit unsigned integer literals
+  -- > 14u :: UInt
   | LitUInt Natural
   deriving (Show, Eq, Ord)
 
-foldNumericLiteral :: (Integer -> r) -> (Double -> r) -> (Natural -> r) -> NumericLiteral -> r
+-- | Transform a 'NumericLiteral' using the given functions to handle the
+-- various internal number representations.
+foldNumericLiteral 
+  :: (Integer -> r) -> (Double -> r) -> (Natural -> r) -> NumericLiteral 
+  -> r
 foldNumericLiteral f g k l = case l of
   LitInt n -> f n
   LitNumber n -> g n

--- a/src/Language/PureScript/AST/Literals.hs
+++ b/src/Language/PureScript/AST/Literals.hs
@@ -1,15 +1,11 @@
 -- |
 -- The core functional representation for literal values.
 --
-module Language.PureScript.AST.Literals 
-  ( module Language.PureScript.AST.Literals 
-  , NumericLiteral(..)
-  , foldNumericLiteral
-  ) where
+module Language.PureScript.AST.Literals where
 
 import Prelude.Compat
 import Language.PureScript.PSString (PSString)
-import Language.PureScript.Parser.Lexer (NumericLiteral(..), foldNumericLiteral)
+import Numeric.Natural (Natural)
 
 -- |
 -- Data type for literal values. Parameterised so it can be used for Exprs and
@@ -41,3 +37,15 @@ data Literal a
   --
   | ObjectLiteral [(PSString, a)]
   deriving (Eq, Ord, Show, Functor)
+
+data NumericLiteral
+  = LitInt Integer
+  | LitNumber Double
+  | LitUInt Natural
+  deriving (Show, Eq, Ord)
+
+foldNumericLiteral :: (Integer -> r) -> (Double -> r) -> (Natural -> r) -> NumericLiteral -> r
+foldNumericLiteral f g k l = case l of
+  LitInt n -> f n
+  LitNumber n -> g n
+  LitUInt n -> k n

--- a/src/Language/PureScript/AST/Literals.hs
+++ b/src/Language/PureScript/AST/Literals.hs
@@ -1,10 +1,15 @@
 -- |
 -- The core functional representation for literal values.
 --
-module Language.PureScript.AST.Literals where
+module Language.PureScript.AST.Literals 
+  ( module Language.PureScript.AST.Literals 
+  , NumericLiteral(..)
+  , foldNumericLiteral
+  ) where
 
 import Prelude.Compat
 import Language.PureScript.PSString (PSString)
+import Language.PureScript.Parser.Lexer (NumericLiteral(..), foldNumericLiteral)
 
 -- |
 -- Data type for literal values. Parameterised so it can be used for Exprs and
@@ -14,7 +19,7 @@ data Literal a
   -- |
   -- A numeric literal
   --
-  = NumericLiteral (Either Integer Double)
+  = NumericLiteral NumericLiteral
   -- |
   -- A string literal
   --

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -375,7 +375,7 @@ moduleToJs (Module coms mn _ imps exps foreigns decls) foreign_ =
     return (AST.VariableIntroduction Nothing (identToJs ident) (Just (AST.Var Nothing varName)) : js)
 
   literalToBinderJS :: Text -> [AST] -> Literal (Binder Ann) -> m [AST]
-  literalToBinderJS varName done (NumericLiteral num) = do
+  literalToBinderJS varName done (NumericLiteral num) =
     return [AST.IfElse Nothing (AST.Binary Nothing AST.EqualTo (AST.Var Nothing varName) (AST.NumericLiteral Nothing num)) (AST.Block Nothing done) Nothing]
   literalToBinderJS varName done (CharLiteral c) =
     return [AST.IfElse Nothing (AST.Binary Nothing AST.EqualTo (AST.Var Nothing varName) (AST.StringLiteral Nothing (fromString [c]))) (AST.Block Nothing done) Nothing]

--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -17,7 +17,7 @@ import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
 
-import Language.PureScript.AST (SourceSpan(..))
+import Language.PureScript.AST (SourceSpan(..), foldNumericLiteral)
 import Language.PureScript.CodeGen.JS.Common
 import Language.PureScript.CoreImp.AST
 import Language.PureScript.Comments
@@ -34,7 +34,7 @@ literals = mkPattern' match'
   match' js = (addMapping' (getSourceSpan js) <>) <$> match js
 
   match :: (Emit gen) => AST -> StateT PrinterState Maybe gen
-  match (NumericLiteral _ n) = return $ emit $ T.pack $ either show show n
+  match (NumericLiteral _ n) = return $ emit $ T.pack $ foldNumericLiteral show show show n
   match (StringLiteral _ s) = return $ emit $ prettyPrintStringJS s
   match (BooleanLiteral _ True) = return $ emit "true"
   match (BooleanLiteral _ False) = return $ emit "false"

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -257,11 +257,17 @@ semiringNumber = "semiringNumber"
 semiringInt :: forall a. (IsString a) => a
 semiringInt = "semiringInt"
 
+semiringUInt :: forall a. (IsString a) => a
+semiringUInt = "semiringUInt"
+
 ringNumber :: forall a. (IsString a) => a
 ringNumber = "ringNumber"
 
 ringInt :: forall a. (IsString a) => a
 ringInt = "ringInt"
+
+ringUInt :: forall a. (IsString a) => a
+ringUInt = "ringUInt"
 
 moduloSemiringNumber :: forall a. (IsString a) => a
 moduloSemiringNumber = "moduloSemiringNumber"
@@ -284,6 +290,9 @@ ordNumber = "ordNumber"
 ordInt :: forall a. (IsString a) => a
 ordInt = "ordInt"
 
+ordUInt :: forall a. (IsString a) => a
+ordUInt = "ordUInt"
+
 ordString :: forall a. (IsString a) => a
 ordString = "ordString"
 
@@ -295,6 +304,9 @@ eqNumber = "eqNumber"
 
 eqInt :: forall a. (IsString a) => a
 eqInt = "eqInt"
+
+eqUInt :: forall a. (IsString a) => a
+eqUInt = "eqUInt"
 
 eqString :: forall a. (IsString a) => a
 eqString = "eqString"
@@ -487,6 +499,9 @@ dataFunctionUncurried = "Data_Function_Uncurried"
 
 dataIntBits :: forall a. (IsString a) => a
 dataIntBits = "Data_Int_Bits"
+
+dataUIntBits :: forall a. (IsString a) => a
+dataUIntBits = "Data_UInt_Bits"
 
 partialUnsafe :: forall a. (IsString a) => a
 partialUnsafe = "Partial_Unsafe"

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -69,8 +69,9 @@ literalFromJSON t = withObject "Literal" literalFromObj
   literalFromObj o = do
     type_ <- o .: "literalType" :: Parser Text
     case type_ of
-      "IntLiteral"      -> NumericLiteral . Left <$> o .: "value"
-      "NumberLiteral"   -> NumericLiteral . Right <$> o .: "value"
+      "IntLiteral"      -> NumericLiteral . LitInt <$> o .: "value"
+      "NumberLiteral"   -> NumericLiteral . LitNumber <$> o .: "value"
+      "UIntLiteral"     -> NumericLiteral . LitUInt <$> o .: "value"
       "StringLiteral"   -> StringLiteral <$> o .: "value"
       "CharLiteral"     -> CharLiteral <$> o .: "value"
       "BooleanLiteral"  -> BooleanLiteral <$> o .: "value"

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -50,14 +50,19 @@ annToJSON (ss, _, _, m) = object [ T.pack "sourceSpan"  .= sourceSpanToJSON ss
                                  ]
 
 literalToJSON :: (a -> Value) -> Literal a -> Value
-literalToJSON _ (NumericLiteral (Left n))
+literalToJSON _ (NumericLiteral (LitInt n))
   = object
     [ T.pack "literalType" .= "IntLiteral"
     , T.pack "value"       .= n
     ]
-literalToJSON _ (NumericLiteral (Right n))
+literalToJSON _ (NumericLiteral (LitNumber n))
   = object
       [ T.pack "literalType"  .= "NumberLiteral"
+      , T.pack "value"        .= n
+      ]
+literalToJSON _ (NumericLiteral (LitUInt n))
+  = object
+      [ T.pack "literalType"  .= "UIntLiteral"
       , T.pack "value"        .= n
       ]
 literalToJSON _ (StringLiteral s)

--- a/src/Language/PureScript/CoreImp/AST.hs
+++ b/src/Language/PureScript/CoreImp/AST.hs
@@ -7,7 +7,7 @@ import Control.Monad ((>=>))
 import Control.Monad.Identity (Identity(..), runIdentity)
 import Data.Text (Text)
 
-import Language.PureScript.AST (SourceSpan(..))
+import Language.PureScript.AST (SourceSpan(..), NumericLiteral(..), foldNumericLiteral)
 import Language.PureScript.Comments
 import Language.PureScript.PSString (PSString)
 import Language.PureScript.Traversals
@@ -46,7 +46,7 @@ data BinaryOperator
 
 -- | Data type for simplified JavaScript expressions
 data AST
-  = NumericLiteral (Maybe SourceSpan) (Either Integer Double)
+  = NumericLiteral (Maybe SourceSpan) NumericLiteral
   -- ^ A numeric literal
   | StringLiteral (Maybe SourceSpan) PSString
   -- ^ A string literal

--- a/src/Language/PureScript/CoreImp/AST.hs
+++ b/src/Language/PureScript/CoreImp/AST.hs
@@ -7,7 +7,7 @@ import Control.Monad ((>=>))
 import Control.Monad.Identity (Identity(..), runIdentity)
 import Data.Text (Text)
 
-import Language.PureScript.AST (SourceSpan(..), NumericLiteral(..), foldNumericLiteral)
+import Language.PureScript.AST (SourceSpan(..), NumericLiteral(..))
 import Language.PureScript.Comments
 import Language.PureScript.PSString (PSString)
 import Language.PureScript.Traversals

--- a/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
@@ -86,8 +86,8 @@ inlineCommonValues = everywhere convert
   where
   convert :: AST -> AST
   convert (App ss fn [dict])
-    | isDict' [semiringNumber, semiringInt] dict && isDict fnZero fn = NumericLiteral ss (LitInt 0)
-    | isDict' [semiringNumber, semiringInt] dict && isDict fnOne fn = NumericLiteral ss (LitInt 1)
+    | isDict' [semiringNumber, semiringInt, semiringUInt] dict && isDict fnZero fn = NumericLiteral ss (LitInt 0)
+    | isDict' [semiringNumber, semiringInt, semiringUInt] dict && isDict fnOne fn = NumericLiteral ss (LitInt 1)
     | isDict boundedBoolean dict && isDict fnBottom fn = BooleanLiteral ss False
     | isDict boundedBoolean dict && isDict fnTop fn = BooleanLiteral ss True
   convert (App ss (App _ fn [dict]) [x])
@@ -95,6 +95,8 @@ inlineCommonValues = everywhere convert
   convert (App ss (App _ (App _ fn [dict]) [x]) [y])
     | isDict semiringInt dict && isDict fnAdd fn = intOp ss Add x y
     | isDict semiringInt dict && isDict fnMultiply fn = intOp ss Multiply x y
+    | isDict semiringUInt dict && isDict fnAdd fn = uintOp ss Add x y
+    | isDict semiringUInt dict && isDict fnMultiply fn = uintOp ss Multiply x y
     | isDict euclideanRingInt dict && isDict fnDivide fn = intOp ss Divide x y
     | isDict ringInt dict && isDict fnSubtract fn = intOp ss Subtract x y
   convert other = other
@@ -108,6 +110,7 @@ inlineCommonValues = everywhere convert
   fnSubtract = (C.dataRing, C.sub)
   fnNegate = (C.dataRing, C.negate)
   intOp ss op x y = Binary ss BitwiseOr (Binary ss op x y) (NumericLiteral ss (LitInt 0))
+  uintOp ss op x y = Binary ss ZeroFillShiftRight (Binary ss op x y) (NumericLiteral ss (LitInt 0))
 
 inlineCommonOperators :: AST -> AST
 inlineCommonOperators = everywhereTopDown $ applyAll $
@@ -124,6 +127,8 @@ inlineCommonOperators = everywhereTopDown $ applyAll $
   , binary eqNumber opNotEq NotEqualTo
   , binary eqInt opEq EqualTo
   , binary eqInt opNotEq NotEqualTo
+  , binary eqUInt opEq EqualTo
+  , binary eqUInt opNotEq NotEqualTo
   , binary eqString opEq EqualTo
   , binary eqString opNotEq NotEqualTo
   , binary eqChar opEq EqualTo
@@ -143,6 +148,10 @@ inlineCommonOperators = everywhereTopDown $ applyAll $
   , binary ordInt opLessThanOrEq LessThanOrEqualTo
   , binary ordInt opGreaterThan GreaterThan
   , binary ordInt opGreaterThanOrEq GreaterThanOrEqualTo
+  , binary ordUInt opLessThan LessThan
+  , binary ordUInt opLessThanOrEq LessThanOrEqualTo
+  , binary ordUInt opGreaterThan GreaterThan
+  , binary ordUInt opGreaterThanOrEq GreaterThanOrEqualTo
   , binary ordNumber opLessThan LessThan
   , binary ordNumber opLessThanOrEq LessThanOrEqualTo
   , binary ordNumber opGreaterThan GreaterThan
@@ -165,6 +174,13 @@ inlineCommonOperators = everywhereTopDown $ applyAll $
   , binary' C.dataIntBits C.shr ShiftRight
   , binary' C.dataIntBits C.zshr ZeroFillShiftRight
   , unary'  C.dataIntBits C.complement BitwiseNot
+  , binary' C.dataUIntBits C.or BitwiseOr
+  , binary' C.dataUIntBits C.and BitwiseAnd
+  , binary' C.dataUIntBits C.xor BitwiseXor
+  , binary' C.dataUIntBits C.shl ShiftLeft
+  , binary' C.dataUIntBits C.shr ShiftRight
+  , binary' C.dataUIntBits C.zshr ZeroFillShiftRight
+  , unary'  C.dataUIntBits C.complement BitwiseNot
 
   , inlineNonClassFunction (isModFn (C.dataFunction, C.apply)) $ \f x -> App Nothing f [x]
   , inlineNonClassFunction (isModFn (C.dataFunction, C.applyFlipped)) $ \x f -> App Nothing f [x]
@@ -306,6 +322,9 @@ semiringNumber = (C.dataSemiring, C.semiringNumber)
 semiringInt :: forall a b. (IsString a, IsString b) => (a, b)
 semiringInt = (C.dataSemiring, C.semiringInt)
 
+semiringUInt :: forall a b. (IsString a, IsString b) => (a, b)
+semiringUInt = (C.dataSemiring, C.semiringUInt)
+
 ringNumber :: forall a b. (IsString a, IsString b) => (a, b)
 ringNumber = (C.dataRing, C.ringNumber)
 
@@ -324,6 +343,9 @@ eqNumber = (C.dataEq, C.eqNumber)
 eqInt :: forall a b. (IsString a, IsString b) => (a, b)
 eqInt = (C.dataEq, C.eqInt)
 
+eqUInt :: forall a b. (IsString a, IsString b) => (a, b)
+eqUInt = (C.dataEq, C.eqUInt)
+
 eqString :: forall a b. (IsString a, IsString b) => (a, b)
 eqString = (C.dataEq, C.eqString)
 
@@ -341,6 +363,9 @@ ordNumber = (C.dataOrd, C.ordNumber)
 
 ordInt :: forall a b. (IsString a, IsString b) => (a, b)
 ordInt = (C.dataOrd, C.ordInt)
+
+ordUInt :: forall a b. (IsString a, IsString b) => (a, b)
+ordUInt = (C.dataOrd, C.ordUInt)
 
 ordString :: forall a b. (IsString a, IsString b) => (a, b)
 ordString = (C.dataOrd, C.ordString)

--- a/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
@@ -24,7 +24,7 @@ import qualified Data.Text as T
 import Language.PureScript.PSString (PSString)
 import Language.PureScript.CoreImp.AST
 import Language.PureScript.CoreImp.Optimizer.Common
-import Language.PureScript.AST (SourceSpan(..))
+import Language.PureScript.AST (SourceSpan(..), NumericLiteral(..))
 import qualified Language.PureScript.Constants as C
 
 -- TODO: Potential bug:
@@ -86,12 +86,12 @@ inlineCommonValues = everywhere convert
   where
   convert :: AST -> AST
   convert (App ss fn [dict])
-    | isDict' [semiringNumber, semiringInt] dict && isDict fnZero fn = NumericLiteral ss (Left 0)
-    | isDict' [semiringNumber, semiringInt] dict && isDict fnOne fn = NumericLiteral ss (Left 1)
+    | isDict' [semiringNumber, semiringInt] dict && isDict fnZero fn = NumericLiteral ss (LitInt 0)
+    | isDict' [semiringNumber, semiringInt] dict && isDict fnOne fn = NumericLiteral ss (LitInt 1)
     | isDict boundedBoolean dict && isDict fnBottom fn = BooleanLiteral ss False
     | isDict boundedBoolean dict && isDict fnTop fn = BooleanLiteral ss True
   convert (App ss (App _ fn [dict]) [x])
-    | isDict ringInt dict && isDict fnNegate fn = Binary ss BitwiseOr (Unary ss Negate x) (NumericLiteral ss (Left 0))
+    | isDict ringInt dict && isDict fnNegate fn = Binary ss BitwiseOr (Unary ss Negate x) (NumericLiteral ss (LitInt 0))
   convert (App ss (App _ (App _ fn [dict]) [x]) [y])
     | isDict semiringInt dict && isDict fnAdd fn = intOp ss Add x y
     | isDict semiringInt dict && isDict fnMultiply fn = intOp ss Multiply x y
@@ -107,7 +107,7 @@ inlineCommonValues = everywhere convert
   fnMultiply = (C.dataSemiring, C.mul)
   fnSubtract = (C.dataRing, C.sub)
   fnNegate = (C.dataRing, C.negate)
-  intOp ss op x y = Binary ss BitwiseOr (Binary ss op x y) (NumericLiteral ss (Left 0))
+  intOp ss op x y = Binary ss BitwiseOr (Binary ss op x y) (NumericLiteral ss (LitInt 0))
 
 inlineCommonOperators :: AST -> AST
 inlineCommonOperators = everywhereTopDown $ applyAll $

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -19,6 +19,7 @@ primDocsModule = Module
       , record
       , number
       , int
+      , uint
       , string
       , char
       , boolean

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -176,6 +176,16 @@ int = primType "Int" $ T.unlines
   , "    x = 23 :: Int"
   ]
 
+uint :: Declaration
+uint = primType "UInt" $ T.unlines
+  [ "A 32-bit unsigned integer. See the purescript-uint package for details"
+  , "of how this is accomplished when compiling to JavaScript."
+  , ""
+  , "Construct values of this type with literals:"
+  , ""
+  , "    x = 23u :: UInt"
+  ]
+
 string :: Declaration
 string = primType "String" $ T.unlines
   [ "A String. As in JavaScript, String values represent sequences of UTF-16"

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -293,6 +293,10 @@ tyNumber = primTy "Number"
 tyInt :: Type
 tyInt = primTy "Int"
 
+-- | Type constructor for unsigned integers
+tyUInt :: Type
+tyUInt = primTy "UInt"
+
 -- | Type constructor for booleans
 tyBoolean :: Type
 tyBoolean = primTy "Boolean"

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -346,6 +346,7 @@ primTypes =
     , (primName "Char",       (kindType, ExternData))
     , (primName "Number",     (kindType, ExternData))
     , (primName "Int",        (kindType, ExternData))
+    , (primName "UInt",       (kindType, ExternData))
     , (primName "Boolean",    (kindType, ExternData))
     , (primName "Partial",    (kindType, ExternData))
     , (primName "Union",      (FunKind (Row kindType) (FunKind (Row kindType) (FunKind (Row kindType) kindType)), ExternData))

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -900,9 +900,19 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderSimpleErrorMessage (DuplicateExportRef name) =
       line $ "Export list contains multiple references to " <> printName (Qualified Nothing name)
 
-    renderSimpleErrorMessage (IntOutOfRange value backend lo hi) =
-      paras [ line $ "Integer value " <> markCode (T.pack (show value)) <> " is out of range for the " <> backend <> " backend."
-            , line $ "Acceptable values fall within the range " <> markCode (T.pack (show lo)) <> " to " <> markCode (T.pack (show hi)) <> " (inclusive)." ]
+    renderSimpleErrorMessage (IntOutOfRange value backend lo hi)
+        | value > hi && value < hi * 2 =
+          paras [ line $ "Integer value " <> markCode (T.pack (show value)) <> " is out of range for the " <> backend <> " backend."
+                , line $ "Acceptable values fall within the range " <> markCode (T.pack (show lo)) <> " to " <> markCode (T.pack (show hi)) <> " (inclusive)." 
+                , line $ "Consider using the UInt unsigned integer type, which has a range from " 
+                  <> markCode "0"
+                  <> " to "
+                  <> markCode (T.pack (show (hi * 2)))
+                  <> " (inclusive)."
+                ]
+        | otherwise =
+          paras [ line $ "Integer value " <> markCode (T.pack (show value)) <> " is out of range for the " <> backend <> " backend."
+                , line $ "Acceptable values fall within the range " <> markCode (T.pack (show lo)) <> " to " <> markCode (T.pack (show hi)) <> " (inclusive)." ]
     renderSimpleErrorMessage (NegativeUInt value backend hi) =
       paras [ line $ "Unsigned integers may not be negative. The value " <> markCode (T.pack (show value)) <> " was marked as unsigned, but is negative. Did you want to use an Int?"
             , line $ "Acceptable values in the " <> backend <> " backend fall within the range " <> markCode (T.pack (show (0 :: Int))) <> " to " <> markCode (T.pack (show hi)) <> " (inclusive)." ]

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -166,6 +166,7 @@ errorCode em = case unwrapErrorMessage em of
   DuplicateImportRef{} -> "DuplicateImportRef"
   DuplicateExportRef{} -> "DuplicateExportRef"
   IntOutOfRange{} -> "IntOutOfRange"
+  NegativeUInt{} -> "NegativeUInt"
   ImplicitQualifiedImport{} -> "ImplicitQualifiedImport"
   ImplicitImport{} -> "ImplicitImport"
   HidingImport{} -> "HidingImport"
@@ -902,6 +903,9 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderSimpleErrorMessage (IntOutOfRange value backend lo hi) =
       paras [ line $ "Integer value " <> markCode (T.pack (show value)) <> " is out of range for the " <> backend <> " backend."
             , line $ "Acceptable values fall within the range " <> markCode (T.pack (show lo)) <> " to " <> markCode (T.pack (show hi)) <> " (inclusive)." ]
+    renderSimpleErrorMessage (NegativeUInt value backend hi) =
+      paras [ line $ "Unsigned integers may not be negative. The value " <> markCode (T.pack (show value)) <> " was marked as unsigned, but is negative. Did you want to use an Int?"
+            , line $ "Acceptable values in the " <> backend <> " backend fall within the range " <> markCode (T.pack (show (0 :: Int))) <> " to " <> markCode (T.pack (show hi)) <> " (inclusive)." ]
 
     renderSimpleErrorMessage msg@(ImplicitQualifiedImport importedModule asModule _) =
       paras [ line $ "Module " <> markCode (runModuleName importedModule) <> " was imported as " <> markCode (runModuleName asModule) <> " with unspecified imports."

--- a/src/Language/PureScript/Parser.hs
+++ b/src/Language/PureScript/Parser.hs
@@ -3,9 +3,9 @@
 --
 --  [@Language.PureScript.Parser.Kinds@] Parser for kinds
 --
---  [@Language.PureScript.Parser.Values@] Parser for values
---
 --  [@Language.PureScript.Parser.Types@] Parser for types
+--
+--  [@Language.PureScript.Parser.Lexer@] Parser for lexemes
 --
 --  [@Language.PureScript.Parser.Declaration@] Parsers for declarations and modules
 --

--- a/src/Language/PureScript/Parser/Lexer.hs
+++ b/src/Language/PureScript/Parser/Lexer.hs
@@ -77,11 +77,11 @@ import Data.Monoid ((<>))
 import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as T
-import Numeric.Natural (Natural)
 
 import Language.PureScript.Comments
 import Language.PureScript.Parser.State
 import Language.PureScript.PSString (PSString)
+import Language.PureScript.AST.Literals (NumericLiteral(..), foldNumericLiteral)
 
 import qualified Text.Parsec as P
 import qualified Text.Parsec.Token as PT
@@ -117,18 +117,6 @@ data Token
   | Number NumericLiteral
   | HoleLit Text
   deriving (Show, Eq, Ord)
-
-data NumericLiteral
-  = LitInt Integer
-  | LitNumber Double
-  | LitUInt Natural
-  deriving (Show, Eq, Ord)
-
-foldNumericLiteral :: (Integer -> r) -> (Double -> r) -> (Natural -> r) -> NumericLiteral -> r
-foldNumericLiteral f g k l = case l of
-  LitInt n -> f n
-  LitNumber n -> g n
-  LitUInt n -> k n
 
 prettyPrintToken :: Token -> Text
 prettyPrintToken LParen            = "("

--- a/src/Language/PureScript/Parser/Lexer.hs
+++ b/src/Language/PureScript/Parser/Lexer.hs
@@ -302,7 +302,7 @@ parseToken = P.choice
       (P.notFollowedBy P.digit P.<?> "no leading zero in number literal"))
     intOrNat :: Lexer u NumericLiteral
     intOrNat = do
-      i <- read <$> P.try nat
+      i <- P.try nat
       (P.char 'u' *> pure (LitUInt (fromInteger i))) <|> pure (LitInt i)
 
     -- these functions are inlined from "Text.Parsec.Token". Why not just
@@ -316,7 +316,7 @@ parseToken = P.choice
     nat = zeroNumber <|> decimal
 
     zeroNumber = do
-      P.char '0'
+      _ <- P.char '0'
       hexadecimal <|> octal <|> decimal <|> return 0
 
     decimal = number' 10 P.digit

--- a/src/Language/PureScript/Parser/Lexer.hs
+++ b/src/Language/PureScript/Parser/Lexer.hs
@@ -288,8 +288,9 @@ parseToken = P.choice
     -- if notFollowedBy fails though, the consumed '0' will break the choice chain
     consumeLeadingZero = P.lookAhead (P.char '0' *>
       (P.notFollowedBy P.digit P.<?> "no leading zero in number literal"))
+
     intOrNat :: Lexer u NumericLiteral
-    intOrNat = do
+    intOrNat = PT.lexeme tokenParser $ do
       i <- P.try nat
       (P.char 'u' *> pure (LitUInt (fromInteger i))) <|> pure (LitInt i)
 

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -117,7 +117,7 @@ prettyPrintValueAtom d (UnaryMinus expr) = text "(-" <> prettyPrintValue d expr 
 prettyPrintValueAtom d expr = (text "(" <> prettyPrintValue d expr) `before` text ")"
 
 prettyPrintLiteralValue :: Int -> Literal Expr -> Box
-prettyPrintLiteralValue _ (NumericLiteral n) = text $ either show show n
+prettyPrintLiteralValue _ (NumericLiteral n) = text $ foldNumericLiteral show show show n
 prettyPrintLiteralValue _ (StringLiteral s) = text $ T.unpack $ prettyPrintString s
 prettyPrintLiteralValue _ (CharLiteral c) = text $ show c
 prettyPrintLiteralValue _ (BooleanLiteral True) = text "true"
@@ -202,7 +202,7 @@ prettyPrintBinderAtom (ParensInBinder b) = parensT (prettyPrintBinder b)
 prettyPrintLiteralBinder :: Literal Binder -> Text
 prettyPrintLiteralBinder (StringLiteral str) = prettyPrintString str
 prettyPrintLiteralBinder (CharLiteral c) = T.pack (show c)
-prettyPrintLiteralBinder (NumericLiteral num) = either (T.pack . show) (T.pack . show) num
+prettyPrintLiteralBinder (NumericLiteral num) = foldNumericLiteral (T.pack . show) (T.pack . show) (T.pack . show) num
 prettyPrintLiteralBinder (BooleanLiteral True) = "true"
 prettyPrintLiteralBinder (BooleanLiteral False) = "false"
 prettyPrintLiteralBinder (ObjectLiteral bs) =

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -305,8 +305,9 @@ infer'
    . (MonadSupply m, MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
   => Expr
   -> m Expr
-infer' v@(Literal (NumericLiteral (Left _))) = return $ TypedValue True v tyInt
-infer' v@(Literal (NumericLiteral (Right _))) = return $ TypedValue True v tyNumber
+infer' v@(Literal (NumericLiteral (LitInt _))) = return $ TypedValue True v tyInt
+infer' v@(Literal (NumericLiteral (LitNumber _))) = return $ TypedValue True v tyNumber
+infer' v@(Literal (NumericLiteral (LitUInt _))) = return $ TypedValue True v tyUInt
 infer' v@(Literal (StringLiteral _)) = return $ TypedValue True v tyString
 infer' v@(Literal (CharLiteral _)) = return $ TypedValue True v tyChar
 infer' v@(Literal (BooleanLiteral _)) = return $ TypedValue True v tyBoolean
@@ -469,8 +470,9 @@ inferBinder
 inferBinder _ NullBinder = return M.empty
 inferBinder val (LiteralBinder (StringLiteral _)) = unifyTypes val tyString >> return M.empty
 inferBinder val (LiteralBinder (CharLiteral _)) = unifyTypes val tyChar >> return M.empty
-inferBinder val (LiteralBinder (NumericLiteral (Left _))) = unifyTypes val tyInt >> return M.empty
-inferBinder val (LiteralBinder (NumericLiteral (Right _))) = unifyTypes val tyNumber >> return M.empty
+inferBinder val (LiteralBinder (NumericLiteral (LitInt _))) = unifyTypes val tyInt >> return M.empty
+inferBinder val (LiteralBinder (NumericLiteral (LitNumber _))) = unifyTypes val tyNumber >> return M.empty
+inferBinder val (LiteralBinder (NumericLiteral (LitUInt _))) = unifyTypes val tyUInt >> return M.empty
 inferBinder val (LiteralBinder (BooleanLiteral _)) = unifyTypes val tyBoolean >> return M.empty
 inferBinder val (VarBinder name) = return $ M.singleton name val
 inferBinder val (ConstructorBinder ctor binders) = do
@@ -632,9 +634,11 @@ check' val u@(TUnknown _) = do
   (val'', ty') <- instantiatePolyTypeWithUnknowns val' ty
   unifyTypes ty' u
   return $ TypedValue True val'' ty'
-check' v@(Literal (NumericLiteral (Left _))) t | t == tyInt =
+check' v@(Literal (NumericLiteral (LitInt _))) t | t == tyInt =
   return $ TypedValue True v t
-check' v@(Literal (NumericLiteral (Right _))) t | t == tyNumber =
+check' v@(Literal (NumericLiteral (LitNumber _))) t | t == tyNumber =
+  return $ TypedValue True v t
+check' v@(Literal (NumericLiteral (LitUInt _))) t | t == tyUInt =
   return $ TypedValue True v t
 check' v@(Literal (StringLiteral _)) t | t == tyString =
   return $ TypedValue True v t

--- a/tests/TestCompiler.hs
+++ b/tests/TestCompiler.hs
@@ -227,7 +227,7 @@ checkShouldFailWith expected errs =
   let actual = map P.errorCode $ P.runMultipleErrors errs
   in if sort expected == sort (map T.unpack actual)
     then Nothing
-    else Just $ "Expected these errors: " ++ show expected ++ ", but got these: " ++ show actual
+    else Just $ "Expected these errors: " ++ show expected ++ ", but got these: " ++ show (P.runMultipleErrors errs) ++ ", with errorCode " ++ show actual
 
 assertCompiles
   :: [P.Module]

--- a/tests/TestCoreFn.hs
+++ b/tests/TestCoreFn.hs
@@ -84,8 +84,8 @@ spec = context "CoreFnFromJsonTest" $ do
   context "Expr" $ do
     specify "should parse literals" $ do
       let m = Module [] mn mp [] [] []
-                [ NonRec ann (Ident "x1") $ Literal ann (NumericLiteral (Left 1))
-                , NonRec ann (Ident "x2") $ Literal ann (NumericLiteral (Right 1.0))
+                [ NonRec ann (Ident "x1") $ Literal ann (NumericLiteral (LitInt 1))
+                , NonRec ann (Ident "x2") $ Literal ann (NumericLiteral (LitNumber 1.0))
                 , NonRec ann (Ident "x3") $ Literal ann (StringLiteral (mkString "abc"))
                 , NonRec ann (Ident "x4") $ Literal ann (CharLiteral 'c')
                 , NonRec ann (Ident "x5") $ Literal ann (BooleanLiteral True)
@@ -102,7 +102,7 @@ spec = context "CoreFnFromJsonTest" $ do
     specify "should parse Accessor" $ do
       let m = Module [] mn mp [] [] []
                 [ NonRec ann (Ident "x") $
-                    Accessor ann (mkString "field") (Literal ann $ ObjectLiteral [(mkString "field", Literal ann (NumericLiteral (Left 1)))]) ]
+                    Accessor ann (mkString "field") (Literal ann $ ObjectLiteral [(mkString "field", Literal ann (NumericLiteral (LitInt 1)))]) ]
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse ObjectUpdate" $ do

--- a/tests/support/bower.json
+++ b/tests/support/bower.json
@@ -26,7 +26,7 @@
     "purescript-newtype": "2.0.0",
     "purescript-nonempty": "4.0.0",
     "purescript-partial": "1.2.1",
-    "purescript-prelude": "3.1.0",
+    "purescript-prelude": "https://www.github.com/parsonsmatt/purescript-prelude.git#a793cd7eb7843b271255c986df173e2368644456",
     "purescript-proxy": "2.1.0",
     "purescript-psci-support": "3.0.0",
     "purescript-refs": "3.0.0",


### PR DESCRIPTION
This PR introduces support for unsigned integers using a `u` postfix marker.

```purescript
let uint :: UInt
    uint = 0u
```

Negative `UInt` literals will be rejected.

- [x] Lexer/Parser
- [x] AST representation
- [x] `purescript-prelude` patch written
- [x] Optimizations/inlinings for `Int` copied for `UInt` as well

Fixes #3146 