### PR TITLE
Add nix config to stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,3 +2,7 @@ resolver: lts-12.0
 packages:
 - '.'
 extra-deps:
+nix:
+  enable: false
+  packages:
+  - zlib


### PR DESCRIPTION
The missing `zlib` dependency made stack build fail on NixOS