### PR TITLE
Bump ghc: 8.4.3 -> 8.4.4

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.0
+resolver: lts-12.15 # ghc-8.4.4
 packages:
 - '.'
 extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.15 # ghc-8.4.4
+resolver: lts-12.15  # ghc-8.4.4
 packages:
 - '.'
 extra-deps:


### PR DESCRIPTION
Fiixes builds on unstable NixOS, where ghc-8.4.3 is no longer available.

https://www.stackage.org/diff/lts-12.0/lts-12.15

ansi-terminal-0.8.0.4 -> ansi-terminal-0.8.1
base-compat-0.10.4 -> base-compat-0.10.5
dlist-0.8.0.4 -> dlist-0.8.0.5
Glob-0.9.2 -> Glob-0.9.3
monad-logger-0.3.28.5 -> monad-logger-0.3.30
parallel-3.2.1.1 -> parallel-3.2.2.0
stm-2.4.5.0 -> stm-2.4.5.1
text-1.2.3.0 -> text-1.2.3.1
http-types-0.12.1 -> http-types-0.12.2
optparse-applicative-0.14.2.0 -> optparse-applicative-0.14.3.0 
warp-3.2.22 -> warp-3.2.25 
websockets-0.12.5.1 -> websockets-0.12.5.2
tasty-1.1.0.2 -> tasty-1.1.0.4 
hspec-2.5.4 -> hspec-2.5.5 
hspec-discover-2.5.4 -> hspec-discover-2.5.5