### PR TITLE
Display type class members and let identifiers in errors

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -452,6 +452,8 @@ unwrapTypeDeclaration td = (tydeclIdent td, tydeclType td)
 -- In this example @double@ is the identifier, @x@ is a binder and @x + x@ is the expression.
 data ValueDeclarationData a = ValueDeclarationData
   { valdeclSourceAnn :: !SourceAnn
+  , valdeclPublicName :: !(Maybe Ident)
+  -- ^ The declared value's name - renders instead of valdeclIdent
   , valdeclIdent :: !Ident
   -- ^ The declared value's name
   , valdeclName :: !NameKind
@@ -467,9 +469,9 @@ getValueDeclaration :: Declaration -> Maybe (ValueDeclarationData [GuardedExpr])
 getValueDeclaration (ValueDeclaration d) = Just d
 getValueDeclaration _ = Nothing
 
-pattern ValueDecl :: SourceAnn -> Ident -> NameKind -> [Binder] -> [GuardedExpr] -> Declaration
-pattern ValueDecl sann ident name binders expr
-  = ValueDeclaration (ValueDeclarationData sann ident name binders expr)
+pattern ValueDecl :: SourceAnn -> Maybe Ident -> Ident -> NameKind -> [Binder] -> [GuardedExpr] -> Declaration
+pattern ValueDecl sann publicName ident name binders expr
+  = ValueDeclaration (ValueDeclarationData sann publicName ident name binders expr)
 
 -- |
 -- The data type of declarations

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -53,8 +53,8 @@ everywhereOnValues f g h = (f', g', h')
   where
   f' :: Declaration -> Declaration
   f' (DataBindingGroupDeclaration ds) = f (DataBindingGroupDeclaration (fmap f' ds))
-  f' (ValueDecl sa name nameKind bs val) =
-     f (ValueDecl sa name nameKind (fmap h' bs) (fmap (mapGuardedExpr handleGuard g') val))
+  f' (ValueDecl sa publicName name nameKind bs val) =
+     f (ValueDecl sa publicName name nameKind (fmap h' bs) (fmap (mapGuardedExpr handleGuard g') val))
   f' (BoundValueDeclaration sa b expr) = f (BoundValueDeclaration sa (h' b) (g' expr))
   f' (BindingGroupDeclaration ds) = f (BindingGroupDeclaration (fmap (\(name, nameKind, val) -> (name, nameKind, g' val)) ds))
   f' (TypeClassDeclaration sa name args implies deps ds) = f (TypeClassDeclaration sa name args implies deps (fmap f' ds))
@@ -127,8 +127,8 @@ everywhereOnValuesTopDownM f g h = (f' <=< f, g' <=< g, h' <=< h)
 
   f' :: Declaration -> m Declaration
   f' (DataBindingGroupDeclaration ds) = DataBindingGroupDeclaration <$> traverse (f' <=< f) ds
-  f' (ValueDecl sa name nameKind bs val) =
-     ValueDecl sa name nameKind <$> traverse (h' <=< h) bs <*> traverse (guardedExprM handleGuard (g' <=< g)) val
+  f' (ValueDecl sa publicName name nameKind bs val) =
+     ValueDecl sa publicName name nameKind <$> traverse (h' <=< h) bs <*> traverse (guardedExprM handleGuard (g' <=< g)) val
   f' (BindingGroupDeclaration ds) = BindingGroupDeclaration <$> traverse (\(name, nameKind, val) -> (,,) name nameKind <$> (g val >>= g')) ds
   f' (TypeClassDeclaration sa name args implies deps ds) = TypeClassDeclaration sa name args implies deps <$> traverse (f' <=< f) ds
   f' (TypeInstanceDeclaration sa ch idx name cs className args ds) = TypeInstanceDeclaration sa ch idx name cs className args <$> traverseTypeInstanceBody (traverse (f' <=< f)) ds
@@ -196,8 +196,8 @@ everywhereOnValuesM f g h = (f', g', h')
 
   f' :: Declaration -> m Declaration
   f' (DataBindingGroupDeclaration ds) = (DataBindingGroupDeclaration <$> traverse f' ds) >>= f
-  f' (ValueDecl sa name nameKind bs val) =
-    ValueDecl sa name nameKind <$> traverse h' bs <*> traverse (guardedExprM handleGuard g') val >>= f
+  f' (ValueDecl sa publicName name nameKind bs val) =
+    ValueDecl sa publicName name nameKind <$> traverse h' bs <*> traverse (guardedExprM handleGuard g') val >>= f
   f' (BindingGroupDeclaration ds) = (BindingGroupDeclaration <$> traverse (\(name, nameKind, val) -> (,,) name nameKind <$> g' val) ds) >>= f
   f' (BoundValueDeclaration sa b expr) = (BoundValueDeclaration sa <$> h' b <*> g' expr) >>= f
   f' (TypeClassDeclaration sa name args implies deps ds) = (TypeClassDeclaration sa name args implies deps <$> traverse f' ds) >>= f
@@ -434,8 +434,8 @@ everywhereWithContextOnValuesM s0 f g h i j = (f'' s0, g'' s0, h'' s0, i'' s0, j
   f'' s = uncurry f' <=< f s
 
   f' s (DataBindingGroupDeclaration ds) = DataBindingGroupDeclaration <$> traverse (f'' s) ds
-  f' s (ValueDecl sa name nameKind bs val) =
-    ValueDecl sa name nameKind <$> traverse (h'' s) bs <*> traverse (guardedExprM (k' s) (g'' s)) val
+  f' s (ValueDecl sa publicName name nameKind bs val) =
+    ValueDecl sa publicName name nameKind <$> traverse (h'' s) bs <*> traverse (guardedExprM (k' s) (g'' s)) val
   f' s (BindingGroupDeclaration ds) = BindingGroupDeclaration <$> traverse (thirdM (g'' s)) ds
   f' s (TypeClassDeclaration sa name args implies deps ds) = TypeClassDeclaration sa name args implies deps <$> traverse (f'' s) ds
   f' s (TypeInstanceDeclaration sa ch idx name cs className args ds) = TypeInstanceDeclaration sa ch idx name cs className args <$> traverseTypeInstanceBody (traverse (f'' s)) ds
@@ -521,7 +521,7 @@ everythingWithScope f g h i j = (f'', g'', h'', i'', \s -> snd . j'' s)
   f' s (DataBindingGroupDeclaration ds) =
     let s' = S.union s (S.fromList (map ToplevelIdent (mapMaybe getDeclIdent (NEL.toList ds))))
     in foldMap (f'' s') ds
-  f' s (ValueDecl _ name _ bs val) =
+  f' s (ValueDecl _ _ name _ bs val) =
     let s' = S.insert (ToplevelIdent name) s
         s'' = S.union s' (S.fromList (concatMap localBinderNames bs))
     in foldMap (h'' s') bs <> foldMap (l' s'') val

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -109,9 +109,9 @@ basicDeclaration :: P.SourceAnn -> Text -> DeclarationInfo -> Maybe Intermediate
 basicDeclaration sa title = Just . Right . mkDeclaration sa title
 
 convertDeclaration :: P.Declaration -> Text -> Maybe IntermediateDeclaration
-convertDeclaration (P.ValueDecl sa _ _ _ [P.MkUnguarded (P.TypedValue _ _ ty)]) title =
+convertDeclaration (P.ValueDecl sa _ _ _ _ [P.MkUnguarded (P.TypedValue _ _ ty)]) title =
   basicDeclaration sa title (ValueDeclaration ty)
-convertDeclaration (P.ValueDecl sa _ _ _ _) title =
+convertDeclaration (P.ValueDecl sa _ _ _ _ _) title =
   -- If no explicit type declaration was provided, insert a wildcard, so that
   -- the actual type will be added during type checking.
   basicDeclaration sa title (ValueDeclaration (P.TypeWildcard (fst sa)))

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -187,7 +187,7 @@ data NameKind
   -- ^ A private value introduced as an artifact of code generation (class instances, class member
   -- accessors, etc.)
   | Public
-  -- ^ A public value for a module member or foreing import declaration
+  -- ^ A public value for a module member or foreign import declaration
   | External
   -- ^ A name for member introduced by foreign import
   deriving (Show, Eq, Generic)

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -76,7 +76,7 @@ extractSpans
   -> [(IdeNamespaced, P.SourceSpan)]
   -- ^ Declarations and their source locations
 extractSpans d = case d of
-  P.ValueDecl (ss, _) i _ _ _ ->
+  P.ValueDecl (ss, _) _ i _ _ _ ->
     [(IdeNamespaced IdeNSValue (P.runIdent i), ss)]
   P.TypeSynonymDeclaration (ss, _) name _ _ ->
     [(IdeNamespaced IdeNSType (P.runProperName name), ss)]

--- a/src/Language/PureScript/Interactive/Module.hs
+++ b/src/Language/PureScript/Interactive/Module.hs
@@ -53,14 +53,14 @@ createTemporaryModule exec st val =
     supportImport = (supportModuleName, P.Implicit, Just (P.ModuleName [P.ProperName "$Support"]))
     eval          = P.Var internalSpan (P.Qualified (Just (P.ModuleName [P.ProperName "$Support"])) (P.Ident "eval"))
     mainValue     = P.App eval (P.Var internalSpan (P.Qualified Nothing (P.Ident "it")))
-    itDecl        = P.ValueDecl (internalSpan, []) (P.Ident "it") P.Public [] [P.MkUnguarded val]
+    itDecl        = P.ValueDecl (internalSpan, []) Nothing (P.Ident "it") P.Public [] [P.MkUnguarded val]
     typeDecl      = P.TypeDeclaration
                       (P.TypeDeclarationData (internalSpan, []) (P.Ident "$main")
                         (P.TypeApp
                           (P.TypeConstructor
                             (P.Qualified (Just (P.ModuleName [P.ProperName "$Effect"])) (P.ProperName "Effect")))
                                   (P.TypeWildcard internalSpan)))
-    mainDecl      = P.ValueDecl (internalSpan, []) (P.Ident "$main") P.Public [] [P.MkUnguarded mainValue]
+    mainDecl      = P.ValueDecl (internalSpan, []) Nothing (P.Ident "$main") P.Public [] [P.MkUnguarded mainValue]
     decls         = if exec then [itDecl, typeDecl, mainDecl] else [itDecl]
   in
     P.Module internalSpan

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -295,7 +295,7 @@ checkExhaustive ss env mn numArgs cas expr = makeResult . first ordNub $ foldl' 
     where
       partial :: Text -> Text -> Declaration
       partial var tyVar =
-        ValueDecl (ss, []) UnusedIdent Private [] $
+        ValueDecl (ss, []) Nothing UnusedIdent Private [] $
         [MkUnguarded
           (TypedValue
            True
@@ -331,8 +331,8 @@ checkExhaustiveExpr initSS env mn = onExpr initSS
   where
   onDecl :: Declaration -> m Declaration
   onDecl (BindingGroupDeclaration bs) = BindingGroupDeclaration <$> mapM (\(sai@((ss, _), _), nk, expr) -> (sai, nk,) <$> onExpr ss expr) bs
-  onDecl (ValueDecl sa@(ss, _) name x y [MkUnguarded e]) =
-     ValueDecl sa name x y . mkUnguardedExpr <$> censor (addHint (ErrorInValueDeclaration name)) (onExpr ss e)
+  onDecl (ValueDecl sa@(ss, _) publicName name x y [MkUnguarded e]) =
+     ValueDecl sa publicName name x y . mkUnguardedExpr <$> censor (addHint (ErrorInValueDeclaration name)) (onExpr ss e)
   onDecl decl = return decl
 
   onExpr :: SourceSpan -> Expr -> m Expr

--- a/src/Language/PureScript/Parser/Declarations.hs
+++ b/src/Language/PureScript/Parser/Declarations.hs
@@ -87,7 +87,7 @@ parseValueWithIdentAndBinders ident bs = do
                            <*> (indented *> equals
                                          *> withSourceSpan PositionedValue parseValueWithWhereClause))
     )
-  return $ \sa -> ValueDecl sa ident Public bs value
+  return $ \sa -> ValueDecl sa Nothing ident Public bs value
 
 parseValueDeclaration :: TokenParser Declaration
 parseValueDeclaration = withSourceAnnF $ do

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -15,6 +15,7 @@ import Data.Text (Text)
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Monoid as Monoid ((<>))
 import qualified Data.Text as T
+import Data.Maybe (fromMaybe)
 
 import Language.PureScript.AST
 import Language.PureScript.Crash
@@ -131,12 +132,12 @@ prettyPrintDeclaration :: Int -> Declaration -> Box
 prettyPrintDeclaration d _ | d < 0 = ellipsis
 prettyPrintDeclaration _ (TypeDeclaration td) =
   text (T.unpack (showIdent (tydeclIdent td)) ++ " :: ") <> typeAsBox (tydeclType td)
-prettyPrintDeclaration d (ValueDecl _ ident _ [] [GuardedExpr [] val]) =
-  text (T.unpack (showIdent ident) ++ " = ") <> prettyPrintValue (d - 1) val
+prettyPrintDeclaration d (ValueDecl _ publicName ident _ [] [GuardedExpr [] val]) =
+  text (T.unpack (showIdent (fromMaybe ident publicName)) ++ " = ") <> prettyPrintValue (d - 1) val
 prettyPrintDeclaration d (BindingGroupDeclaration ds) =
   vsep 1 left (NEL.toList (fmap (prettyPrintDeclaration (d - 1) . toDecl) ds))
   where
-  toDecl ((sa, nm), t, e) = ValueDecl sa nm t [] [GuardedExpr [] e]
+  toDecl ((sa, nm), t, e) = ValueDecl sa Nothing nm t [] [GuardedExpr [] e]
 prettyPrintDeclaration _ _ = internalError "Invalid argument to prettyPrintDeclaration"
 
 prettyPrintCaseAlternative :: Int -> CaseAlternative -> Box

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -98,7 +98,7 @@ collapseBindingGroups =
   go (DataBindingGroupDeclaration ds) = NEL.toList ds
   go (BindingGroupDeclaration ds) =
     NEL.toList $ fmap (\((sa, ident), nameKind, val) ->
-      ValueDecl sa ident nameKind [] [MkUnguarded val]) ds
+      ValueDecl sa Nothing ident nameKind [] [MkUnguarded val]) ds
   go other = [other]
 
 collapseBindingGroupsForValue :: Expr -> Expr
@@ -187,7 +187,7 @@ toBindingGroup moduleName (CyclicSCC ds') = do
   toBinding (CyclicSCC ds) = throwError $ foldMap cycleError ds
 
   cycleError :: ValueDeclarationData Expr -> MultipleErrors
-  cycleError (ValueDeclarationData (ss, _) n _ _ _) = errorMessage' ss $ CycleInDeclaration n
+  cycleError (ValueDeclarationData (ss, _) _ n _ _ _) = errorMessage' ss $ CycleInDeclaration n
 
 toDataBindingGroup
   :: MonadError MultipleErrors m
@@ -209,5 +209,5 @@ mkDeclaration :: ValueDeclarationData Expr -> Declaration
 mkDeclaration = ValueDeclaration . fmap (pure . MkUnguarded)
 
 fromValueDecl :: ValueDeclarationData Expr -> ((SourceAnn, Ident), NameKind, Expr)
-fromValueDecl (ValueDeclarationData sa ident nameKind [] val) = ((sa, ident), nameKind, val)
+fromValueDecl (ValueDeclarationData sa _ ident nameKind [] val) = ((sa, ident), nameKind, val)
 fromValueDecl ValueDeclarationData{} = internalError "Binders should have been desugared"

--- a/src/Language/PureScript/Sugar/CaseDeclarations.hs
+++ b/src/Language/PureScript/Sugar/CaseDeclarations.hs
@@ -65,7 +65,7 @@ desugarGuardedExprs ss (Case scrut alternatives)
     (scrut', scrut_decls) <- unzip <$> forM scrut (\e -> do
       scrut_id <- freshIdent'
       pure ( Var ss (Qualified Nothing scrut_id)
-           , ValueDecl (ss, []) scrut_id Private [] [MkUnguarded e]
+           , ValueDecl (ss, []) Nothing scrut_id Private [] [MkUnguarded e]
            )
       )
     Let FromLet scrut_decls <$> desugarGuardedExprs ss (Case scrut' alternatives)
@@ -231,7 +231,7 @@ desugarGuardedExprs ss (Case scrut alternatives) =
           alt_fail = [CaseAlternative [NullBinder] [MkUnguarded goto_rem_case]]
 
         pure $ Let FromLet [
-          ValueDecl (ss, []) rem_case_id Private []
+          ValueDecl (ss, []) Nothing rem_case_id Private []
             [MkUnguarded (Abs (VarBinder ss unused_binder) desugared)]
           ] (mk_body alt_fail)
 
@@ -328,10 +328,10 @@ desugarCases = desugarRest <=< fmap join . flip parU toDecls . groupBy inSameGro
     desugarRest :: [Declaration] -> m [Declaration]
     desugarRest (TypeInstanceDeclaration sa cd idx name constraints className tys ds : rest) =
       (:) <$> (TypeInstanceDeclaration sa cd idx name constraints className tys <$> traverseTypeInstanceBody desugarCases ds) <*> desugarRest rest
-    desugarRest (ValueDecl sa name nameKind bs result : rest) =
+    desugarRest (ValueDecl sa publicName name nameKind bs result : rest) =
       let (_, f, _) = everywhereOnValuesTopDownM return go return
           f' = mapM (\(GuardedExpr gs e) -> GuardedExpr gs <$> f e)
-      in (:) <$> (ValueDecl sa name nameKind bs <$> f' result) <*> desugarRest rest
+      in (:) <$> (ValueDecl sa publicName name nameKind bs <$> f' result) <*> desugarRest rest
       where
       go (Let w ds val') = Let w <$> desugarCases ds <*> pure val'
       go other = return other
@@ -343,11 +343,11 @@ inSameGroup (ValueDeclaration vd1) (ValueDeclaration vd2) = valdeclIdent vd1 == 
 inSameGroup _ _ = False
 
 toDecls :: forall m. (MonadSupply m, MonadError MultipleErrors m) => [Declaration] -> m [Declaration]
-toDecls [ValueDecl sa@(ss, _) ident nameKind bs [MkUnguarded val]] | all isIrrefutable bs = do
+toDecls [ValueDecl sa@(ss, _) publicName ident nameKind bs [MkUnguarded val]] | all isIrrefutable bs = do
   args <- mapM fromVarBinder bs
   let body = foldr (Abs . VarBinder ss) val args
   guardWith (errorMessage' ss (OverlappingArgNames (Just ident))) $ length (ordNub args) == length args
-  return [ValueDecl sa ident nameKind [] [MkUnguarded body]]
+  return [ValueDecl sa publicName ident nameKind [] [MkUnguarded body]]
   where
   fromVarBinder :: Binder -> m Ident
   fromVarBinder NullBinder = freshIdent'
@@ -355,7 +355,7 @@ toDecls [ValueDecl sa@(ss, _) ident nameKind bs [MkUnguarded val]] | all isIrref
   fromVarBinder (PositionedBinder _ _ b) = fromVarBinder b
   fromVarBinder (TypedBinder _ b) = fromVarBinder b
   fromVarBinder _ = internalError "fromVarBinder: Invalid argument"
-toDecls ds@(ValueDecl (ss, _) ident _ bs (result : _) : _) = do
+toDecls ds@(ValueDecl (ss, _) _ ident _ bs (result : _) : _) = do
   let tuples = map toTuple ds
 
       isGuarded (MkUnguarded _) = False
@@ -370,7 +370,7 @@ toDecls ds@(ValueDecl (ss, _) ident _ bs (result : _) : _) = do
 toDecls ds = return ds
 
 toTuple :: Declaration -> ([Binder], [GuardedExpr])
-toTuple (ValueDecl _ _ _ bs result) = (bs, result)
+toTuple (ValueDecl _ _ _ _ bs result) = (bs, result)
 toTuple _ = internalError "Not a value declaration"
 
 makeCaseDeclaration :: forall m. (MonadSupply m) => SourceSpan -> Ident -> [([Binder], [GuardedExpr])] -> m Declaration
@@ -384,7 +384,7 @@ makeCaseDeclaration ss ident alternatives = do
       binders = [ CaseAlternative bs result | (bs, result) <- alternatives ]
   let value = foldr (Abs . VarBinder ss) (Case vars binders) args
 
-  return $ ValueDecl (ss, []) ident Public [] [MkUnguarded value]
+  return $ ValueDecl (ss, []) Nothing ident Public [] [MkUnguarded value]
   where
   -- We will construct a table of potential names.
   -- VarBinders will become Just _ which is a potential name.

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -62,7 +62,7 @@ desugarDo d =
   go _ [DoNotationLet _] = throwError . errorMessage $ InvalidDoLet
   go pos (DoNotationLet ds : rest) = do
     let checkBind :: Declaration -> m ()
-        checkBind (ValueDecl (ss, _) i@(Ident name) _ _ _)
+        checkBind (ValueDecl (ss, _) _ i@(Ident name) _ _ _)
           | name `elem` [ C.bind, C.discard ] = throwError . errorMessage' ss $ CannotUseBindWithDo i
         checkBind _ = pure ()
     mapM_ checkBind ds

--- a/src/Language/PureScript/Sugar/ObjectWildcards.hs
+++ b/src/Language/PureScript/Sugar/ObjectWildcards.hs
@@ -69,7 +69,7 @@ desugarDecl d = rethrowWithPosition (declSourceSpan d) $ fn d
       then Abs (VarBinder nullSourceSpan val) <$> wrapLambda (buildUpdates valExpr) ps
       else wrapLambda (buildLet val . buildUpdates valExpr) ps
     where
-      buildLet val = Let FromLet [ValueDecl (declSourceSpan d, []) val Public [] [MkUnguarded obj]]
+      buildLet val = Let FromLet [ValueDecl (declSourceSpan d, []) Nothing val Public [] [MkUnguarded obj]]
 
       -- recursively build up the nested `ObjectUpdate` expressions
       buildUpdates :: Expr -> PathTree Expr -> Expr

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -297,13 +297,13 @@ deriveGenericRep ss mn syns ds tyConNm tyConArgs repTy = do
       let rep = toRepTy reps
           inst | null reps =
                    -- If there are no cases, spin
-                   [ ValueDecl (ss', []) (Ident "to") Public [] $ unguarded $
+                   [ ValueDecl (ss', []) Nothing (Ident "to") Public [] $ unguarded $
                       lamCase ss' x
                         [ CaseAlternative
                             [NullBinder]
                             (unguarded (App toName (Var ss' (Qualified Nothing x))))
                         ]
-                   , ValueDecl (ss', []) (Ident "from") Public [] $ unguarded $
+                   , ValueDecl (ss', []) Nothing (Ident "from") Public [] $ unguarded $
                       lamCase ss' x
                         [ CaseAlternative
                             [NullBinder]
@@ -311,9 +311,9 @@ deriveGenericRep ss mn syns ds tyConNm tyConArgs repTy = do
                         ]
                    ]
                | otherwise =
-                   [ ValueDecl (ss', []) (Ident "to") Public [] $ unguarded $
+                   [ ValueDecl (ss', []) Nothing (Ident "to") Public [] $ unguarded $
                        lamCase ss' x (zipWith ($) (map underBinder (sumBinders (length dctors))) to)
-                   , ValueDecl (ss', []) (Ident "from") Public [] $ unguarded $
+                   , ValueDecl (ss', []) Nothing (Ident "from") Public [] $ unguarded $
                        lamCase ss' x (zipWith ($) (map underExpr (sumExprs (length dctors))) from)
                    ]
 
@@ -443,7 +443,7 @@ deriveEq
 deriveEq ss mn syns ds tyConNm = do
   tyCon <- findTypeDecl ss tyConNm ds
   eqFun <- mkEqFunction tyCon
-  return [ ValueDecl (ss, []) (Ident C.eq) Public [] (unguarded eqFun) ]
+  return [ ValueDecl (ss, []) Nothing (Ident C.eq) Public [] (unguarded eqFun) ]
   where
     mkEqFunction :: Declaration -> m Expr
     mkEqFunction (DataDeclaration (ss', _) _ _ _ args) = do
@@ -494,7 +494,7 @@ deriveEq ss mn syns ds tyConNm = do
 
 deriveEq1 :: SourceSpan -> [Declaration]
 deriveEq1 ss =
-  [ ValueDecl (ss, []) (Ident C.eq1) Public [] (unguarded preludeEq)]
+  [ ValueDecl (ss, []) Nothing (Ident C.eq1) Public [] (unguarded preludeEq)]
   where
     preludeEq :: Expr
     preludeEq = Var ss (Qualified (Just dataEq) (Ident C.eq))
@@ -511,7 +511,7 @@ deriveOrd
 deriveOrd ss mn syns ds tyConNm = do
   tyCon <- findTypeDecl ss tyConNm ds
   compareFun <- mkCompareFunction tyCon
-  return [ ValueDecl (ss, []) (Ident C.compare) Public [] (unguarded compareFun) ]
+  return [ ValueDecl (ss, []) Nothing (Ident C.compare) Public [] (unguarded compareFun) ]
   where
     mkCompareFunction :: Declaration -> m Expr
     mkCompareFunction (DataDeclaration (ss', _) _ _ _ args) = do
@@ -595,7 +595,7 @@ deriveOrd ss mn syns ds tyConNm = do
 
 deriveOrd1 :: SourceSpan -> [Declaration]
 deriveOrd1 ss =
-  [ ValueDecl (ss, []) (Ident C.compare1) Public [] (unguarded dataOrdCompare)]
+  [ ValueDecl (ss, []) Nothing (Ident C.compare1) Public [] (unguarded dataOrdCompare)]
   where
     dataOrdCompare :: Expr
     dataOrdCompare = Var ss (Qualified (Just dataOrd) (Ident C.compare))
@@ -625,9 +625,9 @@ deriveNewtype ss mn syns ds tyConNm tyConArgs unwrappedTy = do
       let (ctorName, [ty]) = head dctors
       ty' <- replaceAllTypeSynonymsM syns ty
       let inst =
-            [ ValueDecl (ss', []) (Ident "wrap") Public [] $ unguarded $
+            [ ValueDecl (ss', []) Nothing (Ident "wrap") Public [] $ unguarded $
                 Constructor ss' (Qualified (Just mn) ctorName)
-            , ValueDecl (ss', []) (Ident "unwrap") Public [] $ unguarded $
+            , ValueDecl (ss', []) Nothing (Ident "unwrap") Public [] $ unguarded $
                 lamCase ss' wrappedIdent
                   [ CaseAlternative
                       [ConstructorBinder ss' (Qualified (Just mn) ctorName) [VarBinder ss' unwrappedIdent]]
@@ -696,7 +696,7 @@ deriveFunctor
 deriveFunctor ss mn syns ds tyConNm = do
   tyCon <- findTypeDecl ss tyConNm ds
   mapFun <- mkMapFunction tyCon
-  return [ ValueDecl (ss, []) (Ident C.map) Public [] (unguarded mapFun) ]
+  return [ ValueDecl (ss, []) Nothing (Ident C.map) Public [] (unguarded mapFun) ]
   where
     mkMapFunction :: Declaration -> m Expr
     mkMapFunction (DataDeclaration (ss', _) _ _ tys ctors) = case reverse tys of

--- a/src/Language/PureScript/Sugar/TypeDeclarations.hs
+++ b/src/Language/PureScript/Sugar/TypeDeclarations.hs
@@ -31,19 +31,19 @@ desugarTypeDeclarationsModule (Module modSS coms name ds exps) =
   desugarTypeDeclarations :: [Declaration] -> m [Declaration]
   desugarTypeDeclarations (TypeDeclaration (TypeDeclarationData sa name' ty) : d : rest) = do
     (_, nameKind, val) <- fromValueDeclaration d
-    desugarTypeDeclarations (ValueDecl sa name' nameKind [] [MkUnguarded (TypedValue True val ty)] : rest)
+    desugarTypeDeclarations (ValueDecl sa Nothing name' nameKind [] [MkUnguarded (TypedValue True val ty)] : rest)
     where
     fromValueDeclaration :: Declaration -> m (Ident, NameKind, Expr)
-    fromValueDeclaration (ValueDecl _ name'' nameKind [] [MkUnguarded val])
+    fromValueDeclaration (ValueDecl _ _ name'' nameKind [] [MkUnguarded val])
       | name' == name'' = return (name'', nameKind, val)
     fromValueDeclaration d' =
       throwError . errorMessage' (declSourceSpan d') $ OrphanTypeDeclaration name'
   desugarTypeDeclarations [TypeDeclaration (TypeDeclarationData (ss, _) name' _)] =
     throwError . errorMessage' ss $ OrphanTypeDeclaration name'
-  desugarTypeDeclarations (ValueDecl sa name' nameKind bs val : rest) = do
+  desugarTypeDeclarations (ValueDecl sa publicName name' nameKind bs val : rest) = do
     let (_, f, _) = everywhereOnValuesTopDownM return go return
         f' = mapM (\(GuardedExpr g e) -> GuardedExpr g <$> f e)
-    (:) <$> (ValueDecl sa name' nameKind bs <$> f' val)
+    (:) <$> (ValueDecl sa publicName name' nameKind bs <$> f' val)
         <*> desugarTypeDeclarations rest
     where
     go (Let w ds' val') = Let w <$> desugarTypeDeclarations ds' <*> pure val'

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -272,14 +272,14 @@ typeCheckAll moduleName _ = traverse go
     return $ TypeSynonymDeclaration sa name args ty
   go TypeDeclaration{} =
     internalError "Type declarations should have been removed before typeCheckAlld"
-  go (ValueDecl sa@(ss, _) name nameKind [] [MkUnguarded val]) = do
+  go (ValueDecl sa@(ss, _) publicName name nameKind [] [MkUnguarded val]) = do
     env <- getEnv
     warnAndRethrow (addHint (ErrorInValueDeclaration name) . addHint (positionedError ss)) $ do
       val' <- checkExhaustiveExpr ss env moduleName val
       valueIsNotDefined moduleName name
       [(_, (val'', ty))] <- typesOf NonRecursiveBindingGroup moduleName [((sa, name), val')]
       addValue moduleName name ty nameKind
-      return $ ValueDecl sa name nameKind [] [MkUnguarded val'']
+      return $ ValueDecl sa publicName name nameKind [] [MkUnguarded val'']
   go ValueDeclaration{} = internalError "Binders were not desugared"
   go BoundValueDeclaration{} = internalError "BoundValueDeclaration should be desugared"
   go (BindingGroupDeclaration vals) = do

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -426,24 +426,26 @@ inferLetBinding
   -> (Expr -> m Expr)
   -> m ([Declaration], Expr)
 inferLetBinding seen [] ret j = (,) seen <$> withBindingGroupVisible (j ret)
-inferLetBinding seen (ValueDecl sa@(ss, _) ident nameKind [] [MkUnguarded tv@(TypedValue checkType val ty)] : rest) ret j =
-  warnAndRethrowWithPositionTC ss $ do
-    Just moduleName <- checkCurrentModule <$> get
-    (kind, args) <- kindOfWithScopedVars ty
-    checkTypeKind ty kind
-    let dict = M.singleton (Qualified Nothing ident) (ty, nameKind, Undefined)
-    ty' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty
-    TypedValue _ val' ty'' <- if checkType then withScopedTypeVars moduleName args (bindNames dict (check val ty')) else return tv
-    bindNames (M.singleton (Qualified Nothing ident) (ty'', nameKind, Defined))
-      $ inferLetBinding (seen ++ [ValueDecl sa ident nameKind [] [MkUnguarded (TypedValue checkType val' ty'')]]) rest ret j
-inferLetBinding seen (ValueDecl sa@(ss, _) ident nameKind [] [MkUnguarded val] : rest) ret j =
-  warnAndRethrowWithPositionTC ss $ do
-    valTy <- freshType
-    let dict = M.singleton (Qualified Nothing ident) (valTy, nameKind, Undefined)
-    TypedValue _ val' valTy' <- bindNames dict $ infer val
-    unifyTypes valTy valTy'
-    bindNames (M.singleton (Qualified Nothing ident) (valTy', nameKind, Defined))
-      $ inferLetBinding (seen ++ [ValueDecl sa ident nameKind [] [MkUnguarded val']]) rest ret j
+inferLetBinding seen (ValueDecl sa@(ss, _) publicName ident nameKind [] [MkUnguarded tv@(TypedValue checkType val ty)] : rest) ret j =
+  warnAndRethrow (addHint (ErrorInValueDeclaration (fromMaybe ident publicName))) $
+    warnAndRethrowWithPositionTC ss $ do
+      Just moduleName <- checkCurrentModule <$> get
+      (kind, args) <- kindOfWithScopedVars ty
+      checkTypeKind ty kind
+      let dict = M.singleton (Qualified Nothing ident) (ty, nameKind, Undefined)
+      ty' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty
+      TypedValue _ val' ty'' <- if checkType then withScopedTypeVars moduleName args (bindNames dict (check val ty')) else return tv
+      bindNames (M.singleton (Qualified Nothing ident) (ty'', nameKind, Defined))
+        $ inferLetBinding (seen ++ [ValueDecl sa publicName ident nameKind [] [MkUnguarded (TypedValue checkType val' ty'')]]) rest ret j
+inferLetBinding seen (ValueDecl sa@(ss, _) publicName ident nameKind [] [MkUnguarded val] : rest) ret j =
+  warnAndRethrow (addHint (ErrorInValueDeclaration (fromMaybe ident publicName))) $
+    warnAndRethrowWithPositionTC ss $ do
+      valTy <- freshType
+      let dict = M.singleton (Qualified Nothing ident) (valTy, nameKind, Undefined)
+      TypedValue _ val' valTy' <- bindNames dict $ infer val
+      unifyTypes valTy valTy'
+      bindNames (M.singleton (Qualified Nothing ident) (valTy', nameKind, Defined))
+        $ inferLetBinding (seen ++ [ValueDecl sa publicName ident nameKind [] [MkUnguarded val']]) rest ret j
 inferLetBinding seen (BindingGroupDeclaration ds : rest) ret j = do
   Just moduleName <- checkCurrentModule <$> get
   SplitBindingGroup untyped typed dict <- typeDictionaryForBindingGroup Nothing . NEL.toList $ fmap (\(i, _, v) -> (i, v)) ds

--- a/tests/Language/PureScript/Ide/SourceFileSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFileSpec.hs
@@ -23,7 +23,7 @@ ann2 = (span2, [])
 
 typeAnnotation1, value1, synonym1, class1, class2, data1, data2, valueFixity, typeFixity, foreign1, foreign2, foreign3, member1 :: P.Declaration
 typeAnnotation1 = P.TypeDeclaration (P.TypeDeclarationData ann1 (P.Ident "value1") P.REmpty)
-value1 = P.ValueDecl ann1 (P.Ident "value1") P.Public [] []
+value1 = P.ValueDecl ann1 Nothing (P.Ident "value1") P.Public [] []
 synonym1 = P.TypeSynonymDeclaration ann1 (P.ProperName "Synonym1") [] P.REmpty
 class1 = P.TypeClassDeclaration ann1 (P.ProperName "Class1") [] [] [] []
 class2 = P.TypeClassDeclaration ann1 (P.ProperName "Class2") [] [] [] [member1]


### PR DESCRIPTION
Example code:
```purescript
class Abc a where
  abc :: a -> a

instance abcInt :: Abc Int where
  abc a = let bac :: Int -> Int
              bac = 3 in bac a
```

Error diff:
```diff
    Could not match type
      Int
    with type
      Int -> Int

  while checking that type Int
    is at least as general as type Int -> Int
  while checking that expression 3
    has type Int -> Int
+ in value declaration bac
+ in value declaration abc
  in value declaration abcInt
```

I think this could be sufficient for the second half of #3390.