### PR TITLE
Improve parser error ErrRecordUpdateInCtr

### DIFF
--- a/src/Language/PureScript/CST/Errors.hs
+++ b/src/Language/PureScript/CST/Errors.hs
@@ -80,7 +80,7 @@ prettyPrintErrorMessage (ParserError {..}) = case errType of
   ErrBinderInDecl ->
     "Expected declaration, saw pattern"
   ErrRecordUpdateInCtr ->
-    "Expected ':', saw '='"
+    "Expected ':' or '}', saw '='"
   ErrRecordPunInUpdate ->
     "Expected record update, saw pun"
   ErrRecordCtrInUpdate ->


### PR DESCRIPTION
When parsing a record literal, if we encounter a = after a label, we
emit a parse error, because = is only for record updates.

However, the error says "Expected ':', saw '='", which implies that ':'
would be the only valid token following a record label, although
a label could also be followed by '}' in a record pun.