### PR TITLE
Prevent invalid JS being generated from awkward record labels

### DIFF
--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -233,16 +233,16 @@ moduleToJs (Module _ coms mn _ imps exps foreigns decls) foreign_ =
     ds' <- concat <$> mapM bindToJs ds
     ret <- valueToJs val
     return $ AST.App Nothing (AST.Function Nothing Nothing [] (AST.Block Nothing (ds' ++ [AST.Return Nothing ret]))) []
-  valueToJs' (Constructor (_, _, _, Just IsNewtype) _ (ProperName ctor) _) =
+  valueToJs' (Constructor (_, _, _, Just IsNewtype) _ ctor _) =
     return $ AST.VariableIntroduction Nothing (properToJs ctor) (Just $
                 AST.ObjectLiteral Nothing [("create",
                   AST.Function Nothing Nothing ["value"]
                     (AST.Block Nothing [AST.Return Nothing $ AST.Var Nothing "value"]))])
-  valueToJs' (Constructor _ _ (ProperName ctor) []) =
+  valueToJs' (Constructor _ _ ctor []) =
     return $ iife (properToJs ctor) [ AST.Function Nothing (Just (properToJs ctor)) [] (AST.Block Nothing [])
            , AST.Assignment Nothing (accessorString "value" (AST.Var Nothing (properToJs ctor)))
                 (AST.Unary Nothing AST.New $ AST.App Nothing (AST.Var Nothing (properToJs ctor)) []) ]
-  valueToJs' (Constructor _ _ (ProperName ctor) fields) =
+  valueToJs' (Constructor _ _ ctor fields) =
     let constructor =
           let body = [ AST.Assignment Nothing ((accessorString $ mkString $ identToJs f) (AST.Var Nothing "this")) (var f) | f <- fields ]
           in AST.Function Nothing (Just (properToJs ctor)) (identToJs `map` fields) (AST.Block Nothing body)

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -33,14 +33,29 @@ identToJs UnusedIdent = "$__unused"
 properToJs :: ProperName a -> Text
 properToJs = anyNameToJs . runProperName
 
+-- | Convert any name into a valid JavaScript identifier.
+--
+-- Note that this function assumes that the argument is a valid PureScript
+-- identifier (either an 'Ident' or a 'ProperName') to begin with; as such it
+-- will not produce valid JavaScript identifiers if the argument e.g. begins
+-- with a digit. Prefer 'identToJs' or 'properToJs' where possible.
 anyNameToJs :: Text -> Text
-anyNameToJs name =
+anyNameToJs name
   | nameIsJsReserved name || nameIsJsBuiltIn name = "$$" <> name
   | otherwise = T.concatMap identCharToText name
 
--- | Test if a string is a valid AST identifier without escaping.
-identNeedsEscaping :: Text -> Bool
-identNeedsEscaping s = s /= properToJs s || T.null s
+-- | Test if a string is a valid JavaScript identifier as-is. Note that, while
+-- a return value of 'True' guarantees that the string is a valid JS
+-- identifier, a return value of 'False' does not guarantee that the string is
+-- not a valid JS identifier. That is, this check is more conservative than
+-- absolutely necessary.
+isValidJsIdentifier :: Text -> Bool
+isValidJsIdentifier s =
+  and
+    [ not (T.null s)
+    , isAlpha (T.head s)
+    , s == anyNameToJs s
+    ]
 
 -- | Attempts to find a human-readable name for a symbol, if none has been specified returns the
 -- ordinal value.

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -20,15 +20,21 @@ moduleNameToJs (ModuleName pns) =
 --  * Alphanumeric characters are kept unmodified.
 --
 --  * Reserved javascript identifiers are prefixed with '$$'.
---
---  * Symbols are prefixed with '$' followed by a symbol name or their ordinal value.
 identToJs :: Ident -> Text
-identToJs (Ident name) = properToJs name
+identToJs (Ident name) = anyNameToJs name
 identToJs (GenIdent _ _) = internalError "GenIdent in identToJs"
 identToJs UnusedIdent = "$__unused"
 
-properToJs :: Text -> Text
-properToJs name
+-- | Convert a 'ProperName' into a valid JavaScript identifier:
+--
+--  * Alphanumeric characters are kept unmodified.
+--
+--  * Reserved javascript identifiers are prefixed with '$$'.
+properToJs :: ProperName a -> Text
+properToJs = anyNameToJs . runProperName
+
+anyNameToJs :: Text -> Text
+anyNameToJs name =
   | nameIsJsReserved name || nameIsJsBuiltIn name = "$$" <> name
   | otherwise = T.concatMap identCharToText name
 

--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -57,7 +57,7 @@ literals = mkPattern' match'
     objectPropertyToString :: (Emit gen) => PSString -> gen
     objectPropertyToString s =
       emit $ case decodeString s of
-        Just s' | not (identNeedsEscaping s') ->
+        Just s' | isValidJsIdentifier s' ->
           s'
         _ ->
           prettyPrintStringJS s
@@ -154,7 +154,7 @@ accessor = mkPattern match
   where
   match (Indexer _ (StringLiteral _ prop) val) =
     case decodeString prop of
-      Just s | not (identNeedsEscaping s) -> Just (s, val)
+      Just s | isValidJsIdentifier s -> Just (s, val)
       _ -> Nothing
   match _ = Nothing
 

--- a/tests/purs/passing/3481.purs
+++ b/tests/purs/passing/3481.purs
@@ -1,0 +1,7 @@
+module Main where
+
+import Effect.Console (log)
+
+message = { "0": { "1": "Done" }}
+
+main = log message."0"."1"


### PR DESCRIPTION
Fixes #3481. I've also included a commit with a small refactoring and improvement of some docs: in particular, I've removed a the now-misleading comment about what is done with symbols, because `Ident` values no longer contain symbols since we started requiring symbols to be aliases for named functions. I'd suggest reviewing each commit separately.