### PR TITLE
Load externs concurrently

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -61,6 +61,7 @@ dependencies:
   - Glob >=0.9 && <0.10
   - haskeline >=0.7.0.0
   - language-javascript >=0.6.0.9 && <0.7
+  - lifted-async >=0.10.0.3 && <0.10.1
   - lifted-base >=0.2.3 && <0.2.4
   - microlens-platform >=0.3.9.0 && <0.4
   - monad-control >=1.0.0.0 && <1.1


### PR DESCRIPTION
Previously externs were loaded serially with `foldM`. This means that if a change is detected farther upstream, it won't try to read downstream externs. This PR loads and parses them all concurrently, which will result in downstream results that are thrown away if there are upstream changes. However, I think this is a decent tradeoff since during development, changes generally happen downstream.

On my machine, with 551 modules compiled and a noop call to `purs compile`, v0.12.5 takes ~4s, while this PR takes ~2.6s, and with the parser changes as well in #3608 it takes ~1.6s.