### PR TITLE
add Boolean kind to Prim.Boolean

### DIFF
--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -378,6 +378,17 @@ pattern Partial = Qualified (Just Prim) (ProperName "Partial")
 pattern Record :: Qualified (ProperName 'TypeName)
 pattern Record = Qualified (Just Prim) (ProperName "Record")
 
+-- Prim.Boolean
+
+pattern PrimBoolean :: ModuleName
+pattern PrimBoolean = ModuleName [ProperName "Prim", ProperName "Boolean"]
+
+booleanTrue :: Qualified (ProperName 'TypeName)
+booleanTrue = Qualified (Just PrimBoolean) (ProperName "True")
+
+booleanFalse :: Qualified (ProperName 'TypeName)
+booleanFalse = Qualified (Just PrimBoolean) (ProperName "False")
+
 -- Prim.Ordering
 
 pattern PrimOrdering :: ModuleName
@@ -449,7 +460,7 @@ pattern Warn :: Qualified (ProperName 'ClassName)
 pattern Warn = Qualified (Just PrimTypeError) (ProperName "Warn")
 
 primModules :: [ModuleName]
-primModules = [Prim, PrimOrdering, PrimRow, PrimRowList, PrimSymbol, PrimTypeError]
+primModules = [Prim, PrimBoolean, PrimOrdering, PrimRow, PrimRowList, PrimSymbol, PrimTypeError]
 
 -- Data.Symbol
 
@@ -461,6 +472,9 @@ pattern IsSymbol = Qualified (Just DataSymbol) (ProperName "IsSymbol")
 
 typ :: forall a. (IsString a) => a
 typ = "Type"
+
+kindBoolean :: forall a. (IsString a) => a
+kindBoolean = "Boolean"
 
 kindOrdering :: forall a. (IsString a) => a
 kindOrdering = "Ordering"
@@ -478,6 +492,9 @@ doc = "Doc"
 
 prim :: forall a. (IsString a) => a
 prim = "Prim"
+
+moduleBoolean :: forall a. (IsString a) => a
+moduleBoolean = "Boolean"
 
 moduleOrdering :: forall a. (IsString a) => a
 moduleOrdering = "Ordering"

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -18,6 +18,7 @@ import qualified Language.PureScript as P
 primModules :: [Module]
 primModules =
   [ primDocsModule
+  , primBooleanDocsModule
   , primOrderingDocsModule
   , primRowDocsModule
   , primRowListDocsModule
@@ -45,10 +46,22 @@ primDocsModule = Module
   , modReExports = []
   }
 
+primBooleanDocsModule :: Module
+primBooleanDocsModule = Module
+  { modName = P.moduleNameFromString "Prim.Boolean"
+  , modComments = Just "The Prim.Boolean module is embedded in the PureScript compiler. Unlike `Prim`, it is not imported implicitly. It contains a type level `Boolean` data structure."
+  , modDeclarations =
+      [ kindBoolean
+      , booleanTrue
+      , booleanFalse
+      ]
+  , modReExports = []
+  }
+
 primOrderingDocsModule :: Module
 primOrderingDocsModule = Module
   { modName = P.moduleNameFromString "Prim.Ordering"
-  , modComments = Just "The Prim.Row module is embedded in the PureScript compiler. Unlike `Prim`, it is not imported implicitly. It contains a type level `Ordering` data structure."
+  , modComments = Just "The Prim.Ordering module is embedded in the PureScript compiler. Unlike `Prim`, it is not imported implicitly. It contains a type level `Ordering` data structure."
   , modDeclarations =
       [ kindOrdering
       , orderingLT
@@ -153,6 +166,7 @@ lookupPrimTypeKindOf
   -> P.Kind
 lookupPrimTypeKindOf k = fst . unsafeLookupOf k
   ( P.primTypes <>
+    P.primBooleanTypes <>
     P.primOrderingTypes <>
     P.primRowTypes <>
     P.primRowListTypes <>
@@ -328,6 +342,21 @@ partial = primClass "Partial" $ T.unlines
   , "thrown, although it is not safe to assume that this will happen in all"
   , "cases. For more information, see"
   , "[the Partial type class guide](https://github.com/purescript/documentation/blob/master/guides/The-Partial-type-class.md)."
+  ]
+
+kindBoolean :: Declaration
+kindBoolean = primKindOf (P.primSubName "Boolean") "Boolean" $ T.unlines
+  [ "The `Boolean` kind provides True/False types at the type level"
+  ]
+
+booleanTrue :: Declaration
+booleanTrue = primTypeOf (P.primSubName "Boolean") "True" $ T.unlines
+  [ "The 'True' boolean type."
+  ]
+
+booleanFalse :: Declaration
+booleanFalse = primTypeOf (P.primSubName "Boolean") "False" $ T.unlines
+  [ "The 'False' boolean type."
   ]
 
 kindOrdering :: Declaration

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -290,6 +290,9 @@ kindSymbol = primKind C.symbol
 kindDoc :: Kind
 kindDoc = primSubKind C.typeError C.doc
 
+kindBoolean :: Kind
+kindBoolean = primSubKind C.moduleBoolean C.kindBoolean
+
 kindOrdering :: Kind
 kindOrdering = primSubKind C.moduleOrdering C.kindOrdering
 
@@ -355,6 +358,12 @@ primKinds = S.fromList
   , primName C.symbol
   ]
 
+-- | Kinds in @Prim.Boolean@
+primBooleanKinds :: S.Set (Qualified (ProperName 'KindName))
+primBooleanKinds = S.fromList
+  [ primSubName C.moduleBoolean C.kindBoolean
+  ]
+
 -- | Kinds in @Prim.Ordering@
 primOrderingKinds :: S.Set (Qualified (ProperName 'KindName))
 primOrderingKinds = S.fromList
@@ -377,6 +386,7 @@ primTypeErrorKinds = S.fromList
 allPrimKinds :: S.Set (Qualified (ProperName 'KindName))
 allPrimKinds = fold
   [ primKinds
+  , primBooleanKinds
   , primOrderingKinds
   , primRowListKinds
   , primTypeErrorKinds
@@ -402,12 +412,20 @@ primTypes = M.fromList
 allPrimTypes :: M.Map (Qualified (ProperName 'TypeName)) (Kind, TypeKind)
 allPrimTypes = M.unions
   [ primTypes
+  , primBooleanTypes
   , primOrderingTypes
   , primRowTypes
   , primRowListTypes
   , primSymbolTypes
   , primTypeErrorTypes
   ]
+
+primBooleanTypes :: M.Map (Qualified (ProperName 'TypeName)) (Kind, TypeKind)
+primBooleanTypes =
+  M.fromList
+    [ (primSubName C.moduleBoolean "True", (kindBoolean, ExternData))
+    , (primSubName C.moduleBoolean "False", (kindBoolean, ExternData))
+    ]
 
 primOrderingTypes :: M.Map (Qualified (ProperName 'TypeName)) (Kind, TypeKind)
 primOrderingTypes =

--- a/src/Language/PureScript/Ide/Prim.hs
+++ b/src/Language/PureScript/Ide/Prim.hs
@@ -13,6 +13,9 @@ idePrimDeclarations =
   [ ( C.Prim
     , mconcat [primTypes, primKinds, primClasses]
     )
+  , ( C.PrimBoolean
+    , mconcat [primBooleanTypes, primBooleanKinds]
+    )
   , ( C.PrimOrdering
     , mconcat [primOrderingTypes, primOrderingKinds]
     )
@@ -42,6 +45,7 @@ idePrimDeclarations =
       Map.difference types (Map.mapKeys (map P.coerceProperName) classes)
 
     primTypes = annType (removeClasses PEnv.primTypes PEnv.primClasses)
+    primBooleanTypes = annType PEnv.primBooleanTypes
     primOrderingTypes = annType PEnv.primOrderingTypes
     primRowTypes = annType (removeClasses PEnv.primRowTypes PEnv.primRowClasses)
     primRowListTypes = annType (removeClasses PEnv.primRowListTypes PEnv.primRowListClasses)
@@ -55,6 +59,9 @@ idePrimDeclarations =
     primTypeErrorClasses = annClass PEnv.primTypeErrorClasses
 
     primKinds = foreach (Set.toList PEnv.primKinds) $ \kn ->
+      IdeDeclarationAnn emptyAnn (IdeDeclKind (P.disqualify kn))
+
+    primBooleanKinds = foreach (Set.toList PEnv.primBooleanKinds) $ \kn ->
       IdeDeclarationAnn emptyAnn (IdeDeclKind (P.disqualify kn))
 
     primOrderingKinds = foreach (Set.toList PEnv.primOrderingKinds) $ \kn ->

--- a/src/Language/PureScript/Sugar/Names/Env.hs
+++ b/src/Language/PureScript/Sugar/Names/Env.hs
@@ -188,6 +188,12 @@ primExports :: Exports
 primExports = mkPrimExports primTypes primClasses primKinds
 
 -- |
+-- The exported types from the @Prim.Boolean@ module
+--
+primBooleanExports :: Exports
+primBooleanExports = mkPrimExports primBooleanTypes mempty primBooleanKinds
+
+-- |
 -- The exported types from the @Prim.Ordering@ module
 --
 primOrderingExports :: Exports
@@ -241,6 +247,9 @@ primEnv :: Env
 primEnv = M.fromList
   [ ( C.Prim
     , (internalModuleSourceSpan "<Prim>", nullImports, primExports)
+    )
+  , ( C.PrimBoolean
+    , (internalModuleSourceSpan "<Prim.Boolean>", nullImports, primBooleanExports)
     )
   , ( C.PrimOrdering
     , (internalModuleSourceSpan "<Prim.Ordering>", nullImports, primOrderingExports)

--- a/tests/TestPrimDocs.hs
+++ b/tests/TestPrimDocs.hs
@@ -21,6 +21,7 @@ main = do
         -- note that prim type classes are listed in P.primTypes
         (map (P.runProperName . P.disqualify . fst) $ Map.toList
           ( P.primTypes <>
+            P.primBooleanTypes <>
             P.primOrderingTypes <>
             P.primRowTypes <>
             P.primRowListTypes <>


### PR DESCRIPTION
Adds Boolean kind and True/False types of Boolean to Prim.Boolean. Related to #3383 

Corresponding typelevel-prelude change: https://github.com/justinwoo/purescript-typelevel-prelude/commit/b82137f42bdc0f880ddc36c3986b337d42a42d73
