### PR TITLE
Fix isUnquotedKey check to allow reserved names

### DIFF
--- a/src/Language/PureScript/Parser/Lexer.hs
+++ b/src/Language/PureScript/Parser/Lexer.hs
@@ -604,8 +604,7 @@ isUnquotedKeyTailChar c = (c `elem` ("_'" :: [Char])) || isAlphaNum c
 --
 isUnquotedKey :: Text -> Bool
 isUnquotedKey t =
-  t `notElem` reservedPsNames
-  && case T.uncons t of
-      Nothing -> False
-      Just (hd, tl) -> isUnquotedKeyHeadChar hd &&
-                       T.all isUnquotedKeyTailChar tl
+  case T.uncons t of
+    Nothing -> False
+    Just (hd, tl) -> isUnquotedKeyHeadChar hd &&
+                     T.all isUnquotedKeyTailChar tl


### PR DESCRIPTION
Fixes #3482. We have allowed reserved names (like `data` or `type`) to
be used as record labels without being quoted since #699 was resolved.
This commit makes the `isUnquotedKey` function aware of this, having the
effect that these labels are no longer unnecessarily quoted in error
messages. For example, if we enter

    > {} :: { data :: Int }

in the repl, we now receive:

    Error found:

      Type of expression lacks required label data.

    while checking that expression {}
      has type { data :: Int
               }

whereas previously, `data` would have been quoted.