### PR TITLE
Add some source span to ErrorParsingFFIModule

### DIFF
--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -247,7 +247,7 @@ checkForeignDecls modSS m path = do
   mname = CF.moduleName m
 
   errorParsingModule :: Bundle.ErrorMessage -> SupplyT Make a
-  errorParsingModule = throwError . errorMessage . ErrorParsingFFIModule path . Just
+  errorParsingModule = throwError . errorMessage' modSS . ErrorParsingFFIModule path . Just
 
   getExps :: JS.JSAST -> Either Bundle.ErrorMessage [String]
   getExps = Bundle.getExportedIdentifiers (T.unpack (runModuleName mname))


### PR DESCRIPTION
https://github.com/purescript/purescript/issues/3208

Added the entire corresponding module as source span, as this is what happens for MissingFFIModule already 