### PR TITLE
Fix handling of Prim submodules in docs

### DIFF
--- a/app/Command/Docs.hs
+++ b/app/Command/Docs.hs
@@ -62,7 +62,7 @@ docgen (PSCDocsOptions fmt inputGlob output) = do
     Ctags -> mapM_ putStrLn $ dumpCtags fileMs
     Html -> do
       let outputDir = "./generated-docs" -- TODO: make this configurable
-      let msHtml = map asHtml (D.primDocsModule : ms)
+      let msHtml = map asHtml (D.primModules ++ ms)
       createDirectoryIfMissing False outputDir
       writeHtmlModules outputDir msHtml
 

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -394,7 +394,7 @@ rowListNil = primTypeOf (P.primSubName "RowList") "Nil" $ T.unlines
   ]
 
 rowToList :: Declaration
-rowToList = primTypeOf (P.primSubName "RowList") "RowToList" $ T.unlines
+rowToList = primClassOf (P.primSubName "RowList") "RowToList" $ T.unlines
   [ "Compiler solved type class for generating a `RowList` from a closed row"
   , "of types.  Entries are sorted by label and duplicates are preserved in"
   , "the order they appeared in the row."

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -425,7 +425,8 @@ data LinkLocation
 
   -- | A link to a declaration that is built in to the compiler, e.g. the Prim
   -- module. In this case we only need to store the module that the builtin
-  -- comes from (at the time of writing, this will only ever be "Prim").
+  -- comes from. Note that all builtin modules begin with "Prim", and that the
+  -- compiler rejects attempts to define modules whose names start with "Prim".
   | BuiltinModule P.ModuleName
   deriving (Show, Eq, Ord, Generic)
 
@@ -458,11 +459,12 @@ getLink LinksContext{..} curMn namespace target containingMod = do
             pkgVersion <- lookup pkgName ctxResolvedDependencies
             return $ DepsModule curMn pkgName pkgVersion destMn
 
-  builtinLinkLocation = do
-    let primMn = P.moduleNameFromString "Prim"
-    guard $ containingMod == OtherModule primMn
-    -- TODO: ensure the declaration exists in the builtin module too
-    return $ BuiltinModule primMn
+  builtinLinkLocation =
+    case containingMod of
+      OtherModule mn | P.isBuiltinModuleName mn ->
+        pure $ BuiltinModule mn
+      _ ->
+        empty
 
 getLinksContext :: Package a -> LinksContext
 getLinksContext Package{..} =

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -119,14 +119,12 @@ make ma@MakeActions{..} ms = do
 
   checkNoPrim :: m ()
   checkNoPrim =
-    for_ ms $ \m -> do
-      case getModuleName m of
-        mn@(ModuleName (ProperName "Prim" : _)) ->
-          throwError
-            . errorMessage' (getModuleSourceSpan m)
-            $ CannotDefinePrimModules mn
-        _ ->
-          pure ()
+    for_ ms $ \m ->
+      let mn = getModuleName m
+      in when (isBuiltinModuleName mn) $
+           throwError
+             . errorMessage' (getModuleSourceSpan m)
+             $ CannotDefinePrimModules mn
 
   checkModuleNamesAreUnique :: m ()
   checkModuleNamesAreUnique =

--- a/src/Language/PureScript/Names.hs
+++ b/src/Language/PureScript/Names.hs
@@ -177,6 +177,10 @@ moduleNameFromString = ModuleName . splitProperNames
     s' -> ProperName w : splitProperNames s''
       where (w, s'') = T.break (== '.') s'
 
+isBuiltinModuleName :: ModuleName -> Bool
+isBuiltinModuleName (ModuleName (ProperName "Prim" : _)) = True
+isBuiltinModuleName _ = False
+
 -- |
 -- A qualified name, i.e. a name with an optional module name
 --

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -2,6 +2,7 @@ module Language.PureScript.Sugar.Names
   ( desugarImports
   , desugarImportsWithEnv
   , Env
+  , primEnv
   , ImportRecord(..)
   , ImportProvenance(..)
   , Imports(..)

--- a/tests/purs/docs/src/PrimSubmodules.purs
+++ b/tests/purs/docs/src/PrimSubmodules.purs
@@ -1,0 +1,11 @@
+module PrimSubmodules (Lol(..), x, y, module O) where
+
+import Prim.Ordering (kind Ordering, LT, EQ, GT) as O
+
+data Lol (a :: O.Ordering) = Lol Int
+
+x :: Lol O.LT
+x = Lol 0
+
+y :: Lol O.EQ
+y = Lol 1


### PR DESCRIPTION
Fixes #3347 

This PR mainly consists of re-export handling so `purs docs` doesn't
choke on modules which re-export things from submodules of Prim.

It also fixes an issue with the builtin Prim docs which meant that the
RowToList class was being considered a type, leading to incorrect
information in the rendered HTML docs, as well as internal errors in
certain situations.

Finally, we fix handling of links to Prim submodules, ensuring that all
builtin modules are actually considered builtin, not just Prim. This has
no effect on `purs docs` but it will affect Pursuit, once we get around
to updating it.