### PR TITLE
Fix compilation with ghc-8.4

### DIFF
--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -1,9 +1,15 @@
+{-# LANGUAGE CPP #-}
+
 -- |
 -- AST traversal helpers
 --
 module Language.PureScript.AST.Traversals where
 
+#if MIN_VERSION_base(4,11,0)
+import Prelude.Compat hiding ((<>))
+#else
 import Prelude.Compat
+#endif
 
 import Control.Monad
 

--- a/src/Language/PureScript/CoreFn/Traversals.hs
+++ b/src/Language/PureScript/CoreFn/Traversals.hs
@@ -1,9 +1,14 @@
+{-# LANGUAGE CPP #-}
 -- |
 -- CoreFn traversal helpers
 --
 module Language.PureScript.CoreFn.Traversals where
 
+#if MIN_VERSION_base(4,11,0)
+import Prelude.Compat hiding ((<>))
+#else
 import Prelude.Compat
+#endif
 
 import Control.Arrow (second, (***), (+++))
 

--- a/src/Language/PureScript/CoreImp/AST.hs
+++ b/src/Language/PureScript/CoreImp/AST.hs
@@ -1,7 +1,13 @@
+{-# LANGUAGE CPP #-}
+
 -- | Data types for the imperative core AST
 module Language.PureScript.CoreImp.AST where
 
+#if MIN_VERSION_base(4,11,0)
+import Prelude.Compat hiding ((<>))
+#else
 import Prelude.Compat
+#endif
 
 import Control.Monad ((>=>))
 import Control.Monad.Identity (Identity(..), runIdentity)

--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -405,12 +405,12 @@ data TypeClassEnv = TypeClassEnv
 
 instance Sem.Semigroup TypeClassEnv where
   (TypeClassEnv a1 b1 c1) <> (TypeClassEnv a2 b2 c2) =
-    TypeClassEnv (a1 <> a2) (b1 <> b2) (c1 <> c2)
+    TypeClassEnv (a1 Sem.<> a2) (b1 Sem.<> b2) (c1 Sem.<> c2)
 
 instance Monoid TypeClassEnv where
   mempty =
     TypeClassEnv mempty mempty mempty
-  mappend = (<>)
+  mappend = (Sem.<>)
 
 -- |
 -- Take a TypeClassEnv and handle all of the type class members in it, either

--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -16,6 +16,7 @@ import Data.Map (Map)
 import Data.Maybe (mapMaybe)
 import Data.Monoid ((<>))
 import qualified Data.Map as Map
+import qualified Data.Semigroup as Sem
 import Data.Text (Text)
 import qualified Data.Text as T
 
@@ -402,12 +403,14 @@ data TypeClassEnv = TypeClassEnv
   }
   deriving (Show)
 
+instance Sem.Semigroup TypeClassEnv where
+  (TypeClassEnv a1 b1 c1) <> (TypeClassEnv a2 b2 c2) =
+    TypeClassEnv (a1 <> a2) (b1 <> b2) (c1 <> c2)
+
 instance Monoid TypeClassEnv where
   mempty =
     TypeClassEnv mempty mempty mempty
-  mappend (TypeClassEnv a1 b1 c1)
-          (TypeClassEnv a2 b2 c2) =
-    TypeClassEnv (a1 <> a2) (b1 <> b2) (c1 <> c2)
+  mappend = (<>)
 
 -- |
 -- Take a TypeClassEnv and handle all of the type class members in it, either

--- a/src/Language/PureScript/Docs/RenderedCode/Types.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Types.hs
@@ -52,6 +52,7 @@ import Control.Monad.Error.Class (MonadError(..))
 import Data.Monoid ((<>))
 import Data.Aeson.BetterErrors (Parse, nth, withText, withValue, toAesonParser, perhaps, asText, eachInArray)
 import qualified Data.Aeson as A
+import qualified Data.Semigroup as Sem
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.ByteString.Lazy as BS
@@ -248,7 +249,7 @@ asRenderedCodeElement =
 --
 newtype RenderedCode
   = RC { unRC :: [RenderedCodeElement] }
-  deriving (Show, Eq, Ord, Monoid)
+  deriving (Show, Eq, Ord, Sem.Semigroup, Monoid)
 
 instance A.ToJSON RenderedCode where
   toJSON (RC elems) = A.toJSON elems

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -23,6 +23,7 @@ import qualified Data.List.NonEmpty as NEL
 import           Data.Maybe (maybeToList, fromMaybe, mapMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
+import qualified Data.Semigroup as Sem
 import qualified Data.Text as T
 import           Data.Text (Text)
 import           Language.PureScript.AST
@@ -183,7 +184,7 @@ errorCode em = case unwrapErrorMessage em of
 -- | A stack trace for an error
 newtype MultipleErrors = MultipleErrors
   { runMultipleErrors :: [ErrorMessage]
-  } deriving (Show, Monoid)
+  } deriving (Show, Sem.Semigroup, Monoid)
 
 -- | Check whether a collection of errors is empty or not.
 nonEmpty :: MultipleErrors -> Bool

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -28,6 +28,7 @@ import           Protolude                     hiding (isPrefixOf)
 
 import           Data.Aeson
 import           Data.List.NonEmpty            (NonEmpty)
+import qualified Data.Semigroup as Sem
 import           Data.Text                     (isPrefixOf)
 import qualified Language.PureScript.Ide.Filter.Declaration as D
 import           Language.PureScript.Ide.Types
@@ -35,7 +36,7 @@ import           Language.PureScript.Ide.Util
 import qualified Language.PureScript           as P
 
 newtype Filter = Filter (Endo [Module])
-  deriving (Monoid)
+  deriving (Sem.Semigroup, Monoid)
 
 type Module = (P.ModuleName, [IdeDeclarationAnn])
 

--- a/src/Language/PureScript/Ide/Matcher.hs
+++ b/src/Language/PureScript/Ide/Matcher.hs
@@ -25,6 +25,7 @@ module Language.PureScript.Ide.Matcher
 import           Protolude
 
 import           Data.Aeson
+import qualified Data.Semigroup                as Sem
 import qualified Data.Text                     as T
 import qualified Data.Text.Encoding            as TE
 import           Language.PureScript.Ide.Types
@@ -35,7 +36,7 @@ import           Text.Regex.TDFA               ((=~))
 
 type ScoredMatch a = (Match a, Double)
 
-newtype Matcher a = Matcher (Endo [Match a]) deriving (Monoid)
+newtype Matcher a = Matcher (Endo [Match a]) deriving (Sem.Semigroup, Monoid)
 
 instance FromJSON (Matcher IdeDeclarationAnn) where
   parseJSON = withObject "matcher" $ \o -> do

--- a/src/Language/PureScript/Kinds.hs
+++ b/src/Language/PureScript/Kinds.hs
@@ -1,8 +1,13 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE CPP #-}
 
 module Language.PureScript.Kinds where
 
+#if MIN_VERSION_base(4,11,0)
+import Prelude.Compat hiding ((<>))
+#else
 import Prelude.Compat
+#endif
 
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)

--- a/src/Language/PureScript/Label.hs
+++ b/src/Language/PureScript/Label.hs
@@ -6,7 +6,7 @@ module Language.PureScript.Label (Label(..)) where
 import Prelude.Compat hiding (lex)
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
-import Data.Monoid ()
+import qualified Data.Semigroup as Sem
 import Data.String (IsString(..))
 import qualified Data.Aeson as A
 
@@ -17,6 +17,6 @@ import Language.PureScript.PSString (PSString)
 -- because records are indexable by PureScript strings at runtime.
 --
 newtype Label = Label { runLabel :: PSString }
-  deriving (Show, Eq, Ord, IsString, Monoid, A.ToJSON, A.FromJSON, Generic)
+  deriving (Show, Eq, Ord, IsString, Sem.Semigroup, Monoid, A.ToJSON, A.FromJSON, Generic)
 
 instance NFData Label

--- a/src/Language/PureScript/PSString.hs
+++ b/src/Language/PureScript/PSString.hs
@@ -21,6 +21,7 @@ import Control.Applicative ((<|>))
 import Data.Char (chr)
 import Data.Bits (shiftR)
 import Data.List (unfoldr)
+import qualified Data.Semigroup as Sem
 import Data.Monoid ((<>))
 import Data.Scientific (toBoundedInteger)
 import Data.String (IsString(..))
@@ -52,7 +53,7 @@ import qualified Data.Aeson.Types as A
 -- and arrays of UTF-16 code units (integers) otherwise.
 --
 newtype PSString = PSString { toUTF16CodeUnits :: [Word16] }
-  deriving (Eq, Ord, Monoid, Generic)
+  deriving (Eq, Ord, Sem.Semigroup, Monoid, Generic)
 
 instance NFData PSString
 

--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -57,12 +57,12 @@ newtype StrPos = StrPos (SourcePos, Text, [SMap])
 -- the length of the left.
 --
 instance Sem.Semigroup StrPos where
-  StrPos (a,b,c) <> StrPos (a',b',c') = StrPos (a `addPos` a', b <> b', c ++ (bumpPos a <$> c'))
+  StrPos (a,b,c) <> StrPos (a',b',c') = StrPos (a `addPos` a', b Sem.<> b', c ++ (bumpPos a <$> c'))
 
 instance Monoid StrPos where
   mempty = StrPos (SourcePos 0 0, "", [])
 
-  mappend = (<>)
+  mappend = (Sem.<>)
 
   mconcat ms =
     let s' = foldMap (\(StrPos(_, s, _)) -> s) ms

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- |
 -- Pretty printer for Types
 --
@@ -14,7 +16,11 @@ module Language.PureScript.Pretty.Types
   , prettyPrintObjectKey
   ) where
 
+#if MIN_VERSION_base(4,11,0)
+import Prelude.Compat hiding ((<>))
+#else
 import Prelude.Compat
+#endif
 
 import Control.Arrow ((<+>))
 import Control.PatternArrows as PA

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- |
 -- Pretty printer for values
 --
@@ -7,7 +9,11 @@ module Language.PureScript.Pretty.Values
   , prettyPrintBinderAtom
   ) where
 
+#if MIN_VERSION_base(4,11,0)
+import Prelude.Compat hiding ((<>))
+#else
 import Prelude.Compat
+#endif
 
 import Control.Arrow (second)
 

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -315,11 +315,11 @@ data CollectedWarnings = CollectedWarnings
 instance Sem.Semigroup CollectedWarnings where
   (CollectedWarnings as bs cs d es) <>
           (CollectedWarnings as' bs' cs' d' es') =
-    CollectedWarnings (as <> as') (bs <> bs') (cs <> cs') (d <> d') (es <> es')
+    CollectedWarnings (as Sem.<> as') (bs Sem.<> bs') (cs Sem.<> cs') (d Sem.<> d') (es Sem.<> es')
 
 instance Monoid CollectedWarnings where
   mempty = CollectedWarnings mempty mempty mempty mempty mempty
-  mappend = (<>)
+  mappend = (Sem.<>)
 
 collectWarnings :: [PackageWarning] -> CollectedWarnings
 collectWarnings = foldMap singular

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -22,6 +22,7 @@ import Data.List (intersperse)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe
 import Data.Monoid
+import qualified Data.Semigroup as Sem
 import Data.Version
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Text (Text)
@@ -311,11 +312,14 @@ data CollectedWarnings = CollectedWarnings
   }
   deriving (Show, Eq, Ord)
 
-instance Monoid CollectedWarnings where
-  mempty = CollectedWarnings mempty mempty mempty mempty mempty
-  mappend (CollectedWarnings as bs cs d es)
+instance Sem.Semigroup CollectedWarnings where
+  (CollectedWarnings as bs cs d es) <>
           (CollectedWarnings as' bs' cs' d' es') =
     CollectedWarnings (as <> as') (bs <> bs') (cs <> cs') (d <> d') (es <> es')
+
+instance Monoid CollectedWarnings where
+  mempty = CollectedWarnings mempty mempty mempty mempty mempty
+  mappend = (<>)
 
 collectWarnings :: [PackageWarning] -> CollectedWarnings
 collectWarnings = foldMap singular

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -45,13 +45,13 @@ data NewtypeDerivedInstances = NewtypeDerivedInstances
 
 instance Sem.Semigroup NewtypeDerivedInstances where
   x <> y =
-    NewtypeDerivedInstances { ndiClasses          = ndiClasses          x <> ndiClasses          y
-                            , ndiDerivedInstances = ndiDerivedInstances x <> ndiDerivedInstances y
+    NewtypeDerivedInstances { ndiClasses          = ndiClasses          x Sem.<> ndiClasses          y
+                            , ndiDerivedInstances = ndiDerivedInstances x Sem.<> ndiDerivedInstances y
                             }
 
 instance Monoid NewtypeDerivedInstances where
   mempty = NewtypeDerivedInstances mempty mempty
-  mappend = (<>)
+  mappend = (Sem.<>)
 
 -- | Extract the name of the newtype appearing in the last type argument of
 -- a derived newtype instance.

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -15,6 +15,7 @@ import qualified Data.Map as M
 import           Data.Monoid ((<>))
 import           Data.Maybe (fromMaybe, mapMaybe)
 import           Data.Ord (comparing)
+import qualified Data.Semigroup as Sem
 import qualified Data.Set as S
 import           Data.Text (Text)
 import           Language.PureScript.AST
@@ -42,12 +43,15 @@ data NewtypeDerivedInstances = NewtypeDerivedInstances
   -- ^ A list of newtype instances which were derived in this module.
   } deriving Show
 
-instance Monoid NewtypeDerivedInstances where
-  mempty = NewtypeDerivedInstances mempty mempty
-  mappend x y =
+instance Sem.Semigroup NewtypeDerivedInstances where
+  x <> y =
     NewtypeDerivedInstances { ndiClasses          = ndiClasses          x <> ndiClasses          y
                             , ndiDerivedInstances = ndiDerivedInstances x <> ndiDerivedInstances y
                             }
+
+instance Monoid NewtypeDerivedInstances where
+  mempty = NewtypeDerivedInstances mempty mempty
+  mappend = (<>)
 
 -- | Extract the name of the newtype appearing in the last type argument of
 -- a derived newtype instance.

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -148,10 +148,10 @@ instance (Sem.Semigroup t) => Sem.Semigroup (Matched t) where
   _         <> Apart     = Apart
   _         <> _         = Unknown
 
-instance Monoid t => Monoid (Matched t) where
+instance (Sem.Semigroup t, Monoid t) => Monoid (Matched t) where
   mempty = Match mempty
 
-  mappend = (<>)
+  mappend = (Sem.<>)
 
 -- | Check that the current set of type class dictionaries entail the specified type class goal, and, if so,
 -- return a type class dictionary reference.

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -18,7 +18,7 @@ import Control.Arrow (second, (&&&))
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State
 import Control.Monad.Supply.Class (MonadSupply(..))
-import Control.Monad.Writer
+import Control.Monad.Writer hiding ((<>))
 
 import Data.Foldable (for_, fold, toList)
 import Data.Function (on)
@@ -26,6 +26,8 @@ import Data.Functor (($>))
 import Data.List (minimumBy, groupBy, sortBy)
 import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Map as M
+import qualified Data.Semigroup as Sem
+import Data.Monoid ((<>))
 import qualified Data.Set as S
 import Data.Traversable (for)
 import Data.Text (Text, stripPrefix, stripSuffix)
@@ -140,13 +142,16 @@ data Matched t
   | Unknown
   deriving (Eq, Show, Functor)
 
+instance (Sem.Semigroup t) => Sem.Semigroup (Matched t) where
+  (Match l) <> (Match r) = Match (l Sem.<> r)
+  Apart     <> _         = Apart
+  _         <> Apart     = Apart
+  _         <> _         = Unknown
+
 instance Monoid t => Monoid (Matched t) where
   mempty = Match mempty
 
-  mappend (Match l) (Match r) = Match (l <> r)
-  mappend Apart     _         = Apart
-  mappend _         Apart     = Apart
-  mappend _         _         = Unknown
+  mappend = (<>)
 
 -- | Check that the current set of type class dictionaries entail the specified type class goal, and, if so,
 -- return a type class dictionary reference.


### PR DESCRIPTION
Compatibility with the new Semigroup as superclass of Monoid.

The changes were made so that the code still compiles with the current `ghc-8.2.2` compiler (stackage `lts-10.3`), as well as the latest `ghc-8.4.1` (tested with stackage `nightly-2018-03-23`).

Resolves #3284