### PR TITLE
Prevent invalid js generation for module names with an apostrophe:

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -131,6 +131,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@dariooddenino](https://github.com/dariooddenino) | Dario Oddenino | [MIT license](http://opensource.org/licenses/MIT) |
 | [@jordanmartinez](https://github.com/jordanmartinez) | Jordan Martinez | [MIT license](http://opensource.org/licenses/MIT) |
 | [@Saulukass](https://github.com/Saulukass) | Saulius Skliutas | [MIT license](http://opensource.org/licenses/MIT) |
+| [@matthew-hilty](https://github.com/matthew-hilty) | Matthew Hilty | [MIT license](http://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms
 

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -12,7 +12,7 @@ import Language.PureScript.Names
 
 moduleNameToJs :: ModuleName -> Text
 moduleNameToJs (ModuleName pns) =
-  let name = T.intercalate "_" (runProperName `map` pns)
+  let name = T.intercalate "_" (properToJs `map` pns)
   in if nameIsJsBuiltIn name then "$$" <> name else name
 
 -- | Convert an 'Ident' into a valid JavaScript identifier:

--- a/tests/purs/failing/ModuleNameApostropheEnd.purs
+++ b/tests/purs/failing/ModuleNameApostropheEnd.purs
@@ -1,5 +1,5 @@
 -- @shouldFailWith ErrorParsingModule
-module Bad_Module where
+module ModuleNameEndsWithPrime' where
 
 import Effect.Console (log)
 

--- a/tests/purs/failing/ModuleNameApostropheMiddle.purs
+++ b/tests/purs/failing/ModuleNameApostropheMiddle.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module Module'NameHasPrime where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/failing/ModuleNameApostropheStart.purs
+++ b/tests/purs/failing/ModuleNameApostropheStart.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module 'ModuleNameStartsWithPrime where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/failing/ModuleNameLowercaseStart.purs
+++ b/tests/purs/failing/ModuleNameLowercaseStart.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module moduleNameStartsWithMinuscule where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/failing/ModuleNameNumberStart.purs
+++ b/tests/purs/failing/ModuleNameNumberStart.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module 0ModuleNameStartsWithNumber where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/failing/ModuleNameUnderscoreEnd.purs
+++ b/tests/purs/failing/ModuleNameUnderscoreEnd.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module ModuleNameEndsWithUnderscore_ where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/failing/ModuleNameUnderscoreMiddle.purs
+++ b/tests/purs/failing/ModuleNameUnderscoreMiddle.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module Module_NameHasUnderscore where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/failing/ModuleNameUnderscoreStart.purs
+++ b/tests/purs/failing/ModuleNameUnderscoreStart.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module _ModuleStartsWithUnderscore where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/failing/QualifierApostropheEnd.purs
+++ b/tests/purs/failing/QualifierApostropheEnd.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module QualifierEndsWithPrime'.OkModuleName where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/failing/QualifierApostropheMiddle.purs
+++ b/tests/purs/failing/QualifierApostropheMiddle.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module Qualifier'HasPrime.OkModuleName where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/failing/QualifierLowercaseStart.purs
+++ b/tests/purs/failing/QualifierLowercaseStart.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module qualifierStartsWithMinuscule.OkModuleName where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/failing/QualifierNumberStart.purs
+++ b/tests/purs/failing/QualifierNumberStart.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module 0QualifierStartsWithNumber.OkModuleName where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/failing/QualifierUnderscoreEnd.purs
+++ b/tests/purs/failing/QualifierUnderscoreEnd.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module QualifierEndsWithUnderscore_.OkModuleName where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/failing/QualifierUnderscoreMiddle.purs
+++ b/tests/purs/failing/QualifierUnderscoreMiddle.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module Qualifier_HasUnderscore.OkModuleName where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/failing/QualifierUnderscoreStart.purs
+++ b/tests/purs/failing/QualifierUnderscoreStart.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module _QualifierStartsWithUnderscore.OkModuleName where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/passing/ModuleAndQualifierNames.purs
+++ b/tests/purs/passing/ModuleAndQualifierNames.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Prelude
+import Effect (Effect)
+import Effect.Console (log)
+import Qualifier0123456789.Module1
+import Qual0123456789ifier.Module2
+import Mod0123456789ule
+import Module0123456789
+
+main :: Effect Unit
+main = do
+  log "Done"

--- a/tests/purs/passing/ModuleAndQualifierNames/Mod0123456789ule.purs
+++ b/tests/purs/passing/ModuleAndQualifierNames/Mod0123456789ule.purs
@@ -1,0 +1,1 @@
+module Mod0123456789ule where

--- a/tests/purs/passing/ModuleAndQualifierNames/Module0123456789.purs
+++ b/tests/purs/passing/ModuleAndQualifierNames/Module0123456789.purs
@@ -1,0 +1,1 @@
+module Module0123456789 where

--- a/tests/purs/passing/ModuleAndQualifierNames/Module1.purs
+++ b/tests/purs/passing/ModuleAndQualifierNames/Module1.purs
@@ -1,0 +1,1 @@
+module Qualifier0123456789.Module1 where

--- a/tests/purs/passing/ModuleAndQualifierNames/Module2.purs
+++ b/tests/purs/passing/ModuleAndQualifierNames/Module2.purs
@@ -1,0 +1,1 @@
+module Qual0123456789ifier.Module2 where


### PR DESCRIPTION
Formerly, the purescript code

    module Foo' where
    foo = "foo"

    module Bar where
    import Foo'

would be parsed without error but would generate the following invalid javascript:

    var Foo' = require("../Foo'/index.js");

The present commit prevents this error in two ways:
1. requiring that module and qualifier names comprise alphanumeric characters only;
        (I've seen some past discord among ps developers about this restriction,
        but it seems the safest choice and code currently in Parser/Lexer.hs (specifically, 'validUName')
        suggests that's the present naming policy.)
2. applying 'identCharToText' to ModuleNames
       to ensure that the rendered javascript variable names contain no invalid chars,
       should module-naming conventions ever change.