### PR TITLE
Make bundle tests rerun some compile tests

### DIFF
--- a/tests/purs/bundle/RerunCompilerTests.txt
+++ b/tests/purs/bundle/RerunCompilerTests.txt
@@ -1,0 +1,27 @@
+-- Each line in this file that doesn't start with "--" is the name of a test
+-- in purs/passing which should be rerun during bundle testing. Rerunning
+-- every test in purs/passing would take more time than it's worth, so these
+-- tests have been cherry-picked for having moderately complex imports.
+
+Collatz
+DctorOperatorAlias
+--EffFn
+ExtendedInfixOperators
+Fib
+ForeignKind
+--FunWithFunDeps
+GenericsRep
+Import
+ImportExplicit
+ImportQualified
+Let
+Operators
+QualifiedAdo
+QualifiedDo
+SolvingAppendSymbol
+SolvingCompareSymbol
+SolvingIsSymbol
+TCO
+TransitiveImport
+TypeOperators
+TypeWithoutParens


### PR DESCRIPTION
Per @hdgarrood at https://github.com/purescript/purescript/pull/3562#issuecomment-476745811, here's one way to get some more test coverage of the bundler to ensure that DCE isn't overagressive. What do you think about this?

(Note that two of these tests actually *fail* because of a preexisting bug (?) in the bundler—it looks like it's assuming that `"use strict"` is always the first line of a JavaScript file, and when it isn't (in the case of a handwritten foreign module, here), it generates an invalid bundle. I think I should try to fix this in a separate PR?)