### PR TITLE
Added SourceSpan to CoreFn.Module

### DIFF
--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -50,7 +50,7 @@ moduleToJs
   => Module Ann
   -> Maybe AST
   -> m [AST]
-moduleToJs (Module coms mn _ imps exps foreigns decls) foreign_ =
+moduleToJs (Module _ coms mn _ imps exps foreigns decls) foreign_ =
   rethrow (addHint (ErrorInModule mn)) $ do
     let usedNames = concatMap getNames decls
     let mnLookup = renameImports usedNames imps

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -39,7 +39,7 @@ moduleToCoreFn env (A.Module modSS coms mn decls (Just exps)) =
       exps' = ordNub $ concatMap exportToCoreFn exps
       externs = ordNub $ mapMaybe externToCoreFn decls
       decls' = concatMap declToCoreFn decls
-  in Module coms mn (spanName modSS) imports' exps' externs decls'
+  in Module modSS coms mn (spanName modSS) imports' exps' externs decls'
 
   where
 

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -55,14 +55,15 @@ annFromJSON :: FilePath -> Value -> Parser Ann
 annFromJSON modulePath = withObject "Ann" annFromObj
   where
   annFromObj o = do
-    ss <- o .: "sourceSpan" >>= sourceSpanFromJSON
+    ss <- o .: "sourceSpan" >>= sourceSpanFromJSON modulePath
     mm <- o .: "meta" >>= metaFromJSON
     return (ss, [], Nothing, mm)
 
-  sourceSpanFromJSON = withObject "SourceSpan" $ \o ->
-    SourceSpan modulePath <$>
-      o .: "start" <*>
-      o .: "end"
+sourceSpanFromJSON :: FilePath -> Value -> Parser SourceSpan
+sourceSpanFromJSON modulePath = withObject "SourceSpan" $ \o ->
+  SourceSpan modulePath <$>
+    o .: "start" <*>
+    o .: "end"
 
 literalFromJSON :: (Value -> Parser a) -> Value -> Parser (Literal a)
 literalFromJSON t = withObject "Literal" literalFromObj
@@ -112,6 +113,7 @@ moduleFromJSON = withObject "Module" moduleFromObj
     version <- o .: "builtWith" >>= versionFromJSON
     moduleName <- o .: "moduleName" >>= moduleNameFromJSON
     modulePath <- o .: "modulePath"
+    moduleSourceSpan <- o .: "sourceSpan" >>= sourceSpanFromJSON modulePath
     moduleImports <- o .: "imports" >>= listParser (importFromJSON modulePath)
     moduleExports <- o .: "exports" >>= listParser identFromJSON
     moduleDecls <- o .: "decls" >>= listParser (bindFromJSON modulePath)

--- a/src/Language/PureScript/CoreFn/Module.hs
+++ b/src/Language/PureScript/CoreFn/Module.hs
@@ -2,6 +2,7 @@ module Language.PureScript.CoreFn.Module where
 
 import Prelude.Compat
 
+import Language.PureScript.AST.SourcePos
 import Language.PureScript.Comments
 import Language.PureScript.CoreFn.Expr
 import Language.PureScript.Names
@@ -13,7 +14,8 @@ import Language.PureScript.Names
 -- parsing it one gets back `ModuleT () Ann` rathern than `ModuleT Type Ann`,
 -- which is enough for `moduleToJs`.
 data Module a = Module
-  { moduleComments :: [Comment]
+  { moduleSourceSpan :: SourceSpan
+  , moduleComments :: [Comment]
   , moduleName :: ModuleName
   , modulePath :: FilePath
   , moduleImports :: [(a, ModuleName)]

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -104,7 +104,8 @@ moduleNameToJSON (ModuleName pns) = toJSON $ properNameToJSON `map` pns
 
 moduleToJSON :: Version -> Module Ann -> Value
 moduleToJSON v m = object
-  [ T.pack "moduleName" .= moduleNameToJSON (moduleName m)
+  [ T.pack "sourceSpan" .= sourceSpanToJSON (moduleSourceSpan m)
+  , T.pack "moduleName" .= moduleNameToJSON (moduleName m)
   , T.pack "modulePath" .= toJSON (modulePath m)
   , T.pack "imports"    .= map importToJSON (moduleImports m)
   , T.pack "exports"    .= map identToJSON (moduleExports m)

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -158,7 +158,7 @@ shushProgress ma _ =
 -- files though)
 shushCodegen :: P.MakeActions P.Make -> MakeActionsEnv -> P.MakeActions P.Make
 shushCodegen ma MakeActionsEnv{..} =
-  ma { P.codegen = \_ _ _ _ -> pure () }
+  ma { P.codegen = \_ _ _ -> pure () }
 
 -- | Returns a topologically sorted list of dependent ExternsFiles for the given
 -- module. Throws an error if there is a cyclic dependency within the

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -75,7 +75,7 @@ rebuildModule MakeActions{..} externs m@(Module _ _ moduleName _ _) = do
       optimized = CF.optimizeCoreFn corefn
       [renamed] = renameInModules [optimized]
       exts = moduleToExternsFile mod' env'
-  evalSupplyT nextVar' . codegen ss renamed env' . encode $ exts
+  evalSupplyT nextVar' . codegen renamed env' . encode $ exts
   return exts
 
 -- | Compiles in "make" mode, compiling each module separately to a @.js@ file and an @externs.json@ file.

--- a/src/Language/PureScript/Renamer.hs
+++ b/src/Language/PureScript/Renamer.hs
@@ -110,7 +110,7 @@ renameInModules :: [Module Ann] -> [Module Ann]
 renameInModules = map go
   where
   go :: Module Ann -> Module Ann
-  go m@(Module _ _ _ _ _ _ decls) = m { moduleDecls = map (renameInDecl' (findDeclIdents decls)) decls }
+  go m@(Module _ _ _ _ _ _ _ decls) = m { moduleDecls = map (renameInDecl' (findDeclIdents decls)) decls }
 
   renameInDecl' :: [Ident] -> Bind Ann -> Bind Ann
   renameInDecl' scope = runRename scope . renameInDecl True

--- a/tests/TestCoreFn.hs
+++ b/tests/TestCoreFn.hs
@@ -48,35 +48,42 @@ spec = context "CoreFnFromJsonTest" $ do
       ann = ssAnn ss
 
   specify "should parse an empty module" $ do
-    let r = parseMod $ Module [] mn mp [] [] [] []
+    let r = parseMod $ Module ss [] mn mp [] [] [] []
     r `shouldSatisfy` isSuccess
     case r of
       Error _   -> return ()
       Success m -> moduleName m `shouldBe` mn
 
+  specify "should parse source span" $ do
+    let r = parseMod $ Module ss [] mn mp [] [] [] []
+    r `shouldSatisfy` isSuccess
+    case r of
+      Error _   -> return ()
+      Success m -> moduleSourceSpan m `shouldBe` ss
+
   specify "should parse module path" $ do
-    let r = parseMod $ Module [] mn mp [] [] [] []
+    let r = parseMod $ Module ss [] mn mp [] [] [] []
     r `shouldSatisfy` isSuccess
     case r of
       Error _   -> return ()
       Success m -> modulePath m `shouldBe` mp
 
   specify "should parse imports" $ do
-    let r = parseMod $ Module [] mn mp [(ann, mn)] [] [] []
+    let r = parseMod $ Module ss [] mn mp [(ann, mn)] [] [] []
     r `shouldSatisfy` isSuccess
     case r of
       Error _   -> return ()
       Success m -> moduleImports m `shouldBe` [(ann, mn)]
 
   specify "should parse exports" $ do
-    let r = parseMod $ Module [] mn mp [] [Ident "exp"] [] []
+    let r = parseMod $ Module ss [] mn mp [] [Ident "exp"] [] []
     r `shouldSatisfy` isSuccess
     case r of
       Error _   -> return ()
       Success m -> moduleExports m `shouldBe` [Ident "exp"]
 
   specify "should parse foreign" $ do
-    let r = parseMod $ Module [] mn mp [] [] [Ident "exp"] []
+    let r = parseMod $ Module ss [] mn mp [] [] [Ident "exp"] []
     r `shouldSatisfy` isSuccess
     case r of
       Error _   -> return ()
@@ -84,7 +91,7 @@ spec = context "CoreFnFromJsonTest" $ do
 
   context "Expr" $ do
     specify "should parse literals" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec ann (Ident "x1") $ Literal ann (NumericLiteral (Left 1))
                 , NonRec ann (Ident "x2") $ Literal ann (NumericLiteral (Right 1.0))
                 , NonRec ann (Ident "x3") $ Literal ann (StringLiteral (mkString "abc"))
@@ -96,18 +103,18 @@ spec = context "CoreFnFromJsonTest" $ do
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse Constructor" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec ann (Ident "constructor") $ Constructor ann (ProperName "Either") (ProperName "Left") [Ident "value0"] ]
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse Accessor" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec ann (Ident "x") $
                     Accessor ann (mkString "field") (Literal ann $ ObjectLiteral [(mkString "field", Literal ann (NumericLiteral (Left 1)))]) ]
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse ObjectUpdate" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec ann (Ident "objectUpdate") $
                     ObjectUpdate ann
                       (Literal ann $ ObjectLiteral [(mkString "field", Literal ann (StringLiteral (mkString "abc")))])
@@ -116,14 +123,14 @@ spec = context "CoreFnFromJsonTest" $ do
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse Abs" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec ann (Ident "abs")
                     $ Abs ann (Ident "x") (Var ann (Qualified (Just mn) (Ident "x")))
                 ]
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse App" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec ann (Ident "app")
                     $ App ann
                         (Abs ann (Ident "x") (Var ann (Qualified Nothing (Ident "x"))))
@@ -132,7 +139,7 @@ spec = context "CoreFnFromJsonTest" $ do
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse Case" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec ann (Ident "case") $
                     Case ann [Var ann (Qualified Nothing (Ident "x"))]
                       [ CaseAlternative
@@ -143,7 +150,7 @@ spec = context "CoreFnFromJsonTest" $ do
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse Case with guards" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec ann (Ident "case") $
                     Case ann [Var ann (Qualified Nothing (Ident "x"))]
                       [ CaseAlternative
@@ -154,7 +161,7 @@ spec = context "CoreFnFromJsonTest" $ do
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse Let" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec ann (Ident "case") $
                     Let ann
                       [ Rec [((ann, Ident "a"), Var ann (Qualified Nothing (Ident "x")))] ]
@@ -164,28 +171,28 @@ spec = context "CoreFnFromJsonTest" $ do
 
   context "Meta" $ do
     specify "should parse IsConstructor" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec (ss, [], Nothing, Just (IsConstructor ProductType [Ident "x"])) (Ident "x") $
                   Literal (ss, [], Nothing, Just (IsConstructor SumType [])) (CharLiteral 'a')
                 ]
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse IsNewtype" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec (ss, [], Nothing, Just IsNewtype) (Ident "x") $
                   Literal ann (CharLiteral 'a')
                 ]
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse IsTypeClassConstructor" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec (ss, [], Nothing, Just IsTypeClassConstructor) (Ident "x") $
                   Literal ann (CharLiteral 'a')
                 ]
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse IsForeign" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec (ss, [], Nothing, Just IsForeign) (Ident "x") $
                   Literal ann (CharLiteral 'a')
                 ]
@@ -193,7 +200,7 @@ spec = context "CoreFnFromJsonTest" $ do
 
   context "Binders" $ do
     specify "should parse LiteralBinder" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec ann (Ident "case") $
                     Case ann [Var ann (Qualified Nothing (Ident "x"))]
                       [ CaseAlternative
@@ -204,7 +211,7 @@ spec = context "CoreFnFromJsonTest" $ do
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse VarBinder" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec ann (Ident "case") $
                     Case ann [Var ann (Qualified Nothing (Ident "x"))]
                       [ CaseAlternative
@@ -220,7 +227,7 @@ spec = context "CoreFnFromJsonTest" $ do
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse NamedBinder" $ do
-      let m = Module [] mn mp [] [] []
+      let m = Module ss [] mn mp [] [] []
                 [ NonRec ann (Ident "case") $
                     Case ann [Var ann (Qualified Nothing (Ident "x"))]
                       [ CaseAlternative
@@ -232,9 +239,9 @@ spec = context "CoreFnFromJsonTest" $ do
 
   context "Comments" $ do
     specify "should parse LineComment" $ do
-      let m = Module [ LineComment "line" ] mn mp [] [] [] []
+      let m = Module ss [ LineComment "line" ] mn mp [] [] [] []
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse BlockComment" $ do
-      let m = Module [ BlockComment "block" ] mn mp [] [] [] []
+      let m = Module ss [ BlockComment "block" ] mn mp [] [] [] []
       parseMod m `shouldSatisfy` isSuccess


### PR DESCRIPTION
This adds `SourcePos` to `CoreFn.Module`.  This way one can run `codegen` from `MakeActions` when one only has `Language.PureScript.CoreFn.Module` rather than a `Language.PureScript.AST.Declaration.Module`.  This is useful for tools like [zephyr](https://github.com/coot/zephyr) to just run the `codegen` when the `CoreFn` was read from an output directory, so the `Module` is not available.

This change adds module `SourcePos` to `CoreFn` `JSON` representation, and also includes a test. I hope it can be included in `0.12.0`.