### PR TITLE
Consider type operators when reexporting a pseudo-module

### DIFF
--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -147,6 +147,7 @@ resolveExports env ss mn imps exps refs =
     -- values if that fails to see whether the value has been imported at all.
     testQuals :: (forall a b. M.Map (Qualified a) b -> [Qualified a]) -> ModuleName -> Bool
     testQuals f mn' = any (isQualifiedWith mn') (f (importedTypes imps))
+                   || any (isQualifiedWith mn') (f (importedTypeOps imps))
                    || any (isQualifiedWith mn') (f (importedDataConstructors imps))
                    || any (isQualifiedWith mn') (f (importedTypeClasses imps))
                    || any (isQualifiedWith mn') (f (importedValues imps))

--- a/tests/purs/passing/3410.purs
+++ b/tests/purs/passing/3410.purs
@@ -1,0 +1,11 @@
+module Main
+  ( module Prelude
+  , module DEN
+  , main
+  ) where
+
+import Prelude
+import Data.Either.Nested (type (\/)) as DEN
+import Effect.Console (log)
+
+main = log "Done"


### PR DESCRIPTION
Fixes #3410 