### PR TITLE
Ensure associativity error in type operators doesn't crash

### DIFF
--- a/src/Language/PureScript/Sugar/Operators/Types.hs
+++ b/src/Language/PureScript/Sugar/Operators/Types.hs
@@ -4,7 +4,6 @@ import Prelude.Compat
 
 import Control.Monad.Except
 import Language.PureScript.AST
-import Language.PureScript.Crash
 import Language.PureScript.Errors
 import Language.PureScript.Names
 import Language.PureScript.Sugar.Operators.Common
@@ -12,10 +11,11 @@ import Language.PureScript.Types
 
 matchTypeOperators
   :: MonadError MultipleErrors m
-  => [[(Qualified (OpName 'TypeOpName), Associativity)]]
+  => SourceSpan
+  -> [[(Qualified (OpName 'TypeOpName), Associativity)]]
   -> Type
   -> m Type
-matchTypeOperators = matchOperators isBinOp extractOp fromOp reapply id
+matchTypeOperators ss = matchOperators isBinOp extractOp fromOp reapply id
   where
 
   isBinOp :: Type -> Bool
@@ -26,8 +26,8 @@ matchTypeOperators = matchOperators isBinOp extractOp fromOp reapply id
   extractOp (BinaryNoParensType op l r) = Just (op, l, r)
   extractOp _ = Nothing
 
-  fromOp :: Type -> Maybe (a, Qualified (OpName 'TypeOpName))
-  fromOp (TypeOp q@(Qualified _ (OpName _))) = Just (internalError "tried to use type operator source span", q)
+  fromOp :: Type -> Maybe (SourceSpan, Qualified (OpName 'TypeOpName))
+  fromOp (TypeOp q@(Qualified _ (OpName _))) = Just (ss, q)
   fromOp _ = Nothing
 
   reapply :: a -> Qualified (OpName 'TypeOpName) -> Type -> Type -> Type

--- a/tests/purs/failing/3335-TypeOpAssociativityError.purs
+++ b/tests/purs/failing/3335-TypeOpAssociativityError.purs
@@ -1,0 +1,7 @@
+-- @shouldFailWith NonAssociativeError
+module Main where
+
+infix 6 type Function as >>
+
+const :: forall a b. a >> b >> a
+const a _ = a


### PR DESCRIPTION
Resolves #3335 

This uses the whole type annotation for the span (or whatever enclosing source span it has on hand) since we don't have any position information in types. It's still decent though:

```
[1/1 NonAssociativeError] src\3335-TypeOpAssociativityError.purs:6:1

  6  const :: forall a b. a >> b >> a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  Cannot parse an expression that uses multiple instances of the non-associative operator Main.(>>).
  Use parentheses to resolve this ambiguity.
```