### PR TITLE
Add tests for grammar fixes addressed by CST

### DIFF
--- a/tests/purs/failing/ApostropheModuleName.purs
+++ b/tests/purs/failing/ApostropheModuleName.purs
@@ -1,0 +1,7 @@
+-- @shouldFailWith ErrorParsingModule
+-- see #3601
+module Bad'Module where
+
+import Effect.Console (log)
+
+main = log "Done"

--- a/tests/purs/passing/FunctionAndCaseGuards.purs
+++ b/tests/purs/passing/FunctionAndCaseGuards.purs
@@ -1,0 +1,21 @@
+-- See #3443
+module Main where
+
+import Prelude
+import Effect (Effect)
+import Effect.Console (log)
+
+-- this is just a really convoluted `const true`
+test :: Int -> Boolean
+test a
+  | false =
+      case false of
+        true | a > 0 -> true
+        _ -> true
+  | otherwise = true
+
+main :: Effect Unit
+main = do
+  if test 0
+    then log "Done"
+    else pure unit

--- a/tests/purs/passing/TypeAnnotationPrecedence.purs
+++ b/tests/purs/passing/TypeAnnotationPrecedence.purs
@@ -1,0 +1,11 @@
+-- See #3554
+module Main where
+
+import Prelude
+import Effect (Effect)
+import Effect.Console (log)
+import Data.Tuple (Tuple(..), uncurry)
+
+appendAndLog = log <<< uncurry append :: Tuple String String -> Effect Unit
+
+main = appendAndLog (Tuple "Do" "ne")


### PR DESCRIPTION
Closes #3554, closes #3443, closes #3601, by adding tests for these
issues. I've verified that the `passing` test fails to compile and that
the `failing` test does compile on v0.12.5.