### PR TITLE
Remove references to previous kinds * and !

### DIFF
--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -203,8 +203,7 @@ primClassOf gen title comments = Declaration
 
 kindType :: Declaration
 kindType = primKind "Type" $ T.unlines
-  [ "`Type` (also known as `*`) is the kind of all proper types: those that"
-  , "classify value-level terms."
+  [ "`Type` is the kind of all proper types: those that classify value-level terms."
   , "For example the type `Boolean` has kind `Type`; denoted by `Boolean :: Type`."
   ]
 

--- a/src/Language/PureScript/Parser/Kinds.hs
+++ b/src/Language/PureScript/Parser/Kinds.hs
@@ -12,23 +12,13 @@ import Language.PureScript.Parser.Lexer
 import qualified Text.Parsec as P
 import qualified Text.Parsec.Expr as P
 
-parseStar :: TokenParser Kind
-parseStar = symbol' "*" *>
-  P.parserFail "The `*` symbol is no longer used for the kind of types.\n  The new equivalent is the named kind `Type`."
-
-parseBang :: TokenParser Kind
-parseBang = symbol' "!" *>
-  P.parserFail "The `!` symbol is no longer used for the kind of effects.\n  The new equivalent is the named kind `Effect`, defined in `Control.Monad.Eff` in the `purescript-eff` library."
-
 parseNamedKind :: TokenParser Kind
 parseNamedKind = NamedKind <$> parseQualified kindName
 
 parseKindAtom :: TokenParser Kind
 parseKindAtom =
   indented *> P.choice
-    [ parseStar
-    , parseBang
-    , parseNamedKind
+    [ parseNamedKind
     , parens parseKind
     ]
 


### PR DESCRIPTION
The kinds * and ! were switched to parse errors in 0.11.
Now we're at 0.12 we can remove them.