### PR TITLE
Fixes #3388

### DIFF
--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -132,7 +132,7 @@ everywhereOnValuesTopDownM f g h = (f' <=< f, g' <=< g, h' <=< h)
   f' (BindingGroupDeclaration ds) = BindingGroupDeclaration <$> traverse (\(name, nameKind, val) -> (,,) name nameKind <$> (g val >>= g')) ds
   f' (TypeClassDeclaration sa name args implies deps ds) = TypeClassDeclaration sa name args implies deps <$> traverse (f' <=< f) ds
   f' (TypeInstanceDeclaration sa ch idx name cs className args ds) = TypeInstanceDeclaration sa ch idx name cs className args <$> traverseTypeInstanceBody (traverse (f' <=< f)) ds
-  f' (BoundValueDeclaration sa b expr) = BoundValueDeclaration sa <$> h' b <*> g' expr
+  f' (BoundValueDeclaration sa b expr) = BoundValueDeclaration sa <$> (h' <=< h) b <*> (g' <=< g) expr
   f' other = f other
 
   g' :: Expr -> m Expr

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -59,11 +59,11 @@ desugar
   -> m [Module]
 desugar externs =
   map desugarSignedLiterals
-    >>> traverse desugarDoModule
-    >=> traverse desugarAdoModule
-    >=> traverse desugarCasesModule
-    >=> map desugarLetPatternModule
     >>> traverse desugarObjectConstructors
+    >=> traverse desugarDoModule
+    >=> traverse desugarAdoModule
+    >=> map desugarLetPatternModule
+    >>> traverse desugarCasesModule
     >=> traverse desugarTypeDeclarationsModule
     >=> desugarImports externs
     >=> rebracket externs

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -59,11 +59,11 @@ desugar
   -> m [Module]
 desugar externs =
   map desugarSignedLiterals
-    >>> traverse desugarObjectConstructors
-    >=> traverse desugarDoModule
+    >>> traverse desugarDoModule
     >=> traverse desugarAdoModule
+    >=> traverse desugarCasesModule
     >=> map desugarLetPatternModule
-    >>> traverse desugarCasesModule
+    >>> traverse desugarObjectConstructors
     >=> traverse desugarTypeDeclarationsModule
     >=> desugarImports externs
     >=> rebracket externs

--- a/tests/purs/passing/3388.purs
+++ b/tests/purs/passing/3388.purs
@@ -1,0 +1,10 @@
+module Main where
+
+import Prelude
+import Effect.Console (log)
+
+main = do
+  let
+    x = { a: 42, b: "foo" }
+    { a, b } = x { a = 43 }
+  log "Done"


### PR DESCRIPTION
Rearranges desugaring phases to avoid leaking `ObjectNestedUpdate`.

To be honest, I'm not sure exactly why this fixes it, but desugaring appears to be sensitive to this ordering. `ObjectNestedUpdate` is supposed to be erased by `desugarObjectConstructors`, yet somehow it was leaking all the way through to type checking when paired with `BoundValueDeclaration`. I thought that maybe `everywhereOnValuesTopDownM` might have an error, resulting in a missed case, but at a cursory glance it seemed OK. I found that desugaring cases/letpattern before object constructors works. I'd like to know what thoughts y'all have on this issue, and if you have a hunch for a better fix.