### PR TITLE
Explain --editor-mode intent

### DIFF
--- a/psc-ide/README.md
+++ b/psc-ide/README.md
@@ -27,7 +27,7 @@ It supports the following options:
   files. This flag is reversed on Windows and polling is the default.
 - `--log-level`: Can be set to one of "all", "none", "debug" and "perf"
 - `--no-watch`: Disables the filewatcher
-- `--editor-mode`: Rather than watch source files, expect an editor to report
+- `--editor-mode`: Rather than watch externs files, expect an editor to report
   changed source files.
 - `--version`: Output psc-ide version
 

--- a/psc-ide/README.md
+++ b/psc-ide/README.md
@@ -27,7 +27,8 @@ It supports the following options:
   files. This flag is reversed on Windows and polling is the default.
 - `--log-level`: Can be set to one of "all", "none", "debug" and "perf"
 - `--no-watch`: Disables the filewatcher
-- `--editor-mode`: Only reload on source file changes reported by the editor
+- `--editor-mode`: Rather than watch source files, expect an editor to report
+  changed source files.
 - `--version`: Output psc-ide version
 
 ## Issuing queries


### PR DESCRIPTION
I was confused the intent of the --editor-mode flag in `purs ide server`. I found https://github.com/purescript/purescript/pull/3006, which explained the intent. I hope this little change helps future people.