### PR TITLE
replace unknown names with holes in name desugaring

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -144,6 +144,7 @@ data SimpleErrorMessage
   | UnusedTypeVar Text
   | WildcardInferredType SourceType Context
   | HoleInferredType Text SourceType Context (Maybe TypeSearch)
+  | UnknownValueHint Text SourceType Context (Maybe TypeSearch)
   | MissingTypeDeclaration Ident SourceType
   | OverlappingPattern [[Binder]] Bool
   | IncompleteExhaustivityCheck
@@ -819,6 +820,10 @@ data Expr
   -- A typed hole that will be turned into a hint/error during typechecking
   --
   | Hole Text
+  -- |
+  -- An unknown name that will be turned into a hint/error during typechecking
+  --
+  | UnknownValue Text
   -- |
   -- A value with source position information
   --

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -153,6 +153,7 @@ errorCode em = case unwrapErrorMessage em of
   UnusedTypeVar{} -> "UnusedTypeVar"
   WildcardInferredType{} -> "WildcardInferredType"
   HoleInferredType{} -> "HoleInferredType"
+  UnknownValueHint{} -> "UnknownValueHint"
   MissingTypeDeclaration{} -> "MissingTypeDeclaration"
   OverlappingPattern{} -> "OverlappingPattern"
   IncompleteExhaustivityCheck{} -> "IncompleteExhaustivityCheck"
@@ -883,6 +884,31 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
           _ -> []
       in
         paras $ [ line $ "Hole '" <> markCode name <> "' has the inferred type "
+                , markCodeBox (indent (typeAsBox maxBound ty))
+                ] ++ tsResult ++ renderContext ctx
+    renderSimpleErrorMessage (UnknownValueHint name ty ctx ts) =
+      let
+        maxTSResults = 15
+        tsResult = case ts of
+          Just (TSAfter{tsAfterIdentifiers=idents}) | not (null idents) ->
+            let
+              formatTS (names, types) =
+                let
+                  idBoxes = Box.text . T.unpack . showQualified id <$> names
+                  tyBoxes = (\t -> BoxHelpers.indented
+                              (Box.text ":: " Box.<> typeAsBox prettyDepth t)) <$> types
+                  longestId = maximum (map Box.cols idBoxes)
+                in
+                  Box.vcat Box.top $
+                      zipWith (Box.<>)
+                      (Box.alignHoriz Box.left longestId <$> idBoxes)
+                      tyBoxes
+            in [ line "You could substitute the unknown value with one of these values:"
+               , markCodeBox (indent (formatTS (unzip (take maxTSResults idents))))
+               ]
+          _ -> []
+      in
+        paras $ [ line $ "Unknown name '" <> markCode name <> "' has the inferred type "
                 , markCodeBox (indent (typeAsBox maxBound ty))
                 ] ++ tsResult ++ renderContext ctx
     renderSimpleErrorMessage (MissingTypeDeclaration ident ty) =

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -94,6 +94,7 @@ prettyPrintValue d (TypedValue _ val _) = prettyPrintValue d val
 prettyPrintValue d (PositionedValue _ _ val) = prettyPrintValue d val
 prettyPrintValue d (Literal _ l) = prettyPrintLiteralValue d l
 prettyPrintValue _ (Hole name) = text "?" <> textT name
+prettyPrintValue _ (UnknownValue name) = textT name
 prettyPrintValue d expr@AnonymousArgument{} = prettyPrintValueAtom d expr
 prettyPrintValue d expr@Constructor{} = prettyPrintValueAtom d expr
 prettyPrintValue d expr@Var{} = prettyPrintValueAtom d expr

--- a/tests/purs/failing/1733.purs
+++ b/tests/purs/failing/1733.purs
@@ -1,4 +1,4 @@
--- @shouldFailWith UnknownName
+-- @shouldFailWith UnknownValueHint
 module Main where
 
 import Thingy as Thing

--- a/tests/purs/failing/1825.purs
+++ b/tests/purs/failing/1825.purs
@@ -1,4 +1,4 @@
--- @shouldFailWith UnknownName
+-- @shouldFailWith UnknownValueHint
 
 module Main where
 

--- a/tests/purs/failing/ExportExplicit1.purs
+++ b/tests/purs/failing/ExportExplicit1.purs
@@ -1,4 +1,4 @@
--- @shouldFailWith UnknownName
+-- @shouldFailWith UnknownValueHint
 module Main where
 
 import M1

--- a/tests/purs/failing/ExportExplicit3.purs
+++ b/tests/purs/failing/ExportExplicit3.purs
@@ -1,4 +1,4 @@
--- @shouldFailWith UnknownName
+-- @shouldFailWith UnknownValueHint
 module Main where
 
 import M1 as M

--- a/tests/purs/failing/LetPatterns2.purs
+++ b/tests/purs/failing/LetPatterns2.purs
@@ -1,4 +1,4 @@
--- @shouldFailWith UnknownName
+-- @shouldFailWith UnknownValueHint
 module Main where
 
 import Prelude

--- a/tests/purs/failing/MultipleErrors2.purs
+++ b/tests/purs/failing/MultipleErrors2.purs
@@ -1,5 +1,4 @@
--- @shouldFailWith UnknownName
--- @shouldFailWith UnknownName
+-- @shouldFailWith UnknownValueHint
 module MultipleErrors2 where
 
 import Prelude


### PR DESCRIPTION
Replaces unknown names with holes in name desugaring

* Introduces new `UnknownValueHint` error 
* Introduces new `UnknownValue` case to `Expr` 
* modifies name desugaring (in the `updateValue` phase) to replace unknown names with `UnknownValue`
* modifies typechecking to turn `UnknownValue` into `UnknownValueHint` errors

I have written a first pass at the error message, but I think it can definitely be improved.

Here is an example:

```
module Foo where

import Prelude

foo :: Int
foo = bar 10
```

Previously, this would fail with an `UnknownName` error, but now it fails with a `UnknownValueHint` error, stating

```
[1/1 UnknownValueHint] src/Main.purs:6:7

  6  foo = bar 10
           ^^^

  Unknown name 'bar' has the inferred type

    t0

  You could substitute the unknown value with one of these values:

    Control.Category.identity  :: forall t a. Category a => a t t
    Data.EuclideanRing.degree  :: forall a. EuclideanRing a => a -> Int
    Data.Ord.abs               :: forall a. Ord a => Ring a => ... -> ...
    Data.Ord.signum            :: forall a. Ord a => Ring a => ... -> ...
    Data.Ring.negate           :: forall a. Ring a => a -> a
    Data.Semiring.one          :: forall a. Semiring a => a
    Data.Semiring.zero         :: forall a. Semiring a => a

  in value declaration foo
```