### PR TITLE
Remove unused entry from `opTable`s

### DIFF
--- a/src/Language/PureScript/Sugar/Operators/Common.hs
+++ b/src/Language/PureScript/Sugar/Operators/Common.hs
@@ -47,7 +47,6 @@ opTable
   -> [[P.Operator (Chain a) () Identity a]]
 opTable ops fromOp reapply =
   map (map (\(name, a) -> P.Infix (P.try (matchOp fromOp name) >> return (reapply name)) (toAssoc a))) ops
-  ++ [[ P.Infix (P.try (parseOp fromOp >>= \ident -> return (reapply ident))) P.AssocLeft ]]
 
 matchOperators
   :: forall a nameType


### PR DESCRIPTION
&lt;I-have-no-idea-dog>

I _think_ this is leftover from before we required that all operators were declared via fixity statement though - a default associativity that any undeclared operators would fall back to.

Maybe @paf31 can confirm?


