### PR TITLE
Skip SourceSpan in Binder Eq, Ord for faster exhaustivity check

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,6 +26,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@balajirrao](https://github.com/balajirrao) | Balaji Rao | MIT license |
 | [@bbqbaron](https://github.com/bbqbaron) | Eric Loren | [MIT license](http://opensource.org/licenses/MIT) |
 | [@bergmark](https://github.com/bergmark) | Adam Bergmark | MIT license |
+| [@bitemyapp](https://github.com/bitemyapp) | Chris Allen | [MIT license](http://opensource.org/licenses/MIT) |
 | [@bmjames](https://github.com/bmjames) | Ben James | [MIT license](http://opensource.org/licenses/MIT) |
 | [@Bogdanp](https://github.com/Bogdanp) | Bogdan Paul Popa | [MIT license](http://opensource.org/licenses/MIT) |
 | [@brandonhamilton](https://github.com/brandonhamilton) | Brandon Hamilton | [MIT license](http://opensource.org/licenses/MIT) |

--- a/src/Language/PureScript/AST/Binders.hs
+++ b/src/Language/PureScript/AST/Binders.hs
@@ -61,7 +61,107 @@ data Binder
   -- A binder with a type annotation
   --
   | TypedBinder Type Binder
-  deriving (Show, Eq, Ord)
+  deriving (Show)
+
+instance Eq Binder where
+  (==) NullBinder NullBinder = True
+  (==) NullBinder _ = False
+
+  (==) (LiteralBinder lb) (LiteralBinder lb') = (==) lb lb'
+  (==) LiteralBinder{} _ = False
+
+  (==) (VarBinder _ ident) (VarBinder _ ident') = (==) ident ident'
+  (==) VarBinder{} _ = False
+
+  (==) (ConstructorBinder _ qpc bs) (ConstructorBinder _ qpc' bs') =
+    (==) qpc qpc' && (==) bs bs'
+  (==) ConstructorBinder{} _ = False
+
+  (==) (OpBinder _ qov) (OpBinder _ qov') =
+    (==) qov qov'
+  (==) OpBinder{} _ = False
+
+  (==) (BinaryNoParensBinder b1 b2 b3) (BinaryNoParensBinder b1' b2' b3') =
+    (==) b1 b1' && (==) b2 b2' && (==) b3 b3'
+  (==) BinaryNoParensBinder{} _ = False
+
+  (==) (ParensInBinder b) (ParensInBinder b') =
+    (==) b b'
+  (==) ParensInBinder{} _ = False
+
+  (==) (NamedBinder _ ident b) (NamedBinder _ ident' b') =
+    (==) ident ident' && (==) b b'
+  (==) NamedBinder{} _ = False
+
+  (==) (PositionedBinder _ comments b) (PositionedBinder _ comments' b') =
+    (==) comments comments' && (==) b b'
+  (==) PositionedBinder{} _ = False
+
+  (==) (TypedBinder ty b) (TypedBinder ty' b') =
+    (==) ty ty' && (==) b b'
+  (==) TypedBinder{} _ = False
+
+nextIfEq :: Ordering -> Ordering -> Ordering
+nextIfEq EQ o = o
+nextIfEq o _ = o
+
+instance Ord Binder where
+  compare NullBinder NullBinder = EQ
+  compare NullBinder _ = LT
+
+  compare (LiteralBinder lb) (LiteralBinder lb') = compare lb lb'
+  compare LiteralBinder{} NullBinder = GT
+  compare LiteralBinder{} _ = LT
+
+  compare (VarBinder _ ident) (VarBinder _ ident') = compare ident ident'
+  compare VarBinder{} NullBinder = GT
+  compare VarBinder{} LiteralBinder{} = GT
+  compare VarBinder{} _ = LT
+
+  compare (ConstructorBinder _ qpc bs) (ConstructorBinder _ qpc' bs') =
+    compare qpc qpc' `nextIfEq` compare bs bs'
+  compare ConstructorBinder{} NullBinder = GT
+  compare ConstructorBinder{} LiteralBinder{} = GT
+  compare ConstructorBinder{} VarBinder{} = GT
+  compare ConstructorBinder{} _ = LT
+
+  compare (OpBinder _ qov) (OpBinder _ qov') =
+    compare qov qov'
+  compare OpBinder{} NullBinder = GT
+  compare OpBinder{} LiteralBinder{} = GT
+  compare OpBinder{} VarBinder{} = GT
+  compare OpBinder{} ConstructorBinder{} = GT
+  compare OpBinder{} _ = LT
+
+  compare (BinaryNoParensBinder b1 b2 b3) (BinaryNoParensBinder b1' b2' b3') =
+    compare b1 b1' `nextIfEq` compare b2 b2' `nextIfEq` compare b3 b3'
+  compare BinaryNoParensBinder{} ParensInBinder{} = LT
+  compare BinaryNoParensBinder{} NamedBinder{} = LT
+  compare BinaryNoParensBinder{} PositionedBinder{} = LT
+  compare BinaryNoParensBinder{} TypedBinder{} = LT
+  compare BinaryNoParensBinder{} _ = GT
+
+  compare (ParensInBinder b) (ParensInBinder b') =
+    compare b b'
+  compare ParensInBinder{} NamedBinder{} = LT
+  compare ParensInBinder{} PositionedBinder{} = LT
+  compare ParensInBinder{} TypedBinder{} = LT
+  compare ParensInBinder{} _ = GT
+
+  compare (NamedBinder _ ident b) (NamedBinder _ ident' b') =
+    compare ident ident' `nextIfEq` compare b b'
+  compare NamedBinder{} PositionedBinder{} = LT
+  compare NamedBinder{} TypedBinder{} = LT
+  compare NamedBinder{} _ = GT
+
+  compare (PositionedBinder _ comments b) (PositionedBinder _ comments' b') =
+    compare comments comments' `nextIfEq` compare b b'
+  compare PositionedBinder{} TypedBinder{} = LT
+  compare PositionedBinder{} _ = GT
+
+  compare (TypedBinder ty b) (TypedBinder ty' b') =
+    compare ty ty' `nextIfEq` compare b b'
+  compare TypedBinder{} _ = GT
 
 -- |
 -- Collect all names introduced in binders in an expression

--- a/src/Language/PureScript/AST/Binders.hs
+++ b/src/Language/PureScript/AST/Binders.hs
@@ -5,6 +5,8 @@ module Language.PureScript.AST.Binders where
 
 import Prelude.Compat
 
+import Data.Semigroup
+
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.AST.Literals
 import Language.PureScript.Names
@@ -101,10 +103,6 @@ instance Eq Binder where
     (==) ty ty' && (==) b b'
   (==) TypedBinder{} _ = False
 
-nextIfEq :: Ordering -> Ordering -> Ordering
-nextIfEq EQ o = o
-nextIfEq o _ = o
-
 instance Ord Binder where
   compare NullBinder NullBinder = EQ
   compare NullBinder _ = LT
@@ -119,7 +117,7 @@ instance Ord Binder where
   compare VarBinder{} _ = LT
 
   compare (ConstructorBinder _ qpc bs) (ConstructorBinder _ qpc' bs') =
-    compare qpc qpc' `nextIfEq` compare bs bs'
+    compare qpc qpc' <> compare bs bs'
   compare ConstructorBinder{} NullBinder = GT
   compare ConstructorBinder{} LiteralBinder{} = GT
   compare ConstructorBinder{} VarBinder{} = GT
@@ -134,7 +132,7 @@ instance Ord Binder where
   compare OpBinder{} _ = LT
 
   compare (BinaryNoParensBinder b1 b2 b3) (BinaryNoParensBinder b1' b2' b3') =
-    compare b1 b1' `nextIfEq` compare b2 b2' `nextIfEq` compare b3 b3'
+    compare b1 b1' <> compare b2 b2' <> compare b3 b3'
   compare BinaryNoParensBinder{} ParensInBinder{} = LT
   compare BinaryNoParensBinder{} NamedBinder{} = LT
   compare BinaryNoParensBinder{} PositionedBinder{} = LT
@@ -149,18 +147,18 @@ instance Ord Binder where
   compare ParensInBinder{} _ = GT
 
   compare (NamedBinder _ ident b) (NamedBinder _ ident' b') =
-    compare ident ident' `nextIfEq` compare b b'
+    compare ident ident' <> compare b b'
   compare NamedBinder{} PositionedBinder{} = LT
   compare NamedBinder{} TypedBinder{} = LT
   compare NamedBinder{} _ = GT
 
   compare (PositionedBinder _ comments b) (PositionedBinder _ comments' b') =
-    compare comments comments' `nextIfEq` compare b b'
+    compare comments comments' <> compare b b'
   compare PositionedBinder{} TypedBinder{} = LT
   compare PositionedBinder{} _ = GT
 
   compare (TypedBinder ty b) (TypedBinder ty' b') =
-    compare ty ty' `nextIfEq` compare b b'
+    compare ty ty' <> compare b b'
   compare TypedBinder{} _ = GT
 
 -- |


### PR DESCRIPTION
I get a speedup of about 17x for `LargeSumType.purs` from this change. My curiosity was piqued by something @parsonsmatt mentioned while he was doing something unrelated.

Optimized run went from 5 seconds to 0.29 seconds, profiled run went from 17 seconds to 1 second.

Here's a dump of some of what I was looking while optimizing this:

### Before optimizing:

```
compare                 Language.PureScript.AST.SourcePos     src/Language/PureScript/AST/SourcePos.hs:53:25-27               28.3    0.0
>>=                     Text.Parsec.Prim                      Text/Parsec/Prim.hs:202:5-29                                    18.1   10.8
>>=.\.succ'             Data.Attoparsec.Internal.Types        Data/Attoparsec/Internal/Types.hs:146:13-76                      6.7    1.7
compareText.go          Data.Text                             Data/Text.hs:(416,5)-(422,33)                                    6.4    0.0
parsecMap.\             Text.Parsec.Prim                      Text/Parsec/Prim.hs:190:7-48                                     4.2    6.2
```

I found this flamegraph more helpful:

![hmhq9xa](https://user-images.githubusercontent.com/320177/36991211-99322264-206c-11e8-87d8-9772f1810cb8.png)

Big props to @MonoidMusician for pointing me in the right direction here.

Zooming in a couple parts of the main left block of the flamegraph:

![screenshot from 2018-03-05 00-02-29](https://user-images.githubusercontent.com/320177/36961920-ffc7a1f2-2012-11e8-8194-9c39bee64b16.png)

![screenshot from 2018-03-05 00-02-20](https://user-images.githubusercontent.com/320177/36961921-ffd6833e-2012-11e8-9a83-a4f1e184abcc.png)

### After writing the custom Ord instance:

![screenshot from 2018-03-05 01-25-00](https://user-images.githubusercontent.com/320177/36962172-1897e0ec-2014-11e8-9726-dd8c61cbeae1.png)

It's mostly disappeared from the flamegraph. Based on this and the human-readable `.prof` it seems like time is getting dominated by Parsec now.

Normally I have moral objections to manual instances varying from derived instances but it isn't clear that incorporating the `SourceSpan` into `Binder`'s `Ord` or `Eq` comparisons would serve any purpose. I don't have a lot of choice with the exhaustivity checking using `Ord` instances as-written because there `ordNubBy` isn't a thing for what are obvious reasons if you look at the implementation of `ordNub`. Any options for hacking around this seem more odious than the custom Eq/Ord. The speedup was purely from the `Ord` instance but I did the `Eq` instance as well to harmonize its behavior with `Ord`.