### PR TITLE
Allow functor derivation under quantification

### DIFF
--- a/examples/passing/DerivingFunctor.purs
+++ b/examples/passing/DerivingFunctor.purs
@@ -13,6 +13,7 @@ data M f a
   | M2 (f a)
   | M3 { foo :: Int, bar :: a, baz :: f a }
   | M4 (MyRecord a)
+  | M5 (forall x. a)
 
 derive instance eqM :: (Eq1 f, Eq a) => Eq (M f a)
 
@@ -26,4 +27,5 @@ main = do
   assert $ map show (M2 [0, 1] :: MA Int) == M2 ["0", "1"]
   assert $ map show (M3 {foo: 0, bar: 1, baz: [2, 3]} :: MA Int) == M3 {foo: 0, bar: "1", baz: ["2", "3"]}
   assert $ map show (M4 { myField: 42 }) == M4 { myField: "42" } :: MA String
+  assert $ map show (M5 42) == M5 "42" :: MA String
   log "Done"

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -742,6 +742,9 @@ deriveFunctor ss mn syns ds tyConNm = do
                     mkAssignment ((Label l), x) = (l, App x (Accessor l argVar))
                 return (lam ss arg (ObjectUpdate argVar (mkAssignment <$> updates)))
 
+          -- quantification
+          goType (ForAll _ t _) = goType t
+
           -- under a `* -> *`, just assume functor for now
           goType (TypeApp _ t) = fmap (App mapVar) <$> goType t
 


### PR DESCRIPTION
When "functor variables" exist within a quantifier, they don't seem to
derive properly:

```
data T a = T (forall x. a)
```

This commit (hopefully!) fixes this, allowing the compiler to drill down
through these skolem scopes.