### PR TITLE
WIP - Consider constraints when selecting instances

### DIFF
--- a/tests/purs/passing/3596.purs
+++ b/tests/purs/passing/3596.purs
@@ -1,0 +1,21 @@
+module Main where
+
+import Prelude
+import Effect (Effect)
+import Effect.Console (error, log)
+
+class Foo a where
+  isEquatable :: a -> Boolean
+
+data Bar = Bar
+
+instance barFoo :: Foo Bar where
+  isEquatable _ = false
+
+instance equatableFoo :: (Eq a) => Foo a where
+  isEquatable _ = true
+
+main :: Effect Unit
+main = do
+  when (isEquatable Bar) $ error "wrong instance"
+  log "Done"


### PR DESCRIPTION
This is a first stab at an implementation of #3596, mostly intended to serve as a talking point. I know the responses on #3596 were lukewarm-to-negative, so I hope this isn't taken as too pushy, but I thought it would be helpful for that conversation to have a sense of how much the code actually needed to change and how difficult it would be to understand and maintain.

---

Previously, instance selection ignored instance constraints when
determining if instances overlapped, and considered all instances with
matching type arguments. This meant that `instance x :: SomeClass X` and
`instance y :: (SomeConstraint a) => SomeClass a` were considered
overlapping even if `X` doesn't satisfy `SomeConstraint`.

This commit relaxes the check on instance declarations to permit
instances to overlap in a limited way: for each type in the instance, a
concrete type is allowed to overlap with a type variable if the type
variable appears in an instance constraint. Two type variables, even if
given different constraints, are not allowed to overlap in any case.

This commit also modifies instance selection to attempt to solve for all
the overlapping instances with matching type arguments, and if exactly
one instance can be solved, select it instead of throwing an overlapping
instance error. If zero or more than one have solutions, the original
overlapping instance error is thrown.

The upshot is that there are now some (more?) cases where truly
ambiguous overlapping instances are detected at use instead of at
declaration, but in exchange, some cases of nonambiguous "overlapping"
instances, such as the above example, are now permitted.

---

The above text is slightly aspirational. While I have tested this code on compiling my own projects, and that works great, there are two open questions that I have about how entailment works which may reflect flaws in this implementation.

1. Why did `overlapping` choose to ignore some overlaps, and is it correct to continue to do the same overlap check and `minimumBy` after trying to solve subgoals?

The comment there says that subclass dictionaries can't overlap, which sort of makes sense to me but I don't really understand how it works in practice; but then the code goes on to also give a pass to instances that don't have any dependencies, which I completely don't understand. I did what I think is the conservative thing, but since I don't really understand the reasoning behind the original code, I can't be sure—I'll probably have more specific questions about this once I understand it better.

2. What are generalization and defer passes for, and how is my feature constrained by the fact that this implementation doesn't do further passes when it's solving overlapping instances in parallel?

My biggest worry is whether this is a loophole through which incoherency can enter—if, for example, there are two instances that truly could both apply to a use site, but only one of them can be known to apply without doing another generalization pass to show it, this implementation will choose that instance. Can the compiler be tricked into choosing the other instance somewhere else? Even if incoherency is not a danger, will a failure to generalize/defer in these circumstances cause surprise?

Modulo those two questions, I do believe this is fairly robust—in particular, there should be no performance impact on any code that currently compiles, since pretty much all the new computation is in the `PotentialOverlap` branch, which can only be reached on code that would cause an overlapping instance error today.