### PR TITLE
Fix `isUnquotedKey`, fixes #3479

### DIFF
--- a/src/Language/PureScript/Parser/Lexer.hs
+++ b/src/Language/PureScript/Parser/Lexer.hs
@@ -69,7 +69,7 @@ import Prelude.Compat hiding (lex)
 import Control.Applicative ((<|>))
 import Control.Monad (void, guard)
 import Control.Monad.Identity (Identity)
-import Data.Char (isSpace, isAscii, isSymbol, isAlphaNum)
+import Data.Char (isSpace, isAscii, isSymbol, isAlphaNum, isAlpha, isLower)
 import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -591,7 +591,7 @@ isSymbolChar c = (c `elem` (":!#$%&*+./<=>?@\\^|-~" :: [Char])) || (not (isAscii
 -- The characters allowed in the head of an unquoted record key
 --
 isUnquotedKeyHeadChar :: Char -> Bool
-isUnquotedKeyHeadChar c = (c == '_') || isAlphaNum c
+isUnquotedKeyHeadChar c = (c == '_') || (isAlpha c && isLower c)
 
 -- |
 -- The characters allowed in the tail of an unquoted record key
@@ -603,7 +603,9 @@ isUnquotedKeyTailChar c = (c `elem` ("_'" :: [Char])) || isAlphaNum c
 -- Strings allowed to be left unquoted in a record key
 --
 isUnquotedKey :: Text -> Bool
-isUnquotedKey t = case T.uncons t of
-  Nothing -> False
-  Just (hd, tl) -> isUnquotedKeyHeadChar hd &&
-                   T.all isUnquotedKeyTailChar tl
+isUnquotedKey t =
+  t `notElem` reservedPsNames
+  && case T.uncons t of
+      Nothing -> False
+      Just (hd, tl) -> isUnquotedKeyHeadChar hd &&
+                       T.all isUnquotedKeyTailChar tl

--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -12,10 +12,9 @@ import Control.Monad.State (StateT, modify, get)
 import Data.List (elemIndices, intersperse)
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Char (isUpper)
 
 import Language.PureScript.AST (SourcePos(..), SourceSpan(..))
-import Language.PureScript.Parser.Lexer (isUnquotedKey, reservedPsNames)
+import Language.PureScript.Parser.Lexer (isUnquotedKey)
 
 import Text.PrettyPrint.Boxes hiding ((<>))
 import qualified Text.PrettyPrint.Boxes as Box
@@ -148,11 +147,7 @@ prettyPrintMany f xs = do
   return $ intercalate (emit "\n") $ map (mappend indentString) ss
 
 objectKeyRequiresQuoting :: Text -> Bool
-objectKeyRequiresQuoting s =
-  s `elem` reservedPsNames || not (isUnquotedKey s) || startsUppercase s where
-    startsUppercase label = case T.uncons label of
-      Just (c, _) -> isUpper c
-      _ -> False
+objectKeyRequiresQuoting = not . isUnquotedKey
 
 -- | Place a box before another, vertically when the first box takes up multiple lines.
 before :: Box -> Box -> Box


### PR DESCRIPTION
Fixes labels not being quoted in error messages in some cases where they
should have been. For example:

Input code:
```
test :: { "Oops" :: Int }
test = { }
```

Before:
```
  Type of expression lacks required label Oops.

while checking that expression {}
  has type { Oops :: Int
           }
in value declaration test
```

After:
```
  Type of expression lacks required label "Oops".

while checking that expression {}
  has type { "Oops" :: Int
           }
in value declaration test
```

At the time of writing, there is just this one use of `isUnquotedKey`
throughout the entire compiler, so the refactoring I've done here is
safe.

There doesn't appear to be a good way to test this, so I haven't added tests.