### PR TITLE
[purs ide] Represent Filters as a datatype rather than functions

### DIFF
--- a/psc-ide/DESIGN.org
+++ b/psc-ide/DESIGN.org
@@ -165,9 +165,11 @@
     the PROTOCOL.md file.
     
 *** Filters
-    Filters are functions of type =Map ModuleName [IdeDeclaration] -> Map
-    ModuleName [IdeDeclaration]=. We keep the =Map= structure around to make the
-    common case of filtering by module names fast.
+    Filters are functions of type =Map ModuleName [IdeDeclaration] ->
+    Map ModuleName [IdeDeclaration]=. They only ever keep or remove
+    declarations, they never modify or add them. We keep the =Map=
+    structure around to make the common case of filtering by module
+    names fast. Filters are commutative.
 
 *** Matchers
     Matchers operate on individual declarations rather than a =Map=. They also

--- a/psc-ide/PROTOCOL.md
+++ b/psc-ide/PROTOCOL.md
@@ -598,37 +598,22 @@ Valid namespaces are `value`, `type` and `kind`.
 ### Declaration type filter
 A filter which allows to filter type declarations. Valid type declarations are
 `value`, `type`, `synonym`, `dataconstructor`, `typeclass`, `valueoperator`,
-`typeoperator` and `kind`.
+`typeoperator`, `kind`, and `module`.
 
 ```json
 {
   "filter": "declarations",
-  "params": [
-    {
-      "declarationtype": "value"
-    },
-    {
-      "declarationtype": "type"
-    },
-    {
-      "declarationtype": "synonym"
-    },
-    {
-      "declarationtype": "dataconstructor"
-    }
-    {
-      "declarationtype": "typeclass"
-    },
-    {
-      "declarationtype": "valueoperator"
-    },
-    {
-      "declarationtype": "typeoperator"
-    },
-    {
-      "declarationtype": "kind"
-    }
-  ]
+  "params":
+    [ "value"
+    , "type"
+    , "synonym"
+    , "dataconstructor"
+    , "typeclass"
+    , "valueoperator"
+    , "typeoperator"
+    , "kind"
+    , "module"
+    ]
 }
 ```
 

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -114,7 +114,7 @@ findCompletions
   -> m Success
 findCompletions filters matcher currentModule complOptions = do
   modules <- getAllModules currentModule
-  let insertPrim = Map.union (Map.fromList idePrimDeclarations)
+  let insertPrim = Map.union idePrimDeclarations
   pure (CompletionResult (getCompletions filters matcher complOptions (insertPrim modules)))
 
 findType
@@ -125,7 +125,7 @@ findType
   -> m Success
 findType search filters currentModule = do
   modules <- getAllModules currentModule
-  let insertPrim = Map.union (Map.fromList idePrimDeclarations)
+  let insertPrim = Map.union idePrimDeclarations
   pure (CompletionResult (getExactCompletions search filters (insertPrim modules)))
 
 printModules :: Ide m => m Success

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -113,8 +113,8 @@ findCompletions
   -> CompletionOptions
   -> m Success
 findCompletions filters matcher currentModule complOptions = do
-  modules <- Map.toList <$> getAllModules currentModule
-  let insertPrim = (++) idePrimDeclarations
+  modules <- getAllModules currentModule
+  let insertPrim = Map.union (Map.fromList idePrimDeclarations)
   pure (CompletionResult (getCompletions filters matcher complOptions (insertPrim modules)))
 
 findType
@@ -124,8 +124,8 @@ findType
   -> Maybe P.ModuleName
   -> m Success
 findType search filters currentModule = do
-  modules <- Map.toList <$> getAllModules currentModule
-  let insertPrim = (++) idePrimDeclarations
+  modules <- getAllModules currentModule
+  let insertPrim = Map.union (Map.fromList idePrimDeclarations)
   pure (CompletionResult (getExactCompletions search filters (insertPrim modules)))
 
 printModules :: Ide m => m Success

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -22,8 +22,6 @@ import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
 import           Lens.Micro.Platform hiding ((&))
 
-type Module = (P.ModuleName, [IdeDeclarationAnn])
-
 -- | Applies the CompletionFilters and the Matcher to the given Modules
 --   and sorts the found Completions according to the Matching Score
 getCompletions
@@ -35,7 +33,6 @@ getCompletions
 getCompletions filters matcher options modules =
   modules
   & applyFilters filters
-  & Map.toList
   & matchesFromModules
   & runMatcher matcher
   & applyCompletionOptions options
@@ -45,7 +42,6 @@ getExactMatches :: Text -> [Filter] -> ModuleMap [IdeDeclarationAnn] -> [Match I
 getExactMatches search filters modules =
   modules
   & applyFilters (Filter (Right (Exact search)) : filters)
-  & Map.toList
   & matchesFromModules
 
 getExactCompletions :: Text -> [Filter] -> ModuleMap [IdeDeclarationAnn] -> [Completion]
@@ -55,10 +51,10 @@ getExactCompletions search filters modules =
   <&> simpleExport
   <&> completionFromMatch
 
-matchesFromModules :: [Module] -> [Match IdeDeclarationAnn]
-matchesFromModules = foldMap completionFromModule
+matchesFromModules :: ModuleMap [IdeDeclarationAnn] -> [Match IdeDeclarationAnn]
+matchesFromModules = Map.foldMapWithKey completionFromModule
   where
-    completionFromModule (moduleName, decls) =
+    completionFromModule moduleName decls =
       map (\x -> Match (moduleName, x)) decls
 
 data CompletionOptions = CompletionOptions

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -30,23 +30,25 @@ getCompletions
   :: [Filter]
   -> Matcher IdeDeclarationAnn
   -> CompletionOptions
-  -> [Module]
+  -> ModuleMap [IdeDeclarationAnn]
   -> [Completion]
 getCompletions filters matcher options modules =
   modules
   & applyFilters filters
+  & Map.toList
   & matchesFromModules
   & runMatcher matcher
   & applyCompletionOptions options
   <&> completionFromMatch
 
-getExactMatches :: Text -> [Filter] -> [Module] -> [Match IdeDeclarationAnn]
+getExactMatches :: Text -> [Filter] -> ModuleMap [IdeDeclarationAnn] -> [Match IdeDeclarationAnn]
 getExactMatches search filters modules =
   modules
-  & applyFilters (equalityFilter search : filters)
+  & applyFilters (Filter (Right (Exact search)) : filters)
+  & Map.toList
   & matchesFromModules
 
-getExactCompletions :: Text -> [Filter] -> [Module] -> [Completion]
+getExactCompletions :: Text -> [Filter] -> ModuleMap [IdeDeclarationAnn] -> [Completion]
 getExactCompletions search filters modules =
   modules
   & getExactMatches search filters

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -41,7 +41,7 @@ getCompletions filters matcher options modules =
 getExactMatches :: Text -> [Filter] -> ModuleMap [IdeDeclarationAnn] -> [Match IdeDeclarationAnn]
 getExactMatches search filters modules =
   modules
-  & applyFilters (Filter (Right (Exact search)) : filters)
+  & applyFilters (exactFilter search : filters)
   & matchesFromModules
 
 getExactCompletions :: Text -> [Filter] -> ModuleMap [IdeDeclarationAnn] -> [Completion]

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -15,7 +15,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Language.PureScript.Ide.Filter
-       ( Filter(..)
+       ( Filter
        , moduleFilter
        , namespaceFilter
        , exactFilter

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -16,7 +16,6 @@
 
 module Language.PureScript.Ide.Filter
        ( Filter(..)
-       , DeclarationFilter(..)
        , moduleFilter
        , namespaceFilter
        , exactFilter

--- a/src/Language/PureScript/Ide/Filter/Declaration.hs
+++ b/src/Language/PureScript/Ide/Filter/Declaration.hs
@@ -1,9 +1,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Language.PureScript.Ide.Filter.Declaration
-       ( IdeDeclaration(..)
-       , DeclarationType(..)
-       , typeDeclarationForDeclaration
+       ( DeclarationType(..)
+       , declarationType
        ) where
 
 import           Protolude                     hiding (isPrefixOf)
@@ -37,23 +36,14 @@ instance FromJSON DeclarationType where
       "module"            -> pure Module
       _                   -> mzero
 
-newtype IdeDeclaration = IdeDeclaration
-  { declarationtype :: DeclarationType
-  } deriving (Show, Eq, Ord)
-
-instance FromJSON IdeDeclaration where
-  parseJSON (Object o) =
-    IdeDeclaration <$> o .: "declarationtype"
-  parseJSON _ = mzero
-
-typeDeclarationForDeclaration :: PI.IdeDeclaration -> IdeDeclaration
-typeDeclarationForDeclaration decl = case decl of
-  PI.IdeDeclValue _ -> IdeDeclaration Value
-  PI.IdeDeclType _ -> IdeDeclaration Type
-  PI.IdeDeclTypeSynonym _ -> IdeDeclaration Synonym
-  PI.IdeDeclDataConstructor _ -> IdeDeclaration DataConstructor
-  PI.IdeDeclTypeClass _ -> IdeDeclaration TypeClass
-  PI.IdeDeclValueOperator _ -> IdeDeclaration ValueOperator
-  PI.IdeDeclTypeOperator _ -> IdeDeclaration TypeOperator
-  PI.IdeDeclKind _ -> IdeDeclaration Kind
-  PI.IdeDeclModule _ -> IdeDeclaration Module
+declarationType :: PI.IdeDeclaration -> DeclarationType
+declarationType decl = case decl of
+  PI.IdeDeclValue _ -> Value
+  PI.IdeDeclType _ -> Type
+  PI.IdeDeclTypeSynonym _ -> Synonym
+  PI.IdeDeclDataConstructor _ -> DataConstructor
+  PI.IdeDeclTypeClass _ -> TypeClass
+  PI.IdeDeclValueOperator _ -> ValueOperator
+  PI.IdeDeclTypeOperator _ -> TypeOperator
+  PI.IdeDeclKind _ -> Kind
+  PI.IdeDeclModule _ -> Module

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -275,8 +275,8 @@ addImportForIdentifier
   -> [Filter] -- ^ Filters to apply before searching for the identifier
   -> m (Either [Match IdeDeclaration] [Text])
 addImportForIdentifier fp ident qual filters = do
-  let addPrim = (++) idePrimDeclarations
-  modules <- Map.toList <$> getAllModules Nothing
+  let addPrim = Map.union (Map.fromList idePrimDeclarations)
+  modules <- getAllModules Nothing
   case map (fmap discardAnn) (getExactMatches ident filters (addPrim modules)) of
     [] ->
       throwError (NotFound "Couldn't find the given identifier. \

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -275,7 +275,7 @@ addImportForIdentifier
   -> [Filter] -- ^ Filters to apply before searching for the identifier
   -> m (Either [Match IdeDeclaration] [Text])
 addImportForIdentifier fp ident qual filters = do
-  let addPrim = Map.union (Map.fromList idePrimDeclarations)
+  let addPrim = Map.union idePrimDeclarations
   modules <- getAllModules Nothing
   case map (fmap discardAnn) (getExactMatches ident filters (addPrim modules)) of
     [] ->

--- a/src/Language/PureScript/Ide/Prim.hs
+++ b/src/Language/PureScript/Ide/Prim.hs
@@ -8,8 +8,8 @@ import qualified Language.PureScript.Constants as C
 import qualified Language.PureScript.Environment as PEnv
 import           Language.PureScript.Ide.Types
 
-idePrimDeclarations :: [(P.ModuleName, [IdeDeclarationAnn])]
-idePrimDeclarations =
+idePrimDeclarations :: ModuleMap [IdeDeclarationAnn]
+idePrimDeclarations = Map.fromList
   [ ( C.Prim
     , mconcat [primTypes, primKinds, primClasses]
     )

--- a/tests/Language/PureScript/Ide/FilterSpec.hs
+++ b/tests/Language/PureScript/Ide/FilterSpec.hs
@@ -102,68 +102,57 @@ spec = do
         [moduleA, moduleB, moduleC, moduleD]
         `shouldBe` [moduleA, moduleB, moduleC, moduleD]
   describe "declarationTypeFilter" $ do
-    let moduleADecl = D.Value
-        moduleCDecl = D.Type
-        moduleDDecl = D.Kind
-        moduleEDecl = D.Synonym
-        moduleFDecl = D.DataConstructor
-        moduleGDecl = D.TypeClass
-        moduleHDecl = D.ValueOperator
-        moduleIDecl = D.TypeOperator
-    it "keeps everything on empty list of declarations" $
-      runDeclaration []
-        [moduleA, moduleB, moduleD] `shouldBe` [moduleA, moduleB, moduleD]
     it "extracts modules by filtering `value` declarations" $
-      runDeclaration [moduleADecl]
+      runDeclaration [D.Value]
         [moduleA, moduleB, moduleD] `shouldBe` [moduleA, moduleB]
     it "removes everything if no `value` declarations has been found" $
-      runDeclaration [moduleADecl]
+      runDeclaration [D.Value]
         [moduleD, moduleG, moduleE, moduleH] `shouldBe` []
     it "extracts module by filtering `type` declarations" $
-      runDeclaration [moduleCDecl]
+      runDeclaration [D.Type]
         [moduleA, moduleB, moduleC, moduleD, moduleE] `shouldBe` [moduleC]
     it "removes everything if a `type` declaration have not been found" $
-      runDeclaration [moduleCDecl]
+      runDeclaration [D.Type]
         [moduleA, moduleG, moduleE, moduleH] `shouldBe` []
     it "extracts module by filtering `synonym` declarations" $
-      runDeclaration [moduleEDecl]
+      runDeclaration [D.Synonym]
         [moduleA, moduleB, moduleD, moduleE] `shouldBe` [moduleE]
     it "removes everything if a `synonym` declaration have not been found" $
-      runDeclaration [moduleEDecl]
+      runDeclaration [D.Synonym]
         [moduleA, moduleB, moduleC, moduleH] `shouldBe` []
     it "extracts module by filtering `constructor` declarations" $
-      runDeclaration [moduleFDecl]
+      runDeclaration [D.DataConstructor]
         [moduleA, moduleB, moduleC, moduleF] `shouldBe` [moduleF]
     it "removes everything if a `constructor` declaration have not been found" $
-      runDeclaration [moduleFDecl]
+      runDeclaration [D.DataConstructor]
         [moduleA, moduleB, moduleC, moduleH] `shouldBe` []
     it "extracts module by filtering `typeclass` declarations" $
-      runDeclaration [moduleGDecl]
+      runDeclaration [D.TypeClass]
         [moduleA, moduleC, moduleG] `shouldBe` [moduleG]
     it "removes everything if a `typeclass` declaration have not been found" $
-      runDeclaration [moduleGDecl]
+      runDeclaration [D.TypeClass]
         [moduleA, moduleB, moduleC, moduleH] `shouldBe` []
     it "extracts modules by filtering `valueoperator` declarations" $
-      runDeclaration [moduleHDecl]
+      runDeclaration [D.ValueOperator]
         [moduleA, moduleC, moduleG, moduleH, moduleF] `shouldBe` [moduleH]
     it "removes everything if a `valueoperator` declaration have not been found" $
-      runDeclaration [moduleHDecl]
+      runDeclaration [D.ValueOperator]
         [moduleA, moduleB, moduleC, moduleD] `shouldBe` []
     it "extracts modules by filtering `typeoperator` declarations" $
-      runDeclaration [moduleIDecl]
+      runDeclaration [D.TypeOperator]
         [moduleA, moduleC, moduleG, moduleI, moduleF] `shouldBe` [moduleI]
     it "removes everything if a `typeoperator` declaration have not been found" $
-      runDeclaration [moduleIDecl]
+      runDeclaration [D.TypeOperator]
         [moduleA, moduleD] `shouldBe` []
     it "extracts module by filtering `kind` declarations" $
-      runDeclaration [moduleCDecl]
-        [moduleA, moduleC, moduleG, moduleI, moduleF] `shouldBe` [moduleC]
+      runDeclaration [D.Kind]
+        [moduleA, moduleD, moduleG, moduleI, moduleF] `shouldBe` [moduleD]
     it "removes everything if a `kind` declaration have not been found" $
-      runDeclaration [moduleCDecl]
-        [moduleA, moduleD] `shouldBe` []
+      runDeclaration [D.Kind]
+        [moduleA, moduleC] `shouldBe` []
     it "extracts modules by filtering `value` and `synonym` declarations" $
-      runDeclaration [moduleADecl, moduleEDecl]
+      runDeclaration [D.Value, D.Synonym]
         [moduleA, moduleB, moduleD, moduleE] `shouldBe` [moduleA, moduleB, moduleE]
-    it "extracts modules by filtering `kind`, `synonym` and `valueoperator` declarations" $
-      runDeclaration [moduleADecl, moduleDDecl, moduleHDecl]
+    it "extracts modules by filtering `value`, `kind`, and `valueoperator` declarations" $
+      runDeclaration [D.Value, D.Kind, D.ValueOperator]
         [moduleA, moduleB, moduleD, moduleG, moduleE, moduleH] `shouldBe` [moduleA, moduleB, moduleD, moduleH]

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -3,9 +3,10 @@
 module Language.PureScript.Ide.ImportsSpec where
 
 import           Protolude hiding (moduleName)
-import           Data.Maybe                      (fromJust)
+import           Data.Maybe (fromJust)
+import qualified Data.Set as Set
 
-import qualified Language.PureScript             as P
+import qualified Language.PureScript as P
 import           Language.PureScript.Ide.Command as Command
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Imports
@@ -346,7 +347,7 @@ addExplicitImport i =
 
 addExplicitImportFiltered :: Text -> [P.ModuleName] -> Command
 addExplicitImportFiltered i ms =
-  Command.Import ("src" </> "ImportsSpec.purs") Nothing [moduleFilter ms] (Command.AddImportForIdentifier i Nothing)
+  Command.Import ("src" </> "ImportsSpec.purs") Nothing [moduleFilter (Set.fromList ms)] (Command.AddImportForIdentifier i Nothing)
 
 importShouldBe :: [Text] -> [Text] -> Expectation
 importShouldBe res importSection =


### PR DESCRIPTION
This allows us to reorder the filtering to always filter by module name first and exploit the fact that we store our declarations in a Map of a module names.

Also cleans up the declaration type filter implementation (I don't know of any editor plugin that was using these so far so I decided to break the protocol). If I'm wrong please let me know.