### PR TITLE
More specific error on TransitiveExportError

### DIFF
--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -648,7 +648,7 @@ typeCheckModule (Module ss coms mn decls (Just exps)) =
   checkClassMembersAreExported dr@(TypeClassRef ss' name) = do
     let members = ValueRef ss' `map` head (mapMaybe findClassMembers decls)
     let missingMembers = members \\ exps
-    unless (null missingMembers) . throwError . errorMessage' ss' $ TransitiveExportError dr members
+    unless (null missingMembers) . throwError . errorMessage' ss' $ TransitiveExportError dr missingMembers
     where
     findClassMembers :: Declaration -> Maybe [Ident]
     findClassMembers (TypeClassDeclaration _ name' _ _ _ ds) | name == name' = Just $ map extractMemberName ds


### PR DESCRIPTION
- modifies `checkClassMembersAreExported` within the typechecker to only report class members which have not been exported from the module (instead of reporting all class members, regardless of whether or not they are exported) 

I don't think it is possible to add a failing test in which I specify the constructor of an error and also more arguments with the current setup.  If there is some way to do this, I'd be happy to add a test.

This intends to close #3611 