### PR TITLE
Restrict base for GHC < 8.4.1

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -35,7 +35,7 @@ dependencies:
   - aeson >=1.0 && <1.3
   - aeson-better-errors >=0.8
   - ansi-terminal >=0.7.1 && <0.8
-  - base >=4.8 && <5
+  - base >=4.8 && <4.11
   - base-compat >=0.6.0
   - blaze-html >=0.8.1 && <0.10
   - bower-json >=1.0.0.1 && <1.1


### PR DESCRIPTION
This PR addresses #3284 with a stop-gap measure, explicitly expressing the upper bound on `base` that PureScript currently has.

When PureScript officially supports 8.4.1, this can be dropped.