### PR TITLE
Allow operators shadowed by variables of the same name as the alias

### DIFF
--- a/examples/passing/2803.purs
+++ b/examples/passing/2803.purs
@@ -1,0 +1,17 @@
+module Main where
+
+import Prelude ((+), (-), (==))
+import Effect.Console (log)
+
+f :: Int -> Int -> Int
+f = (+)
+
+infixl 6 f as %
+
+g :: Int -> Int -> Int
+g a b = let f = (-) in a % b
+
+main =
+  if g 10 5 == 15
+    then log "Done"
+    else log "Failed"

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -495,18 +495,6 @@ everywhereWithContextOnValuesM s0 f g h i j = (f'' s0, g'' s0, h'' s0, i'' s0, j
 data ScopedIdent = LocalIdent Ident | ToplevelIdent Ident
   deriving (Show, Eq, Ord)
 
-unwrapScopedIdent :: ScopedIdent -> Ident
-unwrapScopedIdent = foldScopedIdent id id
-
-foldScopedIdent
-  :: (Ident -> a)
-  -> (Ident -> a)
-  -> ScopedIdent
-  -> a
-foldScopedIdent f g = \case
-  LocalIdent i -> f i
-  ToplevelIdent i -> g i
-
 inScope :: Ident -> S.Set ScopedIdent -> Bool
 inScope i s = (LocalIdent i `S.member` s) || (ToplevelIdent i `S.member` s)
 

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -492,47 +492,65 @@ everywhereWithContextOnValuesM s0 f g h i j = (f'' s0, g'' s0, h'' s0, i'' s0, j
   k' s (ConditionGuard e) = ConditionGuard <$> g'' s e
   k' s (PatternGuard b e) = PatternGuard <$> h'' s b <*> g'' s e
 
+data ScopedIdent = LocalIdent Ident | ToplevelIdent Ident
+  deriving (Show, Eq, Ord)
+
+unwrapScopedIdent :: ScopedIdent -> Ident
+unwrapScopedIdent = foldScopedIdent id id
+
+foldScopedIdent
+  :: (Ident -> a)
+  -> (Ident -> a)
+  -> ScopedIdent
+  -> a
+foldScopedIdent f g = \case
+  LocalIdent i -> f i
+  ToplevelIdent i -> g i
+
+inScope :: Ident -> S.Set ScopedIdent -> Bool
+inScope i s = (LocalIdent i `S.member` s) || (ToplevelIdent i `S.member` s)
+
 everythingWithScope
   :: forall r
    . (Monoid r)
-  => (S.Set Ident -> Declaration -> r)
-  -> (S.Set Ident -> Expr -> r)
-  -> (S.Set Ident -> Binder -> r)
-  -> (S.Set Ident -> CaseAlternative -> r)
-  -> (S.Set Ident -> DoNotationElement -> r)
-  -> ( S.Set Ident -> Declaration -> r
-     , S.Set Ident -> Expr -> r
-     , S.Set Ident -> Binder -> r
-     , S.Set Ident -> CaseAlternative -> r
-     , S.Set Ident -> DoNotationElement -> r
+  => (S.Set ScopedIdent -> Declaration -> r)
+  -> (S.Set ScopedIdent -> Expr -> r)
+  -> (S.Set ScopedIdent -> Binder -> r)
+  -> (S.Set ScopedIdent -> CaseAlternative -> r)
+  -> (S.Set ScopedIdent -> DoNotationElement -> r)
+  -> ( S.Set ScopedIdent -> Declaration -> r
+     , S.Set ScopedIdent -> Expr -> r
+     , S.Set ScopedIdent -> Binder -> r
+     , S.Set ScopedIdent -> CaseAlternative -> r
+     , S.Set ScopedIdent -> DoNotationElement -> r
      )
 everythingWithScope f g h i j = (f'', g'', h'', i'', \s -> snd . j'' s)
   where
   -- Avoid importing Data.Monoid and getting shadowed names above
   (<>) = mappend
 
-  f'' :: S.Set Ident -> Declaration -> r
+  f'' :: S.Set ScopedIdent -> Declaration -> r
   f'' s a = f s a <> f' s a
 
-  f' :: S.Set Ident -> Declaration -> r
+  f' :: S.Set ScopedIdent -> Declaration -> r
   f' s (DataBindingGroupDeclaration ds) =
-    let s' = S.union s (S.fromList (mapMaybe getDeclIdent (NEL.toList ds)))
+    let s' = S.union s (S.fromList (map ToplevelIdent (mapMaybe getDeclIdent (NEL.toList ds))))
     in foldMap (f'' s') ds
   f' s (ValueDecl _ name _ bs val) =
-    let s' = S.insert name s
-        s'' = S.union s' (S.fromList (concatMap binderNames bs))
+    let s' = S.insert (ToplevelIdent name) s
+        s'' = S.union s' (S.fromList (concatMap localBinderNames bs))
     in foldMap (h'' s') bs <> foldMap (l' s'') val
   f' s (BindingGroupDeclaration ds) =
-    let s' = S.union s (S.fromList (NEL.toList (fmap (\((_, name), _, _) -> name) ds)))
+    let s' = S.union s (S.fromList (NEL.toList (fmap (\((_, name), _, _) -> ToplevelIdent name) ds)))
     in foldMap (\(_, _, val) -> g'' s' val) ds
   f' s (TypeClassDeclaration _ _ _ _ _ ds) = foldMap (f'' s) ds
   f' s (TypeInstanceDeclaration _ _ _ _ _ _ _ (ExplicitInstance ds)) = foldMap (f'' s) ds
   f' _ _ = mempty
 
-  g'' :: S.Set Ident -> Expr -> r
+  g'' :: S.Set ScopedIdent -> Expr -> r
   g'' s a = g s a <> g' s a
 
-  g' :: S.Set Ident -> Expr -> r
+  g' :: S.Set ScopedIdent -> Expr -> r
   g' s (Literal _ l) = lit g'' s l
   g' s (UnaryMinus _ v1) = g'' s v1
   g' s (BinaryNoParens op v1 v2) = g'' s op <> g'' s v1 <> g'' s v2
@@ -542,14 +560,14 @@ everythingWithScope f g h i j = (f'', g'', h'', i'', \s -> snd . j'' s)
   g' s (ObjectUpdate obj vs) = g'' s obj <> foldMap (g'' s . snd) vs
   g' s (ObjectUpdateNested obj vs) = g'' s obj <> foldMap (g'' s) vs
   g' s (Abs b v1) =
-    let s' = S.union (S.fromList (binderNames b)) s
+    let s' = S.union (S.fromList (localBinderNames b)) s
     in h'' s b <> g'' s' v1
   g' s (App v1 v2) = g'' s v1 <> g'' s v2
   g' s (IfThenElse v1 v2 v3) = g'' s v1 <> g'' s v2 <> g'' s v3
   g' s (Case vs alts) = foldMap (g'' s) vs <> foldMap (i'' s) alts
   g' s (TypedValue _ v1 _) = g'' s v1
   g' s (Let _ ds v1) =
-    let s' = S.union s (S.fromList (mapMaybe getDeclIdent ds))
+    let s' = S.union s (S.fromList (map LocalIdent (mapMaybe getDeclIdent ds)))
     in foldMap (f'' s') ds <> g'' s' v1
   g' s (Do es) = fold . snd . mapAccumL j'' s $ es
   g' s (Ado es v1) =
@@ -558,49 +576,49 @@ everythingWithScope f g h i j = (f'', g'', h'', i'', \s -> snd . j'' s)
   g' s (PositionedValue _ _ v1) = g'' s v1
   g' _ _ = mempty
 
-  h'' :: S.Set Ident -> Binder -> r
+  h'' :: S.Set ScopedIdent -> Binder -> r
   h'' s a = h s a <> h' s a
 
-  h' :: S.Set Ident -> Binder -> r
+  h' :: S.Set ScopedIdent -> Binder -> r
   h' s (LiteralBinder _ l) = lit h'' s l
   h' s (ConstructorBinder _ _ bs) = foldMap (h'' s) bs
   h' s (BinaryNoParensBinder b1 b2 b3) = foldMap (h'' s) [b1, b2, b3]
   h' s (ParensInBinder b) = h'' s b
-  h' s (NamedBinder _ name b1) = h'' (S.insert name s) b1
+  h' s (NamedBinder _ name b1) = h'' (S.insert (LocalIdent name) s) b1
   h' s (PositionedBinder _ _ b1) = h'' s b1
   h' s (TypedBinder _ b1) = h'' s b1
   h' _ _ = mempty
 
-  lit :: (S.Set Ident -> a -> r) -> S.Set Ident -> Literal a -> r
+  lit :: (S.Set ScopedIdent -> a -> r) -> S.Set ScopedIdent -> Literal a -> r
   lit go s (ArrayLiteral as) = foldMap (go s) as
   lit go s (ObjectLiteral as) = foldMap (go s . snd) as
   lit _ _ _ = mempty
 
-  i'' :: S.Set Ident -> CaseAlternative -> r
+  i'' :: S.Set ScopedIdent -> CaseAlternative -> r
   i'' s a = i s a <> i' s a
 
-  i' :: S.Set Ident -> CaseAlternative -> r
+  i' :: S.Set ScopedIdent -> CaseAlternative -> r
   i' s (CaseAlternative bs gs) =
-    let s' = S.union s (S.fromList (concatMap binderNames bs))
+    let s' = S.union s (S.fromList (concatMap localBinderNames bs))
     in foldMap (h'' s) bs <> foldMap (l' s') gs
 
-  j'' :: S.Set Ident -> DoNotationElement -> (S.Set Ident, r)
+  j'' :: S.Set ScopedIdent -> DoNotationElement -> (S.Set ScopedIdent, r)
   j'' s a = let (s', r) = j' s a in (s', j s a <> r)
 
-  j' :: S.Set Ident -> DoNotationElement -> (S.Set Ident, r)
+  j' :: S.Set ScopedIdent -> DoNotationElement -> (S.Set ScopedIdent, r)
   j' s (DoNotationValue v) = (s, g'' s v)
   j' s (DoNotationBind b v) =
-    let s' = S.union (S.fromList (binderNames b)) s
+    let s' = S.union (S.fromList (localBinderNames b)) s
     in (s', h'' s b <> g'' s v)
   j' s (DoNotationLet ds) =
-    let s' = S.union s (S.fromList (mapMaybe getDeclIdent ds))
+    let s' = S.union s (S.fromList (map LocalIdent (mapMaybe getDeclIdent ds)))
     in (s', foldMap (f'' s') ds)
   j' s (PositionedDoNotationElement _ _ e1) = j'' s e1
 
-  k' :: S.Set Ident -> Guard -> (S.Set Ident, r)
+  k' :: S.Set ScopedIdent -> Guard -> (S.Set ScopedIdent, r)
   k' s (ConditionGuard e) = (s, g'' s e)
   k' s (PatternGuard b e) =
-    let s' = S.union (S.fromList (binderNames b)) s
+    let s' = S.union (S.fromList (localBinderNames b)) s
     in (s', h'' s b <> g'' s' e)
 
   l' s (GuardedExpr [] e) = g'' s e
@@ -612,6 +630,8 @@ everythingWithScope f g h i j = (f'', g'', h'', i'', \s -> snd . j'' s)
   getDeclIdent (ValueDeclaration vd) = Just (valdeclIdent vd)
   getDeclIdent (TypeDeclaration td) = Just (tydeclIdent td)
   getDeclIdent _ = Nothing
+
+  localBinderNames = map LocalIdent . binderNames
 
 accumTypes
   :: (Monoid r)

--- a/src/Language/PureScript/Ide/Usage.hs
+++ b/src/Language/PureScript/Ide/Usage.hs
@@ -141,10 +141,7 @@ applySearch module_ search =
       P.Var sp i
         | Just ideValue <- preview _IdeDeclValue (P.disqualify search)
         , P.isQualified search
-          || not (_ideValueIdent ideValue `Set.member` scope)
-          -- This case means we're looking at a recursive definition for a
-          -- value, which we count as a usage.
-          || P.declName decl == Just (P.IdentName (_ideValueIdent ideValue)) ->
+          || not (P.LocalIdent (_ideValueIdent ideValue) `Set.member` scope) ->
           [sp | map P.runIdent i == map identifierFromIdeDeclaration search]
       P.Constructor sp name
         | Just ideDtor <- traverse (preview _IdeDeclDataConstructor) search ->

--- a/src/Language/PureScript/Ide/Usage.hs
+++ b/src/Language/PureScript/Ide/Usage.hs
@@ -131,13 +131,13 @@ applySearch module_ search =
   foldMap findUsageInDeclaration decls
   where
     decls = P.getModuleDeclarations module_
-    findUsageInDeclaration decl =
+    findUsageInDeclaration =
       let
-        (extr, _, _, _, _) = P.everythingWithScope mempty (goExpr decl) goBinder mempty mempty
+        (extr, _, _, _, _) = P.everythingWithScope mempty goExpr goBinder mempty mempty
       in
-        extr mempty decl
+        extr mempty
 
-    goExpr decl scope expr = case expr of
+    goExpr scope expr = case expr of
       P.Var sp i
         | Just ideValue <- preview _IdeDeclValue (P.disqualify search)
         , P.isQualified search

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -112,11 +112,11 @@ usedIdents moduleName = ordNub . usedIdents' S.empty . valdeclExpression
 
   (_, usedIdents', _, _, _) = everythingWithScope def usedNamesE def def def
 
-  usedNamesE :: S.Set Ident -> Expr -> [Ident]
+  usedNamesE :: S.Set ScopedIdent -> Expr -> [Ident]
   usedNamesE scope (Var _ (Qualified Nothing name))
-    | name `S.notMember` scope = [name]
+    | LocalIdent name `S.notMember` scope = [name]
   usedNamesE scope (Var _ (Qualified (Just moduleName') name))
-    | moduleName == moduleName' && name `S.notMember` scope = [name]
+    | moduleName == moduleName' && ToplevelIdent name `S.notMember` scope = [name]
   usedNamesE _ _ = []
 
 usedImmediateIdents :: ModuleName -> Declaration -> [Ident]

--- a/tests/Language/PureScript/Ide/UsageSpec.hs
+++ b/tests/Language/PureScript/Ide/UsageSpec.hs
@@ -53,6 +53,12 @@ spec = describe "Finding Usages" $ do
                     , usage (Test.mn "FindUsage.Recursive") "recursiveUsage" IdeNSValue
                     ]
       usage1 `shouldBeUsage` ("src" </> "FindUsage" </> "Recursive.purs", "7:12-7:26")
+    it "ignores a locally shadowed recursive usage" $ do
+      ([_, Right (UsagesResult usageResult)], _) <- Test.inProject $
+        Test.runIde [ load ["FindUsage.RecursiveShadowed"]
+                    , usage (Test.mn "FindUsage.RecursiveShadowed") "recursiveUsage" IdeNSValue
+                    ]
+      usageResult `shouldBe` []
     it "finds a constructor usage" $ do
       ([_, Right (UsagesResult [usage1])], _) <- Test.inProject $
         Test.runIde [ load ["FindUsage", "FindUsage.Definition", "FindUsage.Reexport"]

--- a/tests/support/pscide/src/FindUsage/RecursiveShadowed.purs
+++ b/tests/support/pscide/src/FindUsage/RecursiveShadowed.purs
@@ -1,0 +1,10 @@
+module FindUsage.RecursiveShadowed where
+
+data Nat = Suc Nat | Z
+
+recursiveUsage :: Nat -> Int
+recursiveUsage = case _ of
+  Suc x ->
+    let recursiveUsage = 3
+    in recursiveUsage
+  Z -> 0


### PR DESCRIPTION
This is a reimplementation of #2964.

Fixes #2803 

It uses a custom `ScopedIdent` type instead of `Qualified Ident`, as the qualifier was effectively used as a boolean, but allowed too many invalid states. Also makes use of the extra information in findUsage for the IDE code.

@LightAndLight If you could take a look that would be great, sorry for taking so long to respond to and review your PR properly. I'm totally happy if you want to work these changes into your PR and merging yours instead.