### PR TITLE
Optimize inferred partial constraint fn

### DIFF
--- a/examples/passing/PartialTCO.purs
+++ b/examples/passing/PartialTCO.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Prelude
+import Control.Monad.Eff.Console (log)
+import Partial.Unsafe (unsafePartial)
+
+main = do
+  let _ = partialTCO true 1000000
+  log "Done"
+
+partialTCO :: Partial => Boolean -> Int -> Int
+partialTCO true 0 = 0
+partialTCO true n = partialTCO true (n - 1)

--- a/examples/passing/PartialTCO.purs
+++ b/examples/passing/PartialTCO.purs
@@ -5,7 +5,7 @@ import Control.Monad.Eff.Console (log)
 import Partial.Unsafe (unsafePartial)
 
 main = do
-  let _ = partialTCO true 1000000
+  let _ = unsafePartial partialTCO true 1000000
   log "Done"
 
 partialTCO :: Partial => Boolean -> Int -> Int

--- a/src/Language/PureScript/CoreFn/Optimizer.hs
+++ b/src/Language/PureScript/CoreFn/Optimizer.hs
@@ -57,6 +57,9 @@ optimizeModuleDecls = map transformBinds
 
   transformExprs = optimizeUnusedPartialFn
 
+-- |
+-- Optimize away function generated to typecheck inferred Partial constraints.
+--
 optimizeUnusedPartialFn :: Expr a -> Expr a
 optimizeUnusedPartialFn (Let _
   [NonRec _ UnusedIdent _]

--- a/src/Language/PureScript/CoreFn/Optimizer.hs
+++ b/src/Language/PureScript/CoreFn/Optimizer.hs
@@ -9,6 +9,7 @@ import Language.PureScript.CoreFn.Ann
 import Language.PureScript.CoreFn.Expr
 import Language.PureScript.CoreFn.Module
 import Language.PureScript.CoreFn.Traversals
+import Language.PureScript.Names (Ident(UnusedIdent), Qualified(Qualified))
 import Language.PureScript.Label
 import Language.PureScript.Types
 import qualified Language.PureScript.Constants as C
@@ -16,7 +17,6 @@ import qualified Language.PureScript.Constants as C
 -- |
 -- CoreFn optimization pass.
 --
-
 optimizeCoreFn :: Module Ann -> Module Ann
 optimizeCoreFn m = m {moduleDecls = optimizeModuleDecls $ moduleDecls m}
 
@@ -47,19 +47,7 @@ closedRecordFields (TypeApp (TypeConstructor C.Record) row) =
     collect _ = Nothing
 closedRecordFields _ = Nothing
 
-optimizeCoreFn :: Module a -> Module a
-optimizeCoreFn m = m {moduleDecls = optimizeModuleDecls $ moduleDecls m}
-
-optimizeModuleDecls :: [Bind a] -> [Bind a]
-optimizeModuleDecls = map transformBinds
-  where
-  (transformBinds, _, _) = everywhereOnValues id transformExprs id
-
-  transformExprs = optimizeUnusedPartialFn
-
--- |
--- Optimize away function generated to typecheck inferred Partial constraints.
---
+-- | See https://github.com/purescript/purescript/issues/3157
 optimizeUnusedPartialFn :: Expr a -> Expr a
 optimizeUnusedPartialFn (Let _
   [NonRec _ UnusedIdent _]

--- a/tests/purs/passing/PartialTCO.purs
+++ b/tests/purs/passing/PartialTCO.purs
@@ -1,7 +1,7 @@
 module Main where
 
 import Prelude
-import Control.Monad.Eff.Console (log)
+import Effect.Console (log)
 import Partial.Unsafe (unsafePartial)
 
 main = do


### PR DESCRIPTION
fixes #3157

supersedes https://github.com/purescript/purescript/pull/3195

Adds a CoreFn optimization pass.