### PR TITLE
Truncate types in errors, fixes #3401

### DIFF
--- a/src/Language/PureScript/Docs/RenderedCode/RenderType.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/RenderType.hs
@@ -35,18 +35,16 @@ typeLiterals = mkPattern match
     Just $ maybe (syntax "_") (syntax . ("?" <>)) name
   match (PPTypeVar var) =
     Just (typeVar var)
-  match (PPRecord row) =
+  match (PPRecord labels tail_) =
     Just $ mintersperse sp
               [ syntax "{"
-              , renderRow row
+              , renderRow labels tail_
               , syntax "}"
               ]
   match (PPTypeConstructor n) =
     Just (typeCtor n)
-  match PPREmpty =
-    Just (syntax "()")
-  match row@PPRCons{} =
-    Just (syntax "(" <> renderRow row <> syntax ")")
+  match (PPRow labels tail_) =
+    Just (syntax "(" <> renderRow labels tail_ <> syntax ")")
   match (PPBinaryNoParensType op l r) =
     Just $ renderTypeAtom' l <> sp <> renderTypeAtom' op <> sp <> renderTypeAtom' r
   match (PPTypeOp n) =
@@ -72,13 +70,8 @@ renderConstraints con ty =
 -- |
 -- Render code representing a Row
 --
-renderRow :: PrettyPrintType -> RenderedCode
-renderRow = uncurry renderRow' . go []
-  where
-  renderRow' h t = renderHead h <> renderTail t
-
-  go ts (PPRCons l t r) = go ((l, t) : ts) r
-  go ts t = (reverse ts, t)
+renderRow :: [(Label, PrettyPrintType)] -> Maybe PrettyPrintType -> RenderedCode
+renderRow h t = renderHead h <> renderTail t
 
 renderHead :: [(Label, PrettyPrintType)] -> RenderedCode
 renderHead = mintersperse (syntax "," <> sp) . map renderLabel
@@ -91,9 +84,9 @@ renderLabel (label, ty) =
     , renderType' ty
     ]
 
-renderTail :: PrettyPrintType -> RenderedCode
-renderTail PPREmpty = mempty
-renderTail other = sp <> syntax "|" <> sp <> renderType' other
+renderTail :: Maybe PrettyPrintType -> RenderedCode
+renderTail Nothing = mempty
+renderTail (Just other) = sp <> syntax "|" <> sp <> renderType' other
 
 typeApp :: Pattern () PrettyPrintType (PrettyPrintType, PrettyPrintType)
 typeApp = mkPattern match
@@ -153,7 +146,7 @@ forall_ = mkPattern match
 -- Render code representing a Type
 --
 renderType :: Type a -> RenderedCode
-renderType = renderType' . convertPrettyPrintType
+renderType = renderType' . convertPrettyPrintType maxBound
 
 renderType' :: PrettyPrintType -> RenderedCode
 renderType'
@@ -164,7 +157,7 @@ renderType'
 -- Render code representing a Type, as it should appear inside parentheses
 --
 renderTypeAtom :: Type a -> RenderedCode
-renderTypeAtom = renderTypeAtom' . convertPrettyPrintType
+renderTypeAtom = renderTypeAtom' . convertPrettyPrintType maxBound
 
 renderTypeAtom' :: PrettyPrintType -> RenderedCode
 renderTypeAtom'

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -508,7 +508,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       line "The same name was used more than once in a let binding."
     renderSimpleErrorMessage (InfiniteType ty) =
       paras [ line "An infinite type was inferred for an expression: "
-            , markCodeBox $ indent $ typeAsBox ty
+            , markCodeBox $ indent $ typeAsBox prettyDepth ty
             ]
     renderSimpleErrorMessage (InfiniteKind ki) =
       paras [ line "An infinite kind was inferred for a type: "
@@ -584,13 +584,13 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             ]
     renderSimpleErrorMessage (EscapedSkolem name Nothing ty) =
       paras [ line $ "The type variable " <> markCode name <> " has escaped its scope, appearing in the type"
-            , markCodeBox $ indent $ typeAsBox ty
+            , markCodeBox $ indent $ typeAsBox prettyDepth ty
             ]
     renderSimpleErrorMessage (EscapedSkolem name (Just srcSpan) ty) =
       paras [ line $ "The type variable " <> markCode name <> ", bound at"
             , indent $ line $ displaySourceSpan relPath srcSpan
             , line "has escaped its scope, appearing in the type"
-            , markCodeBox $ indent $ typeAsBox ty
+            , markCodeBox $ indent $ typeAsBox prettyDepth ty
             ]
     renderSimpleErrorMessage (TypesDoNotUnify u1 u2)
       = let (sorted1, sorted2) = sortRows u1 u2
@@ -610,9 +610,9 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
                      , rowFromList (sort' unique2 ++ sort' common2, r2)
                      )
         in paras [ line "Could not match type"
-                 , markCodeBox $ indent $ typeAsBox sorted1
+                 , markCodeBox $ indent $ typeAsBox prettyDepth sorted1
                  , line "with type"
-                 , markCodeBox $ indent $ typeAsBox sorted2
+                 , markCodeBox $ indent $ typeAsBox prettyDepth sorted2
                  ]
 
     renderSimpleErrorMessage (KindsDoNotUnify k1 k2) =
@@ -623,16 +623,16 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             ]
     renderSimpleErrorMessage (ConstrainedTypeUnified t1 t2) =
       paras [ line "Could not match constrained type"
-            , markCodeBox $ indent $ typeAsBox t1
+            , markCodeBox $ indent $ typeAsBox prettyDepth t1
             , line "with type"
-            , markCodeBox $ indent $ typeAsBox t2
+            , markCodeBox $ indent $ typeAsBox prettyDepth t2
             ]
     renderSimpleErrorMessage (OverlappingInstances _ _ []) = internalError "OverlappingInstances: empty instance list"
     renderSimpleErrorMessage (OverlappingInstances nm ts ds) =
       paras [ line "Overlapping type class instances found for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map typeAtomAsBox ts)
+                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
                 ]
             , line "The following instances were found:"
             , indent $ paras (map (line . showQualified showIdent) ds)
@@ -659,7 +659,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             ]
     renderSimpleErrorMessage (NoInstanceFound (Constraint _ C.Discard [ty] _)) =
       paras [ line "A result of type"
-            , markCodeBox $ indent $ typeAsBox ty
+            , markCodeBox $ indent $ typeAsBox prettyDepth ty
             , line "was implicitly discarded in a do notation block."
             , line ("You can use " <> markCode "_ <- ..." <> " to explicitly discard the result.")
             ]
@@ -667,7 +667,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "No type class instance was found for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map typeAtomAsBox ts)
+                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
                 ]
             , paras [ line "The instance head contains unknown type variables. Consider adding a type annotation."
                     | any containsUnknowns ts
@@ -681,14 +681,14 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
         go _ = False
     renderSimpleErrorMessage (AmbiguousTypeVariables t _) =
       paras [ line "The inferred type"
-            , markCodeBox $ indent $ typeAsBox t
+            , markCodeBox $ indent $ typeAsBox prettyDepth t
             , line "has type variables which are not mentioned in the body of the type. Consider adding a type annotation."
             ]
     renderSimpleErrorMessage (PossiblyInfiniteInstance nm ts) =
       paras [ line "Type class instance for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map typeAtomAsBox ts)
+                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
                 ]
             , line "is possibly infinite."
             ]
@@ -696,7 +696,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "Cannot derive a type class instance for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map typeAtomAsBox ts)
+                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
                 ]
             , line "since instances of this type class are not derivable."
             ]
@@ -704,7 +704,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "Cannot derive newtype instance for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map typeAtomAsBox ts)
+                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
                 ]
             , line "Make sure this is a newtype."
             ]
@@ -712,7 +712,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "The derived newtype instance for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName cl)
-                , Box.vcat Box.left (map typeAtomAsBox ts)
+                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
                 ]
             , line $ "does not include a derived superclass instance for " <> markCode (showQualified runProperName su) <> "."
             ]
@@ -720,7 +720,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "The derived newtype instance for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName cl)
-                , Box.vcat Box.left (map typeAtomAsBox ts)
+                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
                 ]
             , line $ "implies an superclass instance for " <> markCode (showQualified runProperName su) <> " which could not be verified."
             ]
@@ -728,7 +728,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "Cannot derive the type class instance"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map typeAtomAsBox ts)
+                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
                 ]
             , line $ fold $
                 [ "because the "
@@ -744,10 +744,10 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "Cannot derive the type class instance"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map typeAtomAsBox ts)
+                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
                 ]
             , "because the type"
-            , markCodeBox $ indent $ typeAsBox ty
+            , markCodeBox $ indent $ typeAsBox prettyDepth ty
             , line "is not of the required form T a_1 ... a_n, where T is a type constructor defined in the same module."
             ]
     renderSimpleErrorMessage (CannotFindDerivingType nm) =
@@ -755,7 +755,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderSimpleErrorMessage (DuplicateLabel l expr) =
       paras $ [ line $ "Label " <> markCode (prettyPrintLabel l) <> " appears more than once in a row type." ]
                        <> foldMap (\expr' -> [ line "Relevant expression: "
-                                             , markCodeBox $ indent $ prettyPrintValue valueDepth expr'
+                                             , markCodeBox $ indent $ prettyPrintValue prettyDepth expr'
                                              ]) expr
     renderSimpleErrorMessage (DuplicateTypeArgument name) =
       line $ "Type argument " <> markCode name <> " appears more than once."
@@ -768,7 +768,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderSimpleErrorMessage (MissingClassMember identsAndTypes) =
       paras $ [ line "The following type class members have not been implemented:"
               , Box.vcat Box.left
-                [ markCodeBox $ Box.text (T.unpack (showIdent ident)) Box.<> " :: " Box.<> typeAsBox ty
+                [ markCodeBox $ Box.text (T.unpack (showIdent ident)) Box.<> " :: " Box.<> typeAsBox prettyDepth ty
                 | (ident, ty) <- NEL.toList identsAndTypes ]
               ]
     renderSimpleErrorMessage (ExtraneousClassMember ident className) =
@@ -776,7 +776,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderSimpleErrorMessage (ExpectedType ty kind) =
       paras [ line $ "In a type-annotated expression " <> markCode "x :: t" <> ", the type " <> markCode "t" <> " must have kind " <> markCode (prettyPrintKind kindType) <> "."
             , line "The error arises from the type"
-            , markCodeBox $ indent $ typeAsBox ty
+            , markCodeBox $ indent $ typeAsBox prettyDepth ty
             , line "having the kind"
             , indent $ line $ markCode $ prettyPrintKind kind
             , line "instead."
@@ -787,9 +787,9 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             ]
     renderSimpleErrorMessage (ExprDoesNotHaveType expr ty) =
       paras [ line "Expression"
-            , markCodeBox $ indent $ prettyPrintValue valueDepth expr
+            , markCodeBox $ indent $ prettyPrintValue prettyDepth expr
             , line "does not have type"
-            , markCodeBox $ indent $ typeAsBox ty
+            , markCodeBox $ indent $ typeAsBox prettyDepth ty
             ]
     renderSimpleErrorMessage (PropertyIsMissing prop) =
       line $ "Type of expression lacks required label " <> markCode (prettyPrintLabel prop) <> "."
@@ -801,7 +801,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line $ "Orphan instance " <> markCode (showIdent nm) <> " found for "
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName cnm)
-                , Box.vcat Box.left (map typeAtomAsBox ts)
+                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
                 ]
             , Box.vcat Box.left $ case modulesToList of
                 [] -> [ line "There is nowhere this instance can be placed without being an orphan."
@@ -821,7 +821,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             ]
     renderSimpleErrorMessage (InvalidInstanceHead ty) =
       paras [ line "Type class instance head is invalid due to use of type"
-            , markCodeBox $ indent $ typeAsBox ty
+            , markCodeBox $ indent $ typeAsBox prettyDepth ty
             , line "All types appearing in instance declarations must be of the form T a_1 .. a_n, where each type a_i is of the same form, unless the type is fully determined by other type class arguments via functional dependencies."
             ]
     renderSimpleErrorMessage (TransitiveExportError x ys) =
@@ -846,7 +846,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             ]
     renderSimpleErrorMessage (WildcardInferredType ty ctx) =
       paras $ [ line "Wildcard type definition has the inferred type "
-              , markCodeBox $ indent $ typeAsBox ty
+              , markCodeBox $ indent $ typeAsBox prettyDepth ty
               ] <> renderContext ctx
     renderSimpleErrorMessage (HoleInferredType name ty ctx ts) =
       let
@@ -858,7 +858,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
                 let
                   idBoxes = Box.text . T.unpack . showQualified id <$> names
                   tyBoxes = (\t -> BoxHelpers.indented
-                              (Box.text ":: " Box.<> typeAsBox t)) <$> types
+                              (Box.text ":: " Box.<> typeAsBox prettyDepth t)) <$> types
                   longestId = maximum (map Box.cols idBoxes)
                 in
                   Box.vcat Box.top $
@@ -871,13 +871,13 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
           _ -> []
       in
         paras $ [ line $ "Hole '" <> markCode name <> "' has the inferred type "
-                , markCodeBox (indent (typeAsBox ty))
+                , markCodeBox (indent (typeAsBox prettyDepth ty))
                 ] ++ tsResult ++ renderContext ctx
     renderSimpleErrorMessage (MissingTypeDeclaration ident ty) =
       paras [ line $ "No type declaration was provided for the top-level declaration of " <> markCode (showIdent ident) <> "."
             , line "It is good practice to provide type declarations as a form of documentation."
             , line $ "The inferred type of " <> markCode (showIdent ident) <> " was:"
-            , markCodeBox $ indent $ typeAsBox ty
+            , markCodeBox $ indent $ typeAsBox prettyDepth ty
             ]
     renderSimpleErrorMessage (OverlappingPattern bs b) =
       paras $ [ line "A case expression contains unreachable cases:\n"
@@ -964,7 +964,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderSimpleErrorMessage (CannotGeneralizeRecursiveFunction ident ty) =
       paras [ line $ "Unable to generalize the type of the recursive function " <> markCode (showIdent ident) <> "."
             , line $ "The inferred type of " <> markCode (showIdent ident) <> " was:"
-            , markCodeBox $ indent $ typeAsBox ty
+            , markCodeBox $ indent $ typeAsBox prettyDepth ty
             , line "Try adding a type signature."
             ]
 
@@ -990,7 +990,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
           argsMsg = if expected > 1 then "arguments" else "argument"
 
     renderSimpleErrorMessage (UserDefinedWarning msgTy) =
-      let msg = fromMaybe (typeAsBox msgTy) (toTypelevelString msgTy) in
+      let msg = fromMaybe (typeAsBox prettyDepth msgTy) (toTypelevelString msgTy) in
       paras [ line "A custom warning occurred while solving type class constraints:"
             , indent msg
             ]
@@ -1042,16 +1042,16 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderHint (ErrorUnifyingTypes t1 t2) detail =
       paras [ detail
             , Box.hsep 1 Box.top [ line "while trying to match type"
-                                 , markCodeBox $ typeAsBox t1
+                                 , markCodeBox $ typeAsBox prettyDepth t1
                                  ]
             , Box.moveRight 2 $ Box.hsep 1 Box.top [ line "with type"
-                                                   , markCodeBox $ typeAsBox t2
+                                                   , markCodeBox $ typeAsBox prettyDepth t2
                                                    ]
             ]
     renderHint (ErrorInExpression expr) detail =
       paras [ detail
             , Box.hsep 1 Box.top [ Box.text "in the expression"
-                                 , markCodeBox $ markCodeBox $ prettyPrintValue valueDepth expr
+                                 , markCodeBox $ markCodeBox $ prettyPrintValue prettyDepth expr
                                  ]
             ]
     renderHint (ErrorInModule mn) detail =
@@ -1061,10 +1061,10 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderHint (ErrorInSubsumption t1 t2) detail =
       paras [ detail
             , Box.hsep 1 Box.top [ line "while checking that type"
-                                 , markCodeBox $ typeAsBox t1
+                                 , markCodeBox $ typeAsBox prettyDepth t1
                                  ]
             , Box.moveRight 2 $ Box.hsep 1 Box.top [ line "is at least as general as type"
-                                                   , markCodeBox $ typeAsBox t2
+                                                   , markCodeBox $ typeAsBox prettyDepth t2
                                                    ]
             ]
     renderHint (ErrorInInstance nm ts) detail =
@@ -1072,13 +1072,13 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             , line "in type class instance"
             , markCodeBox $ indent $ Box.hsep 1 Box.top
                [ line $ showQualified runProperName nm
-               , Box.vcat Box.left (map typeAtomAsBox ts)
+               , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
                ]
             ]
     renderHint (ErrorCheckingKind ty) detail =
       paras [ detail
             , Box.hsep 1 Box.top [ line "while checking the kind of"
-                                 , markCodeBox $ typeAsBox ty
+                                 , markCodeBox $ typeAsBox prettyDepth ty
                                  ]
             ]
     renderHint ErrorCheckingGuard detail =
@@ -1088,34 +1088,34 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderHint (ErrorInferringType expr) detail =
       paras [ detail
             , Box.hsep 1 Box.top [ line "while inferring the type of"
-                                 , markCodeBox $ prettyPrintValue valueDepth expr
+                                 , markCodeBox $ prettyPrintValue prettyDepth expr
                                  ]
             ]
     renderHint (ErrorCheckingType expr ty) detail =
       paras [ detail
             , Box.hsep 1 Box.top [ line "while checking that expression"
-                                 , markCodeBox $ prettyPrintValue valueDepth expr
+                                 , markCodeBox $ prettyPrintValue prettyDepth expr
                                  ]
             , Box.moveRight 2 $ Box.hsep 1 Box.top [ line "has type"
-                                                   , markCodeBox $ typeAsBox ty
+                                                   , markCodeBox $ typeAsBox prettyDepth ty
                                                    ]
             ]
     renderHint (ErrorCheckingAccessor expr prop) detail =
       paras [ detail
             , Box.hsep 1 Box.top [ line "while checking type of property accessor"
-                                 , markCodeBox $ prettyPrintValue valueDepth (Accessor prop expr)
+                                 , markCodeBox $ prettyPrintValue prettyDepth (Accessor prop expr)
                                  ]
             ]
     renderHint (ErrorInApplication f t a) detail =
       paras [ detail
             , Box.hsep 1 Box.top [ line "while applying a function"
-                                 , markCodeBox $ prettyPrintValue valueDepth f
+                                 , markCodeBox $ prettyPrintValue prettyDepth f
                                  ]
             , Box.moveRight 2 $ Box.hsep 1 Box.top [ line "of type"
-                                                   , markCodeBox $ typeAsBox t
+                                                   , markCodeBox $ typeAsBox prettyDepth t
                                                    ]
             , Box.moveRight 2 $ Box.hsep 1 Box.top [ line "to argument"
-                                                   , markCodeBox $ prettyPrintValue valueDepth a
+                                                   , markCodeBox $ prettyPrintValue prettyDepth a
                                                    ]
             ]
     renderHint (ErrorInDataConstructor nm) detail =
@@ -1159,7 +1159,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             , line "while solving type class constraint"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map typeAtomAsBox ts)
+                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
                 ]
             ]
     renderHint (PositionedError srcSpan) detail =
@@ -1173,7 +1173,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       [ line "in the following context:"
       , indent $ paras
           [ Box.hcat Box.left [ Box.text (T.unpack (showIdent ident) ++ " :: ")
-                              , markCodeBox $ typeAsBox ty'
+                              , markCodeBox $ typeAsBox prettyDepth ty'
                               ]
           | (ident, ty') <- take 5 ctx
           ]
@@ -1212,9 +1212,9 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     runName (Qualified _ ModName{}) =
       internalError "qualified ModName in runName"
 
-  valueDepth :: Int
-  valueDepth | full = 1000
-             | otherwise = 3
+  prettyDepth :: Int
+  prettyDepth | full = 1000
+              | otherwise = 3
 
   levelText :: Text
   levelText = case level of
@@ -1420,7 +1420,7 @@ toTypelevelString (TypeLevelString _ s) =
 toTypelevelString (TypeApp _ (TypeConstructor _ f) x)
   | f == primSubName C.typeError "Text" = toTypelevelString x
 toTypelevelString (TypeApp _ (TypeConstructor _ f) x)
-  | f == primSubName C.typeError "Quote" = Just (typeAsBox x)
+  | f == primSubName C.typeError "Quote" = Just (typeAsBox maxBound x)
 toTypelevelString (TypeApp _ (TypeConstructor _ f) (TypeLevelString _ x))
   | f == primSubName C.typeError "QuoteLabel" = Just . line . prettyPrintLabel . Label $ x
 toTypelevelString (TypeApp _ (TypeApp _ (TypeConstructor _ f) x) ret)

--- a/src/Language/PureScript/Ide/CaseSplit.hs
+++ b/src/Language/PureScript/Ide/CaseSplit.hs
@@ -93,7 +93,7 @@ prettyPrintWildcard (WildcardAnnotations True) = prettyWildcard
 prettyPrintWildcard (WildcardAnnotations False) = const "_"
 
 prettyWildcard :: P.Type a -> Text
-prettyWildcard t = "( _ :: " <> T.strip (T.pack (P.prettyPrintTypeAtom t)) <> ")"
+prettyWildcard t = "( _ :: " <> T.strip (T.pack (P.prettyPrintTypeAtom maxBound t)) <> ")"
 
 -- | Constructs Patterns to insert into a sourcefile
 makePattern :: Text -- ^ Current line

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -83,4 +83,4 @@ textError (ParseError parseError msg) = let escape = show
 textError (RebuildError err)          = show err
 
 prettyPrintTypeSingleLine :: P.Type a -> Text
-prettyPrintTypeSingleLine = T.unwords . map T.strip . T.lines . T.pack . P.prettyPrintTypeWithUnicode
+prettyPrintTypeSingleLine = T.unwords . map T.strip . T.lines . T.pack . P.prettyPrintTypeWithUnicode maxBound

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -274,7 +274,7 @@ handleTypeOf print' val = do
     Left errs -> printErrors errs
     Right (_, env') ->
       case M.lookup (P.mkQualified (P.Ident "it") (P.ModuleName [P.ProperName "$PSCI"])) (P.names env') of
-        Just (ty, _, _) -> print' . P.prettyPrintType $ ty
+        Just (ty, _, _) -> print' . P.prettyPrintType maxBound $ ty
         Nothing -> print' "Could not find type"
 
 -- | Takes a type and prints its kind

--- a/src/Language/PureScript/Interactive/Printer.hs
+++ b/src/Language/PureScript/Interactive/Printer.hs
@@ -43,7 +43,7 @@ printModuleSignatures moduleName P.Environment{..} =
         findNameType envNames m = (P.disqualify m, M.lookup m envNames)
 
         showNameType :: (P.Ident, Maybe (P.SourceType, P.NameKind, P.NameVisibility)) -> Box.Box
-        showNameType (mIdent, Just (mType, _, _)) = textT (P.showIdent mIdent <> " :: ") Box.<> P.typeAsBox mType
+        showNameType (mIdent, Just (mType, _, _)) = textT (P.showIdent mIdent <> " :: ") Box.<> P.typeAsBox maxBound mType
         showNameType _ = P.internalError "The impossible happened in printModuleSignatures."
 
         findTypeClass
@@ -61,13 +61,13 @@ printModuleSignatures moduleName P.Environment{..} =
                     if null typeClassSuperclasses
                     then Box.text ""
                     else Box.text "("
-                         Box.<> Box.hcat Box.left (intersperse (Box.text ", ") $ map (\(P.Constraint _ (P.Qualified _ pn) lt _) -> textT (P.runProperName pn) Box.<+> Box.hcat Box.left (map P.typeAtomAsBox lt)) typeClassSuperclasses)
+                         Box.<> Box.hcat Box.left (intersperse (Box.text ", ") $ map (\(P.Constraint _ (P.Qualified _ pn) lt _) -> textT (P.runProperName pn) Box.<+> Box.hcat Box.left (map (P.typeAtomAsBox maxBound) lt)) typeClassSuperclasses)
                          Box.<> Box.text ") <= "
                 className =
                     textT (P.runProperName name)
                     Box.<> textT (foldMap ((" " <>) . fst) typeClassArguments)
                 classBody =
-                    Box.vcat Box.top (map (\(i, t) -> textT (P.showIdent i <> " ::") Box.<+> P.typeAsBox t) typeClassMembers)
+                    Box.vcat Box.top (map (\(i, t) -> textT (P.showIdent i <> " ::") Box.<+> P.typeAsBox maxBound t) typeClassMembers)
 
             in
               Just $
@@ -99,7 +99,7 @@ printModuleSignatures moduleName P.Environment{..} =
                 else
                   Just $
                     textT ("type " <> P.runProperName name <> foldMap ((" " <>) . fst) typevars)
-                    Box.// Box.moveRight 2 (Box.text "=" Box.<+> P.typeAsBox dtType)
+                    Box.// Box.moveRight 2 (Box.text "=" Box.<+> P.typeAsBox maxBound dtType)
 
             (Just (_, P.DataType typevars pt), _) ->
               let prefix =
@@ -122,7 +122,7 @@ printModuleSignatures moduleName P.Environment{..} =
                     mapFirstRest (Box.text "=" Box.<+>) (Box.text "|" Box.<+>) $
                     map (\(cons,idents) -> (textT (P.runProperName cons) Box.<> Box.hcat Box.left (map prettyPrintType idents))) pt
 
-                prettyPrintType t = Box.text " " Box.<> P.typeAtomAsBox t
+                prettyPrintType t = Box.text " " Box.<> P.typeAtomAsBox maxBound t
 
                 mapFirstRest _ _ [] = []
                 mapFirstRest f g (x:xs) = f x : map g xs

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -86,7 +86,7 @@ prettyPrintValue d (Do m els) =
 prettyPrintValue d (Ado m els yield) =
   textT (maybe "" ((Monoid.<> ".") . runModuleName) m) <> text "ado " <> vcat left (map (prettyPrintDoNotationElement (d - 1)) els) //
   (text "in " <> prettyPrintValue (d - 1) yield)
-prettyPrintValue _ (TypeClassDictionary (Constraint _ name tys _) _ _) = foldl1 beforeWithSpace $ text ("#dict " ++ T.unpack (runProperName (disqualify name))) : map typeAtomAsBox tys
+prettyPrintValue d (TypeClassDictionary (Constraint _ name tys _) _ _) = foldl1 beforeWithSpace $ text ("#dict " ++ T.unpack (runProperName (disqualify name))) : map (typeAtomAsBox d) tys
 prettyPrintValue _ (DeferredDictionary name _) = text $ "#dict " ++ T.unpack (runProperName (disqualify name))
 prettyPrintValue _ (TypeClassDictionaryAccessor className ident) =
     text "#dict-accessor " <> text (T.unpack (runProperName (disqualify className))) <> text "." <> text (T.unpack (showIdent ident)) <> text ">"
@@ -130,8 +130,8 @@ prettyPrintLiteralValue d (ObjectLiteral ps) = prettyPrintObject (d - 1) $ secon
 
 prettyPrintDeclaration :: Int -> Declaration -> Box
 prettyPrintDeclaration d _ | d < 0 = ellipsis
-prettyPrintDeclaration _ (TypeDeclaration td) =
-  text (T.unpack (showIdent (tydeclIdent td)) ++ " :: ") <> typeAsBox (tydeclType td)
+prettyPrintDeclaration d (TypeDeclaration td) =
+  text (T.unpack (showIdent (tydeclIdent td)) ++ " :: ") <> typeAsBox d (tydeclType td)
 prettyPrintDeclaration d (ValueDecl _ ident _ [] [GuardedExpr [] val]) =
   text (T.unpack (showIdent ident) ++ " = ") <> prettyPrintValue (d - 1) val
 prettyPrintDeclaration d (BindingGroupDeclaration ds) =

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -275,7 +275,7 @@ displayAssertionFailure = \case
     "expected " <> decl <> " to be a " <> expected <> " declaration, but it" <>
     " was a " <> actual <> " declaration"
   DeclarationWrongType _ decl actual ->
-    decl <> " had the wrong type; got " <> T.pack (P.prettyPrintType actual)
+    decl <> " had the wrong type; got " <> T.pack (P.prettyPrintType maxBound actual)
   TypeSynonymMismatch _ decl expected actual ->
     "expected the RHS of " <> decl <> " to be " <> expected <>
     "; got " <> actual


### PR DESCRIPTION
Fixes #3401 

This commit truncates types in error messages below a depth of 3 levels
in the type AST. If the --verbose-errors flag is provided, the
truncation depth is instead set to 1000 (the same as with
pretty-printing of values). Suggestions and docs code is not affected,
since in both of these cases, we always want to print the entire type.

In the process, I've done a minor refactoring of the PrettyPrintType
type to change how rows and records are represented, to make them a
little easier to deal with.