### PR TITLE
Hashable with hashWithSeed

### DIFF
--- a/src/Language/PureScript/Constants/Prelude.hs
+++ b/src/Language/PureScript/Constants/Prelude.hs
@@ -202,8 +202,8 @@ returnEscaped = "$return"
 unit :: forall a. (IsString a) => a
 unit = "unit"
 
-hash :: forall a. (IsString a) => a
-hash = "hash"
+hashWithSalt :: forall a. (IsString a) => a
+hashWithSalt = "hashWithSalt"
 
 -- Core lib values
 

--- a/src/Language/PureScript/Constants/Prelude.hs
+++ b/src/Language/PureScript/Constants/Prelude.hs
@@ -202,6 +202,9 @@ returnEscaped = "$return"
 unit :: forall a. (IsString a) => a
 unit = "unit"
 
+hash :: forall a. (IsString a) => a
+hash = "hash"
+
 -- Core lib values
 
 runST :: forall a. (IsString a) => a


### PR DESCRIPTION
Matches purescript/purescript-prelude#198 i.e. Hashable with hashWithSalt.

This passes the incoming salt to the recursive calls. Maybe it should chain calls instead. Again, the hash function itself is easily changed.