### PR TITLE
[purs ide] Treat module declarations like any other

### DIFF
--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -121,6 +121,7 @@ completionFromMatch (Match (m, IdeDeclarationAnn ann decl), mns) =
       IdeDeclTypeOperator (IdeTypeOperator op ref precedence associativity kind) ->
         (P.runOpName op, maybe (showFixity precedence associativity (typeOperatorAliasT ref) op) P.prettyPrintKind kind)
       IdeDeclKind k -> (P.runProperName k, "kind")
+      IdeDeclModule mn -> (P.runModuleName mn, "module")
 
     complExportedFrom = mns
 

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -61,12 +61,13 @@ convertExterns :: P.ExternsFile -> ([IdeDeclarationAnn], [(P.ModuleName, P.Decla
 convertExterns ef =
   (decls, exportDecls)
   where
-    decls = map
+    decls = moduleDecl : map
       (IdeDeclarationAnn emptyAnn)
       (resolvedDeclarations <> operatorDecls <> tyOperatorDecls)
     exportDecls = mapMaybe convertExport (P.efExports ef)
     operatorDecls = convertOperator <$> P.efFixities ef
     tyOperatorDecls = convertTypeOperator <$> P.efTypeFixities ef
+    moduleDecl = IdeDeclarationAnn emptyAnn (IdeDeclModule (P.efModuleName ef))
     (toResolve, declarations) =
       second catMaybes (partitionEithers (map convertDecl (P.efDeclarations ef)))
 

--- a/src/Language/PureScript/Ide/Filter/Declaration.hs
+++ b/src/Language/PureScript/Ide/Filter/Declaration.hs
@@ -11,7 +11,8 @@ import           Protolude                     hiding (isPrefixOf)
 import           Data.Aeson
 import qualified Language.PureScript.Ide.Types as PI
 
-data DeclarationType = Value
+data DeclarationType
+  = Value
   | Type
   | Synonym
   | DataConstructor
@@ -19,6 +20,7 @@ data DeclarationType = Value
   | ValueOperator
   | TypeOperator
   | Kind
+  | Module
   deriving (Show, Eq, Ord)
 
 instance FromJSON DeclarationType where
@@ -32,6 +34,7 @@ instance FromJSON DeclarationType where
       "valueoperator"     -> pure ValueOperator
       "typeoperator"      -> pure TypeOperator
       "kind"              -> pure Kind
+      "module"            -> pure Module
       _                   -> mzero
 
 newtype IdeDeclaration = IdeDeclaration
@@ -53,3 +56,4 @@ typeDeclarationForDeclaration decl = case decl of
   PI.IdeDeclValueOperator _ -> IdeDeclaration ValueOperator
   PI.IdeDeclTypeOperator _ -> IdeDeclaration TypeOperator
   PI.IdeDeclKind _ -> IdeDeclaration Kind
+  PI.IdeDeclModule _ -> IdeDeclaration Module

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -44,7 +44,7 @@ import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Prim
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
-import           Lens.Micro.Platform                ((^.), (%~), ix)
+import           Lens.Micro.Platform                ((^.), (%~), ix, has)
 import           System.IO.UTF8                     (writeUTF8FileT)
 import qualified Text.Parsec as Parsec
 
@@ -194,12 +194,14 @@ addExplicitImport' decl moduleName qualifier imports =
         not (any (\case
           Import C.Prim (P.Explicit _) Nothing -> True
           _ -> False) imports)
+    -- We can't import Modules from other modules
+    isModule = has _IdeDeclModule decl
 
     matches (Import mn (P.Explicit _) qualifier') = mn == moduleName && qualifier == qualifier'
     matches _ = False
     freshImport = Import moduleName (P.Explicit [refFromDeclaration decl]) qualifier
   in
-    if isImplicitlyImported || isNotExplicitlyImportedFromPrim
+    if isImplicitlyImported || isNotExplicitlyImportedFromPrim || isModule
     then imports
     else updateAtFirstOrPrepend matches (insertDeclIntoImport decl) freshImport imports
   where

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -59,8 +59,11 @@ parseModulesFromFiles paths = do
 extractAstInformation
   :: P.Module
   -> (DefinitionSites P.SourceSpan, TypeAnnotations)
-extractAstInformation (P.Module _ _ _ decls _) =
-  let definitions = Map.fromList (concatMap extractSpans decls)
+extractAstInformation (P.Module moduleSpan _ mn decls _) =
+  let definitions =
+        Map.insert
+          (IdeNamespaced IdeNSModule (P.runModuleName mn)) moduleSpan
+          (Map.fromList (concatMap extractSpans decls))
       typeAnnotations = Map.fromList (extractTypeAnnotations decls)
   in (definitions, typeAnnotations)
 

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -39,6 +39,7 @@ data IdeDeclaration
   | IdeDeclTypeClass IdeTypeClass
   | IdeDeclValueOperator IdeValueOperator
   | IdeDeclTypeOperator IdeTypeOperator
+  | IdeDeclModule P.ModuleName
   | IdeDeclKind (P.ProperName 'P.KindName)
   deriving (Show, Eq, Ord, Generic, NFData)
 
@@ -125,6 +126,10 @@ _IdeDeclTypeOperator _ x = pure x
 _IdeDeclKind :: Traversal' IdeDeclaration (P.ProperName 'P.KindName)
 _IdeDeclKind f (IdeDeclKind x) = map IdeDeclKind (f x)
 _IdeDeclKind _ x = pure x
+
+_IdeDeclModule :: Traversal' IdeDeclaration P.ModuleName
+_IdeDeclModule f (IdeDeclModule x) = map IdeDeclModule (f x)
+_IdeDeclModule _ x = pure x
 
 anyOf :: Getting Any s a -> (a -> Bool) -> s -> Bool
 anyOf g p = getAny . getConst . g (Const . Any . p)
@@ -298,14 +303,15 @@ encodeImport (P.runModuleName -> mn, importType, map P.runModuleName -> qualifie
              ] ++ map (\x -> "qualifier" .= x) (maybeToList qualifier)
 
 -- | Denotes the different namespaces a name in PureScript can reside in.
-data IdeNamespace = IdeNSValue | IdeNSType | IdeNSKind
+data IdeNamespace = IdeNSValue | IdeNSType | IdeNSKind | IdeNSModule
   deriving (Show, Eq, Ord, Generic, NFData)
 
 instance FromJSON IdeNamespace where
   parseJSON (String s) = case s of
     "value" -> pure IdeNSValue
-    "type"  -> pure IdeNSType
-    "kind"  -> pure IdeNSKind
+    "type" -> pure IdeNSType
+    "kind" -> pure IdeNSKind
+    "module" -> pure IdeNSModule
     _       -> mzero
   parseJSON _ = mzero
 

--- a/src/Language/PureScript/Ide/Usage.hs
+++ b/src/Language/PureScript/Ide/Usage.hs
@@ -112,6 +112,9 @@ matchesRef declaration ref = case declaration of
   IdeDeclKind kind -> case ref of
     P.KindRef _ kindName -> kindName == kind
     _ -> False
+  IdeDeclModule m -> case ref of
+    P.ModuleRef _ mn -> m == mn
+    _ -> False
 
 eligibleModules
   :: (P.ModuleName, IdeDeclaration)

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -53,6 +53,7 @@ identifierFromIdeDeclaration d = case d of
   IdeDeclValueOperator op -> op ^. ideValueOpName & P.runOpName
   IdeDeclTypeOperator op -> op ^. ideTypeOpName & P.runOpName
   IdeDeclKind name -> P.runProperName name
+  IdeDeclModule name -> P.runModuleName name
 
 namespaceForDeclaration :: IdeDeclaration -> IdeNamespace
 namespaceForDeclaration d = case d of
@@ -64,6 +65,7 @@ namespaceForDeclaration d = case d of
   IdeDeclValueOperator _ -> IdeNSValue
   IdeDeclTypeOperator _ -> IdeNSType
   IdeDeclKind _ -> IdeNSKind
+  IdeDeclModule _ -> IdeNSModule
 
 discardAnn :: IdeDeclarationAnn -> IdeDeclaration
 discardAnn (IdeDeclarationAnn _ d) = d

--- a/tests/Language/PureScript/Ide/CompletionSpec.hs
+++ b/tests/Language/PureScript/Ide/CompletionSpec.hs
@@ -65,3 +65,10 @@ spec = describe "Applying completion options" $ do
                   , typ "withType"
                   ]
     result `shouldSatisfy` \res -> complDocumentation res == Just "Doc *123*\n"
+
+  it "gets docs on module declaration" $ do
+    ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
+      Test.runIde [ load ["CompletionSpecDocs"]
+                  , typ "CompletionSpecDocs"
+                  ]
+    result `shouldSatisfy` \res -> complDocumentation res == Just "Module Documentation\n"

--- a/tests/Language/PureScript/Ide/SourceFileSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFileSpec.hs
@@ -93,6 +93,9 @@ spec = do
     it "finds a type operator declaration" $ do
       Just r <- getLocation "~>"
       r `shouldBe` typeOpSS
+    it "finds a module declaration" $ do
+      Just r <- getLocation "SfModule"
+      r `shouldBe` moduleSS
 
 getLocation :: Text -> IO (Maybe P.SourceSpan)
 getLocation s = do
@@ -102,7 +105,8 @@ getLocation s = do
   where
     ideState = emptyIdeState `volatileState`
       [ ("Test",
-         [ ideValue "sfValue" Nothing `annLoc` valueSS
+         [ ideModule "SfModule" `annLoc` moduleSS
+         , ideValue "sfValue" Nothing `annLoc` valueSS
          , ideSynonym "SFType" Nothing Nothing `annLoc` synonymSS
          , ideType "SFData" Nothing [] `annLoc` typeSS
          , ideDtor "SFOne" "SFData" Nothing `annLoc` typeSS

--- a/tests/Language/PureScript/Ide/Test.hs
+++ b/tests/Language/PureScript/Ide/Test.hs
@@ -101,7 +101,11 @@ ideTypeOp opName ident precedence assoc k =
 ideKind :: Text -> IdeDeclarationAnn
 ideKind pn = ida (IdeDeclKind (P.ProperName pn))
 
-valueSS, synonymSS, typeSS, classSS, valueOpSS, typeOpSS :: P.SourceSpan
+ideModule :: Text -> IdeDeclarationAnn
+ideModule name = ida (IdeDeclModule (mn name))
+
+moduleSS, valueSS, synonymSS, typeSS, classSS, valueOpSS, typeOpSS :: P.SourceSpan
+moduleSS = ss 1 1
 valueSS = ss 3 1
 synonymSS = ss 5 1
 typeSS = ss 7 1

--- a/tests/support/pscide/src/CompletionSpecDocs.purs
+++ b/tests/support/pscide/src/CompletionSpecDocs.purs
@@ -1,3 +1,4 @@
+-- | Module Documentation
 module CompletionSpecDocs where
 
 -- | Doc x


### PR DESCRIPTION
This means we can now complete module names with the completion API as well as being able to query for module level documentation and goto-definition for module names.

~TODO: Still need to add regression tests~