### PR TITLE
Make REPL completion tests faster

### DIFF
--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -17,8 +17,9 @@ import           TestUtils (getSupportModuleNames)
 
 completionTests :: Spec
 completionTests = context "completionTests" $ do
-  mns <- runIO $ getSupportModuleNames
-  mapM_ assertCompletedOk (completionTestData mns)
+  mns       <- runIO getSupportModuleNames
+  psciState <- runIO getPSCiStateForCompletion
+  mapM_ (assertCompletedOk psciState) (completionTestData mns)
 
 -- If the cursor is at the right end of the line, with the 1st element of the
 -- pair as the text in the line, then pressing tab should offer all the
@@ -85,16 +86,14 @@ completionTestData supportModuleNames =
   , ("Control.Monad.ST.new", ["Control.Monad.ST.newSTRef"])
   ]
 
-assertCompletedOk :: (String, [String]) -> Spec
-assertCompletedOk (line, expecteds) = specify line $ do
-  results <- runCM (completion' (reverse line, ""))
+assertCompletedOk :: PSCiState -> (String, [String]) -> Spec
+assertCompletedOk psciState (line, expecteds) = specify line $ do
+  results <- runCM psciState (completion' (reverse line, ""))
   let actuals = formatCompletions results
   sort actuals `shouldBe` sort expecteds
 
-runCM :: CompletionM a -> IO a
-runCM act = do
-  psciState <- getPSCiStateForCompletion
-  evalStateT (liftCompletionM act) psciState
+runCM :: PSCiState -> CompletionM a -> IO a
+runCM psciState act = evalStateT (liftCompletionM act) psciState
 
 getPSCiStateForCompletion :: IO PSCiState
 getPSCiStateForCompletion = do


### PR DESCRIPTION
Rather than rebuild the same code for each assertion, this builds the environment once and reuses it. The whole repl set of tests went from about 35s to 10s. Now about half of the remaining time is setup done by `stack test` and the other half is `TestPsci` (a similar optimization might be possible there, but it's less clear).