### PR TITLE
Shrink types less aggressively, fixes #3577

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -879,7 +879,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
           _ -> []
       in
         paras $ [ line $ "Hole '" <> markCode name <> "' has the inferred type "
-                , markCodeBox (indent (typeAsBox prettyDepth ty))
+                , markCodeBox (indent (typeAsBox maxBound ty))
                 ] ++ tsResult ++ renderContext ctx
     renderSimpleErrorMessage (MissingTypeDeclaration ident ty) =
       paras [ line $ "No type declaration was provided for the top-level declaration of " <> markCode (showIdent ident) <> "."

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -77,9 +77,7 @@ convertPrettyPrintType = go
   go _ (REmpty _) = PPRow [] Nothing
   go d ty@RCons{} = uncurry PPRow (goRow d ty)
   go d (ForAll _ v ty _) = goForAll d [v] ty
-  go d (TypeApp _ (TypeApp _ f arg) ret) | eqType f tyFunction = PPFunction (go (d-1) arg) (go (d-1) ret)
-  go d (TypeApp _ o ty@RCons{}) | eqType o tyRecord = uncurry PPRecord (goRow d ty)
-  go d (TypeApp _ a b) = PPTypeApp (go (d-1) a) (go (d-1) b)
+  go d (TypeApp _ a b) = goTypeApp d a b
 
   goForAll d vs (ForAll _ v ty _) = goForAll d (v : vs) ty
   goForAll d vs ty = PPForAll vs (go (d-1) ty)
@@ -91,6 +89,13 @@ convertPrettyPrintType = go
            REmpty _ -> Nothing
            _ -> Just (go (d-1) tail_)
        )
+
+  goTypeApp d (TypeApp _ f a) b
+    | eqType f tyFunction = PPFunction (go (d-1) a) (go (d-1) b)
+    | otherwise = PPTypeApp (goTypeApp d f a) (go (d-1) b)
+  goTypeApp d o ty@RCons{}
+    | eqType o tyRecord = uncurry PPRecord (goRow d ty)
+  goTypeApp d a b = PPTypeApp (go (d-1) a) (go (d-1) b)
 
 -- TODO(Christoph): get rid of T.unpack s
 


### PR DESCRIPTION
Shrink types less aggressively by treating nested type applications as
all being at the same level. Now, given the following module:

    module Main where

    import Data.Tuple.Nested (Tuple4)

    something :: Tuple4 Int String Int String
    something = ?y

the error we get is displayed as:

    Hole 'y' has the inferred type

      Tuple Int (Tuple String (Tuple Int (... ... ...)))

    You could substitute the hole with one of these values:

      Main.something  :: Tuple4 Int String Int String

    in value declaration something