### PR TITLE
Include full file path in CJS requires.

### DIFF
--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -104,7 +104,8 @@ moduleToJs (Module coms mn _ imps exps foreigns decls) foreign_ =
   importToJs :: M.Map ModuleName (Ann, ModuleName) -> ModuleName -> m AST
   importToJs mnLookup mn' = do
     let ((ss, _, _, _), mnSafe) = fromMaybe (internalError "Missing value in mnLookup") $ M.lookup mn' mnLookup
-    let moduleBody = AST.App Nothing (AST.Var Nothing "require") [AST.StringLiteral Nothing (fromString (".." </> T.unpack (runModuleName mn')))]
+    let moduleBody = AST.App Nothing (AST.Var Nothing "require")
+          [AST.StringLiteral Nothing (fromString (".." </> T.unpack (runModuleName mn') </> "index.js"))]
     withPos ss $ AST.VariableIntroduction Nothing (moduleNameToJs mnSafe) (Just moduleBody)
 
   -- | Replaces the `ModuleName`s in the AST so that the generated code refers to

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -148,7 +148,7 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
             return Nothing
         | otherwise -> do
             checkForeignDecls modSS m path
-            return $ Just $ Imp.App Nothing (Imp.Var Nothing "require") [Imp.StringLiteral Nothing "./foreign"]
+            return $ Just $ Imp.App Nothing (Imp.Var Nothing "require") [Imp.StringLiteral Nothing "./foreign.js"]
       Nothing | requiresForeign m -> throwError . errorMessage' modSS $ MissingFFIModule mn
               | otherwise -> return Nothing
     rawJs <- J.moduleToJs m foreignInclude


### PR DESCRIPTION
Fixes https://github.com/purescript/purescript/issues/2621

Changes the JS output from `require("../SomeModule")` to `require("../SomeModule/index.js")`, and same for the implicit FFI imports.

`stack test` is proving difficult. First time I ran it, it had trouble installing bower dependencies, giving `ECONFLICT Unable to find suitable version for purescript-either`. After manually installing them, I got errors about `Monoid` being a duplicate module, which occurred because it's been moved to Prelude in the latest version (so we may need to adjust the version range in the bower file). After manually deleting Monoid stuff from the PS Prelude it was using, I get test failures caused by stuff missing from Prim -- `Module Prim.RowList was not found.`, and same for Prim.Ordering and Prim.Symbol.