### PR TITLE
Add source spans to desugared do blocks

### DIFF
--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -25,46 +25,47 @@ desugarDoModule (Module ss coms mn ds exts) = Module ss coms mn <$> parU ds desu
 -- | Desugar a single do statement
 desugarDo :: forall m. (MonadSupply m, MonadError MultipleErrors m) => Declaration -> m Declaration
 desugarDo d =
-  let (f, _, _) = everywhereOnValuesM return replace return
-  in rethrowWithPosition (declSourceSpan d) $ f d
+  let ss = declSourceSpan d
+      (f, _, _) = everywhereOnValuesM return (replace ss) return
+  in rethrowWithPosition ss $ f d
   where
-  bind :: Expr
-  bind = Var nullSourceSpan (Qualified Nothing (Ident C.bind))
+  bind :: SourceSpan -> Expr
+  bind = flip Var (Qualified Nothing (Ident C.bind))
 
-  discard :: Expr
-  discard = Var nullSourceSpan (Qualified Nothing (Ident C.discard))
+  discard :: SourceSpan -> Expr
+  discard = flip Var (Qualified Nothing (Ident C.discard))
 
-  replace :: Expr -> m Expr
-  replace (Do els) = go els
-  replace (PositionedValue pos com v) = PositionedValue pos com <$> rethrowWithPosition pos (replace v)
-  replace other = return other
+  replace :: SourceSpan -> Expr -> m Expr
+  replace pos (Do els) = go pos els
+  replace _ (PositionedValue pos com v) = PositionedValue pos com <$> rethrowWithPosition pos (replace pos v)
+  replace _ other = return other
 
-  go :: [DoNotationElement] -> m Expr
-  go [] = internalError "The impossible happened in desugarDo"
-  go [DoNotationValue val] = return val
-  go (DoNotationValue val : rest) = do
-    rest' <- go rest
-    return $ App (App discard val) (Abs (VarBinder nullSourceSpan UnusedIdent) rest')
-  go [DoNotationBind _ _] = throwError . errorMessage $ InvalidDoBind
-  go (DoNotationBind b _ : _) | First (Just ident) <- foldMap fromIdent (binderNames b) =
+  go :: SourceSpan -> [DoNotationElement] -> m Expr
+  go _ [] = internalError "The impossible happened in desugarDo"
+  go _ [DoNotationValue val] = return val
+  go pos (DoNotationValue val : rest) = do
+    rest' <- go pos rest
+    return $ App (App (discard pos) val) (Abs (VarBinder pos UnusedIdent) rest')
+  go _ [DoNotationBind _ _] = throwError . errorMessage $ InvalidDoBind
+  go _ (DoNotationBind b _ : _) | First (Just ident) <- foldMap fromIdent (binderNames b) =
       throwError . errorMessage $ CannotUseBindWithDo (Ident ident)
     where
       fromIdent (Ident i) | i `elem` [ C.bind, C.discard ] = First (Just i)
       fromIdent _ = mempty
-  go (DoNotationBind (VarBinder ss ident) val : rest) = do
-    rest' <- go rest
-    return $ App (App bind val) (Abs (VarBinder ss ident) rest')
-  go (DoNotationBind binder val : rest) = do
-    rest' <- go rest
+  go pos (DoNotationBind (VarBinder ss ident) val : rest) = do
+    rest' <- go pos rest
+    return $ App (App (bind pos) val) (Abs (VarBinder ss ident) rest')
+  go pos (DoNotationBind binder val : rest) = do
+    rest' <- go pos rest
     ident <- freshIdent'
-    return $ App (App bind val) (Abs (VarBinder nullSourceSpan ident) (Case [Var nullSourceSpan (Qualified Nothing ident)] [CaseAlternative [binder] [MkUnguarded rest']]))
-  go [DoNotationLet _] = throwError . errorMessage $ InvalidDoLet
-  go (DoNotationLet ds : rest) = do
+    return $ App (App (bind pos) val) (Abs (VarBinder pos ident) (Case [Var pos (Qualified Nothing ident)] [CaseAlternative [binder] [MkUnguarded rest']]))
+  go _ [DoNotationLet _] = throwError . errorMessage $ InvalidDoLet
+  go pos (DoNotationLet ds : rest) = do
     let checkBind :: Declaration -> m ()
         checkBind (ValueDecl (ss, _) i@(Ident name) _ _ _)
           | name `elem` [ C.bind, C.discard ] = throwError . errorMessage' ss $ CannotUseBindWithDo i
         checkBind _ = pure ()
     mapM_ checkBind ds
-    rest' <- go rest
+    rest' <- go pos rest
     return $ Let FromLet ds rest'
-  go (PositionedDoNotationElement pos com el : rest) = rethrowWithPosition pos $ PositionedValue pos com <$> go (el : rest)
+  go _ (PositionedDoNotationElement pos com el : rest) = rethrowWithPosition pos $ PositionedValue pos com <$> go pos (el : rest)


### PR DESCRIPTION
Fixes #3418 

This adds position information to desugared do code, where it was previously using `nullSourceSpan` before.

The example now yields this error:

```
[1/1 UnknownName] /Users/nathan/Sites/git/purescript/BadSpan.purs:6:3

  6    log "What"
       ^^^^^^^^^^

  Unknown value discard. You're probably using do-notation, which the compiler replaces with calls to the discard function. Please import discard from module Prelude
```