### PR TITLE
Improve display of internal errors

### DIFF
--- a/src/Language/PureScript/Crash.hs
+++ b/src/Language/PureScript/Crash.hs
@@ -24,4 +24,3 @@ internalError =
   error
   . ("An internal error occurred during compilation: " ++)
   . (++ "\nPlease report this at https://github.com/purescript/purescript/issues")
-  . show


### PR DESCRIPTION
There is no need to `show` error messages, since they are already
strings. Example:

Before:

    purs: An internal error occurred during compilation: "Failed to produce docs for Data.Bifunctor; details:\nError found:\nin module \ESC[33mData.Bifunctor\ESC[0m\nat ../../../support/bower_components/purescript-bifunctors/src/Data/Bifunctor.purs:3:1 - 3:35 (line 3, column 1 - line 3, column 35)\n\n  Unknown module \ESC[33mControl.Category\ESC[0m\n\n\nSee https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,\nor to contribute content related to this error.\n\n"
    Please report this at https://github.com/purescript/purescript/issues
    CallStack (from HasCallStack):
      error, called at src/Language/PureScript/Crash.hs:24:3 in purescript-0.12.5-3daYxGi6wB3EfBqURAef82:Language.PureScript.Crash
      internalError, called at src/Language/PureScript/Make.hs:92:29 in purescript-0.12.5-3daYxGi6wB3EfBqURAef82:Language.PureScript.Make
    purs: thread blocked indefinitely in an MVar operation

After:

    purs: An internal error occurred during compilation: Failed to produce docs for Data.Show; details:
    Error found:
    in module Data.Show
    at ../../../support/bower_components/purescript-prelude/src/Data/Show.purs:6:1 - 6:63 (line 6, column 1 - line 6, column 63)

      Unknown module Data.Symbol

    See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
    or to contribute content related to this error.

    Please report this at https://github.com/purescript/purescript/issues
    CallStack (from HasCallStack):
      error, called at src/Language/PureScript/Crash.hs:24:3 in purescript-0.12.5-3daYxGi6wB3EfBqURAef82:Language.PureScript.Crash
      internalError, called at src/Language/PureScript/Make.hs:92:29 in purescript-0.12.5-3daYxGi6wB3EfBqURAef82:Language.PureScript.Make
    purs: thread blocked indefinitely in an MVar operation