### PR TITLE
Makefiles make things easier for new and regular contributors alike

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,14 @@ tmp/
 output
 examples/docs/docs/
 core-tests/full-core-docs.md
+tests/support/package-lock.json
 .psc-ide-port
 .psc-package/
 purescript.cabal
+
+# Profiling related
+*.aux
+*.hp
+*.prof
+*.ps
+*.svg

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,6 +26,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@balajirrao](https://github.com/balajirrao) | Balaji Rao | MIT license |
 | [@bbqbaron](https://github.com/bbqbaron) | Eric Loren | [MIT license](http://opensource.org/licenses/MIT) |
 | [@bergmark](https://github.com/bergmark) | Adam Bergmark | MIT license |
+| [@bitemyapp](https://github.com/bitemyapp) | Chris Allen | [MIT license](http://opensource.org/licenses/MIT) |
 | [@bmjames](https://github.com/bmjames) | Ben James | [MIT license](http://opensource.org/licenses/MIT) |
 | [@Bogdanp](https://github.com/Bogdanp) | Bogdan Paul Popa | [MIT license](http://opensource.org/licenses/MIT) |
 | [@brandonhamilton](https://github.com/brandonhamilton) | Brandon Hamilton | [MIT license](http://opensource.org/licenses/MIT) |

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test-ghci:
 # rerun the profiled test run.
 test-profiling:
 	$(stack) test --executable-profiling --ta '+RTS -pj -RTS' $(package)
-	cat tests.prof | ghc-prof-aeson-flamegraph | flamegraph.pl > tests.svg
+	cat tests.prof | stack exec ghc-prof-aeson-flamegraph | flamegraph.pl > tests.svg
 
 bench:
 	$(stack) bench $(package)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+package = purescript
+exe_target = purs
+stack_yaml = STACK_YAML="stack.yaml"
+stack = $(stack_yaml) stack
+
+build:
+	$(stack) build $(package)
+
+build-dirty:
+	$(stack) build --ghc-options=-fforce-recomp $(package)
+
+run:
+	$(stack) build --fast && $(stack) exec -- $(package)
+
+install:
+	$(stack) install
+
+ghci:
+	$(stack) ghci $(package):lib
+
+test:
+	$(stack) test --fast $(package)
+
+test-ghci:
+	$(stack) ghci $(package):test:$(package)-tests
+
+# If you want to profile a particular test, such
+# as LargeSumType.purs, add -p to the test arguments like so:
+# stack test --executable-profiling --ta '-p LargeSum +RTS -pj -RTS'
+
+# Also, you'll need flamegraph.pl and ghc-prof-aeson-flamegraph
+# (cf. dev-deps), I git cloned the FlameGraph repository and
+# symlinked the Perl script into my path.
+# Open the SVG with your browser, you can reload the browser when you
+# rerun the profiled test run.
+test-profiling:
+	$(stack) test --executable-profiling --ta '+RTS -pj -RTS' $(package)
+	cat tests.prof | ghc-prof-aeson-flamegraph | flamegraph.pl > tests.svg
+
+bench:
+	$(stack) bench $(package)
+
+ghcid:
+	$(stack) exec -- ghcid -c "stack ghci $(package):lib --test --ghci-options='-fobject-code -fno-warn-unused-do-bind'"
+
+# if you want these to be globally available run it outside of purescript
+# but incompatibilities might arise between ghcid and the version of GHC
+# you're using to build PureScript.
+dev-deps:
+	stack install ghcid ghc-prof-aeson-flamegraph
+
+.PHONY : build build-dirty run install ghci test test-ghci test-profiling ghcid dev-deps


### PR DESCRIPTION
I use a `Makefile` in almost all of my software projects as a sort of exobrain/secondary memory and regularized shortcut mechanism for doing common tasks. PureScript didn't have one, so I've PR'd one based on my small but burgeoning collection at https://github.com/bitemyapp/makefiles from which https://github.com/bitemyapp/lefortovo grabs things.

I also updated the `.gitignore` to ignore profiling bumf.