### PR TITLE
Fixes ambiguous occurrence ‘<>’ with Prelude.Compat

### DIFF
--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -13,7 +13,7 @@
 module Command.REPL (command) where
 
 import           Prelude ()
-import           Prelude.Compat
+import           Prelude.Compat hiding ((<>))
 import           Control.Applicative (many, (<|>))
 import           Control.Concurrent (forkIO)
 import           Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, takeMVar,

--- a/src/Control/Monad/Supply/Class.hs
+++ b/src/Control/Monad/Supply/Class.hs
@@ -7,7 +7,7 @@
 
 module Control.Monad.Supply.Class where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Monad.Supply
 import Control.Monad.State

--- a/src/Language/PureScript/AST/SourcePos.hs
+++ b/src/Language/PureScript/AST/SourcePos.hs
@@ -4,7 +4,7 @@
 --
 module Language.PureScript.AST.SourcePos where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.DeepSeq (NFData)
 import Data.Aeson ((.=), (.:))

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -6,7 +6,7 @@ module Language.PureScript.CodeGen.JS
   , moduleToJs
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 import Protolude (ordNub)
 
 import Control.Arrow ((&&&))

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -1,7 +1,7 @@
 -- | Common code generation utility functions
 module Language.PureScript.CodeGen.JS.Common where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Data.Char
 import Data.Monoid ((<>))

--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -4,7 +4,7 @@ module Language.PureScript.CodeGen.JS.Printer
   , prettyPrintJSWithSourceMaps
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Arrow ((<+>))
 import Control.Monad (forM, mzero)

--- a/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
@@ -11,7 +11,7 @@ module Language.PureScript.CoreImp.Optimizer.Inliner
   , evaluateIifes
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Monad.Supply.Class (MonadSupply, freshName)
 

--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -1,7 +1,7 @@
 -- | This module implements tail call elimination.
 module Language.PureScript.CoreImp.Optimizer.TCO (tco) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Data.Text (Text)
 import Data.Monoid ((<>))

--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -6,7 +6,7 @@ module Language.PureScript.Docs.AsMarkdown
   , codeToString
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Monad (unless, zipWithM_)
 import Control.Monad.Error.Class (MonadError)

--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -2,7 +2,7 @@ module Language.PureScript.Docs.Convert.ReExports
   ( updateReExports
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Arrow ((&&&), first, second)
 import Control.Monad

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -6,7 +6,7 @@ module Language.PureScript.Docs.Prim
   , primModules
   ) where
 
-import Prelude.Compat hiding (fail)
+import Prelude.Compat hiding (fail, (<>))
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -480,4 +480,3 @@ aboveDoc = primTypeOf (P.primSubName "TypeError") "Above" $ T.unlines
   , "For more information, see"
   , "[the Custom Type Errors guide](https://github.com/purescript/documentation/blob/master/guides/Custom-Type-Errors.md)."
   ]
-

--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -9,7 +9,7 @@
 
 module Language.PureScript.Docs.Render where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Data.Maybe (maybeToList)
 import Data.Monoid ((<>))

--- a/src/Language/PureScript/Docs/RenderedCode/RenderKind.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/RenderKind.hs
@@ -7,7 +7,7 @@ module Language.PureScript.Docs.RenderedCode.RenderKind
 -- TODO: This is pretty much copied from Language.PureScript.Pretty.Kinds.
 -- Ideally we would unify the two.
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Arrow (ArrowPlus(..))
 import Control.PatternArrows as PA

--- a/src/Language/PureScript/Docs/RenderedCode/RenderType.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/RenderType.hs
@@ -10,7 +10,7 @@ module Language.PureScript.Docs.RenderedCode.RenderType
   , renderTypeAtomWithOptions
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))

--- a/src/Language/PureScript/Docs/RenderedCode/Types.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Types.hs
@@ -43,7 +43,7 @@ module Language.PureScript.Docs.RenderedCode.Types
  , aliasName
  ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 import GHC.Generics (Generic)
 
 import Control.DeepSeq (NFData)

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -6,7 +6,7 @@ module Language.PureScript.Errors
   , module Language.PureScript.Errors
   ) where
 
-import           Prelude.Compat
+import           Prelude.Compat hiding ((<>))
 import           Protolude (ordNub)
 
 import           Control.Arrow ((&&&))

--- a/src/Language/PureScript/Errors/JSON.hs
+++ b/src/Language/PureScript/Errors/JSON.hs
@@ -2,7 +2,7 @@
 
 module Language.PureScript.Errors.JSON where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import qualified Data.Aeson.TH as A
 import qualified Data.List.NonEmpty as NEL

--- a/src/Language/PureScript/Hierarchy.hs
+++ b/src/Language/PureScript/Hierarchy.hs
@@ -15,7 +15,7 @@
 
 module Language.PureScript.Hierarchy where
 
-import           Prelude.Compat
+import           Prelude.Compat hiding ((<>))
 import           Protolude (ordNub)
 
 import           Data.List (sort)

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -10,7 +10,7 @@ module Language.PureScript.Interactive
   ) where
 
 import           Prelude ()
-import           Prelude.Compat
+import           Prelude.Compat hiding ((<>))
 import           Protolude (ordNub)
 
 import           Data.List (sort, find, foldl')

--- a/src/Language/PureScript/Interactive/Printer.hs
+++ b/src/Language/PureScript/Interactive/Printer.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Interactive.Printer where
 
-import           Prelude.Compat
+import           Prelude.Compat hiding ((<>))
 
 import           Data.List (intersperse)
 import qualified Data.Map as M

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.Linter (lint, module L) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 import Protolude (ordNub)
 
 import Control.Monad.Writer.Class

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -8,7 +8,7 @@ module Language.PureScript.Linter.Exhaustive
   ( checkExhaustiveExpr
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 import Protolude (ordNub)
 
 import Control.Applicative

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -8,7 +8,7 @@ module Language.PureScript.Make
   , module Actions
   ) where
 
-import           Prelude.Compat
+import           Prelude.Compat hiding ((<>))
 
 import           Control.Concurrent.Lifted as C
 import           Control.Monad hiding (sequence)

--- a/src/Language/PureScript/Names.hs
+++ b/src/Language/PureScript/Names.hs
@@ -8,7 +8,7 @@
 --
 module Language.PureScript.Names where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Monad.Supply.Class
 import Control.DeepSeq (NFData)

--- a/src/Language/PureScript/PSString.hs
+++ b/src/Language/PureScript/PSString.hs
@@ -13,7 +13,7 @@ module Language.PureScript.PSString
   , mkString
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 import Control.Exception (try, evaluate)

--- a/src/Language/PureScript/Parser/Common.hs
+++ b/src/Language/PureScript/Parser/Common.hs
@@ -1,7 +1,7 @@
 -- | Useful common functions for building parsers
 module Language.PureScript.Parser.Common where
 
-import           Prelude.Compat
+import           Prelude.Compat hiding ((<>))
 
 import           Control.Applicative ((<|>))
 import           Control.Monad (guard)

--- a/src/Language/PureScript/Parser/Lexer.hs
+++ b/src/Language/PureScript/Parser/Lexer.hs
@@ -64,7 +64,7 @@ module Language.PureScript.Parser.Lexer
   )
   where
 
-import Prelude.Compat hiding (lex)
+import Prelude.Compat hiding (lex, (<>))
 
 import Control.Applicative ((<|>))
 import Control.Monad (void, guard)

--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -5,7 +5,7 @@
 --
 module Language.PureScript.Pretty.Common where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Monad.State (StateT, modify, get)
 

--- a/src/Language/PureScript/Pretty/Kinds.hs
+++ b/src/Language/PureScript/Pretty/Kinds.hs
@@ -5,7 +5,7 @@ module Language.PureScript.Pretty.Kinds
   ( prettyPrintKind
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Arrow (ArrowPlus(..))
 import Control.PatternArrows as PA

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -14,7 +14,7 @@ module Language.PureScript.Pretty.Types
   , prettyPrintObjectKey
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Arrow ((<+>))
 import Control.PatternArrows as PA

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -7,7 +7,7 @@ module Language.PureScript.Pretty.Values
   , prettyPrintBinderAtom
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Arrow (second)
 

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -13,7 +13,7 @@ module Language.PureScript.Publish.ErrorsWarnings
   , renderWarnings
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Exception (IOException)
 

--- a/src/Language/PureScript/Renamer.hs
+++ b/src/Language/PureScript/Renamer.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.Renamer (renameInModules) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Monad.State
 

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -1,7 +1,7 @@
 -- | This module implements the generic deriving elaboration that takes place during desugaring.
 module Language.PureScript.Sugar.TypeClasses.Deriving (deriveInstances) where
 
-import           Prelude.Compat
+import           Prelude.Compat hiding ((<>))
 import           Protolude (ordNub)
 
 import           Control.Arrow (second)

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -9,7 +9,7 @@ module Language.PureScript.TypeChecker
   , checkNewtype
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 import Protolude (ordNub)
 
 import Control.Monad (when, unless, void, forM)

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -11,7 +11,7 @@ module Language.PureScript.TypeChecker.Entailment
   , entails
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 import Protolude (ordNub)
 
 import Control.Arrow (second, (&&&))

--- a/src/Language/PureScript/TypeChecker/Skolems.hs
+++ b/src/Language/PureScript/TypeChecker/Skolems.hs
@@ -8,7 +8,7 @@ module Language.PureScript.TypeChecker.Skolems
   , skolemEscapeCheck
   ) where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Class (MonadState(..), gets, modify)

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -24,7 +24,7 @@ module Language.PureScript.TypeChecker.Types
       Check a function of a given type returns a value of another type when applied to its arguments
 -}
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 import Protolude (ordNub)
 
 import Control.Arrow (first, second, (***))

--- a/src/Language/PureScript/TypeClassDictionaries.hs
+++ b/src/Language/PureScript/TypeClassDictionaries.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE DeriveGeneric     #-}
 module Language.PureScript.TypeClassDictionaries where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -7,7 +7,7 @@
 --
 module Language.PureScript.Types where
 
-import Prelude.Compat
+import Prelude.Compat hiding ((<>))
 import Protolude (ordNub)
 
 import Control.Arrow (first)


### PR DESCRIPTION
without this change I'm getting a lot of errors alike:

```
    Ambiguous occurrence ‘<>’
    It could refer to either ‘Prelude.Compat.<>’,
                             imported from ‘Prelude.Compat’ at src/Language/PureScript/Docs/Prim.hs:9:1-35
                             (and originally defined in ‘Data.Semigroup’)
                          or ‘Data.Monoid.<>’,
                             imported from ‘Data.Monoid’ at src/Language/PureScript/Docs/Prim.hs:10:21-24
```