### PR TITLE
Implement QualifiedDo

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -775,7 +775,7 @@ data Expr
   -- |
   -- A do-notation block
   --
-  | Do [DoNotationElement]
+  | Do (Maybe ModuleName) [DoNotationElement]
   -- |
   -- An ado-notation block
   --

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -779,7 +779,7 @@ data Expr
   -- |
   -- An ado-notation block
   --
-  | Ado [DoNotationElement] Expr
+  | Ado (Maybe ModuleName) [DoNotationElement] Expr
   -- |
   -- An application of a typeclass dictionary constructor. The value should be
   -- an ObjectLiteral.

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -77,7 +77,7 @@ everywhereOnValues f g h = (f', g', h')
   g' (TypedValue check v ty) = g (TypedValue check (g' v) ty)
   g' (Let w ds v) = g (Let w (fmap f' ds) (g' v))
   g' (Do m es) = g (Do m (fmap handleDoNotationElement es))
-  g' (Ado es v) = g (Ado (fmap handleDoNotationElement es) (g' v))
+  g' (Ado m es v) = g (Ado m (fmap handleDoNotationElement es) (g' v))
   g' (PositionedValue pos com v) = g (PositionedValue pos com (g' v))
   g' other = g other
 
@@ -151,7 +151,7 @@ everywhereOnValuesTopDownM f g h = (f' <=< f, g' <=< g, h' <=< h)
   g' (TypedValue check v ty) = TypedValue check <$> (g v >>= g') <*> pure ty
   g' (Let w ds v) = Let w <$> traverse (f' <=< f) ds <*> (g v >>= g')
   g' (Do m es) = Do m <$> traverse handleDoNotationElement es
-  g' (Ado es v) = Ado <$> traverse handleDoNotationElement es <*> (g v >>= g')
+  g' (Ado m es v) = Ado m <$> traverse handleDoNotationElement es <*> (g v >>= g')
   g' (PositionedValue pos com v) = PositionedValue pos com <$> (g v >>= g')
   g' other = g other
 
@@ -220,7 +220,7 @@ everywhereOnValuesM f g h = (f', g', h')
   g' (TypedValue check v ty) = (TypedValue check <$> g' v <*> pure ty) >>= g
   g' (Let w ds v) = (Let w <$> traverse f' ds <*> g' v) >>= g
   g' (Do m es) = (Do m <$> traverse handleDoNotationElement es) >>= g
-  g' (Ado es v) = (Ado <$> traverse handleDoNotationElement es <*> g' v) >>= g
+  g' (Ado m es v) = (Ado m <$> traverse handleDoNotationElement es <*> g' v) >>= g
   g' (PositionedValue pos com v) = (PositionedValue pos com <$> g' v) >>= g
   g' other = g other
 
@@ -292,7 +292,7 @@ everythingOnValues (<>.) f g h i j = (f', g', h', i', j')
   g' v@(TypedValue _ v1 _) = g v <>. g' v1
   g' v@(Let _ ds v1) = foldl (<>.) (g v) (fmap f' ds) <>. g' v1
   g' v@(Do _ es) = foldl (<>.) (g v) (fmap j' es)
-  g' v@(Ado es v1) = foldl (<>.) (g v) (fmap j' es) <>. g' v1
+  g' v@(Ado _ es v1) = foldl (<>.) (g v) (fmap j' es) <>. g' v1
   g' v@(PositionedValue _ _ v1) = g v <>. g' v1
   g' v = g v
 
@@ -373,7 +373,7 @@ everythingWithContextOnValues s0 r0 (<>.) f g h i j = (f'' s0, g'' s0, h'' s0, i
   g' s (TypedValue _ v1 _) = g'' s v1
   g' s (Let _ ds v1) = foldl (<>.) r0 (fmap (f'' s) ds) <>. g'' s v1
   g' s (Do _ es) = foldl (<>.) r0 (fmap (j'' s) es)
-  g' s (Ado es v1) = foldl (<>.) r0 (fmap (j'' s) es) <>. g'' s v1
+  g' s (Ado _ es v1) = foldl (<>.) r0 (fmap (j'' s) es) <>. g'' s v1
   g' s (PositionedValue _ _ v1) = g'' s v1
   g' _ _ = r0
 
@@ -458,7 +458,7 @@ everywhereWithContextOnValuesM s0 f g h i j = (f'' s0, g'' s0, h'' s0, i'' s0, j
   g' s (TypedValue check v ty) = TypedValue check <$> g'' s v <*> pure ty
   g' s (Let w ds v) = Let w <$> traverse (f'' s) ds <*> g'' s v
   g' s (Do m es) = Do m <$> traverse (j'' s) es
-  g' s (Ado es v) = Ado <$> traverse (j'' s) es <*> g'' s v
+  g' s (Ado m es v) = Ado m <$> traverse (j'' s) es <*> g'' s v
   g' s (PositionedValue pos com v) = PositionedValue pos com <$> g'' s v
   g' _ other = return other
 
@@ -555,7 +555,7 @@ everythingWithScope f g h i j = (f'', g'', h'', i'', \s -> snd . j'' s)
     let s' = S.union s (S.fromList (map LocalIdent (mapMaybe getDeclIdent ds)))
     in foldMap (f'' s') ds <> g'' s' v1
   g' s (Do _ es) = fold . snd . mapAccumL j'' s $ es
-  g' s (Ado es v1) =
+  g' s (Ado _ es v1) =
     let s' = S.union s (foldMap (fst . j'' s) es)
     in g'' s' v1
   g' s (PositionedValue _ _ v1) = g'' s v1

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -76,7 +76,7 @@ everywhereOnValues f g h = (f', g', h')
   g' (Case vs alts) = g (Case (fmap g' vs) (fmap handleCaseAlternative alts))
   g' (TypedValue check v ty) = g (TypedValue check (g' v) ty)
   g' (Let w ds v) = g (Let w (fmap f' ds) (g' v))
-  g' (Do es) = g (Do (fmap handleDoNotationElement es))
+  g' (Do m es) = g (Do m (fmap handleDoNotationElement es))
   g' (Ado es v) = g (Ado (fmap handleDoNotationElement es) (g' v))
   g' (PositionedValue pos com v) = g (PositionedValue pos com (g' v))
   g' other = g other
@@ -150,7 +150,7 @@ everywhereOnValuesTopDownM f g h = (f' <=< f, g' <=< g, h' <=< h)
   g' (Case vs alts) = Case <$> traverse (g' <=< g) vs <*> traverse handleCaseAlternative alts
   g' (TypedValue check v ty) = TypedValue check <$> (g v >>= g') <*> pure ty
   g' (Let w ds v) = Let w <$> traverse (f' <=< f) ds <*> (g v >>= g')
-  g' (Do es) = Do <$> traverse handleDoNotationElement es
+  g' (Do m es) = Do m <$> traverse handleDoNotationElement es
   g' (Ado es v) = Ado <$> traverse handleDoNotationElement es <*> (g v >>= g')
   g' (PositionedValue pos com v) = PositionedValue pos com <$> (g v >>= g')
   g' other = g other
@@ -219,7 +219,7 @@ everywhereOnValuesM f g h = (f', g', h')
   g' (Case vs alts) = (Case <$> traverse g' vs <*> traverse handleCaseAlternative alts) >>= g
   g' (TypedValue check v ty) = (TypedValue check <$> g' v <*> pure ty) >>= g
   g' (Let w ds v) = (Let w <$> traverse f' ds <*> g' v) >>= g
-  g' (Do es) = (Do <$> traverse handleDoNotationElement es) >>= g
+  g' (Do m es) = (Do m <$> traverse handleDoNotationElement es) >>= g
   g' (Ado es v) = (Ado <$> traverse handleDoNotationElement es <*> g' v) >>= g
   g' (PositionedValue pos com v) = (PositionedValue pos com <$> g' v) >>= g
   g' other = g other
@@ -291,7 +291,7 @@ everythingOnValues (<>.) f g h i j = (f', g', h', i', j')
   g' v@(Case vs alts) = foldl (<>.) (foldl (<>.) (g v) (fmap g' vs)) (fmap i' alts)
   g' v@(TypedValue _ v1 _) = g v <>. g' v1
   g' v@(Let _ ds v1) = foldl (<>.) (g v) (fmap f' ds) <>. g' v1
-  g' v@(Do es) = foldl (<>.) (g v) (fmap j' es)
+  g' v@(Do _ es) = foldl (<>.) (g v) (fmap j' es)
   g' v@(Ado es v1) = foldl (<>.) (g v) (fmap j' es) <>. g' v1
   g' v@(PositionedValue _ _ v1) = g v <>. g' v1
   g' v = g v
@@ -372,7 +372,7 @@ everythingWithContextOnValues s0 r0 (<>.) f g h i j = (f'' s0, g'' s0, h'' s0, i
   g' s (Case vs alts) = foldl (<>.) (foldl (<>.) r0 (fmap (g'' s) vs)) (fmap (i'' s) alts)
   g' s (TypedValue _ v1 _) = g'' s v1
   g' s (Let _ ds v1) = foldl (<>.) r0 (fmap (f'' s) ds) <>. g'' s v1
-  g' s (Do es) = foldl (<>.) r0 (fmap (j'' s) es)
+  g' s (Do _ es) = foldl (<>.) r0 (fmap (j'' s) es)
   g' s (Ado es v1) = foldl (<>.) r0 (fmap (j'' s) es) <>. g'' s v1
   g' s (PositionedValue _ _ v1) = g'' s v1
   g' _ _ = r0
@@ -457,7 +457,7 @@ everywhereWithContextOnValuesM s0 f g h i j = (f'' s0, g'' s0, h'' s0, i'' s0, j
   g' s (Case vs alts) = Case <$> traverse (g'' s) vs <*> traverse (i'' s) alts
   g' s (TypedValue check v ty) = TypedValue check <$> g'' s v <*> pure ty
   g' s (Let w ds v) = Let w <$> traverse (f'' s) ds <*> g'' s v
-  g' s (Do es) = Do <$> traverse (j'' s) es
+  g' s (Do m es) = Do m <$> traverse (j'' s) es
   g' s (Ado es v) = Ado <$> traverse (j'' s) es <*> g'' s v
   g' s (PositionedValue pos com v) = PositionedValue pos com <$> g'' s v
   g' _ other = return other
@@ -554,7 +554,7 @@ everythingWithScope f g h i j = (f'', g'', h'', i'', \s -> snd . j'' s)
   g' s (Let _ ds v1) =
     let s' = S.union s (S.fromList (map LocalIdent (mapMaybe getDeclIdent ds)))
     in foldMap (f'' s') ds <> g'' s' v1
-  g' s (Do es) = fold . snd . mapAccumL j'' s $ es
+  g' s (Do _ es) = fold . snd . mapAccumL j'' s $ es
   g' s (Ado es v1) =
     let s' = S.union s (foldMap (fst . j'' s) es)
     in g'' s' v1

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -483,13 +483,13 @@ parseAccessor obj = P.try $ Accessor <$> (indented *> dot *> indented *> parseLa
 
 parseDo :: TokenParser Expr
 parseDo = do
-  m <- P.try (parseQualified (reserved "do") >>= pure . getQual) <|> (reserved "do" *> pure Nothing)
+  m <- P.try (getQual <$> parseQualified (reserved "do")) <|> (reserved "do" *> pure Nothing)
   indented
   Do m <$> mark (P.many1 (same *> mark parseDoNotationElement))
 
 parseAdo :: TokenParser Expr
 parseAdo = do
-  m <- P.try (parseQualified (reserved "ado") >>= pure . getQual) <|> (reserved "ado" *> pure Nothing)
+  m <- P.try (getQual <$> parseQualified (reserved "ado")) <|> (reserved "ado" *> pure Nothing)
   indented
   elements <- mark (P.many (same *> mark parseDoNotationElement))
   yield <- mark (reserved "in" *> parseValue)

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -449,7 +449,7 @@ parseValueAtom = withSourceSpan PositionedValue $ P.choice
                  , parseCase
                  , parseIfThenElse
                  , P.try parseDo
-                 , parseAdo
+                 , P.try parseAdo
                  , parseLet
                  , P.try $ Parens <$> parens parseValue
                  , withSourceSpan' Op $ parseQualified (parens parseOperator)
@@ -489,11 +489,11 @@ parseDo = do
 
 parseAdo :: TokenParser Expr
 parseAdo = do
-  reserved "ado"
+  m <- parseQualified (reserved "ado") >>= \(Qualified m _) -> pure m
   indented
   elements <- mark (P.many (same *> mark parseDoNotationElement))
   yield <- mark (reserved "in" *> parseValue)
-  pure $ Ado elements yield
+  pure $ Ado m elements yield
 
 parseDoNotationLet :: TokenParser DoNotationElement
 parseDoNotationLet = DoNotationLet <$> (reserved "let" *> indented *> mark (P.many1 (same *> parseLocalDeclaration)))

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -448,8 +448,8 @@ parseValueAtom = withSourceSpan PositionedValue $ P.choice
                  , P.try parseVar
                  , parseCase
                  , parseIfThenElse
-                 , P.try parseDo
-                 , P.try parseAdo
+                 , parseDo
+                 , parseAdo
                  , parseLet
                  , P.try $ Parens <$> parens parseValue
                  , withSourceSpan' Op $ parseQualified (parens parseOperator)
@@ -483,13 +483,13 @@ parseAccessor obj = P.try $ Accessor <$> (indented *> dot *> indented *> parseLa
 
 parseDo :: TokenParser Expr
 parseDo = do
-  m <- parseQualified (reserved "do") >>= \(Qualified m _) -> pure m
+  m <- P.try (parseQualified (reserved "do") >>= pure . getQual) <|> (reserved "do" *> pure Nothing)
   indented
   Do m <$> mark (P.many1 (same *> mark parseDoNotationElement))
 
 parseAdo :: TokenParser Expr
 parseAdo = do
-  m <- parseQualified (reserved "ado") >>= \(Qualified m _) -> pure m
+  m <- P.try (parseQualified (reserved "ado") >>= pure . getQual) <|> (reserved "ado" *> pure Nothing)
   indented
   elements <- mark (P.many (same *> mark parseDoNotationElement))
   yield <- mark (reserved "in" *> parseValue)

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -448,7 +448,7 @@ parseValueAtom = withSourceSpan PositionedValue $ P.choice
                  , P.try parseVar
                  , parseCase
                  , parseIfThenElse
-                 , parseDo
+                 , P.try parseDo
                  , parseAdo
                  , parseLet
                  , P.try $ Parens <$> parens parseValue
@@ -483,9 +483,9 @@ parseAccessor obj = P.try $ Accessor <$> (indented *> dot *> indented *> parseLa
 
 parseDo :: TokenParser Expr
 parseDo = do
-  reserved "do"
+  m <- parseQualified (reserved "do") >>= \(Qualified m _) -> pure m
   indented
-  Do <$> mark (P.many1 (same *> mark parseDoNotationElement))
+  Do m <$> mark (P.many1 (same *> mark parseDoNotationElement))
 
 parseAdo :: TokenParser Expr
 parseAdo = do

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -83,8 +83,8 @@ prettyPrintValue d (Let FromLet ds val) =
     (text "in " <> prettyPrintValue (d - 1) val)
 prettyPrintValue d (Do m els) =
   textT (maybe "" ((Monoid.<> ".") . runModuleName) m) <> text "do " <> vcat left (map (prettyPrintDoNotationElement (d - 1)) els)
-prettyPrintValue d (Ado els yield) =
-  text "ado " <> vcat left (map (prettyPrintDoNotationElement (d - 1)) els) //
+prettyPrintValue d (Ado m els yield) =
+  textT (maybe "" ((Monoid.<> ".") . runModuleName) m) <> text "ado " <> vcat left (map (prettyPrintDoNotationElement (d - 1)) els) //
   (text "in " <> prettyPrintValue (d - 1) yield)
 prettyPrintValue _ (TypeClassDictionary (Constraint name tys _) _ _) = foldl1 beforeWithSpace $ text ("#dict " ++ T.unpack (runProperName (disqualify name))) : map typeAtomAsBox tys
 prettyPrintValue _ (DeferredDictionary name _) = text $ "#dict " ++ T.unpack (runProperName (disqualify name))

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -11,6 +11,7 @@ import Prelude.Compat hiding ((<>))
 
 import Control.Arrow (second)
 
+import Data.Maybe (maybe)
 import Data.Text (Text)
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Monoid as Monoid ((<>))
@@ -80,8 +81,8 @@ prettyPrintValue d (Let FromLet ds val) =
   text "let" //
     moveRight 2 (vcat left (map (prettyPrintDeclaration (d - 1)) ds)) //
     (text "in " <> prettyPrintValue (d - 1) val)
-prettyPrintValue d (Do els) =
-  text "do " <> vcat left (map (prettyPrintDoNotationElement (d - 1)) els)
+prettyPrintValue d (Do m els) =
+  textT (maybe "" ((Monoid.<> ".") . runModuleName) m) <> text "do " <> vcat left (map (prettyPrintDoNotationElement (d - 1)) els)
 prettyPrintValue d (Ado els yield) =
   text "ado " <> vcat left (map (prettyPrintDoNotationElement (d - 1)) els) //
   (text "in " <> prettyPrintValue (d - 1) yield)

--- a/src/Language/PureScript/Sugar/AdoNotation.hs
+++ b/src/Language/PureScript/Sugar/AdoNotation.hs
@@ -28,21 +28,21 @@ desugarAdo d =
   let (f, _, _) = everywhereOnValuesM return replace return
   in f d
   where
-  pure' :: Expr
-  pure' = Var nullSourceSpan (Qualified Nothing (Ident C.pure'))
+  pure' :: Maybe ModuleName -> Expr
+  pure' m = Var nullSourceSpan (Qualified m (Ident C.pure'))
 
-  map' :: Expr
-  map' = Var nullSourceSpan (Qualified Nothing (Ident C.map))
+  map' :: Maybe ModuleName -> Expr
+  map' m = Var nullSourceSpan (Qualified m (Ident C.map))
 
-  apply :: Expr
-  apply = Var nullSourceSpan (Qualified Nothing (Ident C.apply))
+  apply :: Maybe ModuleName -> Expr
+  apply m = Var nullSourceSpan (Qualified m (Ident C.apply))
 
   replace :: Expr -> m Expr
-  replace (Ado els yield) = do
+  replace (Ado m els yield) = do
     (func, args) <- foldM go (yield, []) (reverse els)
     return $ case args of
-      [] -> App pure' func
-      hd : tl -> foldl' (\a b -> App (App apply a) b) (App (App map' func) hd) tl
+      [] -> App (pure' m) func
+      hd : tl -> foldl' (\a b -> App (App (apply m) a) b) (App (App (map' m) func) hd) tl
   replace (PositionedValue pos com v) = PositionedValue pos com <$> rethrowWithPosition pos (replace v)
   replace other = return other
 

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -29,43 +29,43 @@ desugarDo d =
       (f, _, _) = everywhereOnValuesM return (replace ss) return
   in rethrowWithPosition ss $ f d
   where
-  bind :: SourceSpan -> Expr
-  bind = flip Var (Qualified Nothing (Ident C.bind))
+  bind :: SourceSpan -> Maybe ModuleName -> Expr
+  bind ss m = Var ss (Qualified m (Ident C.bind))
 
   discard :: SourceSpan -> Expr
   discard = flip Var (Qualified Nothing (Ident C.discard))
 
   replace :: SourceSpan -> Expr -> m Expr
-  replace pos (Do els) = go pos els
+  replace pos (Do m els) = go pos m els
   replace _ (PositionedValue pos com v) = PositionedValue pos com <$> rethrowWithPosition pos (replace pos v)
   replace _ other = return other
 
-  go :: SourceSpan -> [DoNotationElement] -> m Expr
-  go _ [] = internalError "The impossible happened in desugarDo"
-  go _ [DoNotationValue val] = return val
-  go pos (DoNotationValue val : rest) = do
-    rest' <- go pos rest
+  go :: SourceSpan -> Maybe ModuleName -> [DoNotationElement] -> m Expr
+  go _ _ [] = internalError "The impossible happened in desugarDo"
+  go _ _ [DoNotationValue val] = return val
+  go pos m (DoNotationValue val : rest) = do
+    rest' <- go pos m rest
     return $ App (App (discard pos) val) (Abs (VarBinder pos UnusedIdent) rest')
-  go _ [DoNotationBind _ _] = throwError . errorMessage $ InvalidDoBind
-  go _ (DoNotationBind b _ : _) | First (Just ident) <- foldMap fromIdent (binderNames b) =
+  go _ _ [DoNotationBind _ _] = throwError . errorMessage $ InvalidDoBind
+  go _ _ (DoNotationBind b _ : _) | First (Just ident) <- foldMap fromIdent (binderNames b) =
       throwError . errorMessage $ CannotUseBindWithDo (Ident ident)
     where
       fromIdent (Ident i) | i `elem` [ C.bind, C.discard ] = First (Just i)
       fromIdent _ = mempty
-  go pos (DoNotationBind (VarBinder ss ident) val : rest) = do
-    rest' <- go pos rest
-    return $ App (App (bind pos) val) (Abs (VarBinder ss ident) rest')
-  go pos (DoNotationBind binder val : rest) = do
-    rest' <- go pos rest
+  go pos m (DoNotationBind (VarBinder ss ident) val : rest) = do
+    rest' <- go pos m rest
+    return $ App (App (bind pos m) val) (Abs (VarBinder ss ident) rest')
+  go pos m (DoNotationBind binder val : rest) = do
+    rest' <- go pos m rest
     ident <- freshIdent'
-    return $ App (App (bind pos) val) (Abs (VarBinder pos ident) (Case [Var pos (Qualified Nothing ident)] [CaseAlternative [binder] [MkUnguarded rest']]))
-  go _ [DoNotationLet _] = throwError . errorMessage $ InvalidDoLet
-  go pos (DoNotationLet ds : rest) = do
+    return $ App (App (bind pos m) val) (Abs (VarBinder pos ident) (Case [Var pos (Qualified Nothing ident)] [CaseAlternative [binder] [MkUnguarded rest']]))
+  go _ _ [DoNotationLet _] = throwError . errorMessage $ InvalidDoLet
+  go pos m (DoNotationLet ds : rest) = do
     let checkBind :: Declaration -> m ()
         checkBind (ValueDecl (ss, _) i@(Ident name) _ _ _)
           | name `elem` [ C.bind, C.discard ] = throwError . errorMessage' ss $ CannotUseBindWithDo i
         checkBind _ = pure ()
     mapM_ checkBind ds
-    rest' <- go pos rest
+    rest' <- go pos m rest
     return $ Let FromLet ds rest'
-  go _ (PositionedDoNotationElement pos com el : rest) = rethrowWithPosition pos $ PositionedValue pos com <$> go pos (el : rest)
+  go _ m (PositionedDoNotationElement pos com el : rest) = rethrowWithPosition pos $ PositionedValue pos com <$> go pos m (el : rest)

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -32,8 +32,8 @@ desugarDo d =
   bind :: SourceSpan -> Maybe ModuleName -> Expr
   bind ss m = Var ss (Qualified m (Ident C.bind))
 
-  discard :: SourceSpan -> Expr
-  discard = flip Var (Qualified Nothing (Ident C.discard))
+  discard :: SourceSpan -> Maybe ModuleName -> Expr
+  discard ss m = Var ss (Qualified m (Ident C.discard))
 
   replace :: SourceSpan -> Expr -> m Expr
   replace pos (Do m els) = go pos m els
@@ -45,7 +45,7 @@ desugarDo d =
   go _ _ [DoNotationValue val] = return val
   go pos m (DoNotationValue val : rest) = do
     rest' <- go pos m rest
-    return $ App (App (discard pos) val) (Abs (VarBinder pos UnusedIdent) rest')
+    return $ App (App (discard pos m) val) (Abs (VarBinder pos UnusedIdent) rest')
   go _ _ [DoNotationBind _ _] = throwError . errorMessage $ InvalidDoBind
   go _ _ (DoNotationBind b _ : _) | First (Just ident) <- foldMap fromIdent (binderNames b) =
       throwError . errorMessage $ CannotUseBindWithDo (Ident ident)

--- a/tests/purs/passing/QualifiedAdo.purs
+++ b/tests/purs/passing/QualifiedAdo.purs
@@ -4,14 +4,14 @@ import Prelude
 import Effect.Console (log)
 import IxApplicative as Ix
 
-testIndexed :: forall f a. Ix.IxApplicative f => f a a String
-testIndexed = Ix.ado
+testIApplicative :: forall f a. Ix.IxApplicative f => f a a String
+testIApplicative = Ix.ado
   a <- Ix.pure "test"
   b <- Ix.pure "test"
   in (a <> b)
 
-testMonad :: forall f. Applicative f => f String
-testMonad = ado
+testApplicative :: forall f. Applicative f => f String
+testApplicative = ado
   a <- pure "test"
   b <- pure "test"
   in (a <> b)

--- a/tests/purs/passing/QualifiedAdo.purs
+++ b/tests/purs/passing/QualifiedAdo.purs
@@ -1,0 +1,19 @@
+module Main where
+
+import Prelude
+import Effect.Console (log)
+import IxApplicative as Ix
+
+testIndexed :: forall f a. Ix.IxApplicative f => f a a String
+testIndexed = Ix.ado
+  a <- Ix.pure "test"
+  b <- Ix.pure "test"
+  in (a <> b)
+
+testMonad :: forall f. Applicative f => f String
+testMonad = ado
+  a <- pure "test"
+  b <- pure "test"
+  in (a <> b)
+
+main = log "Done"

--- a/tests/purs/passing/QualifiedAdo/IxApplicative.purs
+++ b/tests/purs/passing/QualifiedAdo/IxApplicative.purs
@@ -1,0 +1,8 @@
+module IxApplicative where
+
+class IxFunctor f where
+  map ∷ forall a b x y. (a -> b) -> f x y a -> f x y b
+
+class IxFunctor f <= IxApplicative f where
+  pure ∷ forall a x y. a -> f x y a
+  apply ∷ forall a b x y z. f x y (a -> b) -> f y z a -> f x z b

--- a/tests/purs/passing/QualifiedDo.purs
+++ b/tests/purs/passing/QualifiedDo.purs
@@ -1,0 +1,19 @@
+module Main where
+
+import Prelude
+import Effect.Console (log)
+import IxMonad as I
+
+testIndexed :: forall m a. I.IxMonad m => m a a String
+testIndexed = I.do
+  a <- I.pure "test"
+  b <- I.pure "test"
+  I.pure b
+
+testMonad :: forall m. Monad m => m String
+testMonad = do
+  a <- pure "test"
+  b <- pure "test"
+  pure b
+
+main = log "Done"

--- a/tests/purs/passing/QualifiedDo.purs
+++ b/tests/purs/passing/QualifiedDo.purs
@@ -2,18 +2,18 @@ module Main where
 
 import Prelude
 import Effect.Console (log)
-import IxMonad as I
+import IxMonad as Ix
 
-testIndexed :: forall m a. I.IxMonad m => m a a String
-testIndexed = I.do
-  a <- I.pure "test"
-  b <- I.pure "test"
-  I.pure b
+testIndexed :: forall m a. Ix.IxMonad m => m a a String
+testIndexed = Ix.do
+  a <- Ix.pure "test"
+  b <- Ix.pure "test"
+  Ix.pure (a <> b)
 
 testMonad :: forall m. Monad m => m String
 testMonad = do
   a <- pure "test"
   b <- pure "test"
-  pure b
+  pure (a <> b)
 
 main = log "Done"

--- a/tests/purs/passing/QualifiedDo.purs
+++ b/tests/purs/passing/QualifiedDo.purs
@@ -4,8 +4,8 @@ import Prelude
 import Effect.Console (log)
 import IxMonad as Ix
 
-testIndexed :: forall m a. Ix.IxMonad m => m a a String
-testIndexed = Ix.do
+testIMonad :: forall m a. Ix.IxMonad m => m a a String
+testIMonad = Ix.do
   a <- Ix.pure "test"
   b <- Ix.pure "test"
   Ix.pure (a <> b)

--- a/tests/purs/passing/QualifiedDo/IxMonad.purs
+++ b/tests/purs/passing/QualifiedDo/IxMonad.purs
@@ -1,5 +1,5 @@
 module IxMonad where
 
 class IxMonad m where
-  pure ∷ forall a x. a -> m x x a
+  pure ∷ forall a x y. a -> m x y a
   bind ∷ forall a b x y z. m x y a -> (a -> m y z b) -> m x z b

--- a/tests/purs/passing/QualifiedDo/IxMonad.purs
+++ b/tests/purs/passing/QualifiedDo/IxMonad.purs
@@ -1,0 +1,5 @@
+module IxMonad where
+
+class IxMonad m where
+  pure ∷ forall a x. a -> m x x a
+  bind ∷ forall a b x y z. m x y a -> (a -> m y z b) -> m x z b


### PR DESCRIPTION
Implements https://github.com/purescript/purescript/issues/3245.

Now, the following is possible:

`IxMonad.purs`:

```
module IxMonad where

class IxMonad m where
  pure ∷ forall a x. a -> m x x a
  bind ∷ forall a b x y z. m x y a -> (a -> m y z b) -> m x z b
```
`Main.purs`:

```
import IxMonad as I

test :: forall m a. I.IxMonad m => m a a String
test = I.do
  a <- I.pure "test"
  b <- I.pure "test"
  I.pure (a <> b)
```

instead of having to rebind `bind` explicitly.

There's no change in behaviour if `do` is left unqualified:

```
test :: forall m. Monad m => m String
test = do
  a <- pure "test"
  b <- pure "test"
  pure b
```

If there's interest I'll add support for `ado` as well.
