### PR TITLE
[purs ide] Find usages for recursive definitions

### DIFF
--- a/tests/Language/PureScript/Ide/Test.hs
+++ b/tests/Language/PureScript/Ide/Test.hs
@@ -23,7 +23,7 @@ defConfig =
   IdeConfiguration
     { confLogLevel = LogNone
     , confOutputPath = "output/"
-    , confGlobs = ["src/*.purs"]
+    , confGlobs = ["src/**/*.purs"]
     , confEditorMode = False
     }
 

--- a/tests/Language/PureScript/Ide/UsageSpec.hs
+++ b/tests/Language/PureScript/Ide/UsageSpec.hs
@@ -41,11 +41,12 @@ shouldBeUsage usage' (fp, range) =
 spec :: Spec
 spec = describe "Finding Usages" $ do
     it "finds a simple usage" $ do
-      ([_, Right (UsagesResult [usage1])], _) <- Test.inProject $
+      ([_, Right (UsagesResult [usage1, usage2])], _) <- Test.inProject $
         Test.runIde [ load ["FindUsage", "FindUsage.Definition", "FindUsage.Reexport"]
                     , usage (Test.mn "FindUsage.Definition") "usageId" IdeNSValue
                     ]
       usage1 `shouldBeUsage` ("src" </> "FindUsage.purs", "12:11-12:18")
+      usage2 `shouldBeUsage` ("src" </> "FindUsage/Definition.purs", "13:18-13:18")
     it "finds a simple recursive usage" $ do
       ([_, Right (UsagesResult [usage1])], _) <- Test.inProject $
         Test.runIde [ load ["FindUsage.Recursive"]

--- a/tests/Language/PureScript/Ide/UsageSpec.hs
+++ b/tests/Language/PureScript/Ide/UsageSpec.hs
@@ -46,6 +46,12 @@ spec = describe "Finding Usages" $ do
                     , usage (Test.mn "FindUsage.Definition") "usageId" IdeNSValue
                     ]
       usage1 `shouldBeUsage` ("src" </> "FindUsage.purs", "12:11-12:18")
+    it "finds a simple recursive usage" $ do
+      ([_, Right (UsagesResult [usage1])], _) <- Test.inProject $
+        Test.runIde [ load ["FindUsage.Recursive"]
+                    , usage (Test.mn "FindUsage.Recursive") "recursiveUsage" IdeNSValue
+                    ]
+      usage1 `shouldBeUsage` ("src" </> "FindUsage" </> "Recursive.purs", "7:12-7:26")
     it "finds a constructor usage" $ do
       ([_, Right (UsagesResult [usage1])], _) <- Test.inProject $
         Test.runIde [ load ["FindUsage", "FindUsage.Definition", "FindUsage.Reexport"]

--- a/tests/Language/PureScript/Ide/UsageSpec.hs
+++ b/tests/Language/PureScript/Ide/UsageSpec.hs
@@ -46,7 +46,7 @@ spec = describe "Finding Usages" $ do
                     , usage (Test.mn "FindUsage.Definition") "usageId" IdeNSValue
                     ]
       usage1 `shouldBeUsage` ("src" </> "FindUsage.purs", "12:11-12:18")
-      usage2 `shouldBeUsage` ("src" </> "FindUsage/Definition.purs", "13:18-13:18")
+      usage2 `shouldBeUsage` ("src" </> "FindUsage" </> "Definition.purs", "13:18-13:18")
     it "finds a simple recursive usage" $ do
       ([_, Right (UsagesResult [usage1])], _) <- Test.inProject $
         Test.runIde [ load ["FindUsage.Recursive"]

--- a/tests/support/pscide/src/FindUsage/Recursive.purs
+++ b/tests/support/pscide/src/FindUsage/Recursive.purs
@@ -1,0 +1,8 @@
+module FindUsage.Recursive where
+
+data Nat = Suc Nat | Z
+
+recursiveUsage :: Nat -> Int
+recursiveUsage = case _ of
+  Suc x -> recursiveUsage x
+  Z -> 0


### PR DESCRIPTION
Previously we'd fail to find these because the name is already in "scope", but for recursive definitions that name still refers to the top level declaration and so we should include it as a usage.