### PR TITLE
Tidy up "undetermined class argument" warning

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -987,7 +987,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
 
         case unexplained of
           [required] ->
-            [ line $ "These arguments are: { " <> T.intercalate "," required <> "}"
+            [ line $ "These arguments are: { " <> T.intercalate ", " required <> " }"
             ]
 
           options  ->


### PR DESCRIPTION
The formatting is a bit out-of-line. This is a totally cosmetic change, but it has been irritating me. I have a feeling this one's my fault, too...