### PR TITLE
Fix kind error for recursive data type

### DIFF
--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -189,7 +189,7 @@ solveTypes isData ts kargs tyCon = do
   ks <- traverse (fmap fst . infer) ts
   when isData $ do
     unifyKinds tyCon (foldr srcFunKind kindType kargs)
-    forM_ ks $ \k -> unifyKinds k kindType
+    forM_ ks $ \k -> unifyKinds k (kindType $> getAnnForKind k)
   unless isData $
     unifyKinds tyCon (foldr srcFunKind (head ks) kargs)
   return tyCon


### PR DESCRIPTION
@kRITZCREEK noticed that the kind error noted in https://github.com/purescript/purescript/issues/2216 is not any better.

New error:
```
[1/1 KindsDoNotUnify] KindSpan.purs:5:12

  5    | Cons a List
                ^^^^

  Could not match kind

    Type -> Type

  with kind

    Type

  in type constructor List
```