### PR TITLE
Improve parse error messages for .purs-repl

### DIFF
--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -360,13 +360,10 @@ command = loop <$> options
                       configFile <- (</> ".purs-repl") <$> liftIO getCurrentDirectory
                       exists <- liftIO $ doesFileExist configFile
                       when exists $ do
-                        ls <- lines <$> liftIO (readUTF8File configFile)
-                        for_ ls $ \l -> do
-                          liftIO (putStrLn l)
-                          case parseCommand l of
-                            Left err -> liftIO (putStrLn err >> exitFailure)
-                            Right cmd@Import{} -> handleCommand' state cmd
-                            Right _ -> liftIO (putStrLn "The .purs-repl file only supports import declarations")
+                        cf <- liftIO (readUTF8File configFile)
+                        case parseDotFile configFile cf of
+                          Left err -> liftIO (putStrLn err >> exitFailure)
+                          Right cmds -> liftIO (putStrLn cf) >> for_ cmds (handleCommand' state)
 
                     handleCommandWithInterrupts
                       :: state


### PR DESCRIPTION
This fixes #3248

- Set the file name in error message
- Parse whole file at once so correct lines numbers are given in errors
- Don't fail on empty lines, whitespace, etc

To ensure line numbers are given on errors, I made a new parser that only parses `import` statements, instead of parsing all kinds of commands and rejecting them after the line numbers are forgotten.

Since the whole file is parsed all at once, it no longer makes sense to interleave printing, parsing, and executing line-by-line. So I've printed the whole contents verbatim before executing all the imports (assuming the file parsed).

Example:

```sh
$ cat .purs-repl
import Prelude
:help

$ pulp repl
PSCi, version 0.11.7
Type :? for help

"/home/guest-user/example/.purs-repl" (line 2, column 1):
unexpected :
expecting "import" or end of input
The .purs-repl file only supports import declarations
```