### PR TITLE
Add the module from which something was imported to ReExportRefs

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -308,7 +308,7 @@ data DeclarationRef
   -- A value re-exported from another module. These will be inserted during
   -- elaboration in name desugaring.
   --
-  | ReExportRef SourceSpan ModuleName DeclarationRef
+  | ReExportRef SourceSpan ExportSource DeclarationRef
   deriving (Show, Generic, NFData)
 
 instance Eq DeclarationRef where
@@ -322,6 +322,13 @@ instance Eq DeclarationRef where
   (KindRef _ name) == (KindRef _ name') = name == name'
   (ReExportRef _ mn ref) == (ReExportRef _ mn' ref') = mn == mn' && ref == ref'
   _ == _ = False
+
+data ExportSource =
+  ExportSource
+  { exportSourceImportedFrom :: Maybe ModuleName
+  , exportSourceDefinedIn :: ModuleName
+  }
+  deriving (Eq, Ord, Show, Generic, NFData)
 
 -- enable sorting lists of explicitly imported refs when suggesting imports in linting, IDE, etc.
 -- not an Ord because this implementation is not consistent with its Eq instance.
@@ -902,6 +909,7 @@ newtype AssocList k t = AssocList { runAssocList :: [(k, t)] }
 
 $(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''DeclarationRef)
 $(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''ImportDeclarationType)
+$(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''ExportSource)
 
 isTrueExpr :: Expr -> Bool
 isTrueExpr (Literal _ (BooleanLiteral True)) = True

--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -124,10 +124,10 @@ collectDeclarations imports exports = do
     :: (Eq a, Show a)
     => (P.ModuleName -> a -> m (P.ModuleName, [b]))
     -> [P.ImportRecord a]
-    -> Map a P.ModuleName
+    -> Map a P.ExportSource
     -> m (Map P.ModuleName [b])
   collect lookup' imps exps = do
-    imps' <- traverse (findImport imps) $ Map.toList exps
+    imps' <- traverse (findImport imps) $ Map.toList $ fmap P.exportSourceDefinedIn exps
     Map.fromListWith (<>) <$> traverse (uncurry lookup') imps'
 
   expVals = P.exportedValues exports

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -119,7 +119,7 @@ data ToResolve
   | SynonymToResolve (P.ProperName 'P.TypeName) P.SourceType
 
 convertExport :: P.DeclarationRef -> Maybe (P.ModuleName, P.DeclarationRef)
-convertExport (P.ReExportRef _ m r) = Just (m, r)
+convertExport (P.ReExportRef _ src r) = Just (P.exportSourceDefinedIn src, r)
 convertExport _ = Nothing
 
 convertDecl :: P.ExternsDeclaration -> Either ToResolve (Maybe IdeDeclaration)

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -299,7 +299,7 @@ lintImportDecl env mni qualifierName names ss declType allowImplicit =
 
   dtys
     :: ModuleName
-    -> M.Map (ProperName 'TypeName) ([ProperName 'ConstructorName], ModuleName)
+    -> M.Map (ProperName 'TypeName) ([ProperName 'ConstructorName], ExportSource)
   dtys mn = maybe M.empty exportedTypes $ envModuleExports <$> mn `M.lookup` env
 
   dctorsForType

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -32,29 +32,35 @@ findExportable (Module _ _ mn ds _) =
   updateExports' :: Exports -> Declaration -> m Exports
   updateExports' exps decl = rethrowWithPosition (declSourceSpan decl) $ updateExports exps decl
 
+  source =
+    ExportSource
+    { exportSourceDefinedIn = mn
+    , exportSourceImportedFrom = Nothing
+    }
+
   updateExports :: Exports -> Declaration -> m Exports
   updateExports exps (TypeClassDeclaration (ss, _) tcn _ _ _ ds') = do
-    exps' <- rethrowWithPosition ss $ exportTypeClass ss Internal exps tcn mn
+    exps' <- rethrowWithPosition ss $ exportTypeClass ss Internal exps tcn source
     foldM go exps' ds'
     where
-    go exps'' (TypeDeclaration (TypeDeclarationData (ss', _) name _)) = exportValue ss' exps'' name mn
+    go exps'' (TypeDeclaration (TypeDeclarationData (ss', _) name _)) = exportValue ss' exps'' name source
     go _ _ = internalError "Invalid declaration in TypeClassDeclaration"
   updateExports exps (DataDeclaration (ss, _) _ tn _ dcs) =
-    exportType ss Internal exps tn (map fst dcs) mn
+    exportType ss Internal exps tn (map fst dcs) source
   updateExports exps (TypeSynonymDeclaration (ss, _) tn _ _) =
-    exportType ss Internal exps tn [] mn
+    exportType ss Internal exps tn [] source
   updateExports exps (ExternDataDeclaration (ss, _) tn _) =
-    exportType ss Internal exps tn [] mn
+    exportType ss Internal exps tn [] source
   updateExports exps (ValueDeclaration vd) =
-    exportValue (fst (valdeclSourceAnn vd)) exps (valdeclIdent vd) mn
+    exportValue (fst (valdeclSourceAnn vd)) exps (valdeclIdent vd) source
   updateExports exps (ValueFixityDeclaration (ss, _) _ _ op) =
-    exportValueOp ss exps op mn
+    exportValueOp ss exps op source
   updateExports exps (TypeFixityDeclaration (ss, _) _ _ op) =
-    exportTypeOp ss exps op mn
+    exportTypeOp ss exps op source
   updateExports exps (ExternDeclaration (ss, _) name _) =
-    exportValue ss exps name mn
+    exportValue ss exps name source
   updateExports exps (ExternKindDeclaration (ss, _) pn) =
-    exportKind ss exps pn mn
+    exportKind ss exps pn source
   updateExports exps _ = return exps
 
 -- |
@@ -110,12 +116,12 @@ resolveExports env ss mn imps exps refs =
     reValues <- extract ss' isPseudo name IdentName (importedValues imps)
     reValueOps <- extract ss' isPseudo name ValOpName (importedValueOps imps)
     reKinds <- extract ss' isPseudo name KiName (importedKinds imps)
-    foldM (\exps' ((tctor, dctors), mn') -> exportType ss' ReExport exps' tctor dctors mn') result (resolveTypeExports reTypes reDctors)
-      >>= flip (foldM (uncurry . exportTypeOp ss')) (map resolveTypeOp reTypeOps)
-      >>= flip (foldM (uncurry . exportTypeClass ss' ReExport)) (map resolveClass reClasses)
-      >>= flip (foldM (uncurry . exportValue ss')) (map resolveValue reValues)
-      >>= flip (foldM (uncurry . exportValueOp ss')) (map resolveValueOp reValueOps)
-      >>= flip (foldM (uncurry . exportKind ss')) (map resolveKind reKinds)
+    foldM (\exps' ((tctor, dctors), src) -> exportType ss' ReExport exps' tctor dctors src) result (resolveTypeExports reTypes reDctors)
+      >>= flip (foldM (uncurry . exportTypeOp ss')) (map (resolveTypeOp name) reTypeOps)
+      >>= flip (foldM (uncurry . exportTypeClass ss' ReExport)) (map (resolveClass name) reClasses)
+      >>= flip (foldM (uncurry . exportValue ss')) (map (resolveValue name) reValues)
+      >>= flip (foldM (uncurry . exportValueOp ss')) (map (resolveValueOp name) reValueOps)
+      >>= flip (foldM (uncurry . exportKind ss')) (map (resolveKind name) reKinds)
   elaborateModuleExports result _ = return result
 
   -- Extracts a list of values for a module based on a lookup table. If the
@@ -164,76 +170,83 @@ resolveExports env ss mn imps exps refs =
   resolveTypeExports
     :: [Qualified (ProperName 'TypeName)]
     -> [Qualified (ProperName 'ConstructorName)]
-    -> [((ProperName 'TypeName, [ProperName 'ConstructorName]), ModuleName)]
+    -> [((ProperName 'TypeName, [ProperName 'ConstructorName]), ExportSource)]
   resolveTypeExports tctors dctors = map go tctors
     where
     go
       :: Qualified (ProperName 'TypeName)
-      -> ((ProperName 'TypeName, [ProperName 'ConstructorName]), ModuleName)
+      -> ((ProperName 'TypeName, [ProperName 'ConstructorName]), ExportSource)
     go (Qualified (Just mn'') name) =
       fromMaybe (internalError "Missing value in resolveTypeExports") $ do
         exps' <- envModuleExports <$> mn'' `M.lookup` env
-        (dctors', mnOrig) <- name `M.lookup` exportedTypes exps'
+        (dctors', src) <- name `M.lookup` exportedTypes exps'
         let relevantDctors = mapMaybe (disqualifyFor (Just mn'')) dctors
-        return ((name, relevantDctors `intersect` dctors'), mnOrig)
+        return
+          ( (name, relevantDctors `intersect` dctors')
+          , src { exportSourceImportedFrom = Just mn'' }
+          )
     go (Qualified Nothing _) = internalError "Unqualified value in resolveTypeExports"
 
   -- Looks up an imported type operator and re-qualifies it with the original
   -- module it came from.
-  resolveTypeOp :: Qualified (OpName 'TypeOpName) -> (OpName 'TypeOpName, ModuleName)
-  resolveTypeOp op
-    = splitQual
+  resolveTypeOp :: ModuleName -> Qualified (OpName 'TypeOpName) -> (OpName 'TypeOpName, ExportSource)
+  resolveTypeOp mnFrom op
+    = splitQual mnFrom
     . fromMaybe (internalError "Missing value in resolveValue")
     $ resolve exportedTypeOps op
 
   -- Looks up an imported class and re-qualifies it with the original module it
   -- came from.
-  resolveClass :: Qualified (ProperName 'ClassName) -> (ProperName 'ClassName, ModuleName)
-  resolveClass className
-    = splitQual
+  resolveClass :: ModuleName -> Qualified (ProperName 'ClassName) -> (ProperName 'ClassName, ExportSource)
+  resolveClass mnFrom className
+    = splitQual mnFrom
     . fromMaybe (internalError "Missing value in resolveClass")
     $ resolve exportedTypeClasses className
 
   -- Looks up an imported value and re-qualifies it with the original module it
   -- came from.
-  resolveValue :: Qualified Ident -> (Ident, ModuleName)
-  resolveValue ident
-    = splitQual
+  resolveValue :: ModuleName -> Qualified Ident -> (Ident, ExportSource)
+  resolveValue mnFrom ident
+    = splitQual mnFrom
     . fromMaybe (internalError "Missing value in resolveValue")
     $ resolve exportedValues ident
 
   -- Looks up an imported operator and re-qualifies it with the original
   -- module it came from.
-  resolveValueOp :: Qualified (OpName 'ValueOpName) -> (OpName 'ValueOpName, ModuleName)
-  resolveValueOp op
-    = splitQual
+  resolveValueOp :: ModuleName -> Qualified (OpName 'ValueOpName) -> (OpName 'ValueOpName, ExportSource)
+  resolveValueOp mnFrom op
+    = splitQual mnFrom
     . fromMaybe (internalError "Missing value in resolveValueOp")
     $ resolve exportedValueOps op
 
   -- Looks up an imported kind and re-qualifies it with the original
   -- module it came from.
-  resolveKind :: Qualified (ProperName 'KindName) -> (ProperName 'KindName, ModuleName)
-  resolveKind kind
-    = splitQual
+  resolveKind :: ModuleName -> Qualified (ProperName 'KindName) -> (ProperName 'KindName, ExportSource)
+  resolveKind mnFrom kind
+    = splitQual mnFrom
     . fromMaybe (internalError "Missing value in resolveKind")
     $ resolve exportedKinds kind
 
   resolve
     :: Ord a
-    => (Exports -> M.Map a ModuleName)
+    => (Exports -> M.Map a ExportSource)
     -> Qualified a
     -> Maybe (Qualified a)
   resolve f (Qualified (Just mn'') a) = do
     exps' <- envModuleExports <$> mn'' `M.lookup` env
-    mn''' <- a `M.lookup` f exps'
-    return $ Qualified (Just mn''') a
+    src <- a `M.lookup` f exps'
+    return $ Qualified (Just (exportSourceDefinedIn src)) a
   resolve _ _ = internalError "Unqualified value in resolve"
 
-  -- A partial function that takes a qualified value and extracts the value and
-  -- qualified module components.
-  splitQual :: Qualified a -> (a, ModuleName)
-  splitQual (Qualified (Just mn'') a) = (a, mn'')
-  splitQual _ = internalError "Unqualified value in splitQual"
+  -- A partial function that takes a module from something was imported and
+  -- a qualified value, and extracts the value and qualified module components.
+  splitQual :: ModuleName -> Qualified a -> (a, ExportSource)
+  splitQual mnFrom (Qualified (Just mnOrig) a) =
+    (a, ExportSource { exportSourceImportedFrom = Just mnFrom
+                     , exportSourceDefinedIn = mnOrig
+                     })
+  splitQual _ _ =
+    internalError "Unqualified value in splitQual"
 
 -- |
 -- Filters the full list of exportable values, types, and classes for a module
@@ -277,16 +290,16 @@ filterModule mn exps refs = do
     . mapMaybe (\ref -> (declRefSourceSpan ref,) <$> getTypeRef ref)
 
   filterTypes
-    :: M.Map (ProperName 'TypeName) ([ProperName 'ConstructorName], ModuleName)
+    :: M.Map (ProperName 'TypeName) ([ProperName 'ConstructorName], ExportSource)
     -> DeclarationRef
-    -> m (M.Map (ProperName 'TypeName) ([ProperName 'ConstructorName], ModuleName))
+    -> m (M.Map (ProperName 'TypeName) ([ProperName 'ConstructorName], ExportSource))
   filterTypes result (TypeRef ss name expDcons) =
     case name `M.lookup` exportedTypes exps of
       Nothing -> throwError . errorMessage' ss . UnknownExport $ TyName name
-      Just (dcons, _) -> do
+      Just (dcons, src) -> do
         let expDcons' = fromMaybe dcons expDcons
         traverse_ (checkDcon name dcons) expDcons'
-        return $ M.insert name (expDcons', mn) result
+        return $ M.insert name (expDcons', src) result
     where
     -- Ensures a data constructor is exportable for a given type. Takes a type
     -- name, a list of exportable data constructors for the type, and the name of
@@ -305,14 +318,17 @@ filterModule mn exps refs = do
     :: Ord a
     => (a -> Name)
     -> (DeclarationRef -> Maybe a)
-    -> (Exports -> M.Map a ModuleName)
-    -> M.Map a ModuleName
+    -> (Exports -> M.Map a ExportSource)
+    -> M.Map a ExportSource
     -> DeclarationRef
-    -> m (M.Map a ModuleName)
+    -> m (M.Map a ExportSource)
   filterExport toName get fromExps result ref
     | Just name <- get ref =
         case name `M.lookup` fromExps exps of
-          -- TODO: I'm not sure if we actually need to check mn == mn' here -gb
-          Just mn' | mn == mn' -> return $ M.insert name mn result
-          _ -> throwError . errorMessage' (declRefSourceSpan ref) . UnknownExport $ toName name
+          -- TODO: I'm not sure if we actually need to check that these modules
+          -- are the same here -gb
+          Just source' | mn == exportSourceDefinedIn source' ->
+            return $ M.insert name source' result
+          _ ->
+            throwError . errorMessage' (declRefSourceSpan ref) . UnknownExport $ toName name
   filterExport _ _ _ result _ = return result


### PR DESCRIPTION
Implements what was discussed in #2191 by adding the module from which something was imported to the `ReExportRef` in the externs files. This is a first step towards #3503 (and also removing Docs.Convert.ReExports), but might also be useful for purs repl and/or purs ide?

Here's an example of what a section of an externs.json file might look like before and after this change.

```purescript
-- src/Main.purs
module Main
  ( module P
  ) where

import Prelude (class Eq) as P
```
externs.json (before)
```json
  "ReExportRef": [
    {
      "start": [
        1,
        1
      ],
      "name": "src/Main.purs",
      "end": [
        5,
        50
      ]
    },
    [
      "Data",
      "Eq"
    ],
    {
      "TypeClassRef": [
        {
          "start": [
            1,
            1
          ],
          "name": "src/Main.purs",
          "end": [
            5,
            50
          ]
        },
        "Eq"
      ]
    }
  ]
```
externs.json (after)
```json
  "ReExportRef": [
    {
      "start": [
        1,
        1
      ],
      "name": "src/Main.purs",
      "end": [
        5,
        50
      ]
    },
    {
      "exportSourceImportedFrom": [
        "Prelude"
      ],
      "exportSourceDefinedIn": [
        "Data",
        "Eq"
      ]
    },
    {
      "TypeClassRef": [
        {
          "start": [
            1,
            1
          ],
          "name": "src/Main.purs",
          "end": [
            5,
            50
          ]
```