### PR TITLE
MagicDo: Desugar ForE

### DIFF
--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -204,6 +204,15 @@ unit = "unit"
 
 -- Core lib values
 
+untilE :: forall a. (IsString a) => a
+untilE = "untilE"
+
+whileE :: forall a. (IsString a) => a
+whileE = "whileE"
+
+forE :: forall a. (IsString a) => a
+forE = "forE"
+
 runST :: forall a. (IsString a) => a
 runST = "run"
 

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -204,15 +204,6 @@ unit = "unit"
 
 -- Core lib values
 
-untilE :: forall a. (IsString a) => a
-untilE = "untilE"
-
-whileE :: forall a. (IsString a) => a
-whileE = "whileE"
-
-forE :: forall a. (IsString a) => a
-forE = "forE"
-
 runST :: forall a. (IsString a) => a
 runST = "run"
 
@@ -262,6 +253,7 @@ data EffectDictionaries = EffectDictionaries
   , edMonadDict :: PSString
   , edWhile :: PSString
   , edUntil :: PSString
+  , edFor :: PSString
   }
 
 effDictionaries :: EffectDictionaries
@@ -271,6 +263,7 @@ effDictionaries = EffectDictionaries
   , edMonadDict = "monadEff"
   , edWhile = "whileE"
   , edUntil = "untilE"
+  , edFor = "forE"
   }
 
 effectDictionaries :: EffectDictionaries
@@ -280,6 +273,7 @@ effectDictionaries = EffectDictionaries
   , edMonadDict = "monadEffect"
   , edWhile = "whileE"
   , edUntil = "untilE"
+  , edFor = "forE"
   }
 
 stDictionaries :: EffectDictionaries
@@ -289,6 +283,7 @@ stDictionaries = EffectDictionaries
   , edMonadDict = "monadST"
   , edWhile = "while"
   , edUntil = "until"
+  , edFor = "for"
   }
 
 discardUnitDictionary :: forall a. (IsString a) => a

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -56,10 +56,22 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (Unary s1 Not (App s1 arg [])) (Block s1 []), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar whileE
   convert (App _ (App _ (App s1 f [arg1]) [arg2]) []) | isEffFunc edWhile f =
-    App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
+    App s1 (Function s1 Nothing []
+            (Block s1 [
+              While s1 (App s1 arg1 [])
+                    (Block s1 [ App s1 arg2 [] ]),
+                    Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
-  convert (App _ (App _ (App _ (App s1 f [loArg]) [hiArg]) [intToEff]) []) | isEffFunc C.forE f =
-    App s1 (Function s1 Nothing [] (Block s1 [ VariableIntroduction s1 lo (Just loArg), VariableIntroduction s1 hi (Just hiArg), VariableIntroduction s1 fn (Just intToEff), For s1 counter (Var s1 lo) (Var s1 hi) (Block s1 [App s1 (App s1 (Var s1 fn) [Var s1 counter]) []]), Return s1 $ ObjectLiteral s1 []])) []
+  convert (App _ (App _ (App _ (App s1 f [loArg]) [hiArg]) [intToEff]) [])
+    | isEffFunc C.forE f =
+        App s1 (Function s1 Nothing []
+                 (Block s1 [
+                   VariableIntroduction s1 lo (Just loArg),
+                   VariableIntroduction s1 hi (Just hiArg),
+                   VariableIntroduction s1 fn (Just intToEff),
+                   For s1 counter (Var s1 lo) (Var s1 hi)
+                       (Block s1 [App s1 (App s1 (Var s1 fn) [Var s1 counter]) []]),
+                   Return s1 $ ObjectLiteral s1 []])) []
     where
     counter = "$__i"
     lo = "$__lo"

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -58,10 +58,12 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
   convert (App _ (App _ (App s1 f [arg1]) [arg2]) []) | isEffFunc edWhile f =
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
-  convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
-    App s1 (Function s1 Nothing [] (Block s1 [ VariableIntroduction s1 fn (Just intToEff), For s1 counter lo hi (Block s1 [App s1 (App s1 (Var s1 fn) [Var s1 counter]) []]), Return s1 $ ObjectLiteral s1 []])) []
+  convert (App _ (App _ (App _ (App s1 f [loArg]) [hiArg]) [intToEff]) []) | isEffFunc C.forE f =
+    App s1 (Function s1 Nothing [] (Block s1 [ VariableIntroduction s1 lo (Just loArg), VariableIntroduction s1 hi (Just hiArg), VariableIntroduction s1 fn (Just intToEff), For s1 counter (Var s1 lo) (Var s1 hi) (Block s1 [App s1 (App s1 (Var s1 fn) [Var s1 counter]) []]), Return s1 $ ObjectLiteral s1 []])) []
     where
     counter = "$__i"
+    lo = "$__lo"
+    hi = "$__hi"
     fn = "$__f"
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -59,7 +59,8 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
   convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
-    App s1 (Function s1 Nothing [] (Block s1 [ For s1 "i" lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 "i"]) [])]), Return s1 $ ObjectLiteral s1 []])) []
+    App s1 (Function s1 Nothing [] (Block s1 [ For s1 counter lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 counter]) [])]), Return s1 $ ObjectLiteral s1 []])) []
+    where counter = "$__i"
   -- Note: Desugaring forEachE requires a modification to the AST of "For" to allow
   -- hoisting of the array length.
   -- Inline __do returns

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -61,8 +61,6 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
   convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
     App s1 (Function s1 Nothing [] (Block s1 [ For s1 counter lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 counter]) [])]), Return s1 $ ObjectLiteral s1 []])) []
     where counter = "$__i"
-  -- Note: Desugaring forEachE requires a modification to the AST of "For" to allow
-  -- hoisting of the array length.
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body
   -- Inline double applications

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -59,7 +59,7 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
   convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
-    App s1 (Function s1 Nothing [] (Block s1 [ For s1 counter lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 counter]) [])]), Return s1 $ ObjectLiteral s1 []])) []
+    App s1 (Function s1 Nothing [] (Block s1 [ For s1 counter lo hi (Block s1 [App s1 (App s1 intToEff [Var s1 counter]) []]), Return s1 $ ObjectLiteral s1 []])) []
     where counter = "$__i"
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -59,7 +59,7 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
   convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
-    App s1 (Function s1 Nothing [] (Block s1 [ For s1 "i" lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 "i"]) []), Return s1 $ ObjectLiteral s1 []])])) []
+    App s1 (Function s1 Nothing [] (Block s1 [ For s1 "i" lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 "i"]) [])]), Return s1 $ ObjectLiteral s1 []])) []
   -- Note: Desugaring forEachE requires a modification to the AST of "For" to allow
   -- hoisting of the array length.
   -- Inline __do returns

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -57,6 +57,9 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
   -- Desugar whileE
   convert (App _ (App _ (App s1 f [arg1]) [arg2]) []) | isEffFunc edWhile f =
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
+  -- Desugar forE
+  convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
+    App s1 (Function s1 Nothing [] (Block s1 [ For s1 "i" lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 "i"]) []), Return s1 $ ObjectLiteral s1 []])])) []
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body
   -- Inline double applications

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -63,7 +63,7 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
                     Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
   convert (App _ (App _ (App _ (App s1 f [loArg]) [hiArg]) [intToEff]) [])
-    | isEffFunc C.forE f =
+    | isEffFunc edFor f =
         App s1 (Function s1 Nothing []
                  (Block s1 [
                    VariableIntroduction s1 lo (Just loArg),

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -60,6 +60,8 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
   -- Desugar forE
   convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
     App s1 (Function s1 Nothing [] (Block s1 [ For s1 "i" lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 "i"]) []), Return s1 $ ObjectLiteral s1 []])])) []
+  -- Note: Desugaring forEachE requires a modification to the AST of "For" to allow
+  -- hoisting of the array length.
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body
   -- Inline double applications

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -59,8 +59,10 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
   convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
-    App s1 (Function s1 Nothing [] (Block s1 [ For s1 counter lo hi (Block s1 [App s1 (App s1 intToEff [Var s1 counter]) []]), Return s1 $ ObjectLiteral s1 []])) []
-    where counter = "$__i"
+    App s1 (Function s1 Nothing [] (Block s1 [ VariableIntroduction s1 fn (Just intToEff), For s1 counter lo hi (Block s1 [App s1 (App s1 (Var s1 fn) [Var s1 counter]) []]), Return s1 $ ObjectLiteral s1 []])) []
+    where
+    counter = "$__i"
+    fn = "$__f"
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body
   -- Inline double applications


### PR DESCRIPTION
The "MagicDo" `CoreImp` optimization currently desugars `Purescript.Effect`'s `untilE` and `whileE` loops. This PR adds desugaring for `forE`.

I also add a note regarding desugaring of `foreachE`: I could augment this PR with support for it, but it would require a change to the `CoreImp` AST to allow for initialization of multiple variables in `For`'s initialization expression. Happy to go ahead with this, or make a separate PR for it, if it is agreed to be a permissible change.