### PR TITLE
[purs ide] Use absolute paths for source locations

### DIFF
--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -81,7 +81,7 @@ handleCommand c = case c of
           Nothing -> throwError (GeneralError "Declaration not found")
           Just declaration -> do
             let sourceModule = fromMaybe moduleName (declaration & _idaAnnotation & _annExportedFrom)
-            UsagesResult . fold <$> findUsages (discardAnn declaration) sourceModule
+            UsagesResult . foldMap toList <$> findUsages (discardAnn declaration) sourceModule
   Import fp outfp _ (AddImplicitImport mn) -> do
     rs <- addImplicitImport fp mn
     answerRequest outfp rs

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -99,7 +99,7 @@ handleCommand c = case c of
   RebuildSync file actualFile ->
     rebuildFileSync file actualFile
   Cwd ->
-    TextResult . toS <$> liftIO getCurrentDirectory
+    TextResult . T.pack <$> liftIO getCurrentDirectory
   Reset ->
     resetIdeState $> TextResult "State has been reset."
   Quit ->
@@ -117,8 +117,12 @@ findCompletions filters matcher currentModule complOptions = do
   let insertPrim = (++) idePrimDeclarations
   pure (CompletionResult (getCompletions filters matcher complOptions (insertPrim modules)))
 
-findType :: Ide m =>
-            Text -> [Filter] -> Maybe P.ModuleName -> m Success
+findType
+  :: Ide m
+  => Text
+  -> [Filter]
+  -> Maybe P.ModuleName
+  -> m Success
 findType search filters currentModule = do
   modules <- Map.toList <$> getAllModules currentModule
   let insertPrim = (++) idePrimDeclarations

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -71,7 +71,7 @@ parseImportsFromFile'
   => FilePath
   -> m (P.ModuleName, [Text], [Import], [Text])
 parseImportsFromFile' fp = do
-  file <- ideReadFile fp
+  (_, file) <- ideReadFile fp
   case sliceImportSection (T.lines file) of
     Right res -> pure res
     Left err -> throwError (GeneralError err)

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -49,7 +49,7 @@ rebuildFile file actualFile runOpenBuild = do
 
   input <- ideReadFile file
 
-  m <- case snd <$> P.parseModuleFromFile (maybe identity const actualFile) (file, input) of
+  m <- case snd <$> P.parseModuleFromFile (maybe identity const actualFile) input of
     Left parseError ->
       throwError (RebuildError (P.MultipleErrors [P.toPositionedError parseError]))
     Right m -> pure m

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -29,14 +29,15 @@ import qualified Language.PureScript           as P
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
+import           System.Directory (makeAbsolute)
 
 parseModule
   :: (MonadIO m, MonadError IdeError m)
   => FilePath
   -> m (Either FilePath (FilePath, P.Module))
 parseModule path = do
-  contents <- ideReadFile path
-  pure (parseModule' path contents)
+  (absPath, contents) <- ideReadFile path
+  pure (parseModule' absPath contents)
 
 parseModule' :: FilePath -> Text -> Either FilePath (FilePath, P.Module)
 parseModule' path file =
@@ -49,7 +50,7 @@ parseModulesFromFiles
   => [FilePath]
   -> m [Either FilePath (FilePath, P.Module)]
 parseModulesFromFiles paths = do
-  files <- traverse (\p -> (p,) <$> ideReadFile p) paths
+  files <- traverse ideReadFile paths
   pure (inParallel (map (uncurry parseModule') files))
   where
     inParallel :: [Either e (k, a)] -> [Either e (k, a)]

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -29,7 +29,6 @@ import qualified Language.PureScript           as P
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
-import           System.Directory (makeAbsolute)
 
 parseModule
   :: (MonadIO m, MonadError IdeError m)

--- a/src/Language/PureScript/Ide/Usage.hs
+++ b/src/Language/PureScript/Ide/Usage.hs
@@ -28,13 +28,13 @@ findUsages
   :: (MonadIO m, Ide m)
   => IdeDeclaration
   -> P.ModuleName
-  -> m (ModuleMap [P.SourceSpan])
+  -> m (ModuleMap (NonEmpty P.SourceSpan))
 findUsages declaration moduleName = do
   ms <- getAllModules Nothing
   asts <- Map.map fst . fsModules <$> getFileState
   let elig = eligibleModules (moduleName, declaration) ms asts
   pure
-    $ Map.filter (not . null)
+    $ Map.mapMaybe nonEmpty
     $ Map.mapWithKey (\mn searches ->
         foldMap (\m -> foldMap (applySearch m) searches) (Map.lookup mn asts)) elig
 

--- a/tests/Language/PureScript/Ide/Test.hs
+++ b/tests/Language/PureScript/Ide/Test.hs
@@ -115,10 +115,16 @@ ss x y = P.SourceSpan "Test.purs" (P.SourcePos x y) (P.SourcePos x y)
 mn :: Text -> P.ModuleName
 mn = P.moduleNameFromString
 
+projectDir :: FilePath
+projectDir = "." </> "tests" </> "support" </> "pscide"
+
+getProjectDirectory :: IO FilePath
+getProjectDirectory = makeAbsolute projectDir
+
 inProject :: IO a -> IO a
 inProject f = do
   cwd' <- getCurrentDirectory
-  setCurrentDirectory ("." </> "tests" </> "support" </> "pscide")
+  setCurrentDirectory projectDir
   a <- f
   setCurrentDirectory cwd'
   pure a

--- a/tests/Language/PureScript/Ide/UsageSpec.hs
+++ b/tests/Language/PureScript/Ide/UsageSpec.hs
@@ -11,7 +11,7 @@ import qualified Language.PureScript.Ide.Test as Test
 import qualified Language.PureScript as P
 import           Test.Hspec
 import           Data.Text.Read (decimal)
-import System.FilePath
+import           System.FilePath
 
 load :: [Text] -> Command
 load = LoadSync . map Test.mn
@@ -28,7 +28,8 @@ shouldBeUsage usage' (fp, range) =
     [ endLine, endColumn ] = map unsafeReadInt (Text.splitOn ":" end)
   in
     do
-      fp `shouldBe` P.spanName usage'
+      projectDir <- Test.getProjectDirectory
+      projectDir </> fp `shouldBe` P.spanName usage'
 
       (P.sourcePosLine (P.spanStart usage'), P.sourcePosColumn (P.spanStart usage'))
         `shouldBe`


### PR DESCRIPTION
This caused a few bugs in the Emacs plugin, and I think it's less error-prone to just make sure we emit absolute paths.

I'd like to get this into 0.12