### PR TITLE
Filter unused imports during dead code elimination

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,7 @@ dependencies:
   - aeson >=1.0 && <1.4
   - aeson-better-errors >=0.8
   - ansi-terminal >=0.7.1 && <0.9
+  - array
   - base >=4.8 && <4.12
   - base-compat >=0.6.0
   - blaze-html >=0.8.1 && <0.10


### PR DESCRIPTION
Fixes #2177.

---

See also #3545, but whereas that PR only filtered unused imports created during code gen, this one filters unused imports after DCE, which can cause additional imports to become unused. To fix #2177, this PR is necessary and sufficient; but for processes that don't rely on `purs bundle`, #3545 may also add value.

Before:
```js
// Generated by purs bundle 0.12.3
var PS = {};
(function(exports) {
    "use strict";

  exports.log = function (s) {
    return function () {
      console.log(s);
      return {};
    };
  };
})(PS["Effect.Console"] = PS["Effect.Console"] || {});
(function(exports) {
  // Generated by purs version 0.12.3
  "use strict";
  var $foreign = PS["Effect.Console"];
  var Data_Show = PS["Data.Show"];
  var Data_Unit = PS["Data.Unit"];
  var Effect = PS["Effect"];
  exports["log"] = $foreign.log;
})(PS["Effect.Console"] = PS["Effect.Console"] || {});
(function(exports) {
  // Generated by purs version 0.12.3
  "use strict";
  var Effect = PS["Effect"];
  var Effect_Console = PS["Effect.Console"];
  var Prelude = PS["Prelude"];                 
  var main = Effect_Console.log("Hello, world!");
  exports["main"] = main;
})(PS["Main"] = PS["Main"] || {});
PS["Main"].main();
```

After:
```js
// Generated by purs bundle 0.12.3
var PS = {};
(function(exports) {
    "use strict";

  exports.log = function (s) {
    return function () {
      console.log(s);
      return {};
    };
  };
})(PS["Effect.Console"] = PS["Effect.Console"] || {});
(function(exports) {
  // Generated by purs version 0.12.3
  "use strict";
  var $foreign = PS["Effect.Console"];
  exports["log"] = $foreign.log;
})(PS["Effect.Console"] = PS["Effect.Console"] || {});
(function(exports) {
  // Generated by purs version 0.12.3
  "use strict";
  var Effect_Console = PS["Effect.Console"];                 
  var main = Effect_Console.log("Hello, world!");
  exports["main"] = main;
})(PS["Main"] = PS["Main"] || {});
PS["Main"].main();
```