### PR TITLE
Print types of missing typeclass members

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -124,7 +124,7 @@ data SimpleErrorMessage
   | DuplicateValueDeclaration Ident
   | ArgListLengthsDiffer Ident
   | OverlappingArgNames (Maybe Ident)
-  | MissingClassMember Ident Type
+  | MissingClassMember (NEL.NonEmpty (Ident, Type))
   | ExtraneousClassMember Ident (Qualified (ProperName 'ClassName))
   | ExpectedType Type Kind
   -- | constructor name, expected argument count, actual argument count

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -124,7 +124,7 @@ data SimpleErrorMessage
   | DuplicateValueDeclaration Ident
   | ArgListLengthsDiffer Ident
   | OverlappingArgNames (Maybe Ident)
-  | MissingClassMember Ident
+  | MissingClassMember Ident Type
   | ExtraneousClassMember Ident (Qualified (ProperName 'ClassName))
   | ExpectedType Type Kind
   -- | constructor name, expected argument count, actual argument count

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -753,10 +753,12 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       line $ "Argument list lengths differ in declaration " <> markCode (showIdent ident)
     renderSimpleErrorMessage (OverlappingArgNames ident) =
       line $ "Overlapping names in function/binder" <> foldMap ((" in declaration " <>) . showIdent) ident
-    renderSimpleErrorMessage (MissingClassMember ident ty) =
-      paras [ line $ "Type class member " <> markCode (showIdent ident) <> " has not been implemented. It is expected to have the following type:"
-            , markCodeBox $ indent $ Box.text (T.unpack (showIdent ident)) Box.<> Box.text " :: " Box.<> typeAsBox ty
-            ]
+    renderSimpleErrorMessage (MissingClassMember identsAndTypes) =
+      paras $ [ line "The following type class members have not been implemented:"
+              , Box.vcat Box.left
+                [ markCodeBox $ Box.text (T.unpack (showIdent ident)) Box.<> " :: " Box.<> typeAsBox ty
+                | (ident, ty) <- NEL.toList identsAndTypes ]
+              ]
     renderSimpleErrorMessage (ExtraneousClassMember ident className) =
       line $ "" <> markCode (showIdent ident) <> " is not a member of type class " <> markCode (showQualified runProperName className)
     renderSimpleErrorMessage (ExpectedType ty kind) =

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -753,8 +753,10 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       line $ "Argument list lengths differ in declaration " <> markCode (showIdent ident)
     renderSimpleErrorMessage (OverlappingArgNames ident) =
       line $ "Overlapping names in function/binder" <> foldMap ((" in declaration " <>) . showIdent) ident
-    renderSimpleErrorMessage (MissingClassMember ident) =
-      line $ "Type class member " <> markCode (showIdent ident) <> " has not been implemented."
+    renderSimpleErrorMessage (MissingClassMember ident ty) =
+      paras [ line $ "Type class member " <> markCode (showIdent ident) <> " has not been implemented. It is expected to have the following type:"
+            , markCodeBox $ indent $ Box.text (T.unpack (showIdent ident)) Box.<> Box.text " :: " Box.<> typeAsBox ty
+            ]
     renderSimpleErrorMessage (ExtraneousClassMember ident className) =
       line $ "" <> markCode (showIdent ident) <> " is not a member of type class " <> markCode (showQualified runProperName className)
     renderSimpleErrorMessage (ExpectedType ty kind) =

--- a/tests/purs/failing/MissingClassMember.purs
+++ b/tests/purs/failing/MissingClassMember.purs
@@ -4,6 +4,7 @@ module Main where
 class A a where
   a :: a -> String
   b :: a -> Number
+  c :: forall f. a -> f a
 
 instance aString :: A String where
   a s = s

--- a/tests/purs/failing/MissingClassMember.purs
+++ b/tests/purs/failing/MissingClassMember.purs
@@ -1,8 +1,6 @@
 -- @shouldFailWith MissingClassMember
 module Main where
 
-import Prelude
-
 class A a where
   a :: a -> String
   b :: a -> Number


### PR DESCRIPTION
This fixes the first part of #3390. It does not come with a promise to do the second.

```PureScript
module Main where

class A a where
  a :: a -> String
  b :: a -> Number

instance aString :: A String where
  a s = s
```
errors with this:
```
  Type class member b has not been implemented. It is expected to have the following type:
                         
    b :: String -> Number
```

instead of

```
Type class member b has not been implemented.
```