### PR TITLE
Add `graph` command for graphing module dependencies

### DIFF
--- a/app/Command/Graph.hs
+++ b/app/Command/Graph.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
+
+module Command.Graph (command) where
+
+import           Control.Applicative (many)
+import           Control.Monad (unless, when, forM, foldM)
+import qualified Data.Aeson as A
+import           Data.Aeson ((.=))
+import           Data.Bool (bool)
+import qualified Data.Map as M
+import qualified Data.HashMap.Strict as HM
+import qualified Data.ByteString.Lazy as LB
+import qualified Data.ByteString.Lazy.UTF8 as LBU8
+import           Data.Text (Text)
+import qualified Language.PureScript as P
+import qualified Language.PureScript.CST as CST
+import           Language.PureScript.Errors.JSON
+import           Language.PureScript.Make (runMake)
+import           Language.PureScript.ModuleDependencies
+import qualified Options.Applicative as Opts
+import qualified System.Console.ANSI as ANSI
+import           System.Exit (exitSuccess, exitFailure)
+import           System.Directory (getCurrentDirectory)
+import           System.FilePath.Glob (glob)
+import           System.IO (hPutStr, hPutStrLn, stderr)
+import           System.IO.UTF8 (readUTF8FileT)
+
+data GraphOptions = GraphOptions
+  { graphInput      :: [FilePath]
+  , graphJSONErrors :: Bool
+  }
+
+graph :: GraphOptions -> IO ()
+graph GraphOptions{..} = do
+  input <- globWarningOnMisses (unless graphJSONErrors . warnFileTypeNotFound) graphInput
+  when (null input && not graphJSONErrors) $ do
+    hPutStr stderr $ unlines
+      [ "purs graph: No input files."
+      , "Usage: For basic information, try the `--help' option."
+      ]
+    exitFailure
+
+  moduleFiles <- readInput input
+  (makeResult, makeWarnings) <- runMake P.defaultOptions $ do
+    ms <- CST.parseModulesFromFiles id moduleFiles
+    let parsedModuleSig = moduleSignature . CST.resPartial
+    (_sorted, moduleGraph) <- sortModules (parsedModuleSig . snd) ms
+    let swap (a, b) = (b, a)
+    let pathMap = M.fromList
+                . fmap (swap . fmap (sigModuleName . parsedModuleSig))
+                $ ms
+    pure (moduleGraphToJSON pathMap moduleGraph)
+
+  printWarningsAndErrors True graphJSONErrors makeWarnings makeResult
+  case makeResult of
+    Left _ -> exitSuccess
+    Right Nothing -> undefined
+    Right (Just json) -> LB.putStr $ A.encode json
+
+  where
+  warnFileTypeNotFound :: String -> IO ()
+  warnFileTypeNotFound =
+    hPutStrLn stderr . ("purs compile: No files found using pattern: " <>)
+
+command :: Opts.Parser (IO ())
+command = graph <$> (Opts.helper <*> graphOptions)
+  where
+  graphOptions :: Opts.Parser GraphOptions
+  graphOptions =
+    GraphOptions <$> many inputFile
+                 <*> jsonErrors
+
+  inputFile :: Opts.Parser FilePath
+  inputFile =
+    Opts.strArgument $
+      Opts.metavar "FILE" <>
+      Opts.help "The input .purs file(s)."
+
+  jsonErrors :: Opts.Parser Bool
+  jsonErrors =
+    Opts.switch $
+      Opts.long "json-errors" <>
+      Opts.help "Print errors to stderr as JSON"
+
+moduleGraphToJSON
+  :: M.Map P.ModuleName FilePath -> ModuleGraph -> Maybe A.Value
+moduleGraphToJSON paths = fmap A.Object . foldM insert mempty
+  where
+  insert :: A.Object -> (P.ModuleName, [P.ModuleName]) -> Maybe A.Object
+  insert obj (mn, depends) = flip (HM.insert key) obj <$> value
+    where
+    key :: Text
+    key = P.runModuleName mn
+
+    value :: Maybe A.Value
+    value = do
+      path <- M.lookup mn paths
+      pure $ A.object
+        [ "path"  .= path
+        , "depends" .= fmap P.runModuleName depends
+        ]
+
+-- | Arguments: verbose, use JSON, warnings, errors
+printWarningsAndErrors :: Bool -> Bool -> P.MultipleErrors -> Either P.MultipleErrors a -> IO ()
+printWarningsAndErrors verbose False warnings errors = do
+  pwd <- getCurrentDirectory
+  cc <- bool Nothing (Just P.defaultCodeColor) <$> ANSI.hSupportsANSI stderr
+  let ppeOpts = P.defaultPPEOptions { P.ppeCodeColor = cc, P.ppeFull = verbose, P.ppeRelativeDirectory = pwd }
+  when (P.nonEmpty warnings) $
+    hPutStrLn stderr (P.prettyPrintMultipleWarnings ppeOpts warnings)
+  case errors of
+    Left errs -> do
+      hPutStrLn stderr (P.prettyPrintMultipleErrors ppeOpts errs)
+      exitFailure
+    Right _ -> return ()
+printWarningsAndErrors verbose True warnings errors = do
+  hPutStrLn stderr . LBU8.toString . A.encode $
+    JSONResult (toJSONErrors verbose P.Warning warnings)
+               (either (toJSONErrors verbose P.Error) (const []) errors)
+  either (const exitFailure) (const (return ())) errors
+
+readInput :: [FilePath] -> IO [(FilePath, Text)]
+readInput inputFiles =
+  forM inputFiles $ \inFile -> (inFile, ) <$> readUTF8FileT inFile
+
+globWarningOnMisses :: (String -> IO ()) -> [FilePath] -> IO [FilePath]
+globWarningOnMisses warn = concatMapM globWithWarning
+  where
+  globWithWarning :: String -> IO [FilePath]
+  globWithWarning pattern' = do
+    paths <- glob pattern'
+    when (null paths) $ warn pattern'
+    return paths
+
+  concatMapM :: (a -> IO [b]) -> [a] -> IO [b]
+  concatMapM f = fmap concat . mapM f

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,6 +10,7 @@ module Main where
 import qualified Command.Bundle as Bundle
 import qualified Command.Compile as Compile
 import qualified Command.Docs as Docs
+import qualified Command.Graph as Graph
 import qualified Command.Hierarchy as Hierarchy
 import qualified Command.Ide as Ide
 import qualified Command.Publish as Publish
@@ -69,6 +70,9 @@ main = do
         , Opts.command "docs"
             (Opts.info Docs.command
               (Opts.progDesc "Generate documentation from PureScript source files in a variety of formats, including Markdown and HTML" <> Docs.infoModList))
+        , Opts.command "graph"
+            (Opts.info Graph.command
+              (Opts.progDesc "Module dependency graph"))
         , Opts.command "hierarchy"
             (Opts.info Hierarchy.command
               (Opts.progDesc "Generate a GraphViz directed graph of PureScript type classes"))

--- a/package.yaml
+++ b/package.yaml
@@ -126,6 +126,7 @@ executables:
       - Command.Compile
       - Command.Docs
       - Command.Docs.Html
+      - Command.Graph
       - Command.Hierarchy
       - Command.Ide
       - Command.Publish


### PR DESCRIPTION
This PR proposes adding a `graph` command to the compiler, which takes module files as input (similar to `purs compile`) and returns a JSON description of the module dependency graph. Essentially this just surfaces the output of `Language.PureScript.ModuleDependencies.sortModules` with some serialization logic. 

I think this will be useful for tooling as it let's us be smarter about what actually needs to be compiled. For example, if I'm writing a bundling tool that takes an entrypoint module I can avoid passing the world to `purs compile` (e.g. `"src/**/*.purs" ".psc-package/*/*/*/src/**/*.purs"`) by first invoking this command. 

More concretely, I'd like to improve PureScript support in webpack and parcel, and having this available would really help.

It's very much a first draft, and there are probably a bunch of error cases I need to consider, but comments/feedback would be much appreciated :)