### PR TITLE
Fix: ado notation breaks docs generation

### DIFF
--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -249,6 +249,7 @@ partiallyDesugar = P.evalSupplyT 0 . desugar'
   where
   desugar' =
     traverse P.desugarDoModule
+      >=> traverse P.desugarAdoModule
       >=> map P.desugarLetPatternModule
       >>> traverse P.desugarCasesModule
       >=> traverse P.desugarTypeDeclarationsModule

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -643,6 +643,11 @@ testCases =
   , ("DeclOrderNoExportList",
       shouldBeOrdered (n "DeclOrderNoExportList")
         [ "x1", "x3", "X2", "X4", "A", "B" ])
+
+  , ("Ado",
+      [ ValueShouldHaveTypeSignature (n "Ado") "test" (renderedType "Int")
+      ]
+    )
   ]
 
   where

--- a/tests/purs/docs/src/Ado.purs
+++ b/tests/purs/docs/src/Ado.purs
@@ -1,0 +1,9 @@
+-- See https://github.com/purescript/purescript/issues/3414 
+module Ado where
+  
+test = 
+  ado x <- 1
+   in x
+
+  where
+  map f x = f x


### PR DESCRIPTION
Fixes #3414