### PR TITLE
break on symbol constraint

### DIFF
--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -457,6 +457,12 @@ pattern SymbolAppend = Qualified (Just PrimSymbol) (ProperName "Append")
 pattern SymbolCons :: Qualified (ProperName 'ClassName)
 pattern SymbolCons = Qualified (Just PrimSymbol) (ProperName "Cons")
 
+pattern SymbolContains :: Qualified (ProperName 'ClassName)
+pattern SymbolContains = Qualified (Just PrimSymbol) (ProperName "Contains")
+
+pattern SymbolBreakOn :: Qualified (ProperName 'ClassName)
+pattern SymbolBreakOn = Qualified (Just PrimSymbol) (ProperName "BreakOn")
+
 -- Prim.TypeError
 
 pattern PrimTypeError :: ModuleName

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -109,6 +109,8 @@ primSymbolDocsModule = Module
       [ symbolAppend
       , symbolCompare
       , symbolCons
+      , symbolContains
+      , symbolBreakOn
       ]
   , modReExports = []
   }
@@ -450,6 +452,20 @@ symbolCons = primClassOf (P.primSubName "Symbol") "Cons" $ T.unlines
   , "head and tail or for combining a head and tail into a new symbol."
   , "Requires the head to be a single character and the combined string"
   , "cannot be empty."
+  ]
+
+symbolContains :: Declaration
+symbolContains = primClassOf (P.primSubName "Symbol") "Contains" $ T.unlines
+  [ "Compiler solved type class for checking if a Symbol contains a Symbol."
+  ]
+
+symbolBreakOn :: Declaration
+symbolBreakOn = primClassOf (P.primSubName "Symbol") "BreakOn" $ T.unlines
+  [ "Compiler solved type class for breaking a symbol into its head and tail"
+  , "using the whole symbol and a breaking symbol, or for joining together the"
+  , "head and tail with the breaking symbol."
+  , "Does not resolve when the tail is empty, i.e. the breaker is not in the Symbol."
+  , "Use SymbolContains for conditional logic."
   ]
 
 fail :: Declaration

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -467,6 +467,8 @@ primSymbolTypes =
     [ (primSubName C.moduleSymbol "Append",  (kindSymbol -:> kindSymbol -:> kindSymbol -:> kindConstraint, ExternData))
     , (primSubName C.moduleSymbol "Compare", (kindSymbol -:> kindSymbol -:> kindOrdering -:> kindConstraint, ExternData))
     , (primSubName C.moduleSymbol "Cons",  (kindSymbol -:> kindSymbol -:> kindSymbol -:> kindConstraint, ExternData))
+    , (primSubName C.moduleSymbol "Contains",  (kindSymbol -:> kindSymbol -:> kindBoolean -:> kindConstraint, ExternData))
+    , (primSubName C.moduleSymbol "BreakOn",  (kindSymbol -:> kindSymbol -:> kindSymbol -:> kindSymbol -:> kindConstraint, ExternData))
     ]
 
 primTypeErrorTypes :: M.Map (Qualified (ProperName 'TypeName)) (SourceKind, TypeKind)
@@ -582,6 +584,26 @@ primSymbolClasses =
         ] [] []
         [ FunctionalDependency [0, 1] [2]
         , FunctionalDependency [2] [0, 1]
+        ])
+
+    -- class Contains (pattern :: Symbol) (symbol :: Symbol) (result :: Boolean) | pattern symbol -> result
+    , (primSubName C.moduleSymbol "Contains", makeTypeClassData
+        [ ("pattern", Just kindSymbol)
+        , ("symbol", Just kindSymbol)
+        , ("result", Just kindBoolean)
+        ] [] []
+        [ FunctionalDependency [0, 1] [2]
+        ])
+
+    -- class BreakOn (breakOn :: Symbol) (symbol :: Symbol) (first :: Symbol) (second :: Symbol) | breakOn symbol -> first second, breakOn first second -> symbol
+    , (primSubName C.moduleSymbol "BreakOn", makeTypeClassData
+        [ ("breakOn", Just kindSymbol)
+        , ("symbol", Just kindSymbol)
+        , ("first", Just kindSymbol)
+        , ("second", Just kindSymbol)
+        ] [] []
+        [ FunctionalDependency [0, 1] [2, 3]
+        , FunctionalDependency [0, 2, 3] [1]
         ])
     ]
 

--- a/tests/purs/passing/SymbolBreakOn.purs
+++ b/tests/purs/passing/SymbolBreakOn.purs
@@ -1,0 +1,46 @@
+module Main where
+
+import Prelude
+import Effect.Console
+
+import Data.Symbol (SProxy(..))
+import Prim.Symbol as Symbol
+
+breakOnSymbol
+  :: forall breakOn sym first second
+   . Symbol.BreakOn breakOn sym first second
+  => SProxy breakOn
+  -> SProxy sym
+  -> { first :: SProxy first, second :: SProxy second }
+breakOnSymbol _ _ = { first: SProxy, second: SProxy }
+
+-- inferred type:
+result1 :: { first :: SProxy "a" , second :: SProxy ",b"}
+result1 = breakOnSymbol (SProxy :: SProxy ",") (SProxy :: SProxy "a,b")
+
+-- inferred type, hopelessly broken as expected:
+result2 :: forall second first. Symbol.BreakOn "," "ab" first second => { first :: SProxy first , second :: SProxy second }
+result2 = breakOnSymbol (SProxy :: SProxy ",") (SProxy :: SProxy "ab")
+
+joinSymbol
+  :: forall breakOn sym first second
+   . Symbol.BreakOn breakOn sym first second
+  => SProxy breakOn
+  -> SProxy first
+  -> SProxy second
+  -> SProxy sym
+joinSymbol _ _ _ = SProxy
+
+-- inferred type:
+resultA :: SProxy "a,b"
+resultA = joinSymbol (SProxy :: SProxy ",") (SProxy :: SProxy "a") (SProxy :: SProxy ",b")
+
+-- inferred type, though hopelessly useless:
+resultB :: forall t11. Symbol.BreakOn "," t11 "a" "b" => SProxy t11
+resultB = joinSymbol (SProxy :: SProxy ",") (SProxy :: SProxy "a") (SProxy :: SProxy "b")
+
+-- inferred type, also broken because the first contains the breaker, which is invalid:
+resultC :: forall a. Symbol.BreakOn "," a "a," ",b" => SProxy a
+resultC = joinSymbol (SProxy :: SProxy ",") (SProxy :: SProxy "a,") (SProxy :: SProxy ",b")
+
+main = log "Done"

--- a/tests/purs/passing/SymbolContains.purs
+++ b/tests/purs/passing/SymbolContains.purs
@@ -1,0 +1,26 @@
+module Main where
+
+import Effect.Console
+
+import Data.Symbol (SProxy(..))
+import Prim.Boolean as Boolean
+import Prim.Symbol as Symbol
+import Type.Data.Boolean (BProxy(..))
+
+symbolContains
+  :: forall pattern sym result
+   . Symbol.Contains pattern sym result
+  => SProxy pattern
+  -> SProxy sym
+  -> BProxy result
+symbolContains _ _ = BProxy
+
+-- inferred type:
+resultContains1 :: BProxy Boolean.True
+resultContains1 = symbolContains (SProxy :: SProxy "b") (SProxy :: SProxy "abc")
+
+-- inferred type:
+resultContains2 :: BProxy Boolean.False
+resultContains2 = symbolContains (SProxy :: SProxy "z") (SProxy :: SProxy "abc")
+
+main = log "Done"

--- a/tests/support/bower.json
+++ b/tests/support/bower.json
@@ -33,7 +33,7 @@
     "purescript-tailrec": "4.0.0",
     "purescript-tuples": "5.0.0",
     "purescript-type-equality": "3.0.0",
-    "purescript-typelevel-prelude": "3.0.0",
+    "purescript-typelevel-prelude": "justinwoo/purescript-typelevel-prelude#prim-boolean",
     "purescript-unfoldable": "4.0.0",
     "purescript-unsafe-coerce": "4.0.0"
   }


### PR DESCRIPTION
I would really like to have this or something like this to be able to easily work with breaking a Symbol.

Currently, my approaches are to parse individual Cons'd Symbols and try to figure out this logic, which gives me a LOT of empty dictionaries and fairly bad error messages.

Example of this in work: https://github.com/justinwoo/hack-symbol-breakon/blob/master/src/Main.purs

excerpt:

```ps
breakOnSymbol
  :: forall breakOn sym first second
   . Symbol.BreakOn breakOn sym first second
  => SProxy breakOn
  -> SProxy sym
  -> { first :: SProxy first, second :: SProxy second }
breakOnSymbol _ _ = { first: SProxy, second: SProxy }

-- inferred type:
result1 :: { first :: SProxy "a" , second :: SProxy ",b"}
result1 = breakOnSymbol (SProxy :: SProxy ",") (SProxy :: SProxy "a,b")
```