### PR TITLE
Allow pattern matches with guards

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -489,7 +489,7 @@ data Declaration
   | ValueDeclaration {-# UNPACK #-} !(ValueDeclarationData [GuardedExpr])
   -- |
   -- A declaration paired with pattern matching in let-in expression (binder, optional guard, value)
-  | BoundValueDeclaration SourceAnn Binder Expr
+  | BoundValueDeclaration SourceAnn Binder [GuardedExpr]
   -- |
   -- A minimal mutually recursive set of value declarations
   --

--- a/src/Language/PureScript/Sugar/CaseDeclarations.hs
+++ b/src/Language/PureScript/Sugar/CaseDeclarations.hs
@@ -335,6 +335,13 @@ desugarCases = desugarRest <=< fmap join . flip parU toDecls . groupBy inSameGro
       where
       go (Let ds val') = Let <$> desugarCases ds <*> pure val'
       go other = return other
+    desugarRest (BoundValueDeclaration sa b result : rest) =
+      let (_, f, _) = everywhereOnValuesTopDownM return go return
+          f' = mapM (\(GuardedExpr gs e) -> GuardedExpr gs <$> f e)
+      in (:) <$> (BoundValueDeclaration sa b <$> f' result) <*> desugarRest rest
+      where
+      go (Let ds val') = Let <$> desugarCases ds <*> pure val'
+      go other = return other
     desugarRest (d : ds) = (:) d <$> desugarRest ds
     desugarRest [] = pure []
 

--- a/src/Language/PureScript/Sugar/LetPattern.hs
+++ b/src/Language/PureScript/Sugar/LetPattern.hs
@@ -33,8 +33,10 @@ desugarLetPattern decl =
      -- ^ The original let-in result expression
      -> Expr
   go [] e = e
-  go (BoundValueDeclaration (pos, com) binder boundE : ds) e =
+  go (BoundValueDeclaration (pos, com) binder [MkUnguarded boundE] : ds) e =
     PositionedValue pos com $ Case [boundE] [CaseAlternative [binder] [MkUnguarded $ go ds e]]
+  go (BoundValueDeclaration (pos, com) binder guards : ds) e =
+    PositionedValue pos com $ Case [Case [] [CaseAlternative [] guards]] [CaseAlternative [binder] [MkUnguarded $ go ds e]]
   go (d:ds) e = append d $ go ds e
 
   append :: Declaration -> Expr -> Expr


### PR DESCRIPTION
Currently, constructor patterns with guards like

```purescript
let Tuple x y | a < b = Tuple a b
              | otherwise = Tuple b a
```

is not allowed.  I think this restriction is not necessary.