### PR TITLE
Improve error message on ModuleNotFound error for Prim modules.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@DavidLindbom](https://github.com/DavidLindbom) | David Lindbom | [MIT license](http://opensource.org/licenses/MIT) |
 | [@dckc](https://github.com/dckc) | Dan Connolly | [MIT license](http://opensource.org/licenses/MIT) |
 | [@kleeneplus](https://github.com/dgendill) | Dominick Gendill | [MIT license](http://opensource.org/licenses/MIT) |
+| [@ealmansi](https://github.com/ealmansi) | Emilio Almansi | MIT license |
 | [@eamelink](https://github.com/eamelink) | Erik Bakker | MIT license |
 | [@epost](https://github.com/epost) | Erik Post | MIT license |
 | [@erdeszt](https://github.com/erdeszt) | Tibor Erdesz | [MIT license](http://opensource.org/licenses/MIT) |

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -461,7 +461,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             , line $
                 if isBuiltinModuleName mn
                   then
-                    "Module names in the Prim namespace are reserved for built-in modules, but this version of the compiler does not provide module " <> markCode (runModuleName mn) <> ". Please, consider upgrading your compiler to a newer version."
+                    "Module names in the Prim namespace are reserved for built-in modules, but this version of the compiler does not provide module " <> markCode (runModuleName mn) <> ". You may be able to fix this by updating your compiler to a newer version."
                   else
                     "Make sure the source file exists, and that it has been provided as an input to the compiler."
             ]

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -458,7 +458,12 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderSimpleErrorMessage :: SimpleErrorMessage -> Box.Box
     renderSimpleErrorMessage (ModuleNotFound mn) =
       paras [ line $ "Module " <> markCode (runModuleName mn) <> " was not found."
-            , line "Make sure the source file exists, and that it has been provided as an input to the compiler."
+            , line $
+                if isBuiltinModuleName mn
+                  then
+                    "Module names in the Prim namespace are reserved for built-in modules, but this version of the compiler does not provide module " <> markCode (runModuleName mn) <> ". Please, consider upgrading your compiler to a newer version."
+                  else
+                    "Make sure the source file exists, and that it has been provided as an input to the compiler."
             ]
     renderSimpleErrorMessage (CannotGetFileInfo path) =
       paras [ line "Unable to read file info: "


### PR DESCRIPTION
Fixes #3625.

Provides a more accurate error message when a ModuleNotFound error is raised on a built-in module.

Example output:
```
    Module Foobar was not found.
    Make sure the source file exists, and that it has been provided as an input to the compiler.

    Module Prim.Foobar was not found.
    Module names in the Prim namespace are reserved for built-in modules, but this version of the compiler does not provide module Prim.Foobar. Please, consider upgrading your compiler to a newer version.
```