### PR TITLE
Eliminate built type class dicts when necessarily empty

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -753,6 +753,12 @@ data Expr
   --
   | App Expr Expr
   -- |
+  -- Hint that an expression is unused.
+  -- This is used to ignore type class dictionaries that are necessarily empty.
+  -- The inner expression lets us solve subgoals before eliminating the whole expression.
+  -- The code gen will render this as `undefined`, regardless of what the inner expression is.
+  | Unused Expr
+  -- |
   -- Variable
   --
   | Var SourceSpan (Qualified Ident)

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -28,6 +28,7 @@ import Language.PureScript.Sugar.TypeClasses (typeClassMemberName, superClassDic
 import Language.PureScript.Types
 import Language.PureScript.PSString (mkString)
 import qualified Language.PureScript.AST as A
+import qualified Language.PureScript.Constants as C
 
 -- | Desugars a module from AST to CoreFn representation.
 moduleToCoreFn :: Environment -> A.Module -> Module Ann
@@ -85,6 +86,8 @@ moduleToCoreFn env (A.Module modSS coms mn decls (Just exps)) =
     internalError "Abs with Binder argument was not desugared before exprToCoreFn mn"
   exprToCoreFn ss com ty (A.App v1 v2) =
     App (ss, com, ty, Nothing) (exprToCoreFn ss [] Nothing v1) (exprToCoreFn ss [] Nothing v2)
+  exprToCoreFn ss com ty (A.Unused _) =
+    Var (ss, com, ty, Nothing) (Qualified (Just (ModuleName [ProperName C.prim])) (Ident C.undefined))
   exprToCoreFn _ com ty (A.Var ss ident) =
     Var (ss, com, ty, getValueMeta ident) ident
   exprToCoreFn ss com ty (A.IfThenElse v1 v2 v3) =

--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -4,6 +4,7 @@ module Language.PureScript.CoreImp.Optimizer.TCO (tco) where
 import Prelude.Compat
 
 import Data.Text (Text)
+import qualified Language.PureScript.Constants as C
 import Language.PureScript.CoreImp.AST
 import Language.PureScript.AST.SourcePos (SourceSpan)
 import Safe (headDef, tailSafe)
@@ -120,6 +121,9 @@ tco = everywhere convert where
     markDone ss = Assignment ss (Var ss tcoDone) (BooleanLiteral ss True)
 
     collectArgs :: [[AST]] -> AST -> [[AST]]
+    collectArgs acc (App _ fn []) =
+      -- count 0-argument applications as single-argument so we get the correct number of args
+      collectArgs ([Var Nothing C.undefined] : acc) fn
     collectArgs acc (App _ fn args') = collectArgs (args' : acc) fn
     collectArgs acc _ = acc
 

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -69,6 +69,8 @@ data TypeClassData = TypeClassData
   -- typeClassArguments and typeClassDependencies.
   , typeClassCoveringSets :: S.Set (S.Set Int)
   -- ^ A sets of arguments that can be used to infer all other arguments.
+  , typeClassIsEmpty :: Bool
+  -- ^ Whether or not dictionaries for this type class are necessarily empty.
   } deriving (Show, Generic)
 
 instance NFData TypeClassData
@@ -125,8 +127,9 @@ makeTypeClassData
   -> [(Ident, SourceType)]
   -> [SourceConstraint]
   -> [FunctionalDependency]
+  -> Bool
   -> TypeClassData
-makeTypeClassData args m s deps = TypeClassData args m s deps determinedArgs coveringSets
+makeTypeClassData args m s deps tcIsEmpty = TypeClassData args m s deps determinedArgs coveringSets tcIsEmpty
   where
     argumentIndicies = [0 .. length args - 1]
 
@@ -486,7 +489,7 @@ primTypeErrorTypes =
 primClasses :: M.Map (Qualified (ProperName 'ClassName)) TypeClassData
 primClasses =
   M.fromList
-    [ (primName "Partial", (makeTypeClassData [] [] [] []))
+    [ (primName "Partial", (makeTypeClassData [] [] [] [] True))
     ]
 
 -- | This contains all of the type classes from all Prim modules.
@@ -511,7 +514,7 @@ primRowClasses =
         [ FunctionalDependency [0, 1] [2]
         , FunctionalDependency [1, 2] [0]
         , FunctionalDependency [2, 0] [1]
-        ])
+        ] True)
 
     -- class Nub (original :: # Type) (nubbed :: # Type) | i -> o
     , (primSubName C.moduleRow "Nub", makeTypeClassData
@@ -519,13 +522,13 @@ primRowClasses =
         , ("nubbed", Just (kindRow kindType))
         ] [] []
         [ FunctionalDependency [0] [1]
-        ])
+        ] True)
 
     -- class Lacks (label :: Symbol) (row :: # Type)
     , (primSubName C.moduleRow "Lacks", makeTypeClassData
         [ ("label", Just kindSymbol)
         , ("row", Just (kindRow kindType))
-        ] [] [] [])
+        ] [] [] [] True)
 
     -- class RowCons (label :: Symbol) (a :: Type) (tail :: # Type) (row :: # Type) | label tail a -> row, label row -> tail a
     , (primSubName C.moduleRow "Cons", makeTypeClassData
@@ -536,7 +539,7 @@ primRowClasses =
         ] [] []
         [ FunctionalDependency [0, 1, 2] [3]
         , FunctionalDependency [0, 3] [1, 2]
-        ])
+        ] True)
     ]
 
 primRowListClasses :: M.Map (Qualified (ProperName 'ClassName)) TypeClassData
@@ -548,7 +551,7 @@ primRowListClasses =
         , ("list", Just kindRowList)
         ] [] []
         [ FunctionalDependency [0] [1]
-        ])
+        ] True)
     ]
 
 primSymbolClasses :: M.Map (Qualified (ProperName 'ClassName)) TypeClassData
@@ -563,7 +566,7 @@ primSymbolClasses =
         [ FunctionalDependency [0, 1] [2]
         , FunctionalDependency [1, 2] [0]
         , FunctionalDependency [2, 0] [1]
-        ])
+        ] True)
 
     -- class Compare (left :: Symbol) (right :: Symbol) (ordering :: Ordering) | left right -> ordering
     , (primSubName C.moduleSymbol "Compare", makeTypeClassData
@@ -572,7 +575,7 @@ primSymbolClasses =
         , ("ordering", Just kindOrdering)
         ] [] []
         [ FunctionalDependency [0, 1] [2]
-        ])
+        ] True)
 
     -- class Cons (head :: Symbol) (tail :: Symbol) (symbol :: Symbol) | head tail -> symbol, symbol -> head tail
     , (primSubName C.moduleSymbol "Cons", makeTypeClassData
@@ -582,7 +585,7 @@ primSymbolClasses =
         ] [] []
         [ FunctionalDependency [0, 1] [2]
         , FunctionalDependency [2] [0, 1]
-        ])
+        ] True)
     ]
 
 primTypeErrorClasses :: M.Map (Qualified (ProperName 'ClassName)) TypeClassData
@@ -590,11 +593,11 @@ primTypeErrorClasses =
   M.fromList
     -- class Fail (message :: Symbol)
     [ (primSubName C.typeError "Fail", makeTypeClassData
-        [("message", Just kindDoc)] [] [] [])
+        [("message", Just kindDoc)] [] [] [] True)
 
     -- class Warn (message :: Symbol)
     , (primSubName C.typeError "Warn", makeTypeClassData
-        [("message", Just kindDoc)] [] [] [])
+        [("message", Just kindDoc)] [] [] [] True)
     ]
 
 -- | Finds information about data constructors from the current environment.

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -132,6 +132,7 @@ data ExternsDeclaration =
       , edClassMembers            :: [(Ident, SourceType)]
       , edClassConstraints        :: [SourceConstraint]
       , edFunctionalDependencies  :: [FunctionalDependency]
+      , edIsEmpty                 :: Bool
       }
   -- | An instance declaration
   | EDInstance
@@ -157,7 +158,7 @@ applyExternsFileToEnvironment ExternsFile{..} = flip (foldl' applyDecl) efDeclar
   applyDecl env (EDTypeSynonym pn args ty) = env { typeSynonyms = M.insert (qual pn) (args, ty) (typeSynonyms env) }
   applyDecl env (EDDataConstructor pn dTy tNm ty nms) = env { dataConstructors = M.insert (qual pn) (dTy, tNm, ty, nms) (dataConstructors env) }
   applyDecl env (EDValue ident ty) = env { names = M.insert (Qualified (Just efModuleName) ident) (ty, External, Defined) (names env) }
-  applyDecl env (EDClass pn args members cs deps) = env { typeClasses = M.insert (qual pn) (makeTypeClassData args members cs deps) (typeClasses env) }
+  applyDecl env (EDClass pn args members cs deps tcIsEmpty) = env { typeClasses = M.insert (qual pn) (makeTypeClassData args members cs deps tcIsEmpty) (typeClasses env) }
   applyDecl env (EDKind pn) = env { kinds = S.insert (qual pn) (kinds env) }
   applyDecl env (EDInstance className ident tys cs ch idx) =
     env { typeClassDictionaries =
@@ -227,7 +228,7 @@ moduleToExternsFile (Module ss _ mn ds (Just exps)) env = ExternsFile{..}
     , Just (_, synTy) <- Qualified (Just mn) (coerceProperName className) `M.lookup` typeSynonyms env
     = [ EDType (coerceProperName className) kind TypeSynonym
       , EDTypeSynonym (coerceProperName className) typeClassArguments synTy
-      , EDClass className typeClassArguments typeClassMembers typeClassSuperclasses typeClassDependencies
+      , EDClass className typeClassArguments typeClassMembers typeClassSuperclasses typeClassDependencies typeClassIsEmpty
       ]
   toExternsDeclaration (TypeInstanceRef _ ident)
     = [ EDInstance tcdClassName ident tcdInstanceTypes tcdDependencies tcdChain tcdIndex

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -67,6 +67,7 @@ prettyPrintValue d (ObjectUpdateNested o ps) = prettyPrintValueAtom (d - 1) o `b
     printNode (key, Leaf val) = prettyPrintUpdateEntry d key val
     printNode (key, Branch val) = textT (prettyPrintObjectKey key) `beforeWithSpace` prettyPrintUpdate val
 prettyPrintValue d (App val arg) = prettyPrintValueAtom (d - 1) val `beforeWithSpace` prettyPrintValueAtom (d - 1) arg
+prettyPrintValue d (Unused val) = prettyPrintValue d val
 prettyPrintValue d (Abs arg val) = text ('\\' : T.unpack (prettyPrintBinder arg) ++ " -> ") // moveRight 2 (prettyPrintValue (d - 1) val)
 prettyPrintValue d (TypeClassDictionaryConstructorApp className ps) =
   text (T.unpack (runProperName (disqualify className)) ++ " ") <> prettyPrintValueAtom (d - 1) ps

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -64,8 +64,8 @@ desugarTypeClasses externs = flip evalStateT initialState . traverse desugarModu
     :: ModuleName
     -> ExternsDeclaration
     -> Maybe ((ModuleName, ProperName 'ClassName), TypeClassData)
-  fromExternsDecl mn (EDClass name args members implies deps) = Just ((mn, name), typeClass) where
-    typeClass = makeTypeClassData args members implies deps
+  fromExternsDecl mn (EDClass name args members implies deps tcIsEmpty) = Just ((mn, name), typeClass) where
+    typeClass = makeTypeClassData args members implies deps tcIsEmpty
   fromExternsDecl _ _ = Nothing
 
 desugarModule
@@ -203,7 +203,7 @@ desugarDecl
 desugarDecl mn exps = go
   where
   go d@(TypeClassDeclaration sa name args implies deps members) = do
-    modify (M.insert (mn, name) (makeTypeClassData args (map memberToNameAndType members) implies deps))
+    modify (M.insert (mn, name) (makeTypeClassData args (map memberToNameAndType members) implies deps False))
     return (Nothing, d : typeClassDictionaryDeclaration sa name args implies members : map (typeClassMemberToDictionaryAccessor mn name args) members)
   go (TypeInstanceDeclaration _ _ _ _ _ _ _ DerivedInstance) = internalError "Derived instanced should have been desugared"
   go d@(TypeInstanceDeclaration sa _ _ name deps className tys (ExplicitInstance members)) = do

--- a/tests/purs/passing/EmptyDicts.purs
+++ b/tests/purs/passing/EmptyDicts.purs
@@ -1,0 +1,77 @@
+-- |
+-- The purpose of this test is to make sure that the empty type class
+-- dictionary elimination code doesn't change semantics.
+module Main where
+
+import Prelude
+import Effect.Console (log)
+
+-- |
+-- Data type to check that the result of expressions with eliminated
+-- dictionaries are as expected.
+data Check = Check
+derive instance eqCheck :: Eq Check
+
+-- |
+-- This type class has no constraints and no members.
+-- Is is therefore considered empty.
+class EmptyClass
+instance emptyDictInst :: EmptyClass
+
+-- |
+-- This type class is not empty as it has members, but it has an empty super
+-- class.
+class EmptyClass <= HasEmptySuper where
+  hasEmptySuper :: Check
+instance hasEmptySuperInst :: HasEmptySuper where
+  hasEmptySuper = Check
+
+-- |
+-- This type class has no members, but has a non-empty super class.
+-- It is therefore not empty.
+class HasEmptySuper <= HasNonEmptySuper
+instance hasNonEmptySuperInst :: HasEmptySuper => HasNonEmptySuper
+
+-- |
+-- This type class is empty because all it's super classes are empty and it
+-- has no members.
+class EmptyClass <= AliasEmptyClass
+instance aliasEmptyClassInst :: AliasEmptyClass
+
+whenEmpty :: Check
+whenEmpty = Check :: EmptyClass => Check
+
+whenHasEmptySuper :: Check
+whenHasEmptySuper = Check :: HasEmptySuper => Check
+
+whenHasNonEmptySuper :: Check
+whenHasNonEmptySuper = Check :: HasNonEmptySuper => Check
+
+whenAliasEmptyClass :: Check
+whenAliasEmptyClass = Check :: AliasEmptyClass => Check
+
+class WithArgEmpty t
+instance withArgEmptyCheck :: WithArgEmpty Check
+class WithArgEmpty t <= WithArgHasEmptySuper t where
+  withArgHasEmptySuper :: t
+instance withArgHasEmptySuperCheck :: WithArgHasEmptySuper Check where
+  withArgHasEmptySuper = Check
+
+whenAccessingSuperDict :: Check
+whenAccessingSuperDict = foo Check where
+
+  bar :: forall t . WithArgEmpty t => t -> t
+  bar x = x
+
+  foo :: forall t . WithArgHasEmptySuper t => t -> t
+  foo x = bar x
+
+main =
+  if Check == whenEmpty &&
+     Check == whenHasEmptySuper &&
+     Check == whenHasNonEmptySuper &&
+     Check == whenAliasEmptyClass &&
+     Check == whenAccessingSuperDict
+    then log "Done"
+    else pure unit
+


### PR DESCRIPTION
Had a quick go at this.  I want to switch to `undefined` instead of `{}`, but so far it seems to work.  I want to test it on a lot more dictionary heavy code, though.
Fixes #2768 