### PR TITLE
 Naming a constructor `PS` breaks the javascript

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -68,6 +68,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@lukerandall](https://github.com/lukerandall) | Luke Randall | [MIT license](http://opensource.org/licenses/MIT) |
 | [@matthewleon](https://github.com/matthewleon) | Matthew Leon | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mcoffin](https://github.com/mcoffin) | Matt Coffin | [MIT license](http://opensource.org/licenses/MIT) |
+| [@mhcurylo](https://github.com/mhcurylo) | Mateusz Curylo | [MIT license](http://opensource.org/licenses/MIT) |
 | [@MiracleBlue](https://github.com/MiracleBlue) | Nicholas Kircher | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mrkgnao](https://github.com/mrkgnao) | Soham Chowdhury | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mgmeier](https://github.com/mgmeier) | Michael Gilliland | [MIT license](http://opensource.org/licenses/MIT) |

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -18,6 +18,7 @@ import qualified TestPrimDocs
 import qualified TestPsci
 import qualified TestIde
 import qualified TestPscPublish
+import qualified TestBundle
 import qualified TestUtils
 
 import System.IO (hSetEncoding, stdout, stderr, utf8)
@@ -35,6 +36,7 @@ main = do
   ideTests <- TestIde.main
   compilerTests <- TestCompiler.main
   psciTests <- TestPsci.main
+  pscBundleTests <- TestBundle.main
   coreFnTests <- TestCoreFn.main
   docsTests <- TestDocs.main
   publishTests <- TestPscPublish.main
@@ -45,6 +47,7 @@ main = do
       "Tests"
       [ compilerTests
       , psciTests
+      , pscBundleTests
       , ideTests
       , coreFnTests
       , docsTests

--- a/tests/TestBundle.hs
+++ b/tests/TestBundle.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module TestBundle where
+
+import Prelude ()
+import Prelude.Compat
+
+import qualified Language.PureScript as P
+import Language.PureScript.Bundle 
+
+import Data.Function (on)
+import Data.List (minimumBy)
+
+import qualified Data.Map as M
+
+import Control.Monad
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Except
+
+import System.Exit
+import System.Process
+import System.FilePath
+import System.IO
+import System.IO.UTF8
+import qualified System.FilePath.Glob as Glob
+
+import TestUtils
+import Test.Tasty
+import Test.Tasty.Hspec
+
+main :: IO TestTree
+main = testSpec "bundle" spec
+
+spec :: Spec
+spec = do
+  (supportModules, supportExterns, supportForeigns, [bundleTestCases]) <- runIO $ setUpTests ["bundle"]
+  outputFile <- runIO $ createOutputFile logfile 
+
+  context "Bundle examples" $
+    forM_ bundleTestCases $ \testPurs -> do
+      it ("'" <> takeFileName (getTestMain testPurs) <> "' should compile, bundle and run without error") $
+        assertBundles supportModules supportExterns supportForeigns testPurs outputFile
+  where
+  
+  -- Takes the test entry point from a group of purs files - this is determined
+  -- by the file with the shortest path name, as everything but the main file
+  -- will be under a subdirectory.
+  getTestMain :: [FilePath] -> FilePath
+  getTestMain = minimumBy (compare `on` length)
+
+assertBundles
+  :: [P.Module]
+  -> [P.ExternsFile]
+  -> M.Map P.ModuleName FilePath
+  -> [FilePath]
+  -> Handle
+  -> Expectation
+assertBundles supportModules supportExterns supportForeigns inputFiles outputFile =
+  assert supportModules supportExterns supportForeigns inputFiles checkMain $ \e ->
+    case e of
+      Left errs -> return . Just . P.prettyPrintMultipleErrors P.defaultPPEOptions $ errs
+      Right _ -> do
+        process <- findNodeProcess
+        jsFiles <- Glob.globDir1 (Glob.compile "**/*.js") modulesDir
+        let entryPoint = modulesDir </> "index.js"
+        let entryModule = map (`ModuleIdentifier` Regular) ["Main"] 
+        bundled <- runExceptT $ do
+          input <- forM jsFiles $ \filename -> do
+            js <- liftIO $ readUTF8File filename
+            mid <- guessModuleIdentifier filename
+            length js `seq` return (mid, Just filename, js) 
+          bundleSM input entryModule (Just $ "Main") "PS" (Just entryPoint)
+        case bundled of
+            Right (_, js) -> do
+              writeUTF8File entryPoint js
+              result <- traverse (\node -> readProcessWithExitCode node [entryPoint] "") process
+              hPutStrLn outputFile $ "\n" <> takeFileName (last inputFiles) <> ":"
+              case result of
+                Just (ExitSuccess, out, err)
+                 | not (null err) -> return $ Just $ "Test wrote to stderr:\n\n" <> err
+                 | not (null out) && trim (last (lines out)) == "Done" -> do
+                     hPutStr outputFile out
+                     return Nothing
+                 | otherwise -> return $ Just $ "Test did not finish with 'Done':\n\n" <> out
+                Just (ExitFailure _, _, err) -> return $ Just err
+                Nothing -> return $ Just "Couldn't find node.js executable"
+            Left err -> return . Just $ "Coud not bundle: " ++ show err
+
+logfile :: FilePath
+logfile = "bundle-tests.out"

--- a/tests/purs/bundle/PSasConstructor.purs
+++ b/tests/purs/bundle/PSasConstructor.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Prelude
+import Effect (Effect)
+import Effect.Console (log)
+
+data P = PS 
+
+main :: Effect Unit
+main = do
+  log "Done"


### PR DESCRIPTION
I have fixed the PS constructor braking the exports by changing the IIFE argument from exports to the PS module object.
There are no automated tests for the psc-bundle and I have not added one. Maybe they should be introduced?
Fragment of an output is:
```
function(PS) {
  // Generated by purs version 0.12.2
  "use strict";
  var exports = PS["Effect.Console"] = PS["Effect.Console"] || {};
  var $foreign = PS["Effect.Console"];
  var Data_Show = PS["Data.Show"];
  var Data_Unit = PS["Data.Unit"];
  var Effect = PS["Effect"];
  exports["log"] = $foreign.log;
})(PS); 
```