### PR TITLE
Remove pretty print constructors from Type

### DIFF
--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -42,23 +42,22 @@ moduleAsMarkdown Module{..} = do
   headerLevel 2 $ "Module " <> P.runModuleName modName
   spacer
   for_ modComments tell'
-  mapM_ (declAsMarkdown modName) modDeclarations
+  mapM_ declAsMarkdown modDeclarations
   spacer
   for_ modReExports $ \(mn', decls) -> do
     let mn = ignorePackage mn'
     headerLevel 3 $ "Re-exported from " <> P.runModuleName mn <> ":"
     spacer
-    mapM_ (declAsMarkdown mn) decls
+    mapM_ declAsMarkdown decls
 
-declAsMarkdown :: P.ModuleName -> Declaration -> Docs
-declAsMarkdown mn decl@Declaration{..} = do
-  let options = defaultRenderTypeOptions { currentModule = Just mn }
+declAsMarkdown :: Declaration -> Docs
+declAsMarkdown decl@Declaration{..} = do
   headerLevel 4 (ticks declTitle)
   spacer
 
   let (instances, children) = partition (isChildInstance . cdeclInfo) declChildren
   fencedBlock $ do
-    tell' (codeToString $ Render.renderDeclarationWithOptions options decl)
+    tell' (codeToString $ Render.renderDeclaration decl)
     zipWithM_ (\f c -> tell' (childToString f c)) (First : repeat NotFirst) children
   spacer
 

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -114,9 +114,6 @@ lint (Module _ _ mn ds _) = censor (addHint (ErrorInModule mn)) $ mapM_ lintDecl
       go unused TypeOp{} = (unused, mempty)
       go unused Skolem{} = (unused, mempty)
       go unused REmpty{} = (unused, mempty)
-      go unused PrettyPrintFunction{} = (unused, mempty)
-      go unused PrettyPrintObject{} = (unused, mempty)
-      go unused PrettyPrintForAll{} = (unused, mempty)
 
       combine ::
         (S.Set Text, MultipleErrors) ->


### PR DESCRIPTION
This PR removes the `PrettyPrint` constructors from `Type` in favor of a separate type AST for pretty printing. I also removed `RenderTypeOptions` and all the `*WithOptions` variations for rendering because they only ever used the defaults (`currentModule` was completely unused).