### PR TITLE
Fix ST magic-do and inlining

### DIFF
--- a/src/Language/PureScript/Constants.hs
+++ b/src/Language/PureScript/Constants.hs
@@ -204,29 +204,23 @@ unit = "unit"
 
 -- Core lib values
 
-untilE :: forall a. (IsString a) => a
-untilE = "untilE"
-
-whileE :: forall a. (IsString a) => a
-whileE = "whileE"
-
 runST :: forall a. (IsString a) => a
-runST = "runST"
+runST = "run"
 
 stRefValue :: forall a. (IsString a) => a
 stRefValue = "value"
 
 newSTRef :: forall a. (IsString a) => a
-newSTRef = "newSTRef"
+newSTRef = "new"
 
 readSTRef :: forall a. (IsString a) => a
-readSTRef = "readSTRef"
+readSTRef = "read"
 
 writeSTRef :: forall a. (IsString a) => a
-writeSTRef = "writeSTRef"
+writeSTRef = "write"
 
 modifySTRef :: forall a. (IsString a) => a
-modifySTRef = "modifySTRef"
+modifySTRef = "modify"
 
 mkFn :: forall a. (IsString a) => a
 mkFn = "mkFn"
@@ -257,6 +251,8 @@ data EffectDictionaries = EffectDictionaries
   { edApplicativeDict :: PSString
   , edBindDict :: PSString
   , edMonadDict :: PSString
+  , edWhile :: PSString
+  , edUntil :: PSString
   }
 
 effDictionaries :: EffectDictionaries
@@ -264,6 +260,8 @@ effDictionaries = EffectDictionaries
   { edApplicativeDict = "applicativeEff"
   , edBindDict = "bindEff"
   , edMonadDict = "monadEff"
+  , edWhile = "whileE"
+  , edUntil = "untilE"
   }
 
 effectDictionaries :: EffectDictionaries
@@ -271,6 +269,17 @@ effectDictionaries = EffectDictionaries
   { edApplicativeDict = "applicativeEffect"
   , edBindDict = "bindEffect"
   , edMonadDict = "monadEffect"
+  , edWhile = "whileE"
+  , edUntil = "untilE"
+  }
+
+stDictionaries :: EffectDictionaries
+stDictionaries = EffectDictionaries
+  { edApplicativeDict = "applicativeST"
+  , edBindDict = "bindST"
+  , edMonadDict = "monadST"
+  , edWhile = "while"
+  , edUntil = "until"
   }
 
 discardUnitDictionary :: forall a. (IsString a) => a
@@ -507,7 +516,7 @@ effect :: forall a. (IsString a) => a
 effect = "Effect"
 
 st :: forall a. (IsString a) => a
-st = "Control_Monad_ST"
+st = "Control_Monad_ST_Internal"
 
 controlApplicative :: forall a. (IsString a) => a
 controlApplicative = "Control_Applicative"

--- a/src/Language/PureScript/CoreImp/Optimizer.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer.hs
@@ -38,8 +38,9 @@ optimize js = do
       , inlineCommonOperators
       ]) js
     untilFixedPoint (return . tidyUp) . tco . inlineST
-      =<< untilFixedPoint (return . magicDo')
-      =<< untilFixedPoint (return . magicDo) js'
+      =<< untilFixedPoint (return . magicDoST)
+      =<< untilFixedPoint (return . magicDoEff)
+      =<< untilFixedPoint (return . magicDoEffect) js'
   where
     tidyUp :: AST -> AST
     tidyUp = applyAll

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -1,6 +1,6 @@
 -- | This module implements the "Magic Do" optimization, which inlines calls to return
 -- and bind for the Eff monad, as well as some of its actions.
-module Language.PureScript.CoreImp.Optimizer.MagicDo (magicDo, magicDo', inlineST) where
+module Language.PureScript.CoreImp.Optimizer.MagicDo (magicDoEffect, magicDoEff, magicDoST, inlineST) where
 
 import Prelude.Compat
 import Protolude (ordNub)
@@ -27,14 +27,17 @@ import qualified Language.PureScript.Constants as C
 --    var x = m1();
 --    ...
 --  }
-magicDo :: AST -> AST
-magicDo = magicDo'' C.eff C.effDictionaries
+magicDoEff :: AST -> AST
+magicDoEff = magicDo C.eff C.effDictionaries
 
-magicDo' :: AST -> AST
-magicDo' = magicDo'' C.effect C.effectDictionaries
+magicDoEffect :: AST -> AST
+magicDoEffect = magicDo C.effect C.effectDictionaries
 
-magicDo'' :: Text -> C.EffectDictionaries -> AST -> AST
-magicDo'' effectModule C.EffectDictionaries{..} = everywhereTopDown convert
+magicDoST :: AST -> AST
+magicDoST = magicDo C.st C.stDictionaries
+
+magicDo :: Text -> C.EffectDictionaries -> AST -> AST
+magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
   where
   -- The name of the function block which is added to denote a do block
   fnName = "__do"
@@ -49,10 +52,10 @@ magicDo'' effectModule C.EffectDictionaries{..} = everywhereTopDown convert
   convert (App _ (App _ bind [m]) [Function s1 Nothing [arg] (Block s2 js)]) | isBind bind =
     Function s1 (Just fnName) [] $ Block s2 (VariableIntroduction s2 arg (Just (App s2 m [])) : map applyReturns js)
   -- Desugar untilE
-  convert (App s1 (App _ f [arg]) []) | isEffFunc C.untilE f =
+  convert (App s1 (App _ f [arg]) []) | isEffFunc edUntil f =
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (Unary s1 Not (App s1 arg [])) (Block s1 []), Return s1 $ ObjectLiteral s1 []])) []
   -- Desugar whileE
-  convert (App _ (App _ (App s1 f [arg1]) [arg2]) []) | isEffFunc C.whileE f =
+  convert (App _ (App _ (App s1 f [arg1]) [arg2]) []) | isEffFunc edWhile f =
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (App s1 arg1 []) (Block s1 [ App s1 arg2 [] ]), Return s1 $ ObjectLiteral s1 []])) []
   -- Inline __do returns
   convert (Return _ (App _ (Function _ (Just ident) [] body) [])) | ident == fnName = body
@@ -98,12 +101,12 @@ inlineST = everywhere convertBlock
   -- Look for runST blocks and inline the STRefs there.
   -- If all STRefs are used in the scope of the same runST, only using { read, write, modify }STRef then
   -- we can be more aggressive about inlining, and actually turn STRefs into local variables.
-  convertBlock (App _ f [arg]) | isSTFunc C.runST f =
+  convertBlock (App s1 f [arg]) | isSTFunc C.runST f =
     let refs = ordNub . findSTRefsIn $ arg
         usages = findAllSTUsagesIn arg
         allUsagesAreLocalVars = all (\u -> let v = toVar u in isJust v && fromJust v `elem` refs) usages
         localVarsDoNotEscape = all (\r -> length (r `appearingIn` arg) == length (filter (\u -> let v = toVar u in v == Just r) usages)) refs
-    in everywhere (convert (allUsagesAreLocalVars && localVarsDoNotEscape)) arg
+    in App s1 (everywhere (convert (allUsagesAreLocalVars && localVarsDoNotEscape)) arg) []
   convertBlock other = other
   -- Convert a block in a safe way, preserving object wrappers of references,
   -- or in a more aggressive way, turning wrappers into local variables depending on the
@@ -112,9 +115,9 @@ inlineST = everywhere convertBlock
    Function s1 Nothing [] (Block s1 [Return s1 $ if agg then arg else ObjectLiteral s1 [(mkString C.stRefValue, arg)]])
   convert agg (App _ (App s1 f [ref]) []) | isSTFunc C.readSTRef f =
     if agg then ref else Indexer s1 (StringLiteral s1 C.stRefValue) ref
-  convert agg (App _ (App _ (App s1 f [ref]) [arg]) []) | isSTFunc C.writeSTRef f =
+  convert agg (App _ (App _ (App s1 f [arg]) [ref]) []) | isSTFunc C.writeSTRef f =
     if agg then Assignment s1 ref arg else Assignment s1 (Indexer s1 (StringLiteral s1 C.stRefValue) ref) arg
-  convert agg (App _ (App _ (App s1 f [ref]) [func]) []) | isSTFunc C.modifySTRef f =
+  convert agg (App _ (App _ (App s1 f [func]) [ref]) []) | isSTFunc C.modifySTRef f =
     if agg then Assignment s1 ref (App s1 func [ref]) else Assignment s1 (Indexer s1 (StringLiteral s1 C.stRefValue) ref) (App s1 func [Indexer s1 (StringLiteral s1 C.stRefValue) ref])
   convert _ other = other
   -- Check if an expression represents a function in the ST module
@@ -129,7 +132,7 @@ inlineST = everywhere convertBlock
   findAllSTUsagesIn = everything (++) isSTUsage
     where
     isSTUsage (App _ (App _ f [ref]) []) | isSTFunc C.readSTRef f = [ref]
-    isSTUsage (App _ (App _ (App _ f [ref]) [_]) []) | isSTFunc C.writeSTRef f || isSTFunc C.modifySTRef f = [ref]
+    isSTUsage (App _ (App _ (App _ f [_]) [ref]) []) | isSTFunc C.writeSTRef f || isSTFunc C.modifySTRef f = [ref]
     isSTUsage _ = []
   -- Find all uses of a variable
   appearingIn ref = everything (++) isVar


### PR DESCRIPTION
Example output now:
```js
var sumOfSquares = (function __do() {
    var v = {
        value: 0
    };
    var loop = function (v1) {
        if (v1 === 0) {
            return Control_Monad_ST_Internal.read(v);
        };
        return function __do() {
            var v2 = v.value = (function (v2) {
                return v2 + (v1 * v1 | 0) | 0;
            })(v.value);
            return loop(v1 - 1 | 0)();
        };
    };
    return loop(100)();
})();
var main = Effect_Console.logShow(Data_Show.showInt)(sumOfSquares);
var counter = (function __do() {
    var v = 0;
    (function () {
        while ((function __do() {
            return v < 10;
        })()) {
            (function __do() {
                var v1 = v = (function (v1) {
                    return v1 + 1 | 0;
                })(v);
                return Data_Unit.unit;
            })();
        };
        return {};
    })();
    return v;
})();
```