### PR TITLE
Remove the concept of the 'current module' in Docs

### DIFF
--- a/app/Command/Docs/Html.hs
+++ b/app/Command/Docs/Html.hs
@@ -48,8 +48,7 @@ writeHtmlFile filepath =
 
 getHtmlRenderContext :: P.ModuleName -> D.HtmlRenderContext
 getHtmlRenderContext mn = D.HtmlRenderContext
-  { D.currentModuleName = mn
-  , D.buildDocLink = getLink mn
+  { D.buildDocLink = getLink mn
   , D.renderDocLink = renderLink
   , D.renderSourceLink = const Nothing
   }
@@ -70,11 +69,11 @@ getLink curMn namespace target containingMod = do
   normalLinkLocation = do
     case containingMod of
       D.ThisModule ->
-        return D.SameModule
+        return $ D.LocalModule curMn
       D.OtherModule destMn ->
         -- This is OK because all modules count as 'local' for purs docs in
         -- html mode
-        return $ D.LocalModule curMn destMn
+        return $ D.LocalModule destMn
 
   builtinLinkLocation = do
     let primMn = P.moduleNameFromString "Prim"
@@ -84,9 +83,7 @@ getLink curMn namespace target containingMod = do
 renderLink :: D.DocLink -> Text
 renderLink l =
   case D.linkLocation l of
-    D.SameModule ->
-      ""
-    D.LocalModule _ dest ->
+    D.LocalModule dest ->
       P.runModuleName dest <> ".html"
     D.DepsModule{} ->
       P.internalError "DepsModule: not implemented"


### PR DESCRIPTION
The concept of the current module is unnecessary (we aren't using it
anywhere either in the compiler or in Pursuit) as well as potentially
confusing; for example, what is the 'current module' when we are
rendering re-exported declarations? Additionally, since the information
is not used, it would be easy for it to become incorrect without anyone
noticing.

This commit refactors the Docs related code, removing the concept of the
current module. Specifically, the following have been removed:

- the SameModule constructor from the LinkLocation data type;
  wherever we previously would have used that, we can now use the
  LocalModule constructor, which encodes precisely the same information.
- the 'current module' field from the constructors LocalModule and
  DepsModule of the data type LinkLocation, which was unused.
- the 'currentModuleName' field of the HtmlRenderContext data type,
  which was also unused.

I came across this refactoring opportunity while looking into #3504.