### PR TITLE
Add test for resolved dependencies with no version

### DIFF
--- a/tests/purs/publish/basic-example/resolutions-legacy.json
+++ b/tests/purs/publish/basic-example/resolutions-legacy.json
@@ -16,7 +16,11 @@
     "dependencies": {
       "purescript-prelude": "^4.1.0",
       "purescript-console": "^4.2.0",
-      "purescript-effect": "^2.0.1"
+      "purescript-effect": "^2.0.1",
+      "purescript-newtype": "#master"
+    },
+    "devDependencies": {
+      "purescript-psci-support": "^4.0.0"
     }
   },
   "dependencies": {
@@ -57,8 +61,7 @@
         },
         "_source": "https://github.com/purescript/purescript-console.git",
         "_target": "^4.2.0",
-        "_originalSource": "purescript-console",
-        "_direct": true
+        "_originalSource": "purescript-console"
       },
       "dependencies": {
         "purescript-effect": {
@@ -96,7 +99,7 @@
               "commit": "d2a11e69abcda3b81c750e86e8746cda278f47bf"
             },
             "_source": "https://github.com/purescript/purescript-effect.git",
-            "_target": "^2.0.0",
+            "_target": "^2.0.1",
             "_originalSource": "purescript-effect"
           },
           "dependencies": {
@@ -133,14 +136,14 @@
                   "commit": "7a691ce2658bd8eaf28439391e29506dd154fb3d"
                 },
                 "_source": "https://github.com/purescript/purescript-prelude.git",
-                "_target": "^4.0.0",
+                "_target": "^4.1.0",
                 "_originalSource": "purescript-prelude"
               },
               "dependencies": {},
-              "nrDependants": 3
+              "nrDependants": 1
             }
           },
-          "nrDependants": 2
+          "nrDependants": 1
         },
         "purescript-prelude": {
           "endpoint": {
@@ -175,11 +178,11 @@
               "commit": "7a691ce2658bd8eaf28439391e29506dd154fb3d"
             },
             "_source": "https://github.com/purescript/purescript-prelude.git",
-            "_target": "^4.0.0",
+            "_target": "^4.1.0",
             "_originalSource": "purescript-prelude"
           },
           "dependencies": {},
-          "nrDependants": 3
+          "nrDependants": 1
         }
       },
       "nrDependants": 1
@@ -219,10 +222,91 @@
           "commit": "d2a11e69abcda3b81c750e86e8746cda278f47bf"
         },
         "_source": "https://github.com/purescript/purescript-effect.git",
-        "_target": "^2.0.0",
+        "_target": "^2.0.1",
         "_originalSource": "purescript-effect"
       },
       "dependencies": {},
+      "nrDependants": 1
+    },
+    "purescript-newtype": {
+      "endpoint": {
+        "name": "purescript-newtype",
+        "source": "purescript-newtype",
+        "target": "master"
+      },
+      "canonicalDir": "../../../support/bower_components/purescript-newtype",
+      "pkgMeta": {
+        "name": "purescript-newtype",
+        "homepage": "https://github.com/purescript/purescript-newtype",
+        "description": "Type class and functions for working with newtypes",
+        "license": "BSD-3-Clause",
+        "repository": {
+          "type": "git",
+          "url": "git://github.com/purescript/purescript-newtype.git"
+        },
+        "ignore": [
+          "**/.*",
+          "bower_components",
+          "node_modules",
+          "output",
+          "test",
+          "bower.json",
+          "package.json"
+        ],
+        "dependencies": {
+          "purescript-prelude": "^4.0.0"
+        },
+        "_release": "7d85fa6a04",
+        "_resolution": {
+          "type": "branch",
+          "branch": "master",
+          "commit": "7d85fa6a040208c010b05f7c23af6a943ba08763"
+        },
+        "_source": "https://github.com/garyb/purescript-newtype.git",
+        "_target": "master",
+        "_originalSource": "purescript-newtype"
+      },
+      "dependencies": {
+        "purescript-prelude": {
+          "endpoint": {
+            "name": "purescript-prelude",
+            "source": "purescript-prelude",
+            "target": "^4.0.0"
+          },
+          "canonicalDir": "../../../support/bower_components/purescript-prelude",
+          "pkgMeta": {
+            "name": "purescript-prelude",
+            "homepage": "https://github.com/purescript/purescript-prelude",
+            "description": "The PureScript Prelude",
+            "license": "BSD-3-Clause",
+            "repository": {
+              "type": "git",
+              "url": "git://github.com/purescript/purescript-prelude.git"
+            },
+            "ignore": [
+              "**/.*",
+              "bower_components",
+              "node_modules",
+              "output",
+              "test",
+              "bower.json",
+              "package.json"
+            ],
+            "version": "4.1.0",
+            "_release": "4.1.0",
+            "_resolution": {
+              "type": "version",
+              "tag": "v4.1.0",
+              "commit": "7a691ce2658bd8eaf28439391e29506dd154fb3d"
+            },
+            "_source": "https://github.com/purescript/purescript-prelude.git",
+            "_target": "^4.1.0",
+            "_originalSource": "purescript-prelude"
+          },
+          "dependencies": {},
+          "nrDependants": 1
+        }
+      },
       "nrDependants": 1
     },
     "purescript-prelude": {
@@ -258,10 +342,297 @@
           "commit": "7a691ce2658bd8eaf28439391e29506dd154fb3d"
         },
         "_source": "https://github.com/purescript/purescript-prelude.git",
-        "_target": "^4.0.0",
+        "_target": "^4.1.0",
         "_originalSource": "purescript-prelude"
       },
       "dependencies": {},
+      "nrDependants": 1
+    },
+    "purescript-psci-support": {
+      "endpoint": {
+        "name": "purescript-psci-support",
+        "source": "purescript-psci-support",
+        "target": "^4.0.0"
+      },
+      "canonicalDir": "../../../support/bower_components/purescript-psci-support",
+      "pkgMeta": {
+        "name": "purescript-psci-support",
+        "homepage": "https://github.com/purescript/purescript-psci-support",
+        "description": "Support module for the PSCI interactive mode",
+        "license": "BSD-3-Clause",
+        "repository": {
+          "type": "git",
+          "url": "git://github.com/purescript/purescript-psci-support.git"
+        },
+        "ignore": [
+          "**/.*",
+          "bower_components",
+          "node_modules",
+          "output",
+          "bower.json",
+          "package.json"
+        ],
+        "dependencies": {
+          "purescript-console": "^4.0.0",
+          "purescript-effect": "^2.0.0",
+          "purescript-prelude": "^4.0.0"
+        },
+        "version": "4.0.0",
+        "_release": "4.0.0",
+        "_resolution": {
+          "type": "version",
+          "tag": "v4.0.0",
+          "commit": "a66a0fa8661eb8b5fe75cc862f4e2df2835c058d"
+        },
+        "_source": "https://github.com/purescript/purescript-psci-support.git",
+        "_target": "^4.0.0",
+        "_originalSource": "purescript-psci-support"
+      },
+      "dependencies": {
+        "purescript-console": {
+          "endpoint": {
+            "name": "purescript-console",
+            "source": "purescript-console",
+            "target": "^4.0.0"
+          },
+          "canonicalDir": "../../../support/bower_components/purescript-console",
+          "pkgMeta": {
+            "name": "purescript-console",
+            "homepage": "https://github.com/purescript/purescript-console",
+            "license": "BSD-3-Clause",
+            "repository": {
+              "type": "git",
+              "url": "git://github.com/purescript/purescript-console.git"
+            },
+            "ignore": [
+              "**/.*",
+              "bower_components",
+              "node_modules",
+              "output",
+              "test",
+              "bower.json",
+              "package.json"
+            ],
+            "dependencies": {
+              "purescript-effect": "^2.0.0",
+              "purescript-prelude": "^4.0.0"
+            },
+            "version": "4.2.0",
+            "_release": "4.2.0",
+            "_resolution": {
+              "type": "version",
+              "tag": "v4.2.0",
+              "commit": "add2bdb8a4af2213d993b728805f1f2a5e76deb8"
+            },
+            "_source": "https://github.com/purescript/purescript-console.git",
+            "_target": "^4.2.0",
+            "_originalSource": "purescript-console"
+          },
+          "dependencies": {
+            "purescript-effect": {
+              "endpoint": {
+                "name": "purescript-effect",
+                "source": "purescript-effect",
+                "target": "^2.0.0"
+              },
+              "canonicalDir": "../../../support/bower_components/purescript-effect",
+              "pkgMeta": {
+                "name": "purescript-effect",
+                "homepage": "https://github.com/purescript/purescript-effect",
+                "license": "BSD-3-Clause",
+                "repository": {
+                  "type": "git",
+                  "url": "git://github.com/purescript/purescript-effect.git"
+                },
+                "ignore": [
+                  "**/.*",
+                  "bower_components",
+                  "node_modules",
+                  "output",
+                  "test",
+                  "bower.json",
+                  "package.json"
+                ],
+                "dependencies": {
+                  "purescript-prelude": "^4.0.0"
+                },
+                "version": "2.0.1",
+                "_release": "2.0.1",
+                "_resolution": {
+                  "type": "version",
+                  "tag": "v2.0.1",
+                  "commit": "d2a11e69abcda3b81c750e86e8746cda278f47bf"
+                },
+                "_source": "https://github.com/purescript/purescript-effect.git",
+                "_target": "^2.0.1",
+                "_originalSource": "purescript-effect"
+              },
+              "dependencies": {
+                "purescript-prelude": {
+                  "endpoint": {
+                    "name": "purescript-prelude",
+                    "source": "purescript-prelude",
+                    "target": "^4.0.0"
+                  },
+                  "canonicalDir": "../../../support/bower_components/purescript-prelude",
+                  "pkgMeta": {
+                    "name": "purescript-prelude",
+                    "homepage": "https://github.com/purescript/purescript-prelude",
+                    "description": "The PureScript Prelude",
+                    "license": "BSD-3-Clause",
+                    "repository": {
+                      "type": "git",
+                      "url": "git://github.com/purescript/purescript-prelude.git"
+                    },
+                    "ignore": [
+                      "**/.*",
+                      "bower_components",
+                      "node_modules",
+                      "output",
+                      "test",
+                      "bower.json",
+                      "package.json"
+                    ],
+                    "version": "4.1.0",
+                    "_release": "4.1.0",
+                    "_resolution": {
+                      "type": "version",
+                      "tag": "v4.1.0",
+                      "commit": "7a691ce2658bd8eaf28439391e29506dd154fb3d"
+                    },
+                    "_source": "https://github.com/purescript/purescript-prelude.git",
+                    "_target": "^4.1.0",
+                    "_originalSource": "purescript-prelude"
+                  },
+                  "dependencies": {},
+                  "nrDependants": 1
+                }
+              },
+              "nrDependants": 1
+            },
+            "purescript-prelude": {
+              "endpoint": {
+                "name": "purescript-prelude",
+                "source": "purescript-prelude",
+                "target": "^4.0.0"
+              },
+              "canonicalDir": "../../../support/bower_components/purescript-prelude",
+              "pkgMeta": {
+                "name": "purescript-prelude",
+                "homepage": "https://github.com/purescript/purescript-prelude",
+                "description": "The PureScript Prelude",
+                "license": "BSD-3-Clause",
+                "repository": {
+                  "type": "git",
+                  "url": "git://github.com/purescript/purescript-prelude.git"
+                },
+                "ignore": [
+                  "**/.*",
+                  "bower_components",
+                  "node_modules",
+                  "output",
+                  "test",
+                  "bower.json",
+                  "package.json"
+                ],
+                "version": "4.1.0",
+                "_release": "4.1.0",
+                "_resolution": {
+                  "type": "version",
+                  "tag": "v4.1.0",
+                  "commit": "7a691ce2658bd8eaf28439391e29506dd154fb3d"
+                },
+                "_source": "https://github.com/purescript/purescript-prelude.git",
+                "_target": "^4.1.0",
+                "_originalSource": "purescript-prelude"
+              },
+              "dependencies": {},
+              "nrDependants": 1
+            }
+          },
+          "nrDependants": 1
+        },
+        "purescript-effect": {
+          "endpoint": {
+            "name": "purescript-effect",
+            "source": "purescript-effect",
+            "target": "^2.0.0"
+          },
+          "canonicalDir": "../../../support/bower_components/purescript-effect",
+          "pkgMeta": {
+            "name": "purescript-effect",
+            "homepage": "https://github.com/purescript/purescript-effect",
+            "license": "BSD-3-Clause",
+            "repository": {
+              "type": "git",
+              "url": "git://github.com/purescript/purescript-effect.git"
+            },
+            "ignore": [
+              "**/.*",
+              "bower_components",
+              "node_modules",
+              "output",
+              "test",
+              "bower.json",
+              "package.json"
+            ],
+            "dependencies": {
+              "purescript-prelude": "^4.0.0"
+            },
+            "version": "2.0.1",
+            "_release": "2.0.1",
+            "_resolution": {
+              "type": "version",
+              "tag": "v2.0.1",
+              "commit": "d2a11e69abcda3b81c750e86e8746cda278f47bf"
+            },
+            "_source": "https://github.com/purescript/purescript-effect.git",
+            "_target": "^2.0.1",
+            "_originalSource": "purescript-effect"
+          },
+          "dependencies": {},
+          "nrDependants": 1
+        },
+        "purescript-prelude": {
+          "endpoint": {
+            "name": "purescript-prelude",
+            "source": "purescript-prelude",
+            "target": "^4.0.0"
+          },
+          "canonicalDir": "../../../support/bower_components/purescript-prelude",
+          "pkgMeta": {
+            "name": "purescript-prelude",
+            "homepage": "https://github.com/purescript/purescript-prelude",
+            "description": "The PureScript Prelude",
+            "license": "BSD-3-Clause",
+            "repository": {
+              "type": "git",
+              "url": "git://github.com/purescript/purescript-prelude.git"
+            },
+            "ignore": [
+              "**/.*",
+              "bower_components",
+              "node_modules",
+              "output",
+              "test",
+              "bower.json",
+              "package.json"
+            ],
+            "version": "4.1.0",
+            "_release": "4.1.0",
+            "_resolution": {
+              "type": "version",
+              "tag": "v4.1.0",
+              "commit": "7a691ce2658bd8eaf28439391e29506dd154fb3d"
+            },
+            "_source": "https://github.com/purescript/purescript-prelude.git",
+            "_target": "^4.1.0",
+            "_originalSource": "purescript-prelude"
+          },
+          "dependencies": {},
+          "nrDependants": 1
+        }
+      },
       "nrDependants": 1
     }
   },

--- a/tests/purs/publish/basic-example/resolutions.json
+++ b/tests/purs/publish/basic-example/resolutions.json
@@ -10,5 +10,8 @@
   "purescript-prelude": {
     "version": "1.0.0",
     "path": "../../../support/bower_components/purescript-prelude"
+  },
+  "purescript-newtype": {
+    "path": "../../../support/bower_components/purescript-newtype"
   }
 }

--- a/tests/purs/publish/basic-example/src/Main.purs
+++ b/tests/purs/publish/basic-example/src/Main.purs
@@ -3,6 +3,14 @@ module Main where
 import Prelude
 import Effect (Effect)
 import Effect.Console (log)
+import Data.Newtype (class Newtype, un)
+
+newtype Target = Target String
+
+derive instance newtypeTarget :: Newtype Target _
+
+greetingTarget :: Target
+greetingTarget = Target "world"
 
 main :: Effect Unit
-main = log ("hello, " <> "world!")
+main = log ("hello, " <> un Target greetingTarget <> "!")


### PR DESCRIPTION
Previously, purs publish would fail when given any dependencies which
did not resolve to a version (#3061). This bug was fixed by #3565. This
commit just adds a test to verify that the bug has been fixed.