### PR TITLE
Print error message on failed examples

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -80,6 +80,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@nwolverson](https://github.com/nwolverson) | Nicholas Wolverson | [MIT license](http://opensource.org/licenses/MIT) |
 | [@osa1](https://github.com/osa1) | Ömer Sinan Ağacan | MIT license |
 | [@paf31](https://github.com/paf31) | Phil Freeman | [MIT license](http://opensource.org/licenses/MIT) |
+| [@parsonsmatt](https://github.com/parsonsmatt) | Matt Parsons | [MIT license](http://opensource.org/licenses/MIT) |
 | [@passy](https://github.com/passy) | Pascal Hartig | [MIT license](http://opensource.org/licenses/MIT) |
 | [@paulyoung](https://github.com/paulyoung) | Paul Young | [MIT license](http://opensource.org/licenses/MIT) |
 | [@pelotom](https://github.com/pelotom) | Thomas Crockett | [MIT license](http://opensource.org/licenses/MIT) |

--- a/tests/TestCompiler.hs
+++ b/tests/TestCompiler.hs
@@ -228,7 +228,7 @@ checkShouldFailWith expected errs =
   in if sort expected == sort (map T.unpack actual)
     then Nothing
     else Just $ "Expected these errors: " ++ show expected ++ ", but got these: "
-      ++ show actual ++ ", full error messages: "
+      ++ show actual ++ ", full error messages: \n"
       ++ unlines (map (P.renderBox . P.prettyPrintSingleError P.defaultPPEOptions) (P.runMultipleErrors errs))
 
 assertCompiles

--- a/tests/TestCompiler.hs
+++ b/tests/TestCompiler.hs
@@ -227,7 +227,9 @@ checkShouldFailWith expected errs =
   let actual = map P.errorCode $ P.runMultipleErrors errs
   in if sort expected == sort (map T.unpack actual)
     then Nothing
-    else Just $ "Expected these errors: " ++ show expected ++ ", but got these: " ++ show actual
+    else Just $ "Expected these errors: " ++ show expected ++ ", but got these: "
+      ++ show actual ++ ", full error messages: "
+      ++ unlines (map (P.renderBox . P.prettyPrintSingleError P.defaultPPEOptions) (P.runMultipleErrors errs))
 
 assertCompiles
   :: [P.Module]


### PR DESCRIPTION
When a failed example provides a different error message than expected, it can be difficult to understand why.

This PR prints the given error message, which makes it easy to understand why the error occurred.

Before:

![image](https://user-images.githubusercontent.com/7310112/34220277-4e946e82-e571-11e7-8f09-2192df13d826.png)

After:

![image](https://user-images.githubusercontent.com/7310112/34222258-314b5096-e578-11e7-98ae-9ebd85115259.png)
