### PR TITLE
Add Nix test dependencies to stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -6,3 +6,7 @@ nix:
   enable: false
   packages:
   - zlib
+  # Test dependencies
+  - nodejs
+  - nodePackages.npm
+  - nodePackages.bower


### PR DESCRIPTION
Fixes `make test` on NixOS.