### PR TITLE
Support non-public publishes

### DIFF
--- a/app/Command/Publish.hs
+++ b/app/Command/Publish.hs
@@ -7,6 +7,7 @@ import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy.Char8 as BL
 import           Data.Time.Clock (getCurrentTime)
 import           Data.Version (Version(..))
+import           Language.PureScript.Docs
 import           Language.PureScript.Publish
 import           Language.PureScript.Publish.ErrorsWarnings
 import           Options.Applicative (Parser)
@@ -29,6 +30,11 @@ dryRun = Opts.switch $
      Opts.long "dry-run"
   <> Opts.help "Produce no output, and don't require a tagged version to be checked out."
 
+nonPublic :: Parser Bool
+nonPublic = Opts.switch $
+     Opts.long "non-public"
+  <> Opts.help "Produce output, don't check version or license.  Blank user and version 0.0.0"
+
 dryRunOptions :: PublishOptions
 dryRunOptions = defaultPublishOptions
   { publishGetVersion = return dummyVersion
@@ -37,15 +43,29 @@ dryRunOptions = defaultPublishOptions
   }
   where dummyVersion = ("0.0.0", Version [0,0,0] [])
 
-command :: Opts.Parser (IO ())
-command = publish <$> manifestPath <*> resolutionsPath <*> (Opts.helper <*> dryRun)
+nonPublicOptions :: PublishOptions
+nonPublicOptions = defaultPublishOptions
+  { publishGetVersion = return dummyVersion
+  , publishWorkingTreeDirty = warn DirtyWorkingTree_Warn
+  , publishGetTagTime = const (liftIO getCurrentTime)
+  , publishCheckLicense = \_ -> pure ()
+  , publishGetRepoInfo = \_ -> pure (GithubUser "", GithubRepo "")
+  }
+  where dummyVersion = ("0.0.0", Version [0,0,0] [])
 
-publish :: FilePath -> FilePath -> Bool -> IO ()
-publish manifestFile resolutionsFile isDryRun =
-  if isDryRun
+command :: Opts.Parser (IO ())
+command = publish <$> manifestPath <*> resolutionsPath <*> (Opts.helper <*> dryRun) <*> (Opts.helper <*> nonPublic)
+
+publish :: FilePath -> FilePath -> Bool -> Bool -> IO ()
+publish manifestFile resolutionsFile isDryRun isNonPublic =
+  if isNonPublic
     then do
-      _ <- unsafePreparePackage manifestFile resolutionsFile dryRunOptions
-      putStrLn "Dry run completed, no errors."
-    else do
-      pkg <- unsafePreparePackage manifestFile resolutionsFile defaultPublishOptions
-      BL.putStrLn (A.encode pkg)
+      pkg <- unsafePreparePackage manifestFile resolutionsFile nonPublicOptions
+      BL.putStrLn (A.encode (verifyPackage (GithubUser "") pkg))
+    else if isDryRun
+      then do
+        _ <- unsafePreparePackage manifestFile resolutionsFile dryRunOptions
+        putStrLn "Dry run completed, no errors."
+      else do
+        pkg <- unsafePreparePackage manifestFile resolutionsFile defaultPublishOptions
+        BL.putStrLn (A.encode pkg)


### PR DESCRIPTION
This change adds a `--non-public` flag to `purs publish` which allows the caller to generate a pursuit data file without any of the version/license/github constraints.  I'm wanting to use this to generate the data for a private hosted pursuit instance.

I couldn't find a nice way to do this without changing things.  (Ideas?)