### PR TITLE
Handle "use strict" better in bundler

### DIFF
--- a/tests/purs/bundle/RerunCompilerTests.txt
+++ b/tests/purs/bundle/RerunCompilerTests.txt
@@ -5,11 +5,11 @@
 
 Collatz
 DctorOperatorAlias
---EffFn
+EffFn
 ExtendedInfixOperators
 Fib
 ForeignKind
---FunWithFunDeps
+FunWithFunDeps
 GenericsRep
 Import
 ImportExplicit


### PR DESCRIPTION
This PR changes the behavior of the bundler from ‘assume the first line of input JavaScript files is `"use strict"` and place it before the `exports` var’ to ‘remove any standalone string literals from input JavaScript files and add `"use strict"` back in at the top of the bundle‘. This fixes the failures in #3579 and incidentally makes bundles a little bit smaller.

So now there are three related PRs: this, #3579, and #3562; and my apologies for the multiplication but I thought you might want to review their contents separately. There are no conflicts between the above, and if you merge them in that order, then every commit in the history will build. (#3579 doesn't build without this PR. #3562 builds just fine on its own, but the feedback on that PR is that it needs more tests of the bundler before it's merged, which are provided in #3579.)