### PR TITLE
Fail compilation when a module imports itself

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -565,9 +565,13 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderSimpleErrorMessage (CycleInDeclaration nm) =
       line $ "The value of " <> markCode (showIdent nm) <> " is undefined here, so this reference is not allowed."
     renderSimpleErrorMessage (CycleInModules mns) =
-      paras [ line "There is a cycle in module dependencies in these modules: "
-            , indent $ paras (map (line . markCode . runModuleName) mns)
-            ]
+      case mns of
+        [mn] ->
+          line $ "Module " <> markCode (runModuleName mn) <> " imports itself."
+        _ ->
+          paras [ line "There is a cycle in module dependencies in these modules: "
+                , indent $ paras (map (line . markCode . runModuleName) mns)
+                ]
     renderSimpleErrorMessage (CycleInTypeSynonym name) =
       paras [ line $ case name of
                        Just pn -> "A cycle appears in the definition of type synonym " <> markCode (runProperName pn)

--- a/tests/purs/failing/SelfImport.purs
+++ b/tests/purs/failing/SelfImport.purs
@@ -1,0 +1,9 @@
+-- @shouldFailWith CycleInModules
+
+module Main where
+
+import Main as M
+
+foo = 0
+
+bar = M.foo

--- a/tests/purs/failing/SelfImport/Dummy.purs
+++ b/tests/purs/failing/SelfImport/Dummy.purs
@@ -1,0 +1,5 @@
+-- This module only exists so that we perform a full build for the
+-- SelfImport.purs module. If this module didn't exist, we would perform a
+-- single-module fast rebuild, which doesn't perform the `sortModules` step,
+-- and so the error we want to see wouldn't be emitted.
+module Dummy where


### PR DESCRIPTION
Fixes #3079, fixes #3118. This is a breaking change so we should wait
until after 0.12.4 is released to merge.

I have used the CycleInModules error to indicate this; previously we
only emitted this error for cycles containing two or more modules, but
now we also emit it for singleton cycles (which occur precisely when
modules import themselves).

This commit also fixes a separate issue where the CycleInModules error
was not printing one of the modules in a cycle (specifically, the module
which happened to come first in the cycle), presumably due to
accidentally using the tail rather than the whole list while
constructing the error message. I've made this problem easier to avoid
here by using `nonEmpty` instead of `:|` to construct the non-empty
list, which means that we don't need to bind a reference to the tail at
all.