### PR TITLE
Remove more dead code during bundling

### DIFF
--- a/src/Language/PureScript/Bundle.hs
+++ b/src/Language/PureScript/Bundle.hs
@@ -28,9 +28,9 @@ import Data.Aeson ((.=))
 import Data.Array ((!))
 import Data.Char (chr, digitToInt)
 import Data.Foldable (fold)
-import Data.Generics (GenericM, everything, everywhere, gmapMo, mkMp, mkQ, mkT)
+import Data.Generics (GenericM, everything, everythingWithContext, everywhere, gmapMo, mkMp, mkQ, mkT)
 import Data.Graph
-import Data.List (stripPrefix)
+import Data.List (stripPrefix, (\\))
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import Data.Version (showVersion)
 import qualified Data.Aeson as A
@@ -91,9 +91,14 @@ guessModuleIdentifier filename = ModuleIdentifier (takeFileName (takeDirectory f
     guessModuleType "foreign.js" = pure Foreign
     guessModuleType name = throwError $ UnsupportedModulePath name
 
--- | A piece of code is identified by its module and its name. These keys are used to label vertices
--- in the dependency graph.
-type Key = (ModuleIdentifier, String)
+data Visibility
+  = Public
+  | Internal
+  deriving (Show, Eq, Ord)
+
+-- | A piece of code is identified by its module, its name, and whether it is an internal variable
+-- or a public member. These keys are used to label vertices in the dependency graph.
+type Key = (ModuleIdentifier, String, Visibility)
 
 -- | An export is either a "regular export", which exports a name from the regular module we are in,
 -- or a reexport of a declaration in the corresponding foreign module.
@@ -115,7 +120,7 @@ data ExportType
 -- into the output during codegen.
 data ModuleElement
   = Require JSStatement String (Either String ModuleIdentifier)
-  | Member JSStatement Bool String JSExpression [Key]
+  | Member JSStatement Visibility String JSExpression [Key]
   | ExportsList [(ExportType, String, JSExpression, [Key])]
   | Other JSStatement
   | Skip JSStatement
@@ -133,10 +138,10 @@ instance A.ToJSON ModuleElement where
                , "name"       .= name
                , "targetPath" .= targetPath
                ]
-    (Member _ public name _ dependsOn) ->
+    (Member _ visibility name _ dependsOn) ->
       A.object [ "type"       .= A.String "Member"
                , "name"       .= name
-               , "visibility" .= A.String (if public then "Public" else "Internal")
+               , "visibility" .= show visibility
                , "dependsOn"  .= map keyToJSON dependsOn
                ]
     (ExportsList exports) ->
@@ -154,9 +159,10 @@ instance A.ToJSON ModuleElement where
 
     where
 
-    keyToJSON (mid, member) =
-      A.object [ "module" .= mid
-               , "member" .= member
+    keyToJSON (mid, member, visibility) =
+      A.object [ "module"     .= mid
+               , "member"     .= member
+               , "visibility" .= show visibility
                ]
 
     exportToJSON (RegularExport sourceName, name, _, dependsOn) =
@@ -275,24 +281,33 @@ withDeps (Module modulePath fn es) = Module modulePath fn (map expandDeps es)
       expand (ty, nm, n1, _) = (ty, nm, n1, ordNub (dependencies modulePath n1))
   expandDeps other = other
 
-  dependencies :: ModuleIdentifier -> JSExpression -> [(ModuleIdentifier, String)]
-  dependencies m = everything (++) (mkQ [] toReference)
+  dependencies :: ModuleIdentifier -> JSExpression -> [Key]
+  dependencies m = everythingWithContext boundNames (++) (mkQ (const [] &&& id) toReference)
     where
-    toReference :: JSExpression -> [(ModuleIdentifier, String)]
-    toReference (JSMemberDot mn _ nm)
+    toReference :: JSExpression -> [String] -> ([Key], [String])
+    toReference (JSMemberDot mn _ nm) bn
       | JSIdentifier _ mn' <- mn
       , JSIdentifier _ nm' <- nm
       , Just mid <- lookup mn' imports
-      = [(mid, nm')]
-    toReference (JSMemberSquare mn _ nm _)
+      = ([(mid, nm', Public)], bn)
+    toReference (JSMemberSquare mn _ nm _) bn
       | JSIdentifier _ mn' <- mn
       , Just nm' <- fromStringLiteral nm
       , Just mid <- lookup mn' imports
-      = [(mid, nm')]
-    toReference (JSIdentifier _ nm)
-      | nm `elem` boundNames
-      = [(m, nm)]
-    toReference _ = []
+      = ([(mid, nm', Public)], bn)
+    toReference (JSIdentifier _ nm) bn
+      | nm `elem` bn
+      -- ^ only add a dependency if this name is still in the list of names
+      -- bound to the module level (i.e., hasn't been shadowed by a function
+      -- parameter)
+      = ([(m, nm, Internal)], bn)
+    toReference (JSFunctionExpression _ _ _ params _ _) bn
+      = ([], bn \\ (mapMaybe unIdent $ commaList params))
+    toReference _ bn = ([], bn)
+
+    unIdent :: JSIdent -> Maybe String
+    unIdent (JSIdentName _ name) = Just name
+    unIdent _ = Nothing
 
 -- String literals include the quote chars
 fromStringLiteral :: JSExpression -> Maybe String
@@ -350,8 +365,8 @@ toModule mids mid filename top
     | Just (importName, importPath) <- matchRequire mids mid stmt
     = pure (Require stmt importName importPath)
   toModuleElement stmt
-    | Just (exported, name, decl) <- matchMember stmt
-    = pure (Member stmt exported name decl [])
+    | Just (visibility, name, decl) <- matchMember stmt
+    = pure (Member stmt visibility name decl [])
   toModuleElement stmt
     | Just props <- matchExportsAssignment stmt
     = ExportsList <$> traverse toExport (trailingCommaList props)
@@ -393,7 +408,7 @@ getExportedIdentifiers mname top
   go stmt
     | Just props <- matchExportsAssignment stmt
     = traverse toIdent (trailingCommaList props)
-    | Just (True, name, _) <- matchMember stmt
+    | Just (Public, name, _) <- matchMember stmt
     = pure [name]
     | otherwise
     = pure []
@@ -425,18 +440,18 @@ matchRequire mids mid stmt
   = Nothing
 
 -- Matches JS member declarations.
-matchMember :: JSStatement -> Maybe (Bool, String, JSExpression)
+matchMember :: JSStatement -> Maybe (Visibility, String, JSExpression)
 matchMember stmt
   -- var foo = expr;
   | JSVariable _ jsInit _ <- stmt
   , [JSVarInitExpression var varInit] <- commaList jsInit
   , JSIdentifier _ name <- var
   , JSVarInit _ decl <- varInit
-  = Just (False, name, decl)
+  = Just (Internal, name, decl)
   -- exports.foo = expr; exports["foo"] = expr;
   | JSAssignStatement e (JSAssign _) decl _ <- stmt
   , Just name <- accessor e
-  = Just (True, name, decl)
+  = Just (Public, name, decl)
   | otherwise
   = Nothing
   where
@@ -484,26 +499,20 @@ compile modules entryPoints = filteredModules
     where
     -- | Create a set of vertices for a module element.
     --
-    -- Some special cases worth commenting on:
-    --
-    -- 1) Regular exports which simply export their own name do not count as dependencies.
-    --    Regular exports which rename and reexport an operator do count, however.
-    --
-    -- 2) Require statements don't contribute towards dependencies, since they effectively get
-    --    inlined wherever they are used inside other module elements.
+    -- Require statements don't contribute towards dependencies, since they effectively get
+    -- inlined wherever they are used inside other module elements.
     toVertices :: ModuleIdentifier -> ModuleElement -> [(ModuleElement, Key, [Key])]
-    toVertices p m@(Member _ _ nm _ deps) = [(m, (p, nm), deps)]
-    toVertices p m@(ExportsList exps) = mapMaybe toVertex exps
+    toVertices p m@(Member _ visibility nm _ deps) = [(m, (p, nm, visibility), deps)]
+    toVertices p m@(ExportsList exps) = map toVertex exps
       where
-      toVertex (ForeignReexport, nm, _, ks) = Just (m, (p, nm), ks)
-      toVertex (RegularExport nm, nm1, _, ks) | nm /= nm1 = Just (m, (p, nm1), ks)
-      toVertex _ = Nothing
+      toVertex (ForeignReexport, nm, _, ks) = (m, (p, nm, Public), ks)
+      toVertex (RegularExport _, nm, _, ks) = (m, (p, nm, Public), ks)
     toVertices _ _ = []
 
   -- | The set of vertices whose connected components we are interested in keeping.
   entryPointVertices :: [Vertex]
   entryPointVertices = catMaybes $ do
-    (_, k@(mid, _), _) <- verts
+    (_, k@(mid, _, Public), _) <- verts
     guard $ mid `elem` entryPoints
     return (vertexFor k)
 
@@ -516,7 +525,7 @@ compile modules entryPoints = filteredModules
   moduleReferenceMap = M.fromAscListWith mappend $ map (vertToModule &&& vertToModuleRefs) $ S.toList reachableSet
     where
     vertToModuleRefs v = foldMap (S.singleton . vertToModule) $ graph ! v
-    vertToModule v = m where (_, (m, _), _) = vertexToNode v
+    vertToModule v = m where (_, (m, _, _), _) = vertexToNode v
 
   filteredModules :: [Module]
   filteredModules = map filterUsed modules
@@ -539,11 +548,11 @@ compile modules entryPoints = filteredModules
 
       -- | Filter out the exports for members which aren't used.
       filterExports :: ModuleElement -> ModuleElement
-      filterExports (ExportsList exps) = ExportsList (filter (\(_, nm, _, _) -> isKeyUsed (mid, nm)) exps)
+      filterExports (ExportsList exps) = ExportsList (filter (\(_, nm, _, _) -> isKeyUsed (mid, nm, Public)) exps)
       filterExports me = me
 
       isDeclUsed :: ModuleElement -> Bool
-      isDeclUsed (Member _ _ nm _ _) = isKeyUsed (mid, nm)
+      isDeclUsed (Member _ visibility nm _ _) = isKeyUsed (mid, nm, visibility)
       isDeclUsed (Require _ _ (Right midRef)) = midRef `S.member` modulesReferenced
       isDeclUsed _ = True
 

--- a/tests/purs/bundle/3551.purs
+++ b/tests/purs/bundle/3551.purs
@@ -1,0 +1,21 @@
+module Main where
+
+import Prelude
+import Effect (Effect)
+import Effect.Console (error, log)
+
+import ModuleWithDeadCode (class FooBar, exportThatUsesBar, results)
+
+main :: Effect Unit
+main = do
+  when results.barIsExported $ error "bar is exported"
+  when results.fooIsNotEliminated $ error "foo is not eliminated"
+
+  -- These are brittleness canaries; if they fail, then the compiler output has
+  -- probably changed such that the above checks are not doing their job.
+  unless results.exportThatUsesBarIsExported $
+    error "likely test error: check that barIsExported is working"
+  unless results.barIsNotEliminated $
+    error "likely test error: check that fooIsNotEliminated is working"
+
+  when (exportThatUsesBar 0) $ log "Done"

--- a/tests/purs/bundle/3551/ModuleWithDeadCode.js
+++ b/tests/purs/bundle/3551/ModuleWithDeadCode.js
@@ -1,0 +1,12 @@
+"use strict";
+
+var fs = require('fs');
+
+var source = fs.readFileSync(__filename, 'utf-8');
+
+exports.results = {
+    fooIsNotEliminated: /^ *var foo =/m.test(source),
+    barIsExported: /^ *exports\["bar"\] =/m.test(source),
+    barIsNotEliminated: /^ *var bar =/m.test(source),
+    exportThatUsesBarIsExported: /^ *exports\["exportThatUsesBar"\] =/m.test(source),
+};

--- a/tests/purs/bundle/3551/ModuleWithDeadCode.purs
+++ b/tests/purs/bundle/3551/ModuleWithDeadCode.purs
@@ -1,0 +1,16 @@
+module ModuleWithDeadCode (class FooBar, bar, exportThatUsesBar, foo, results) where
+
+import Prelude
+
+class FooBar a where
+  foo :: a
+  bar :: a -> Boolean
+
+instance intFooBar :: FooBar Int where
+  foo = 0
+  bar _ = true
+
+exportThatUsesBar :: forall a. (FooBar a) => a -> Boolean
+exportThatUsesBar = bar
+
+foreign import results :: { fooIsNotEliminated :: Boolean, barIsExported :: Boolean, barIsNotEliminated :: Boolean, exportThatUsesBarIsExported :: Boolean }


### PR DESCRIPTION
Fixes #3551.

---

I don't know whether defining the `Visibility` type was worth it versus continuing to use a `Bool`—IMO the code is slightly more readable this way, since that value is propagating across more code now, but there's no functional need for a new abstraction here. It'd be an easy change for me to make if you'd prefer going back to `Bool`.