### PR TITLE
Fix ScopeConflict error to include positions

### DIFF
--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -12,6 +12,7 @@ import Control.Monad.Trans.Reader (runReaderT)
 import Control.Monad.Trans.State.Strict (execState)
 
 import Data.Either
+import qualified Data.List.NonEmpty as NEL
 import Data.Map (Map)
 import Data.Maybe (mapMaybe)
 import Data.Monoid ((<>))
@@ -132,24 +133,24 @@ collectDeclarations imports exports = do
     Map.fromListWith (<>) <$> traverse (uncurry lookup') imps'
 
   expVals = P.exportedValues exports
-  impVals = concat (Map.elems (P.importedValues imports))
+  impVals = concat (fmap NEL.toList (Map.elems (P.importedValues imports)))
 
   expValOps = P.exportedValueOps exports
-  impValOps = concat (Map.elems (P.importedValueOps imports))
+  impValOps = concat (fmap NEL.toList (Map.elems (P.importedValueOps imports)))
 
   expTypes = Map.map snd (P.exportedTypes exports)
-  impTypes = concat (Map.elems (P.importedTypes imports))
+  impTypes = concat (fmap NEL.toList (Map.elems (P.importedTypes imports)))
 
   expTypeOps = P.exportedTypeOps exports
-  impTypeOps = concat (Map.elems (P.importedTypeOps imports))
+  impTypeOps = concat (fmap NEL.toList (Map.elems (P.importedTypeOps imports)))
 
   expCtors = concatMap fst (Map.elems (P.exportedTypes exports))
 
   expTCs = P.exportedTypeClasses exports
-  impTCs = concat (Map.elems (P.importedTypeClasses imports))
+  impTCs = concat (fmap NEL.toList (Map.elems (P.importedTypeClasses imports)))
 
   expKinds = P.exportedKinds exports
-  impKinds = concat (Map.elems (P.importedKinds imports))
+  impKinds = concat (fmap NEL.toList (Map.elems (P.importedKinds imports)))
 
 -- |
 -- Given a list of imported declarations (of a particular kind, ie. type, data,

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -17,6 +17,7 @@ import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Lazy
 import Control.Monad.Writer (MonadWriter(..), censor)
 
+import qualified Data.List.NonEmpty as NEL
 import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -382,7 +383,7 @@ renameInModule imports (Module modSS coms mn decls exps) =
   -- (e.g. M.Map -> Data.Map.Map).
   update
     :: (Ord a)
-    => M.Map (Qualified a) [ImportRecord a]
+    => M.Map (Qualified a) (NEL.NonEmpty (ImportRecord a))
     -> (a -> Name)
     -> Qualified a
     -> SourceSpan

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -12,6 +12,7 @@ import Control.Monad.Error.Class (MonadError(..))
 import Data.Function (on)
 import Data.Foldable (traverse_)
 import Data.List (intersect, groupBy, sortBy)
+import qualified Data.List.NonEmpty as NEL
 import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Map as M
 
@@ -124,9 +125,9 @@ resolveExports env ss mn imps exps refs =
     :: Bool
     -> ModuleName
     -> (a -> Name)
-    -> M.Map (Qualified a) [ImportRecord a]
+    -> M.Map (Qualified a) (NEL.NonEmpty (ImportRecord a))
     -> m [Qualified a]
-  extract useQual name toName = fmap (map (importName . head . snd)) . go . M.toList
+  extract useQual name toName = fmap (map (importName . NEL.head . snd)) . go . M.toList
     where
     go = filterM $ \(name', options) -> do
       let isMatch = if useQual then isQualifiedWith name name' else any (checkUnqual name') options


### PR DESCRIPTION
Makes some non-empty lists `NonEmpty` as a bonus (well, not just for the sake of it, it ensures non-partiality for the error message).