### PR TITLE
Implements magic-do for Control.Monad.Effect

### DIFF
--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -2,7 +2,9 @@
 module Language.PureScript.Constants where
 
 import Prelude.Compat
+
 import Data.String (IsString)
+import Language.PureScript.PSString (PSString)
 import Language.PureScript.Names
 
 -- Operators
@@ -245,14 +247,25 @@ undefined = "undefined"
 
 -- Type Class Dictionary Names
 
-monadEffDictionary :: forall a. (IsString a) => a
-monadEffDictionary = "monadEff"
+data EffectDictionaries = EffectDictionaries
+  { edApplicativeDict :: PSString
+  , edBindDict :: PSString
+  , edMonadDict :: PSString
+  }
 
-applicativeEffDictionary :: forall a. (IsString a) => a
-applicativeEffDictionary = "applicativeEff"
+effDictionaries :: EffectDictionaries
+effDictionaries = EffectDictionaries
+  { edApplicativeDict = "applicativeEff"
+  , edBindDict = "bindEff"
+  , edMonadDict = "monadEff"
+  }
 
-bindEffDictionary :: forall a. (IsString a) => a
-bindEffDictionary = "bindEff"
+effectDictionaries :: EffectDictionaries
+effectDictionaries = EffectDictionaries
+  { edApplicativeDict = "applicativeEffect"
+  , edBindDict = "bindEffect"
+  , edMonadDict = "monadEffect"
+  }
 
 discardUnitDictionary :: forall a. (IsString a) => a
 discardUnitDictionary = "discardUnit"
@@ -437,6 +450,9 @@ dataArray = "Data_Array"
 
 eff :: forall a. (IsString a) => a
 eff = "Control_Monad_Eff"
+
+effect :: forall a. (IsString a) => a
+effect = "Control_Monad_Effect"
 
 st :: forall a. (IsString a) => a
 st = "Control_Monad_ST"

--- a/src/Language/PureScript/CoreImp/Optimizer.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer.hs
@@ -37,7 +37,9 @@ optimize js = do
       [ inlineCommonValues
       , inlineCommonOperators
       ]) js
-    untilFixedPoint (return . tidyUp) . tco . inlineST =<< untilFixedPoint (return . magicDo) js'
+    untilFixedPoint (return . tidyUp) . tco . inlineST
+      =<< untilFixedPoint (return . magicDo')
+      =<< untilFixedPoint (return . magicDo) js'
   where
     tidyUp :: AST -> AST
     tidyUp = applyAll


### PR DESCRIPTION
Simplest thing I could come up with. This adds another pass over the JS AST, so if that ends up being to slow I can look into merging these into a single pass, or checking for an import of Control.Monad.Eff/Control.Monad.Effect before doing the traversal.