### PR TITLE
WIP - Add error for redefining `it` in REPL

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -131,6 +131,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@dariooddenino](https://github.com/dariooddenino) | Dario Oddenino | [MIT license](http://opensource.org/licenses/MIT) |
 | [@jordanmartinez](https://github.com/jordanmartinez) | Jordan Martinez | [MIT license](http://opensource.org/licenses/MIT) |
 | [@Saulukass](https://github.com/Saulukass) | Saulius Skliutas | [MIT license](http://opensource.org/licenses/MIT) |
+| [@GoNZooo](https://github.com/GoNZooo) | Rickard Andersson | [MIT license](http://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms
 

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -178,6 +178,7 @@ data SimpleErrorMessage
   | CannotDefinePrimModules ModuleName
   | MixedAssociativityError (NEL.NonEmpty (Qualified (OpName 'AnyOpName), Associativity))
   | NonAssociativeError (NEL.NonEmpty (Qualified (OpName 'AnyOpName)))
+  | NoItInREPL
   deriving (Show)
 
 -- | Error message hints, providing more detailed information about failure.

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -184,6 +184,7 @@ errorCode em = case unwrapErrorMessage em of
   CannotDefinePrimModules{} -> "CannotDefinePrimModules"
   MixedAssociativityError{} -> "MixedAssociativityError"
   NonAssociativeError{} -> "NonAssociativeError"
+  NoItInREPL{} -> "NoItInREPL"
 
 -- | A stack trace for an error
 newtype MultipleErrors = MultipleErrors
@@ -1045,6 +1046,9 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             , indent $ paras $ map (line . markCode . showQualified showOp) (NEL.toList ops)
             , line "Use parentheses to resolve this ambiguity."
             ]
+
+    renderSimpleErrorMessage NoItInREPL =
+      line $ markCode (T.pack "it") <> " is a variable used to refer to the previously evaluated expression in the REPL. Redefining it is not allowed."
 
     renderHint :: ErrorMessageHint -> Box.Box -> Box.Box
     renderHint (ErrorUnifyingTypes t1 t2) detail =

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -171,7 +171,7 @@ handleDecls
   -> m ()
 handleDecls ds
   | isJust (badDeclarationErrors ds) =
-    printErrors $ maybe mempty mconcat (badDeclarationErrors ds)
+    printErrors $ foldMap mconcat (badDeclarationErrors ds)
   | otherwise = do
   st <- gets (updateLets (++ ds))
   let m = createTemporaryModule False st (P.Literal P.nullSourceSpan (P.ObjectLiteral []))

--- a/tests/TestPsci/EvalTest.hs
+++ b/tests/TestPsci/EvalTest.hs
@@ -34,6 +34,7 @@ data EvalLine = Line String
 
 data EvalContext = ShouldEvaluateTo String
                  | Paste [String]
+                 | Prints String
                  | None
                  deriving (Show)
 
@@ -48,6 +49,7 @@ parseEvalLine line =
       case splitOn " " rest of
         "shouldEvaluateTo" : args -> Comment (ShouldEvaluateTo $ intercalate " " args)
         "paste" : [] -> Comment (Paste [])
+        "prints" : args -> Comment (Prints $ intercalate " " args)
         _ -> Invalid line
     Nothing -> Line line
 
@@ -63,4 +65,5 @@ handleLine None (Comment ctx) = pure ctx
 handleLine (ShouldEvaluateTo expected) (Line expr) = expr `evaluatesTo` expected >> pure None
 handleLine (Paste ls) (Line l) = pure . Paste $ ls ++ [l]
 handleLine (Paste ls) (Comment (Paste _)) = run (intercalate "\n" ls) >> pure None
+handleLine (Prints expected) (Line expr) = expr `prints` expected >> pure None
 handleLine _ line = liftIO $ putStrLn ("unexpected: " ++ show line) >> exitFailure

--- a/tests/purs/psci/DefineItFail.purs
+++ b/tests/purs/psci/DefineItFail.purs
@@ -1,0 +1,2 @@
+-- @prints NoItInREPL
+it = 42


### PR DESCRIPTION
Should fix #3527 by way of an error message specifying why `it` isn't a valid identifier.

This isn't 100% complete because I'm having issues creating a test that will actually test the error output correctly. When the test is running you can see the output, but I'd like to assert it properly via a `@prints ...` tag (or the like).

I'm also not sure what to put in the error example file automatically output by the compiler, but this seems almost secondary as it's likely to reiterate the REPL error.