### PR TITLE
Use `microlens-platform` instead of `lens`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -55,8 +55,8 @@ dependencies:
   - Glob >=0.9 && <0.10
   - haskeline >=0.7.0.0
   - language-javascript >=0.6.0.9 && <0.7
-  - lens ==4.*
   - lifted-base >=0.2.3 && <0.2.4
+  - microlens-platform >=0.3.9.0 && <0.4
   - monad-control >=1.0.0.0 && <1.1
   - monad-logger >=0.3 && <0.4
   - mtl >=2.1.0 && <2.3.0

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -11,7 +11,6 @@ module Language.PureScript.Ide.Completion
 
 import           Protolude hiding ((<&>), moduleName)
 
-import           Control.Lens hiding ((&), op)
 import           Data.Aeson
 import qualified Data.Map as Map
 import qualified Data.Text as T
@@ -21,6 +20,7 @@ import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.Matcher
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
+import           Lens.Micro.Platform hiding ((&))
 
 type Module = (P.ModuleName, [IdeDeclarationAnn])
 

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -21,7 +21,6 @@ module Language.PureScript.Ide.Externs
 
 import           Protolude hiding (to, from, (&))
 
-import           Control.Lens
 import           "monad-logger" Control.Monad.Logger
 import           Data.Aeson (decodeStrict)
 import           Data.Aeson.Types (withObject, parseMaybe, (.:))
@@ -29,6 +28,7 @@ import qualified Data.ByteString as BS
 import           Data.Version (showVersion)
 import           Language.PureScript.Ide.Error (IdeError (..))
 import           Language.PureScript.Ide.Types
+import           Lens.Micro.Platform
 
 import qualified Language.PureScript as P
 

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -32,7 +32,6 @@ module Language.PureScript.Ide.Imports
 
 import           Protolude hiding (moduleName)
 
-import           Control.Lens                       ((^.), (%~), ix)
 import           Data.List                          (findIndex, nubBy, partition)
 import qualified Data.Map                           as Map
 import qualified Data.Text                          as T
@@ -45,6 +44,7 @@ import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Prim
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
+import           Lens.Micro.Platform                ((^.), (%~), ix)
 import           System.IO.UTF8                     (writeUTF8FileT)
 import qualified Text.Parsec as Parsec
 

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -25,11 +25,11 @@ module Language.PureScript.Ide.Reexports
 
 import           Protolude hiding (moduleName)
 
-import           Control.Lens                  hiding ((&))
 import qualified Data.Map                      as Map
 import qualified Language.PureScript           as P
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
+import           Lens.Micro.Platform           hiding ((&))
 
 -- | Contains the module with resolved reexports, and possible failures
 data ReexportResult a

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -41,7 +41,6 @@ import           Protolude hiding (moduleName)
 
 import           Control.Arrow
 import           Control.Concurrent.STM
-import           Control.Lens                       hiding (op, (&))
 import           "monad-logger" Control.Monad.Logger
 import qualified Data.Map.Lazy                      as Map
 import qualified Language.PureScript                as P
@@ -52,6 +51,7 @@ import           Language.PureScript.Ide.Reexports
 import           Language.PureScript.Ide.SourceFile
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
+import           Lens.Micro.Platform                hiding ((&))
 
 -- | Resets all State inside psc-ide
 resetIdeState :: Ide m => m ()
@@ -329,7 +329,7 @@ resolveInstances externs declarations =
           mapIf matchTC (idaDeclaration
                          . _IdeDeclTypeClass
                          . ideTCInstances
-                         %~ cons ideInstance)
+                         %~ (ideInstance :))
       in
         acc' & ix classModule %~ updateDeclaration
 

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -22,11 +22,11 @@ module Language.PureScript.Ide.Types where
 import           Protolude hiding (moduleName)
 
 import           Control.Concurrent.STM
-import           Control.Lens.TH
 import           Data.Aeson
 import qualified Data.Map.Lazy as M
 import qualified Language.PureScript as P
 import qualified Language.PureScript.Errors.JSON as P
+import           Lens.Micro.Platform hiding ((.=))
 
 type ModuleIdent = Text
 type ModuleMap a = Map P.ModuleName a
@@ -94,7 +94,41 @@ data IdeTypeOperator = IdeTypeOperator
   , _ideTypeOpKind          :: Maybe P.Kind
   } deriving (Show, Eq, Ord, Generic, NFData)
 
-makePrisms ''IdeDeclaration
+_IdeDeclValue :: Traversal' IdeDeclaration IdeValue
+_IdeDeclValue f (IdeDeclValue x) = map IdeDeclValue (f x)
+_IdeDeclValue _ x = pure x
+
+_IdeDeclType :: Traversal' IdeDeclaration IdeType
+_IdeDeclType f (IdeDeclType x) = map IdeDeclType (f x)
+_IdeDeclType _ x = pure x
+
+_IdeDeclTypeSynonym :: Traversal' IdeDeclaration IdeTypeSynonym
+_IdeDeclTypeSynonym f (IdeDeclTypeSynonym x) = map IdeDeclTypeSynonym (f x)
+_IdeDeclTypeSynonym _ x = pure x
+
+_IdeDeclDataConstructor :: Traversal' IdeDeclaration IdeDataConstructor
+_IdeDeclDataConstructor f (IdeDeclDataConstructor x) = map IdeDeclDataConstructor (f x)
+_IdeDeclDataConstructor _ x = pure x
+
+_IdeDeclTypeClass :: Traversal' IdeDeclaration IdeTypeClass
+_IdeDeclTypeClass f (IdeDeclTypeClass x) = map IdeDeclTypeClass (f x)
+_IdeDeclTypeClass _ x = pure x
+
+_IdeDeclValueOperator :: Traversal' IdeDeclaration IdeValueOperator
+_IdeDeclValueOperator f (IdeDeclValueOperator x) = map IdeDeclValueOperator (f x)
+_IdeDeclValueOperator _ x = pure x
+
+_IdeDeclTypeOperator :: Traversal' IdeDeclaration IdeTypeOperator
+_IdeDeclTypeOperator f (IdeDeclTypeOperator x) = map IdeDeclTypeOperator (f x)
+_IdeDeclTypeOperator _ x = pure x
+
+_IdeDeclKind :: Traversal' IdeDeclaration (P.ProperName 'P.KindName)
+_IdeDeclKind f (IdeDeclKind x) = map IdeDeclKind (f x)
+_IdeDeclKind _ x = pure x
+
+anyOf :: Getting Any s a -> (a -> Bool) -> s -> Bool
+anyOf g p = getAny . getConst . g (Const . Any . p)
+
 makeLenses ''IdeValue
 makeLenses ''IdeType
 makeLenses ''IdeTypeSynonym

--- a/src/Language/PureScript/Ide/Usage.hs
+++ b/src/Language/PureScript/Ide/Usage.hs
@@ -8,13 +8,13 @@ module Language.PureScript.Ide.Usage
 
 import           Protolude hiding (moduleName)
 
-import           Control.Lens (preview)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Language.PureScript as P
 import           Language.PureScript.Ide.State (getAllModules, getFileState)
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
+import           Lens.Micro.Platform (preview)
 
 -- |
 -- How we find usages, given an IdeDeclaration and the module it was defined in:

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -30,9 +30,8 @@ module Language.PureScript.Ide.Util
   ) where
 
 import           Protolude                           hiding (decodeUtf8,
-                                                      encodeUtf8)
+                                                      encodeUtf8, to)
 
-import           Control.Lens                        hiding ((&), op)
 import           Data.Aeson
 import qualified Data.Text.Lazy                      as TL
 import           Data.Text.Lazy.Encoding             as TLE
@@ -40,6 +39,7 @@ import qualified Language.PureScript                 as P
 import           Language.PureScript.Ide.Error       (IdeError(..))
 import           Language.PureScript.Ide.Logging
 import           Language.PureScript.Ide.Types
+import           Lens.Micro.Platform                 hiding ((&))
 import           System.IO.UTF8                      (readUTF8FileT)
 import           System.Directory                    (makeAbsolute)
 
@@ -90,14 +90,14 @@ encodeT = TL.toStrict . TLE.decodeUtf8 . encode
 decodeT :: (FromJSON a) => Text -> Maybe a
 decodeT = decode . TLE.encodeUtf8 . TL.fromStrict
 
-properNameT :: Iso' (P.ProperName a) Text
-properNameT = iso P.runProperName P.ProperName
+properNameT :: Getting r (P.ProperName a) Text
+properNameT = to P.runProperName
 
-identT :: Iso' P.Ident Text
-identT = iso P.runIdent P.Ident
+identT :: Getting r P.Ident Text
+identT = to P.runIdent
 
-opNameT :: Iso' (P.OpName a) Text
-opNameT = iso P.runOpName P.OpName
+opNameT :: Getting r (P.OpName a) Text
+opNameT = to P.runOpName
 
 ideReadFile'
   :: (MonadIO m, MonadError IdeError m)

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -17,7 +17,6 @@ import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Class (MonadState(..), modify, gets)
 import Control.Monad.Supply.Class (MonadSupply)
 import Control.Monad.Writer.Class (MonadWriter(..))
-import Control.Lens ((^..), _1, _2)
 
 import Data.Foldable (for_, traverse_, toList)
 import Data.List (nub, nubBy, (\\), sort, group)
@@ -42,6 +41,8 @@ import Language.PureScript.TypeChecker.Synonyms as T
 import Language.PureScript.TypeChecker.Types as T
 import Language.PureScript.TypeClassDictionaries
 import Language.PureScript.Types
+
+import Lens.Micro.Platform ((^..), _1, _2)
 
 addDataType
   :: (MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)

--- a/tests/Language/PureScript/Ide/StateSpec.hs
+++ b/tests/Language/PureScript/Ide/StateSpec.hs
@@ -3,11 +3,11 @@
 module Language.PureScript.Ide.StateSpec where
 
 import           Protolude
-import           Control.Lens hiding ((&))
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Test
 import qualified Language.PureScript as P
+import           Lens.Micro.Platform hiding ((&))
 import           Test.Hspec
 import qualified Data.Map as Map
 
@@ -91,7 +91,7 @@ spec = do
     it "resolves an instance for an existing type class" $ do
       resolveInstances (Map.singleton (mn "InstanceModule") ef) moduleMap
         `shouldSatisfy`
-        elemOf (ix (mn "ClassModule") . ix 0 . idaDeclaration . _IdeDeclTypeClass . ideTCInstances . folded) ideInstance
+        anyOf (ix (mn "ClassModule") . ix 0 . idaDeclaration . _IdeDeclTypeClass . ideTCInstances . folded) (ideInstance ==)
   describe "resolving data constructors" $ do
     it "resolves a constructor" $ do
       resolveDataConstructorsForModule (snd testModule)


### PR DESCRIPTION
#3389 inspired me to look at the build and see what was causing it to take as much time as it does.

One thing is that we've got a dependency on `lens`, which is a pretty big dependency. Turns out we don't use too much of `lens` and we could drop it in favor of `microlens-platform`–which is a much smaller dependency. Chose `microlens-platform` instead of `microlens` (which is even smaller) because we do some `ix` stuff and we're already paying the cost of things like `unordered-containers`. We can totally go with the smaller footprint ones if we want to rewrite some code. Anyway, the change was small and quick, so I made a PR.

The result of this change on my laptop is about 10% decrease in build time for dependencies:

* With `lens`
    ```
    $ time stack build --only-dependencies                  
    ...
    Completed 139 action(s).     
    stack build --only-dependencies  4087.45s user 195.29s system 537% cpu 13:16.57 total
    ```
* With `microlens-platform`
    ```
    $ time stack build --only-dependencies                  
    ...
    Completed 128 action(s).                      
    stack build --only-dependencies  4016.97s user 187.27s system 590% cpu 11:51.75 total
    ```

It moves the travis builds closer to being within the time limit. It doesn't make the travis builds 100% reliable since those computers have fewer resources and we still have a good deal of dependencies, but they're quicker than currently so more reliable.

In any case, if we're interested in this change, I can clean up some stuff in the PR. I didn't want to spend too much time on an experiment :smiley:.