### PR TITLE
Add hint to run purs COMMAND --help for command specific help

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -19,6 +19,7 @@ import           Data.Monoid ((<>))
 import qualified Options.Applicative as Opts
 import           System.Environment (getArgs)
 import qualified System.IO as IO
+import qualified Text.PrettyPrint.ANSI.Leijen as Doc
 import           Version (versionString)
 
 
@@ -32,7 +33,20 @@ main = do
     opts        = Opts.info (versionInfo <*> Opts.helper <*> commands) infoModList
     infoModList = Opts.fullDesc <> headerInfo <> footerInfo
     headerInfo  = Opts.progDesc "The PureScript compiler and tools"
-    footerInfo  = Opts.footer $ "purs " ++ versionString
+    footerInfo  = Opts.footerDoc (Just footer)
+
+    footer =
+      mconcat
+        [ para $
+            "For help using each individual command, run `purs COMMAND --help`. " ++
+            "For example, `purs compile --help` displays options specific to the `compile` command."
+        , Doc.hardline
+        , Doc.hardline
+        , Doc.text $ "purs " ++ versionString
+        ]
+
+    para :: String -> Doc.Doc
+    para = foldr (Doc.</>) Doc.empty . map Doc.text . words
 
     -- | Displays full command help when invoked with no arguments.
     execParserPure :: Opts.ParserInfo a -> [String] -> Opts.ParserResult a


### PR DESCRIPTION
Here's what `purs --help` outputs after this change:

```
Usage: purs COMMAND
  The PureScript compiler and tools

Available options:
  --version                Show the version number
  -h,--help                Show this help text

Available commands:
  bundle                   Bundle compiled PureScript modules for the browser
  compile                  Compile PureScript source files
  docs                     Generate Markdown documentation from PureScript
                           source files
  hierarchy                Generate a GraphViz directed graph of PureScript type
                           classes
  ide                      Start or query an IDE server process
  publish                  Generates documentation packages for upload to
                           Pursuit
  repl                     Enter the interactive mode (PSCi)

For help using each individual command, run `purs COMMAND --help`. For example,
`purs compile --help` displays options specific to the `compile` command. 

purs 0.12.0 [development build; commit: 939f4bd2f145e243e57b267b439085aae87983f2]
```

In particular, the new paragraph wasn't there before, and might be useful to add in case it's not obvious to everyone.