### PR TITLE
Add compiler derived Prim.Row.Nub class

### DIFF
--- a/examples/passing/RowNub.purs
+++ b/examples/passing/RowNub.purs
@@ -1,0 +1,23 @@
+module Main where
+
+import Control.Monad.Eff.Console (log)
+import Prim.Row (class Nub, class Union)
+import Type.Row (RProxy(..))
+
+nubUnion
+  :: forall r1 r2 r3 r4
+   . Union r1 r2 r3
+  => Nub r3 r4
+  => RProxy r1
+  -> RProxy r2
+  -> RProxy r4
+nubUnion _ _ = RProxy
+
+type InL = (x :: Int, y :: String)
+type InR = (x :: String, y :: Int, z :: Boolean)
+type Out = (x :: Int, y :: String, z :: Boolean)
+
+test :: RProxy Out
+test = nubUnion (RProxy :: RProxy InL) (RProxy :: RProxy InR)
+
+main = log "Done"

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -434,6 +434,9 @@ pattern Warn = Qualified (Just PrimTypeError) (ProperName "Warn")
 pattern Union :: Qualified (ProperName 'ClassName)
 pattern Union = Qualified (Just PrimRow) (ProperName "Union")
 
+pattern Nub :: Qualified (ProperName 'ClassName)
+pattern Nub = Qualified (Just PrimRow) (ProperName "Nub")
+
 pattern RowCons :: Qualified (ProperName 'ClassName)
 pattern RowCons = Qualified (Just PrimRow) (ProperName "Cons")
 

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -44,6 +44,7 @@ primRowDocsModule = Module
   , modComments = Just "The Prim.Row module is embedded in the PureScript compiler. Unlike `Prim`, it is not imported implicitly. It contains automatically solved classes for working with row types."
   , modDeclarations =
       [ union
+      , nub
       , rowCons
       ]
   , modReExports = []
@@ -285,6 +286,11 @@ union = primClassOf (P.primSubName "Row") "Union" $ T.unlines
   , "(left-biased, including duplicates)."
   , ""
   , "The third type argument represents the union of the first two."
+  ]
+
+nub :: Declaration
+nub = primClassOf (P.primSubName "Row") "Nub" $ T.unlines
+  [ "The Nub type class is used to remove duplicate labels from rows."
   ]
 
 rowCons :: Declaration

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -374,6 +374,7 @@ primRowTypes :: M.Map (Qualified (ProperName 'TypeName)) (Kind, TypeKind)
 primRowTypes =
   M.fromList
     [ (primSubName "Row" "Union", (FunKind (Row kindType) (FunKind (Row kindType) (FunKind (Row kindType) kindType)), ExternData))
+    , (primSubName "Row" "Nub", (FunKind (Row kindType) (FunKind (Row kindType) kindType), ExternData))
     , (primSubName "Row" "Cons",  (FunKind kindSymbol (FunKind kindType (FunKind (Row kindType) (FunKind (Row kindType) kindType))), ExternData))
     ]
 
@@ -416,6 +417,13 @@ primRowClasses =
                                   [ FunctionalDependency [0, 1] [2]
                                   , FunctionalDependency [1, 2] [0]
                                   , FunctionalDependency [2, 0] [1]
+                                  ]))
+    -- class Nub (i :: # Type) (o :: # Type) | i -> o
+    , (primSubName "Row" "Nub", (makeTypeClassData
+                                  [ ("i", Just (Row kindType))
+                                  , ("o", Just (Row kindType))
+                                  ] [] []
+                                  [ FunctionalDependency [0] [1]
                                   ]))
     -- class RowCons (l :: Symbol) (a :: Type) (i :: # Type) (o :: # Type) | l i a -> o, l o -> a i
     , (primSubName "Row" "Cons", (makeTypeClassData


### PR DESCRIPTION
This adds a compiler derived class for removing duplicates from rows. This is technically possible to achieve using `RowListNub`, but the machinery is _substantial_ and I think this is a common enough usecase to warrant a primitive class. This can be used to implement a more type-safe record merge than a bare `Union`.