### PR TITLE
Add named type wildcards

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -141,7 +141,7 @@ data SimpleErrorMessage
   | ShadowedName Ident
   | ShadowedTypeVar Text
   | UnusedTypeVar Text
-  | WildcardInferredType SourceType Context
+  | WildcardInferredType SourceType Context (Maybe Text)
   | HoleInferredType Text SourceType Context TypeSearch
   | MissingTypeDeclaration Ident SourceType
   | OverlappingPattern [[Binder]] Bool

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -141,8 +141,8 @@ data SimpleErrorMessage
   | ShadowedName Ident
   | ShadowedTypeVar Text
   | UnusedTypeVar Text
-  | WildcardInferredType SourceType Context (Maybe Text)
-  | HoleInferredType Text SourceType Context TypeSearch
+  | WildcardInferredType SourceType Context
+  | HoleInferredType Text SourceType Context (Maybe TypeSearch)
   | MissingTypeDeclaration Ident SourceType
   | OverlappingPattern [[Binder]] Bool
   | IncompleteExhaustivityCheck

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -115,7 +115,7 @@ convertDeclaration (P.ValueDecl sa _ _ _ [P.MkUnguarded (P.TypedValue _ _ ty)]) 
 convertDeclaration (P.ValueDecl sa _ _ _ _) title =
   -- If no explicit type declaration was provided, insert a wildcard, so that
   -- the actual type will be added during type checking.
-  basicDeclaration sa title (ValueDeclaration (P.TypeWildcard ()))
+  basicDeclaration sa title (ValueDeclaration (P.TypeWildcard () Nothing))
 convertDeclaration (P.ExternDeclaration sa _ ty) title =
   basicDeclaration sa title (ValueDeclaration (ty $> ()))
 convertDeclaration (P.DataDeclaration sa dtype _ args ctors) title =

--- a/src/Language/PureScript/Docs/RenderedCode/RenderType.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/RenderType.hs
@@ -31,8 +31,8 @@ import Language.PureScript.Docs.RenderedCode.RenderKind (renderKind)
 typeLiterals :: Pattern () PrettyPrintType RenderedCode
 typeLiterals = mkPattern match
   where
-  match PPTypeWildcard =
-    Just (syntax "_")
+  match (PPTypeWildcard name) =
+    Just $ maybe (syntax "_") (syntax . ("?" <>)) name
   match (PPTypeVar var) =
     Just (typeVar var)
   match (PPRecord row) =

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -286,8 +286,8 @@ onTypesInErrorMessageM f (ErrorMessage hints simple) = ErrorMessage <$> traverse
   gSimple (ExpectedTypeConstructor cl ts ty) = ExpectedTypeConstructor cl <$> traverse f ts <*> f ty
   gSimple (ExpectedType ty k) = ExpectedType <$> f ty <*> pure k
   gSimple (OrphanInstance nm cl noms ts) = OrphanInstance nm cl noms <$> traverse f ts
-  gSimple (WildcardInferredType ty ctx n) = WildcardInferredType <$> f ty <*> traverse (sndM f) ctx <*> pure n
-  gSimple (HoleInferredType name ty ctx env) = HoleInferredType name <$> f ty <*> traverse (sndM f) ctx  <*> onTypeSearchTypesM f env
+  gSimple (WildcardInferredType ty ctx) = WildcardInferredType <$> f ty <*> traverse (sndM f) ctx
+  gSimple (HoleInferredType name ty ctx env) = HoleInferredType name <$> f ty <*> traverse (sndM f) ctx  <*> traverse (onTypeSearchTypesM f) env
   gSimple (MissingTypeDeclaration nm ty) = MissingTypeDeclaration nm <$> f ty
   gSimple (CannotGeneralizeRecursiveFunction nm ty) = CannotGeneralizeRecursiveFunction nm <$> f ty
   gSimple other = pure other
@@ -320,7 +320,7 @@ errorSuggestion err =
       ImplicitQualifiedImportReExport mn asModule refs -> suggest $ importSuggestion mn refs (Just asModule)
       HidingImport mn refs -> suggest $ importSuggestion mn refs Nothing
       MissingTypeDeclaration ident ty -> suggest $ showIdent ident <> " :: " <> T.pack (prettyPrintSuggestedType ty)
-      WildcardInferredType ty _ _ -> suggest $ T.pack (prettyPrintSuggestedType ty)
+      WildcardInferredType ty _ -> suggest $ T.pack (prettyPrintSuggestedType ty)
       _ -> Nothing
   where
     emptySuggestion = Just $ ErrorSuggestion ""
@@ -835,11 +835,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "hiding imports cannot be used to hide modules."
             , line $ "An attempt was made to hide the import of " <> markCode (runModuleName name)
             ]
-    renderSimpleErrorMessage (WildcardInferredType ty ctx (Just name)) =
-      paras $ [ line $ "Wildcard type definition '" <> markCode name <> "' has the inferred type "
-              , markCodeBox $ indent $ typeAsBox ty
-              ] <> renderContext ctx
-    renderSimpleErrorMessage (WildcardInferredType ty ctx Nothing) =
+    renderSimpleErrorMessage (WildcardInferredType ty ctx) =
       paras $ [ line "Wildcard type definition has the inferred type "
               , markCodeBox $ indent $ typeAsBox ty
               ] <> renderContext ctx
@@ -847,7 +843,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       let
         maxTSResults = 15
         tsResult = case ts of
-          (TSAfter{tsAfterIdentifiers=idents}) | not (null idents) ->
+          Just (TSAfter{tsAfterIdentifiers=idents}) | not (null idents) ->
             let
               formatTS (names, types) =
                 let

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -52,7 +52,7 @@ encodeRebuildErrors = toJSON . map encodeRebuildError . P.runMultipleErrors
     encodeRebuildError err = case err of
       (P.ErrorMessage _
        ((P.HoleInferredType name _ _
-         (P.TSAfter{tsAfterIdentifiers=idents, tsAfterRecordFields=fields})))) ->
+         (Just (P.TSAfter{tsAfterIdentifiers=idents, tsAfterRecordFields=fields}))))) ->
         insertTSCompletions name idents (fromMaybe [] fields) (toJSON (toJSONError False P.Error err))
       _ ->
         (toJSON . toJSONError False P.Error) err

--- a/src/Language/PureScript/Parser/Types.hs
+++ b/src/Language/PureScript/Parser/Types.hs
@@ -37,7 +37,10 @@ parseTypeLevelString :: TokenParser SourceType
 parseTypeLevelString = withSourceAnnF $ flip TypeLevelString <$> stringLiteral
 
 parseTypeWildcard :: TokenParser SourceType
-parseTypeWildcard = withSourceAnnF $ underscore $> TypeWildcard
+parseTypeWildcard = withSourceAnnF $ do
+  name <- Just <$> holeLit
+      <|> Nothing <$ underscore
+  return $ flip TypeWildcard name
 
 parseTypeVariable :: TokenParser SourceType
 parseTypeVariable = withSourceAnnF $ do

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -45,7 +45,7 @@ data PrettyPrintType
   = PPTUnknown Int
   | PPTypeVar Text
   | PPTypeLevelString PSString
-  | PPTypeWildcard
+  | PPTypeWildcard (Maybe Text)
   | PPTypeConstructor (Qualified (ProperName 'TypeName))
   | PPTypeOp (Qualified (OpName 'TypeOpName))
   | PPSkolem Text Int
@@ -68,7 +68,7 @@ convertPrettyPrintType = go
   go (TUnknown _ n) = PPTUnknown n
   go (TypeVar _ t) = PPTypeVar t
   go (TypeLevelString _ s) = PPTypeLevelString s
-  go (TypeWildcard _) = PPTypeWildcard
+  go (TypeWildcard _ n) = PPTypeWildcard n
   go (TypeConstructor _ c) = PPTypeConstructor c
   go (TypeOp _ o) = PPTypeOp o
   go (Skolem _ t n _) = PPSkolem t n
@@ -161,7 +161,7 @@ matchTypeAtom tro@TypeRenderOptions{troSuggesting = suggesting} =
   where
     typeLiterals :: Pattern () PrettyPrintType Box
     typeLiterals = mkPattern match where
-      match PPTypeWildcard = Just $ text "_"
+      match (PPTypeWildcard name) = Just $ maybe (text "_") (text . ('?' :) . T.unpack) name
       match (PPTypeVar var) = Just $ text $ T.unpack var
       match (PPTypeLevelString s) = Just $ text $ T.unpack $ prettyPrintString s
       match (PPRecord row) = Just $ prettyPrintRowWith tro '{' '}' row

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -427,7 +427,7 @@ deriveGenericRep ss mn syns ds tyConNm tyConArgs repTy = do
     argument' = App (Constructor ss argument)
 
 checkIsWildcard :: MonadError MultipleErrors m => SourceSpan -> ProperName 'TypeName -> SourceType -> m ()
-checkIsWildcard _ _ (TypeWildcard _) = return ()
+checkIsWildcard _ _ (TypeWildcard _ Nothing) = return ()
 checkIsWildcard ss tyConNm _ =
   throwError . errorMessage' ss $ ExpectedWildcard tyConNm
 

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -43,8 +43,6 @@ import Language.PureScript.Types
 
 import Lens.Micro.Platform ((^..), _1, _2)
 
-import Debug.Trace as T
-
 addDataType
   :: (MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
   => ModuleName

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -16,10 +16,10 @@ import Control.Monad (when, unless, void, forM)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Class (MonadState(..), modify, gets)
 import Control.Monad.Supply.Class (MonadSupply)
-import Control.Monad.Writer.Class (MonadWriter(..))
+import Control.Monad.Writer.Class (MonadWriter(..), censor)
 
 import Data.Foldable (for_, traverse_, toList)
-import Data.List (nub, nubBy, (\\), sort, group)
+import Data.List (nub, nubBy, (\\), sort, group, intersect)
 import Data.Maybe
 import Data.Text (Text)
 import qualified Data.List.NonEmpty as NEL
@@ -42,6 +42,8 @@ import Language.PureScript.TypeClassDictionaries
 import Language.PureScript.Types
 
 import Lens.Micro.Platform ((^..), _1, _2)
+
+import Debug.Trace as T
 
 addDataType
   :: (MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
@@ -274,12 +276,13 @@ typeCheckAll moduleName _ = traverse go
     internalError "Type declarations should have been removed before typeCheckAlld"
   go (ValueDecl sa@(ss, _) name nameKind [] [MkUnguarded val]) = do
     env <- getEnv
-    warnAndRethrow (addHint (ErrorInValueDeclaration name) . addHint (positionedError ss)) $ do
+    warnAndRethrow (addHint (ErrorInValueDeclaration name) . addHint (positionedError ss)) . censorLocalUnnamedWildcards val $ do
       val' <- checkExhaustiveExpr ss env moduleName val
       valueIsNotDefined moduleName name
       [(_, (val'', ty))] <- typesOf NonRecursiveBindingGroup moduleName [((sa, name), val')]
       addValue moduleName name ty nameKind
       return $ ValueDecl sa name nameKind [] [MkUnguarded val'']
+    where
   go ValueDeclaration{} = internalError "Binders were not desugared"
   go BoundValueDeclaration{} = internalError "BoundValueDeclaration should be desugared"
   go (BindingGroupDeclaration vals) = do
@@ -463,6 +466,21 @@ typeCheckAll moduleName _ = traverse go
   checkOrphanInstance dictName className tys' nonOrphanModules
     | moduleName `S.member` nonOrphanModules = return ()
     | otherwise = throwError . errorMessage $ OrphanInstance dictName className nonOrphanModules tys'
+
+  censorLocalUnnamedWildcards :: Expr -> m a -> m a
+  censorLocalUnnamedWildcards (TypedValue _ _ ty) = censor (filterErrors (not . isLocalUnnamedWildcardError ty))
+  censorLocalUnnamedWildcards _ = id
+
+  isLocalUnnamedWildcardError :: SourceType -> ErrorMessage -> Bool
+  isLocalUnnamedWildcardError ty err@(ErrorMessage _ (WildcardInferredType _ _ Nothing)) =
+    let
+      ssWildcard (TypeWildcard (ss', _) Nothing) = [ss']
+      ssWildcard _ = []
+      sssWildcards = everythingOnTypes (<>) ssWildcard ty
+      sss = maybe [] NEL.toList $ errorSpan err
+    in
+      null $ intersect sss sssWildcards
+  isLocalUnnamedWildcardError _ _ = False
 
   -- |
   -- This function adds the argument kinds for a type constructor so that they may appear in the externs file,

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -470,7 +470,7 @@ typeCheckAll moduleName _ = traverse go
   censorLocalUnnamedWildcards _ = id
 
   isLocalUnnamedWildcardError :: SourceType -> ErrorMessage -> Bool
-  isLocalUnnamedWildcardError ty err@(ErrorMessage _ (WildcardInferredType _ _ Nothing)) =
+  isLocalUnnamedWildcardError ty err@(ErrorMessage _ (WildcardInferredType _ _)) =
     let
       ssWildcard (TypeWildcard (ss', _) Nothing) = [ss']
       ssWildcard _ = []

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -151,12 +151,12 @@ typesOf bindingGroupType moduleName vals = withFreshSubstitution $ do
       -> ErrorMessage
       -> ErrorMessage
     runTypeSearch cons st = \case
-      ErrorMessage hints (HoleInferredType x ty y (TSBefore env)) ->
+      ErrorMessage hints (HoleInferredType x ty y (Just (TSBefore env))) ->
         let subst = checkSubstitution st
             searchResult = onTypeSearchTypes
               (substituteType subst)
               (uncurry TSAfter (typeSearch cons env st (substituteType subst ty)))
-        in ErrorMessage hints (HoleInferredType x ty y searchResult)
+        in ErrorMessage hints (HoleInferredType x ty y (Just searchResult))
       other -> other
 
     -- | Generalize type vars using forall and add inferred constraints
@@ -415,7 +415,7 @@ infer' (Hole name) = do
   ty <- freshType
   ctx <- getLocalContext
   env <- getEnv
-  tell . errorMessage $ HoleInferredType name ty ctx (TSBefore env)
+  tell . errorMessage $ HoleInferredType name ty ctx . Just $ TSBefore env
   return $ TypedValue True (Hole name) ty
 infer' (PositionedValue pos c val) = warnAndRethrowWithPositionTC pos $ do
   TypedValue t v ty <- infer' val

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -187,7 +187,8 @@ replaceTypeWildcards = everywhereOnTypesM replace
   replace (TypeWildcard ann name) = do
     t <- freshType
     ctx <- getLocalContext
-    warnWithPosition (fst ann) $ tell . errorMessage $ WildcardInferredType t ctx name
+    let err = maybe (WildcardInferredType t ctx) (\n -> HoleInferredType n t ctx Nothing) name
+    warnWithPosition (fst ann) $ tell $ errorMessage err
     return t
   replace other = return other
 

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -184,10 +184,10 @@ replaceVarWithUnknown ident ty = do
 replaceTypeWildcards :: (MonadWriter MultipleErrors m, MonadState CheckState m) => SourceType -> m SourceType
 replaceTypeWildcards = everywhereOnTypesM replace
   where
-  replace (TypeWildcard ann) = do
+  replace (TypeWildcard ann name) = do
     t <- freshType
     ctx <- getLocalContext
-    warnWithPosition (fst ann) $ tell . errorMessage $ WildcardInferredType t ctx
+    warnWithPosition (fst ann) $ tell . errorMessage $ WildcardInferredType t ctx name
     return t
   replace other = return other
 

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -56,7 +56,7 @@ data Type a
   -- | A type-level string
   | TypeLevelString a PSString
   -- | A type wildcard, as would appear in a partial type synonym
-  | TypeWildcard a
+  | TypeWildcard a (Maybe Text)
   -- | A type constructor
   | TypeConstructor a (Qualified (ProperName 'TypeName))
   -- | A type operator. This will be desugared into a type constructor during the
@@ -99,7 +99,7 @@ srcTypeLevelString :: PSString -> SourceType
 srcTypeLevelString = TypeLevelString NullSourceAnn
 
 srcTypeWildcard :: SourceType
-srcTypeWildcard = TypeWildcard NullSourceAnn
+srcTypeWildcard = TypeWildcard NullSourceAnn Nothing
 
 srcTypeConstructor :: Qualified (ProperName 'TypeName) -> SourceType
 srcTypeConstructor = TypeConstructor NullSourceAnn
@@ -193,8 +193,8 @@ typeToJSON annToJSON ty =
       variant "TypeVar" a b
     TypeLevelString a b ->
       variant "TypeLevelString" a b
-    TypeWildcard a ->
-      nullary "TypeWildcard" a
+    TypeWildcard a b ->
+      variant "TypeWildcard" a b
     TypeConstructor a b ->
       variant "TypeConstructor" a b
     TypeOp a b ->
@@ -272,8 +272,9 @@ typeFromJSON defaultAnn annFromJSON = A.withObject "Type" $ \o -> do
       TypeVar a <$> contents
     "TypeLevelString" ->
       TypeLevelString a <$> contents
-    "TypeWildcard" ->
-      pure $ TypeWildcard a
+    "TypeWildcard" -> do
+      b <- contents <|> pure Nothing
+      pure $ TypeWildcard a b
     "TypeConstructor" ->
       TypeConstructor a <$> contents
     "TypeOp" ->
@@ -518,7 +519,7 @@ annotationForType :: Type a -> a
 annotationForType (TUnknown a _) = a
 annotationForType (TypeVar a _) = a
 annotationForType (TypeLevelString a _) = a
-annotationForType (TypeWildcard a) = a
+annotationForType (TypeWildcard a _) = a
 annotationForType (TypeConstructor a _) = a
 annotationForType (TypeOp a _) = a
 annotationForType (TypeApp a _ _) = a
@@ -541,7 +542,7 @@ eqType :: Type a -> Type b -> Bool
 eqType (TUnknown _ a) (TUnknown _ a') = a == a'
 eqType (TypeVar _ a) (TypeVar _ a') = a == a'
 eqType (TypeLevelString _ a) (TypeLevelString _ a') = a == a'
-eqType (TypeWildcard _) (TypeWildcard _) = True
+eqType (TypeWildcard _ a) (TypeWildcard _ a') = a == a'
 eqType (TypeConstructor _ a) (TypeConstructor _ a') = a == a'
 eqType (TypeOp _ a) (TypeOp _ a') = a == a'
 eqType (TypeApp _ a b) (TypeApp _ a' b') = eqType a a' && eqType b b'
@@ -567,9 +568,9 @@ compareType (TypeLevelString _ a) (TypeLevelString _ a') = compare a a'
 compareType (TypeLevelString {}) _ = LT
 compareType _ (TypeLevelString {}) = GT
 
-compareType (TypeWildcard _) (TypeWildcard _) = EQ
-compareType (TypeWildcard _) _ = LT
-compareType _ (TypeWildcard _) = GT
+compareType (TypeWildcard _ a) (TypeWildcard _ a') = compare a a'
+compareType (TypeWildcard {}) _ = LT
+compareType _ (TypeWildcard {}) = GT
 
 compareType (TypeConstructor _ a) (TypeConstructor _ a') = compare a a'
 compareType (TypeConstructor {}) _ = LT

--- a/tests/purs/failing/TypedHole2.purs
+++ b/tests/purs/failing/TypedHole2.purs
@@ -1,0 +1,8 @@
+-- @shouldFailWith HoleInferredType
+module Main where
+
+import Prelude
+import Effect (Effect)
+
+main :: Effect ?ummm
+main = pure unit

--- a/tests/purs/warning/WildcardInferredType.purs
+++ b/tests/purs/warning/WildcardInferredType.purs
@@ -1,27 +1,14 @@
 -- @shouldWarnWith WildcardInferredType
 -- @shouldWarnWith WildcardInferredType
--- @shouldWarnWith WildcardInferredType
--- @shouldWarnWith WildcardInferredType
--- @shouldWarnWith WildcardInferredType
 module Main where
 
-x :: Int
-x = 0 :: ?x
+x = 0 :: _
 
-y :: ?y
+y :: _
 y = 0
 
 z :: Int
 z =
-  let n :: ?n
+  let n :: _
       n = 0
   in n
-
-w :: Int
-w = n
-  where
-  n :: ?n
-  n = 0
-
-v :: ?v
-v = 0

--- a/tests/purs/warning/WildcardInferredType.purs
+++ b/tests/purs/warning/WildcardInferredType.purs
@@ -2,22 +2,26 @@
 -- @shouldWarnWith WildcardInferredType
 -- @shouldWarnWith WildcardInferredType
 -- @shouldWarnWith WildcardInferredType
+-- @shouldWarnWith WildcardInferredType
 module Main where
 
 x :: Int
-x = 0 :: _
+x = 0 :: ?x
 
-y :: _
+y :: ?y
 y = 0
 
 z :: Int
 z =
-  let n :: _
+  let n :: ?n
       n = 0
   in n
 
 w :: Int
 w = n
   where
-  n :: _
+  n :: ?n
   n = 0
+
+v :: ?v
+v = 0

--- a/tests/purs/warning/WildcardInferredType2.purs
+++ b/tests/purs/warning/WildcardInferredType2.purs
@@ -1,0 +1,14 @@
+-- @shouldWarnWith WildcardInferredType
+module Main where
+
+x :: _
+x = 42
+
+y :: Int
+y = 42 :: _
+
+z :: Int
+z = n
+  where
+  n :: _
+  n = 42


### PR DESCRIPTION
Implements #715 #1228

This is a slight UX breaking change. This adds `?foo` syntax for types, which act as named wildcards which always warn. The previous `_` syntax acts as a partial type signature, which does not warn unless it's part of a module-level type signature.

I didn't change the warning (`WildcardInferredType`) except to add the name, but maybe it warrants a separate warning.