### PR TITLE
Avoid Data.ByteString.Lazy.toStrict

### DIFF
--- a/app/Command/Bundle.hs
+++ b/app/Command/Bundle.hs
@@ -20,8 +20,7 @@ import           System.Exit (exitFailure)
 import           System.IO (stderr, hPutStr, hPutStrLn)
 import           System.IO.UTF8 (readUTF8File, writeUTF8File)
 import           System.Directory (createDirectoryIfMissing, getCurrentDirectory)
-import qualified Data.ByteString.Lazy as B
-import qualified Data.ByteString.UTF8 as BU8
+import qualified Data.ByteString.Lazy.UTF8 as LBU8
 import           Language.PureScript.Bundle
 import           Options.Applicative (Parser)
 import qualified Options.Applicative as Opts
@@ -123,6 +122,6 @@ command = run <$> (Opts.helper <*> options) where
             case sourcemap of
               Just sm -> do
                 writeUTF8File outputFile $ js ++ "\n//# sourceMappingURL=" ++ (takeFileName outputFile <.> "map") ++ "\n"
-                writeUTF8File (outputFile <.> "map") $ BU8.toString . B.toStrict . encode $ generate sm
+                writeUTF8File (outputFile <.> "map") $ LBU8.toString . encode $ generate sm
               Nothing -> writeUTF8File outputFile js
           Nothing -> putStrLn js

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -10,8 +10,7 @@ import           Control.Applicative
 import           Control.Monad
 import qualified Data.Aeson as A
 import           Data.Bool (bool)
-import qualified Data.ByteString.Lazy as B
-import qualified Data.ByteString.UTF8 as BU8
+import qualified Data.ByteString.Lazy.UTF8 as LBU8
 import           Data.List (intercalate)
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -51,7 +50,7 @@ printWarningsAndErrors verbose False warnings errors = do
       exitFailure
     Right _ -> return ()
 printWarningsAndErrors verbose True warnings errors = do
-  hPutStrLn stderr . BU8.toString . B.toStrict . A.encode $
+  hPutStrLn stderr . LBU8.toString . A.encode $
     JSONResult (toJSONErrors verbose P.Warning warnings)
                (either (toJSONErrors verbose P.Error) (const []) errors)
   either (const exitFailure) (const (return ())) errors

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -18,7 +18,7 @@ import           Control.Monad.Writer.Class (MonadWriter(..))
 import           Data.Aeson (encode)
 import qualified Data.ByteString.Lazy as B
 import qualified Data.ByteString.Lazy as LB
-import qualified Data.ByteString.UTF8 as BU8
+import qualified Data.ByteString.Lazy.UTF8 as LBU8
 import           Data.Either (partitionEithers)
 import           Data.Foldable (for_, minimum)
 import qualified Data.List.NonEmpty as NEL
@@ -229,7 +229,7 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
 checkForeignDecls :: CF.Module ann -> FilePath -> SupplyT Make ()
 checkForeignDecls m path = do
   jsStr <- lift $ readTextFile path
-  js <- either (errorParsingModule . Bundle.UnableToParseModule) pure $ JS.parse (BU8.toString (B.toStrict jsStr)) path
+  js <- either (errorParsingModule . Bundle.UnableToParseModule) pure $ JS.parse (LBU8.toString jsStr) path
 
   foreignIdentsStrs <- either errorParsingModule pure $ getExps js
   foreignIdents <- either


### PR DESCRIPTION
Rather small PR, which removes `toStrict` in favor of using `Data.ByteString.Lazy.UTF8` module.