### PR TITLE
MagicDo: desugar foreachE

### DIFF
--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -204,6 +204,15 @@ unit = "unit"
 
 -- Core lib values
 
+untilE :: forall a. (IsString a) => a
+untilE = "untilE"
+
+whileE :: forall a. (IsString a) => a
+whileE = "whileE"
+
+forE :: forall a. (IsString a) => a
+forE = "forE"
+
 runST :: forall a. (IsString a) => a
 runST = "run"
 

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -204,9 +204,6 @@ unit = "unit"
 
 -- Core lib values
 
-foreachE :: forall a. (IsString a) => a
-foreachE = "foreachE"
-
 runST :: forall a. (IsString a) => a
 runST = "run"
 
@@ -257,6 +254,7 @@ data EffectDictionaries = EffectDictionaries
   , edWhile :: PSString
   , edUntil :: PSString
   , edFor :: PSString
+  , edForeach :: PSString
   }
 
 effDictionaries :: EffectDictionaries
@@ -267,6 +265,7 @@ effDictionaries = EffectDictionaries
   , edWhile = "whileE"
   , edUntil = "untilE"
   , edFor = "forE"
+  , edForeach = "foreachE"
   }
 
 effectDictionaries :: EffectDictionaries
@@ -277,6 +276,7 @@ effectDictionaries = EffectDictionaries
   , edWhile = "whileE"
   , edUntil = "untilE"
   , edFor = "forE"
+  , edForeach = "foreachE"
   }
 
 stDictionaries :: EffectDictionaries
@@ -287,6 +287,7 @@ stDictionaries = EffectDictionaries
   , edWhile = "while"
   , edUntil = "until"
   , edFor = "for"
+  , edForeach = "foreach"
   }
 
 discardUnitDictionary :: forall a. (IsString a) => a

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -204,15 +204,6 @@ unit = "unit"
 
 -- Core lib values
 
-untilE :: forall a. (IsString a) => a
-untilE = "untilE"
-
-whileE :: forall a. (IsString a) => a
-whileE = "whileE"
-
-forE :: forall a. (IsString a) => a
-forE = "forE"
-
 runST :: forall a. (IsString a) => a
 runST = "run"
 
@@ -262,6 +253,7 @@ data EffectDictionaries = EffectDictionaries
   , edMonadDict :: PSString
   , edWhile :: PSString
   , edUntil :: PSString
+  , edFor :: PSString
   }
 
 effDictionaries :: EffectDictionaries
@@ -271,6 +263,7 @@ effDictionaries = EffectDictionaries
   , edMonadDict = "monadEff"
   , edWhile = "whileE"
   , edUntil = "untilE"
+  , edFor = "forE"
   }
 
 effectDictionaries :: EffectDictionaries
@@ -280,6 +273,7 @@ effectDictionaries = EffectDictionaries
   , edMonadDict = "monadEffect"
   , edWhile = "whileE"
   , edUntil = "untilE"
+  , edFor = "forE"
   }
 
 stDictionaries :: EffectDictionaries
@@ -289,6 +283,7 @@ stDictionaries = EffectDictionaries
   , edMonadDict = "monadST"
   , edWhile = "while"
   , edUntil = "until"
+  , edFor = "for"
   }
 
 discardUnitDictionary :: forall a. (IsString a) => a

--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -204,6 +204,9 @@ unit = "unit"
 
 -- Core lib values
 
+foreachE :: forall a. (IsString a) => a
+foreachE = "foreachE"
+
 runST :: forall a. (IsString a) => a
 runST = "run"
 

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -79,7 +79,7 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     fn = "$__f"
   -- Desugar foreachE
   convert (App _ (App _ (App s1 f [asArg]) [aToEff]) [])
-    | isEffFunc C.foreachE f =
+    | isEffFunc edForeach f =
     App s1 (Function s1 Nothing []
              (Block s1 [
                VariableIntroduction s1 as (Just asArg),

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -56,10 +56,22 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (Unary s1 Not (App s1 arg [])) (Block s1 []), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar whileE
   convert (App _ (App _ (App s1 f [arg1]) [arg2]) []) | isEffFunc edWhile f =
-    App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
+    App s1 (Function s1 Nothing []
+            (Block s1 [
+              While s1 (App s1 arg1 [])
+                    (Block s1 [ App s1 arg2 [] ]),
+                    Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
-  convert (App _ (App _ (App _ (App s1 f [loArg]) [hiArg]) [intToEff]) []) | isEffFunc C.forE f =
-    App s1 (Function s1 Nothing [] (Block s1 [ VariableIntroduction s1 lo (Just loArg), VariableIntroduction s1 hi (Just hiArg), VariableIntroduction s1 fn (Just intToEff), For s1 counter (Var s1 lo) (Var s1 hi) (Block s1 [App s1 (App s1 (Var s1 fn) [Var s1 counter]) []]), Return s1 $ ObjectLiteral s1 []])) []
+  convert (App _ (App _ (App _ (App s1 f [loArg]) [hiArg]) [intToEff]) [])
+    | isEffFunc C.forE f =
+        App s1 (Function s1 Nothing []
+                 (Block s1 [
+                   VariableIntroduction s1 lo (Just loArg),
+                   VariableIntroduction s1 hi (Just hiArg),
+                   VariableIntroduction s1 fn (Just intToEff),
+                   For s1 counter (Var s1 lo) (Var s1 hi)
+                       (Block s1 [App s1 (App s1 (Var s1 fn) [Var s1 counter]) []]),
+                   Return s1 $ ObjectLiteral s1 []])) []
     where
     counter = "$__i"
     lo = "$__lo"

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -78,12 +78,14 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     hi = "$__hi"
     fn = "$__f"
   -- Desugar foreachE
-  convert (App _ (App _ (App s1 f [as]) [aToEff]) []) | isEffFunc C.foreachE f =
-    App s1 (Function s1 Nothing [] (Block s1 [VariableIntroduction s1 fn (Just aToEff), VariableIntroduction s1 len Nothing, Assignment s1 (Var s1 len) (Indexer s1 (StringLiteral s1 "length") as), For s1 counter (NumericLiteral s1 $ Left 0) (Var s1 len) (Block s1 [App s1 (App s1 (Var s1 fn) [Indexer s1 (Var s1 counter) as]) []]), Return s1 $ ObjectLiteral s1 []])) []
+  convert (App _ (App _ (App s1 f [asArg]) [aToEff]) []) | isEffFunc C.foreachE f =
+    App s1 (Function s1 Nothing [] (Block s1 [VariableIntroduction s1 as (Just asArg), VariableIntroduction s1 fn (Just aToEff), VariableIntroduction s1 len Nothing, Assignment s1 (Var s1 len) (Indexer s1 (StringLiteral s1 "length") asVar), For s1 counter (NumericLiteral s1 $ Left 0) (Var s1 len) (Block s1 [App s1 (App s1 (Var s1 fn) [Indexer s1 (Var s1 counter) asVar]) []]), Return s1 $ ObjectLiteral s1 []])) []
     where
     counter = "$__i"
     fn = "$__f"
     len = "$__l"
+    as = "$__as"
+    asVar = Var s1 as
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body
   -- Inline double applications

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -58,10 +58,12 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
   convert (App _ (App _ (App s1 f [arg1]) [arg2]) []) | isEffFunc edWhile f =
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
-  convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
-    App s1 (Function s1 Nothing [] (Block s1 [ VariableIntroduction s1 fn (Just intToEff), For s1 counter lo hi (Block s1 [App s1 (App s1 (Var s1 fn) [Var s1 counter]) []]), Return s1 $ ObjectLiteral s1 []])) []
+  convert (App _ (App _ (App _ (App s1 f [loArg]) [hiArg]) [intToEff]) []) | isEffFunc C.forE f =
+    App s1 (Function s1 Nothing [] (Block s1 [ VariableIntroduction s1 lo (Just loArg), VariableIntroduction s1 hi (Just hiArg), VariableIntroduction s1 fn (Just intToEff), For s1 counter (Var s1 lo) (Var s1 hi) (Block s1 [App s1 (App s1 (Var s1 fn) [Var s1 counter]) []]), Return s1 $ ObjectLiteral s1 []])) []
     where
     counter = "$__i"
+    lo = "$__lo"
+    hi = "$__hi"
     fn = "$__f"
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -59,7 +59,8 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
   convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
-    App s1 (Function s1 Nothing [] (Block s1 [ For s1 "i" lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 "i"]) [])]), Return s1 $ ObjectLiteral s1 []])) []
+    App s1 (Function s1 Nothing [] (Block s1 [ For s1 counter lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 counter]) [])]), Return s1 $ ObjectLiteral s1 []])) []
+    where counter = "$__i"
   -- Note: Desugaring forEachE requires a modification to the AST of "For" to allow
   -- hoisting of the array length.
   -- Inline __do returns

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -61,8 +61,6 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
   convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
     App s1 (Function s1 Nothing [] (Block s1 [ For s1 counter lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 counter]) [])]), Return s1 $ ObjectLiteral s1 []])) []
     where counter = "$__i"
-  -- Note: Desugaring forEachE requires a modification to the AST of "For" to allow
-  -- hoisting of the array length.
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body
   -- Inline double applications

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -79,11 +79,10 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     fn = "$__f"
   -- Desugar foreachE
   convert (App _ (App _ (App s1 f [as]) [aToEff]) []) | isEffFunc C.foreachE f =
-    App s1 (Function s1 Nothing [] (Block s1 [VariableIntroduction s1 len Nothing, Assignment s1 (Var s1 len) (Indexer s1 (Var s1 "length") as), For s1 counter (NumericLiteral s1 $ Left 0) (Var s1 len) (Block s1 [App s1 (App s1 aToEff [Indexer s1 (Var s1 counter) as]) []]), Return s1 $ ObjectLiteral s1 []])) []
+    App s1 (Function s1 Nothing [] (Block s1 [VariableIntroduction s1 len Nothing, Assignment s1 (Var s1 len) (Indexer s1 (StringLiteral s1 "length") as), For s1 counter (NumericLiteral s1 $ Left 0) (Var s1 len) (Block s1 [App s1 (App s1 aToEff [Indexer s1 (Var s1 counter) as]) []]), Return s1 $ ObjectLiteral s1 []])) []
     where
     counter = "$__i"
     len = "$__l"
->>>>>>> MagicDo: desugar foreachE
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body
   -- Inline double applications

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -59,7 +59,7 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
   convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
-    App s1 (Function s1 Nothing [] (Block s1 [ For s1 counter lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 counter]) [])]), Return s1 $ ObjectLiteral s1 []])) []
+    App s1 (Function s1 Nothing [] (Block s1 [ For s1 counter lo hi (Block s1 [App s1 (App s1 intToEff [Var s1 counter]) []]), Return s1 $ ObjectLiteral s1 []])) []
     where counter = "$__i"
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -77,6 +77,13 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     lo = "$__lo"
     hi = "$__hi"
     fn = "$__f"
+  -- Desugar foreachE
+  convert (App _ (App _ (App s1 f [as]) [aToEff]) []) | isEffFunc C.foreachE f =
+    App s1 (Function s1 Nothing [] (Block s1 [VariableIntroduction s1 len Nothing, Assignment s1 (Var s1 len) (Indexer s1 (Var s1 "length") as), For s1 counter (NumericLiteral s1 $ Left 0) (Var s1 len) (Block s1 [App s1 (App s1 aToEff [Indexer s1 (Var s1 counter) as]) []]), Return s1 $ ObjectLiteral s1 []])) []
+    where
+    counter = "$__i"
+    len = "$__l"
+>>>>>>> MagicDo: desugar foreachE
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body
   -- Inline double applications

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -59,7 +59,7 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
   convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
-    App s1 (Function s1 Nothing [] (Block s1 [ For s1 "i" lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 "i"]) []), Return s1 $ ObjectLiteral s1 []])])) []
+    App s1 (Function s1 Nothing [] (Block s1 [ For s1 "i" lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 "i"]) [])]), Return s1 $ ObjectLiteral s1 []])) []
   -- Note: Desugaring forEachE requires a modification to the AST of "For" to allow
   -- hoisting of the array length.
   -- Inline __do returns

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -57,6 +57,9 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
   -- Desugar whileE
   convert (App _ (App _ (App s1 f [arg1]) [arg2]) []) | isEffFunc edWhile f =
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
+  -- Desugar forE
+  convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
+    App s1 (Function s1 Nothing [] (Block s1 [ For s1 "i" lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 "i"]) []), Return s1 $ ObjectLiteral s1 []])])) []
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body
   -- Inline double applications

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -63,7 +63,7 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
                     Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
   convert (App _ (App _ (App _ (App s1 f [loArg]) [hiArg]) [intToEff]) [])
-    | isEffFunc C.forE f =
+    | isEffFunc edFor f =
         App s1 (Function s1 Nothing []
                  (Block s1 [
                    VariableIntroduction s1 lo (Just loArg),

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -60,6 +60,8 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
   -- Desugar forE
   convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
     App s1 (Function s1 Nothing [] (Block s1 [ For s1 "i" lo hi (Block s1 [(App s1 (App s1 intToEff [Var s1 "i"]) []), Return s1 $ ObjectLiteral s1 []])])) []
+  -- Note: Desugaring forEachE requires a modification to the AST of "For" to allow
+  -- hoisting of the array length.
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body
   -- Inline double applications

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -78,8 +78,17 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     hi = "$__hi"
     fn = "$__f"
   -- Desugar foreachE
-  convert (App _ (App _ (App s1 f [asArg]) [aToEff]) []) | isEffFunc C.foreachE f =
-    App s1 (Function s1 Nothing [] (Block s1 [VariableIntroduction s1 as (Just asArg), VariableIntroduction s1 fn (Just aToEff), VariableIntroduction s1 len Nothing, Assignment s1 (Var s1 len) (Indexer s1 (StringLiteral s1 "length") asVar), For s1 counter (NumericLiteral s1 $ Left 0) (Var s1 len) (Block s1 [App s1 (App s1 (Var s1 fn) [Indexer s1 (Var s1 counter) asVar]) []]), Return s1 $ ObjectLiteral s1 []])) []
+  convert (App _ (App _ (App s1 f [asArg]) [aToEff]) [])
+    | isEffFunc C.foreachE f =
+    App s1 (Function s1 Nothing []
+             (Block s1 [
+               VariableIntroduction s1 as (Just asArg),
+               VariableIntroduction s1 fn (Just aToEff),
+               VariableIntroduction s1 len Nothing,
+               Assignment s1 (Var s1 len) (Indexer s1 (StringLiteral s1 "length") asVar),
+               For s1 counter (NumericLiteral s1 $ Left 0) (Var s1 len)
+                   (Block s1 [App s1 (App s1 (Var s1 fn) [Indexer s1 (Var s1 counter) asVar]) []]),
+               Return s1 $ ObjectLiteral s1 []])) []
     where
     counter = "$__i"
     fn = "$__f"

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -79,9 +79,10 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     fn = "$__f"
   -- Desugar foreachE
   convert (App _ (App _ (App s1 f [as]) [aToEff]) []) | isEffFunc C.foreachE f =
-    App s1 (Function s1 Nothing [] (Block s1 [VariableIntroduction s1 len Nothing, Assignment s1 (Var s1 len) (Indexer s1 (StringLiteral s1 "length") as), For s1 counter (NumericLiteral s1 $ Left 0) (Var s1 len) (Block s1 [App s1 (App s1 aToEff [Indexer s1 (Var s1 counter) as]) []]), Return s1 $ ObjectLiteral s1 []])) []
+    App s1 (Function s1 Nothing [] (Block s1 [VariableIntroduction s1 fn (Just aToEff), VariableIntroduction s1 len Nothing, Assignment s1 (Var s1 len) (Indexer s1 (StringLiteral s1 "length") as), For s1 counter (NumericLiteral s1 $ Left 0) (Var s1 len) (Block s1 [App s1 (App s1 (Var s1 fn) [Indexer s1 (Var s1 counter) as]) []]), Return s1 $ ObjectLiteral s1 []])) []
     where
     counter = "$__i"
+    fn = "$__f"
     len = "$__l"
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -59,8 +59,10 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar forE
   convert (App _ (App _ (App _ (App s1 f [lo]) [hi]) [intToEff]) []) | isEffFunc C.forE f =
-    App s1 (Function s1 Nothing [] (Block s1 [ For s1 counter lo hi (Block s1 [App s1 (App s1 intToEff [Var s1 counter]) []]), Return s1 $ ObjectLiteral s1 []])) []
-    where counter = "$__i"
+    App s1 (Function s1 Nothing [] (Block s1 [ VariableIntroduction s1 fn (Just intToEff), For s1 counter lo hi (Block s1 [App s1 (App s1 (Var s1 fn) [Var s1 counter]) []]), Return s1 $ ObjectLiteral s1 []])) []
+    where
+    counter = "$__i"
+    fn = "$__f"
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body
   -- Inline double applications


### PR DESCRIPTION
This is a successor to https://github.com/purescript/purescript/pull/3419 and is based off it.

In the same spirit, this desugars `foreachE`, completing desugaring of `Effect`'s looping constructs.

I was able to do this without altering the `CoreImp` AST for `For`. I initialize the length variable outside of the loop. Because this happens within a block/IIFE, it is safe. As noted in the source, separation of variable introduction from assignment is done to prevent over-aggressive inlining.

### Source
```purescript
main = do
  let nums = [0, 1, 2, 3, 4]
  foreachE nums logShow
  logShow "done"
```

### Compiled before
```javascript
var main = (function () {
    var nums = [ 0, 1, 2, 3, 4 ];
    return function __do() {
        Effect.foreachE(nums)(Effect_Console.logShow(Data_Show.showInt))();
        return Effect_Console.logShow(Data_Show.showString)("done")();
    };
})();
```

### Compiled after

```javascript
var main = (function () {
    var nums = [ 0, 1, 2, 3, 4 ];
    return function __do() {
        (function () {
            var $__l;
            $__l = nums[length];
            for (var $__i = 0; $__i < $__l; $__i++) {
                Effect_Console.logShow(Data_Show.showInt)(nums[$__i])();
            };
            return {};
        })();
        return Effect_Console.logShow(Data_Show.showString)("done")();
    };
})();
```