### PR TITLE
Add support for multiple foreign modules based on codegen targets

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -128,6 +128,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@gabejohnson](https://github.com/gabejohnson) | Gabe Johnson | [MIT license](http://opensource.org/licenses/MIT) |
 | [@dariooddenino](https://github.com/dariooddenino) | Dario Oddenino | [MIT license](http://opensource.org/licenses/MIT) |
 | [@jordanmartinez](https://github.com/jordanmartinez) | Jordan Martinez | [MIT license](http://opensource.org/licenses/MIT) |
+| [@jmackie](https://github.com/jmackie) | Jordan Mackie | [MIT license](http://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms
 

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -8,6 +8,7 @@ module Command.Compile (command) where
 
 import           Control.Applicative
 import           Control.Monad
+import           Control.Monad.Reader (asks)
 import qualified Data.Aeson as A
 import           Data.Bool (bool)
 import qualified Data.ByteString.Lazy.UTF8 as LBU8
@@ -67,7 +68,8 @@ compile PSCMakeOptions{..} = do
   (makeErrors, makeWarnings) <- runMake pscmOpts $ do
     ms <- P.parseModulesFromFiles id moduleFiles
     let filePathMap = M.fromList $ map (\(fp, P.Module _ _ mn _ _) -> (mn, Right fp)) ms
-    foreigns <- inferForeignModules filePathMap
+    targets <- asks P.optionsCodegenTargets
+    foreigns <- inferForeignModules targets filePathMap
     let makeActions = buildMakeActions pscmOutputDir filePathMap foreigns pscmUsePrefix
     P.make makeActions (map snd ms)
   printWarningsAndErrors (P.optionsVerboseErrors pscmOpts) pscmJSONErrors makeWarnings makeErrors

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -65,7 +65,7 @@ rebuildFile file actualFile codegenTargets runOpenBuild = do
   -- For rebuilding, we want to 'RebuildAlways', but for inferring foreign
   -- modules using their file paths, we need to specify the path in the 'Map'.
   let filePathMap = M.singleton (P.getModuleName m) (Left P.RebuildAlways)
-  foreigns <- P.inferForeignModules (M.singleton (P.getModuleName m) (Right file))
+  foreigns <- P.inferForeignModules codegenTargets (M.singleton (P.getModuleName m) (Right file))
 
   let makeEnv = MakeActionsEnv outputDirectory filePathMap foreigns False
   -- Rebuild the single module using the cached externs
@@ -138,7 +138,7 @@ data MakeActionsEnv =
   MakeActionsEnv
   { maeOutputDirectory :: FilePath
   , maeFilePathMap     :: ModuleMap (Either P.RebuildPolicy FilePath)
-  , maeForeignPathMap  :: ModuleMap FilePath
+  , maeForeignPathMap  :: ModuleMap (M.Map P.CodegenTarget FilePath)
   , maePrefixComment   :: Bool
   }
 

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -78,11 +78,12 @@ make
   :: [(FilePath, P.Module)]
   -> P.Make ([P.ExternsFile], P.Environment)
 make ms = do
-    foreignFiles <- P.inferForeignModules filePathMap
+    targets <- asks P.optionsCodegenTargets
+    foreignFiles <- P.inferForeignModules targets filePathMap
     externs <- P.make (buildActions foreignFiles) (map snd ms)
     return (externs, foldl' (flip P.applyExternsFileToEnvironment) P.initEnvironment externs)
   where
-    buildActions :: M.Map P.ModuleName FilePath -> P.MakeActions P.Make
+    buildActions :: M.Map P.ModuleName (M.Map P.CodegenTarget FilePath) -> P.MakeActions P.Make
     buildActions foreignFiles =
       P.buildMakeActions modulesDir
                          filePathMap

--- a/src/Language/PureScript/Options.hs
+++ b/src/Language/PureScript/Options.hs
@@ -29,3 +29,10 @@ codegenTargets = Map.fromList
   , ("sourcemaps", JSSourceMap)
   , ("corefn", CoreFn)
   ]
+
+-- | Returns the file extension associated with a given @CodegenTarget@. Used
+-- for locating foreign modules, so returns @Nothing@ if the target has no ffi.
+codegenTargetExt :: CodegenTarget -> Maybe String
+codegenTargetExt JS = Just "js"
+codegenTargetExt JSSourceMap = Nothing
+codegenTargetExt CoreFn = Nothing


### PR DESCRIPTION
Currently only one codegen target (`JS`) supports foreign modules. So it makes sense to pass around a `Map ModuleName FilePath`, where the module in question may or may not have a foreign javascript module associated with it. 

However, if the compiler were to support other non-js backends then `purs compile --codegen js,foo,bar Example.purs` might have to copy not only `Example.js` but also `Example.foo` and `Example.bar`. And so `Map ModuleName FilePath` would have to become `Map ModuleName (Map CodegenTarget FilePath)` (or equivalent), which is the purpose of this PR. 

Note this is motivated by my current efforts to add support for `Go` (https://github.com/purescript-go/purs), where this functionality is needed to have the two codegens exist side-by-side.

Also note this is my first non-trivial contribution, so apologies if I've missed anything!

Keep up the great work guys. PureScript is dope ❤️