### PR TITLE
Prevent typeclass instance self-reference (#3429).

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -132,6 +132,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@jordanmartinez](https://github.com/jordanmartinez) | Jordan Martinez | [MIT license](http://opensource.org/licenses/MIT) |
 | [@Saulukass](https://github.com/Saulukass) | Saulius Skliutas | [MIT license](http://opensource.org/licenses/MIT) |
 | [@adnelson](https://github.com/adnelson) | Allen Nelson | [MIT license](http://opensource.org/licenses/MIT) |
+| [@matthew-hilty](https://github.com/matthew-hilty) | Matthew Hilty | [MIT license](http://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms
 

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -332,6 +332,7 @@ everythingWithContextOnValues
   -> (r -> r -> r)
   -> (s -> Declaration       -> (s, r))
   -> (s -> Expr              -> (s, r))
+  -> (s -> Expr              -> (s, r))
   -> (s -> Binder            -> (s, r))
   -> (s -> CaseAlternative   -> (s, r))
   -> (s -> DoNotationElement -> (s, r))
@@ -340,7 +341,8 @@ everythingWithContextOnValues
      , Binder            -> r
      , CaseAlternative   -> r
      , DoNotationElement -> r)
-everythingWithContextOnValues s0 r0 (<>.) f g h i j = (f'' s0, g'' s0, h'' s0, i'' s0, j'' s0)
+everythingWithContextOnValues s0 r0 (<>.) f g gLit h i j =
+  (f'' s0, g'' s0, h'' s0, i'' s0, j'' s0)
   where
 
   f'' :: s -> Declaration -> r
@@ -358,7 +360,7 @@ everythingWithContextOnValues s0 r0 (<>.) f g h i j = (f'' s0, g'' s0, h'' s0, i
   g'' s v = let (s', r) = g s v in r <>. g' s' v
 
   g' :: s -> Expr -> r
-  g' s (Literal _ l) = lit g'' s l
+  g' s (Literal _ l) = lit gLit'' s l
   g' s (UnaryMinus _ v1) = g'' s v1
   g' s (BinaryNoParens op v1 v2) = g'' s op <>. g'' s v1 <>. g'' s v2
   g' s (Parens v1) = g'' s v1
@@ -376,6 +378,29 @@ everythingWithContextOnValues s0 r0 (<>.) f g h i j = (f'' s0, g'' s0, h'' s0, i
   g' s (Ado _ es v1) = foldl (<>.) r0 (fmap (j'' s) es) <>. g'' s v1
   g' s (PositionedValue _ _ v1) = g'' s v1
   g' _ _ = r0
+
+  gLit'' :: s -> Expr -> r
+  gLit'' s v = let (s', r) = gLit s v in r <>. gLit' s' v
+
+  gLit' :: s -> Expr -> r
+  gLit' s (Literal _ l) = lit gLit'' s l
+  gLit' s (UnaryMinus _ v1) = gLit'' s v1
+  gLit' s (BinaryNoParens op v1 v2) = gLit'' s op <>. gLit'' s v1 <>. gLit'' s v2
+  gLit' s (Parens v1) = gLit'' s v1
+  gLit' s (TypeClassDictionaryConstructorApp _ v1) = gLit'' s v1
+  gLit' s (Accessor _ v1) = gLit'' s v1
+  gLit' s (ObjectUpdate obj vs) = foldl (<>.) (gLit'' s obj) (fmap (gLit'' s . snd) vs)
+  gLit' s (ObjectUpdateNested obj vs) = foldl (<>.) (gLit'' s obj) (fmap (gLit'' s) vs)
+  gLit' s (Abs binder v1) = h'' s binder <>. gLit'' s v1
+  gLit' s (App v1 v2) = gLit'' s v1 <>. gLit'' s v2
+  gLit' s (IfThenElse v1 v2 v3) = gLit'' s v1 <>. gLit'' s v2 <>. gLit'' s v3
+  gLit' s (Case vs alts) = foldl (<>.) (foldl (<>.) r0 (fmap (gLit'' s) vs)) (fmap (i'' s) alts)
+  gLit' s (TypedValue _ v1 _) = gLit'' s v1
+  gLit' s (Let _ ds v1) = foldl (<>.) r0 (fmap (f'' s) ds) <>. gLit'' s v1
+  gLit' s (Do _ es) = foldl (<>.) r0 (fmap (j'' s) es)
+  gLit' s (Ado _ es v1) = foldl (<>.) r0 (fmap (j'' s) es) <>. gLit'' s v1
+  gLit' s (PositionedValue _ _ v1) = gLit'' s v1
+  gLit' _ _ = r0
 
   h'' :: s -> Binder -> r
   h'' s b = let (s', r) = h s b in r <>. h' s' b

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -356,6 +356,14 @@ isTypeOrApplied :: Type a -> Type b -> Bool
 isTypeOrApplied t1 (TypeApp _ t2 _) = eqType t1 t2
 isTypeOrApplied t1 t2 = eqType t1 t2
 
+isFunctionType :: SourceType -> Bool
+isFunctionType = eqType tyFunction . stripForAllAndTypeApp
+
+stripForAllAndTypeApp :: SourceType -> SourceType
+stripForAllAndTypeApp (ForAll _ _ _ st _) = stripForAllAndTypeApp st
+stripForAllAndTypeApp (TypeApp _ st _) = stripForAllAndTypeApp st
+stripForAllAndTypeApp st = st
+
 -- | Smart constructor for function types
 function :: SourceType -> SourceType -> SourceType
 function t1 t2 = TypeApp nullSourceAnn (TypeApp nullSourceAnn tyFunction t1) t2

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -338,7 +338,7 @@ typeInstanceDictionaryDeclaration sa@(ss, _) name mn deps className tys decls =
   memberToValue :: [(Ident, SourceType)] -> Declaration -> Desugar m Expr
   memberToValue tys' (ValueDecl (ss', _) ident _ [] [MkUnguarded val]) = do
     _ <- maybe (throwError . errorMessage' ss' $ ExtraneousClassMember ident className) return $ lookup ident tys'
-    return val
+    return (PositionedValue ss' [] val)
   memberToValue _ _ = internalError "Invalid declaration in type instance definition"
 
 declIdent :: Declaration -> Maybe Ident

--- a/src/Language/PureScript/TypeChecker/Skolems.hs
+++ b/src/Language/PureScript/TypeChecker/Skolems.hs
@@ -89,7 +89,7 @@ skolemEscapeCheck expr@TypedValue{} =
     traverse_ (throwError . singleError) (toSkolemErrors expr)
   where
     toSkolemErrors :: Expr -> [ErrorMessage]
-    (_, toSkolemErrors, _, _, _) = everythingWithContextOnValues (mempty, Nothing) [] (<>) def go def def def
+    (_, toSkolemErrors, _, _, _) = everythingWithContextOnValues (mempty, Nothing) [] (<>) def go go def def def
 
     def s _ = (s, [])
 

--- a/tests/purs/failing/3407-NewtypeInstanceDerivOfRecursType.purs
+++ b/tests/purs/failing/3407-NewtypeInstanceDerivOfRecursType.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith CycleInDeclaration
+-- Example submitted by dbeacham in issue #3407.
+module Main where
+
+import Prelude
+import Data.Maybe
+
+newtype MyRec = MyRec { a :: Int, b :: Maybe MyRec }
+
+derive newtype instance showMyRec :: Show MyRec

--- a/tests/purs/failing/3429-00.purs
+++ b/tests/purs/failing/3429-00.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cInt :: C Int where
+  c0 = 0
+  c1 = c0

--- a/tests/purs/failing/3429-01.purs
+++ b/tests/purs/failing/3429-01.purs
@@ -1,0 +1,14 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B
+
+instance b :: B
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cInt :: B => C Int where
+  c0 = 0
+  c1 = c0

--- a/tests/purs/failing/3429-02.purs
+++ b/tests/purs/failing/3429-02.purs
@@ -1,0 +1,18 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B0
+
+instance b0 :: B0
+
+class B1
+
+instance b1 :: B1
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cInt :: (B0, B1) => C Int where
+  c0 = 0
+  c1 = c0

--- a/tests/purs/failing/3429-03.purs
+++ b/tests/purs/failing/3429-03.purs
@@ -1,0 +1,18 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B0
+
+instance b0 :: B0
+
+class B1 a
+
+instance b1 :: B1 a
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cInt :: (B0, B1 Int) => C Int where
+  c0 = 0
+  c1 = c0

--- a/tests/purs/failing/3429-04.purs
+++ b/tests/purs/failing/3429-04.purs
@@ -1,0 +1,18 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B0
+
+instance b0 :: B0
+
+class B1 a
+
+instance b1 :: B1 a
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cInt :: (B0, B1 Int) => C Int where
+  c0 = 0
+  c1 = c0

--- a/tests/purs/failing/3429-05.purs
+++ b/tests/purs/failing/3429-05.purs
@@ -1,0 +1,25 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B0
+
+instance b0 :: B0
+
+class B1 a where
+  x :: a
+
+instance b1Int :: B1 Int where
+  x = 0
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cInt :: (B0, B1 Int) => C Int where
+  c0 = 0
+  c1 =
+    let
+      const' :: forall a. B1 Int => a -> Int -> a
+      const' a _ = a
+    in
+      const' c0 x

--- a/tests/purs/failing/3429-06.purs
+++ b/tests/purs/failing/3429-06.purs
@@ -1,0 +1,25 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B0
+
+instance b0 :: B0
+
+class B1 a where
+  x :: a
+
+instance b1Int :: B1 Int where
+  x = 0
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cInt :: (B0, B1 Int) => C Int where
+  c0 = 0
+  c1 =
+    let
+      const' :: forall a b. a -> b -> a
+      const' a _ = a
+    in
+      const' c0 (x :: Int)

--- a/tests/purs/failing/3429-07.purs
+++ b/tests/purs/failing/3429-07.purs
@@ -1,0 +1,15 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B
+
+instance b :: B
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cInt :: C Int where
+  c0 = 0
+  c1 :: B => Int
+  c1 = c0

--- a/tests/purs/failing/3429-08.purs
+++ b/tests/purs/failing/3429-08.purs
@@ -1,0 +1,15 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B
+
+instance b :: B
+
+class B <= C a where
+  c0 :: a
+  c1 :: a
+
+instance cInt :: B => C Int where
+  c0 = 0
+  c1 :: B => Int
+  c1 = c0

--- a/tests/purs/failing/3429-09.purs
+++ b/tests/purs/failing/3429-09.purs
@@ -1,0 +1,18 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B
+
+instance b :: B
+
+class C a where
+  c0 :: Int -> a
+  c1 :: Int -> a
+
+instance cInt :: C Int where
+  c0 _ = 0
+  c1 :: B => Int -> Int
+  c1 = c0
+
+c :: Int -> Int
+c = c0

--- a/tests/purs/failing/3429-10.purs
+++ b/tests/purs/failing/3429-10.purs
@@ -1,0 +1,16 @@
+-- @shouldFailWith CycleInDictDeclaration
+-- @shouldFailWith CycleInDictDeclaration
+-- Cf. 3429-20.purs, passing/3429/19.purs, passing/3429/20.purs, passing/3429/21.purs
+module Main where
+
+class C0 a where
+  c0 :: a
+
+class C1 a where
+  c1 :: a
+
+instance c0Int :: C0 Int where
+  c0 = c1
+
+instance c1Int :: C1 Int where
+  c1 = c0

--- a/tests/purs/failing/3429-11.purs
+++ b/tests/purs/failing/3429-11.purs
@@ -1,0 +1,19 @@
+-- @shouldFailWith CycleInDictDeclaration
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B
+
+instance b :: B
+
+class C0 a where
+  c0 :: a
+
+class C1 a where
+  c1 :: a
+
+instance c0Int :: B => C0 Int where
+  c0 = c1
+
+instance c1Int :: C1 Int where
+  c1 = c0

--- a/tests/purs/failing/3429-12.purs
+++ b/tests/purs/failing/3429-12.purs
@@ -1,0 +1,19 @@
+-- @shouldFailWith CycleInDictDeclaration
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B
+
+instance b :: B
+
+class C0 a where
+  c0 :: a
+
+class C1 a where
+  c1 :: a
+
+instance c0Int :: B => C0 Int where
+  c0 = c1
+
+instance c1Int :: B => C1 Int where
+  c1 = c0

--- a/tests/purs/failing/3429-13.purs
+++ b/tests/purs/failing/3429-13.purs
@@ -1,0 +1,20 @@
+-- @shouldFailWith CycleInDictDeclaration
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B
+
+instance b :: B
+
+class C0 a where
+  c0 :: a
+
+class C1 a where
+  c1 :: a
+
+instance c0Int :: C0 Int where
+  c0 :: B => Int
+  c0 = c1
+
+instance c1Int :: C1 Int where
+  c1 = c0

--- a/tests/purs/failing/3429-14.purs
+++ b/tests/purs/failing/3429-14.purs
@@ -1,0 +1,21 @@
+-- @shouldFailWith CycleInDictDeclaration
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B
+
+instance b :: B
+
+class C0 a where
+  c0 :: a
+
+class C1 a where
+  c1 :: a
+
+instance c0Int :: C0 Int where
+  c0 :: B => Int
+  c0 = c1
+
+instance c1Int :: C1 Int where
+  c1 :: B => Int
+  c1 = c0

--- a/tests/purs/failing/3429-15.purs
+++ b/tests/purs/failing/3429-15.purs
@@ -1,0 +1,20 @@
+-- @shouldFailWith CycleInDictDeclaration
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B
+
+instance b :: B
+
+class C0 a where
+  c0 :: a
+
+class C1 a where
+  c1 :: a
+
+instance c0Int :: B => C0 Int where
+  c0 = c1
+
+instance c1Int :: B => C1 Int where
+  c1 :: B => Int
+  c1 = c0

--- a/tests/purs/failing/3429-16.purs
+++ b/tests/purs/failing/3429-16.purs
@@ -1,0 +1,21 @@
+-- @shouldFailWith CycleInDictDeclaration
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B
+
+instance b :: B
+
+class C0 a where
+  c0 :: a
+
+class C1 a where
+  c1 :: a
+
+instance c0Int :: B => C0 Int where
+  c0 :: B => Int
+  c0 = c1
+
+instance c1Int :: B => C1 Int where
+  c1 :: B => Int
+  c1 = c0

--- a/tests/purs/failing/3429-17.purs
+++ b/tests/purs/failing/3429-17.purs
@@ -1,0 +1,45 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+import Data.Tuple (Tuple(Tuple))
+
+class B0
+
+instance b0 :: B0
+
+class B1 a where
+  x1 :: a
+
+instance b1Int :: B1 Int where
+  x1 = 0
+
+class B2 a where
+  x2 :: a
+
+instance b2Tuple :: B1 a => B2 (Tuple a a) where
+  x2 = Tuple x1 x1
+
+class B1 a <= B3 a where
+  x3 :: a
+
+instance b3Int :: B3 Int where
+  x3 = x1
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cInt
+  :: ( B0
+     , B1 Int
+     , B2 (Tuple Int Int)
+     , B3 Int
+     )
+  => C Int where
+  c0 = 0
+  c1 =
+    let
+      const' :: forall a b c d. a -> b -> c -> d -> a
+      const' a _ _ _ = a
+    in
+      const' c0 (x1 :: Int) (x2 :: Tuple Int Int) (x3 :: Int)

--- a/tests/purs/failing/3429-18.purs
+++ b/tests/purs/failing/3429-18.purs
@@ -1,0 +1,14 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B
+
+instance b :: B
+
+class B <= C a where
+  c0 :: a
+  c1 :: a
+
+instance cInt :: C Int where
+  c0 = 0
+  c1 = c0

--- a/tests/purs/failing/3429-19.purs
+++ b/tests/purs/failing/3429-19.purs
@@ -1,0 +1,12 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+data D a = D0 | D1 a
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cD :: C a => C (D a) where
+  c0 = D0
+  c1 = c0

--- a/tests/purs/failing/3429-20.purs
+++ b/tests/purs/failing/3429-20.purs
@@ -1,0 +1,16 @@
+-- @shouldFailWith CycleInDictDeclaration
+-- @shouldFailWith CycleInDictDeclaration
+-- Cf. 3429-20.purs, passing/3429/19.purs, passing/3429/20.purs, passing/3429/21.purs
+module Main where
+
+class C0 a where
+  c0 :: Int -> a
+
+class C1 a where
+  c1 :: Int -> a
+
+instance c0Int :: C0 Int where
+  c0 = c1
+
+instance c1Int :: C1 Int where
+  c1 = c0

--- a/tests/purs/failing/3429-21.purs
+++ b/tests/purs/failing/3429-21.purs
@@ -1,0 +1,15 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class B
+
+instance b :: B
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cInt :: B => C Int where
+  c0 = 0
+  c1 :: B => Int
+  c1 = c0

--- a/tests/purs/failing/3429-22.purs
+++ b/tests/purs/failing/3429-22.purs
@@ -1,0 +1,9 @@
+-- @shouldFailWith CycleInDictDeclaration
+-- Cf. passing/3429/22.purs
+module Main where
+
+class C a where
+  c :: Int -> a
+
+instance cInt :: C Int where
+  c = c

--- a/tests/purs/failing/3429-23.purs
+++ b/tests/purs/failing/3429-23.purs
@@ -1,0 +1,16 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class C a where
+  c0 :: a
+  c1 :: a
+  c2 :: a
+  c3 :: a
+  c4 :: a
+
+instance cInt :: C Int where
+  c0 = 0
+  c1 = c0
+  c2 = c0
+  c3 = c0
+  c4 = c0

--- a/tests/purs/failing/3429-24.purs
+++ b/tests/purs/failing/3429-24.purs
@@ -1,0 +1,16 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+class C a where
+  c0 :: a -> a
+  c1 :: a -> a
+  c2 :: a -> a
+  c3 :: a -> a
+  c4 :: a -> a
+
+instance cInt :: C Int where
+  c0 _ = 0
+  c1 = c0
+  c2 = c0
+  c3 = c0
+  c4 = c0

--- a/tests/purs/failing/3429-HeytingAlgebra.js
+++ b/tests/purs/failing/3429-HeytingAlgebra.js
@@ -1,0 +1,17 @@
+"use strict";
+
+exports.boolConj = function (b1) {
+  return function (b2) {
+    return b1 && b2;
+  };
+};
+
+exports.boolDisj = function (b1) {
+  return function (b2) {
+    return b1 || b2;
+  };
+};
+
+exports.boolNot = function (b) {
+  return !b;
+};

--- a/tests/purs/failing/3429-HeytingAlgebra.purs
+++ b/tests/purs/failing/3429-HeytingAlgebra.purs
@@ -1,0 +1,34 @@
+-- @shouldFailWith CycleInDictDeclaration
+module Main where
+
+import Prelude ((<<<))
+
+class HeytingAlgebra a where
+  ff :: a
+  tt :: a
+  implies :: a -> a -> a
+  conj :: a -> a -> a
+  disj :: a -> a -> a
+  not :: a -> a
+
+foreign import boolConj :: Boolean -> Boolean -> Boolean
+foreign import boolDisj :: Boolean -> Boolean -> Boolean
+foreign import boolNot :: Boolean -> Boolean
+
+-- | Like the analogous instance declaration in 'passing/3429/HeytingAlgebra.purs',
+-- | this definition of `heytingAlgebraBoolean` is self-referential
+-- | in that one of its components, `implies`, depends on two of the instance's
+-- | other members (namely, `not` and `disj`).
+-- | However, although the definition in
+-- | 'passing/3429/HeytingAlgebra.purs' type-checks,
+-- | the following definition does not,
+-- | since the terms `not` and `||` are immediately applied to `<<<`.
+-- | In other words, no `Abs` expression exists to obscure the typechecker's
+-- | process for cycle determination.
+instance heytingAlgebraBoolean :: HeytingAlgebra Boolean where
+  ff = false
+  tt = true
+  implies = disj <<< not
+  conj = boolConj
+  disj = boolDisj
+  not = boolNot

--- a/tests/purs/failing/3429-chrismshelton.purs
+++ b/tests/purs/failing/3429-chrismshelton.purs
@@ -1,0 +1,33 @@
+-- @shouldFailWith CycleInDictDeclaration
+-- Example submitted by chrismshelton.
+-- Cf. passing/3429/chrismshelton.purs
+module Main where
+
+import Prelude
+import Effect (Effect)
+import Effect.Console (log)
+
+class CA v a where
+  lengthA :: forall m . v m a -> Int
+
+class (CA w a) <= CB v w a | v a -> w, w a -> v where
+  lengthB :: v a -> Int
+  fromA :: forall m . w m a -> v a
+  toA   :: forall m . v a -> w m a
+
+defaultLengthB :: forall v w a . (CB v w a) => v a -> Int
+defaultLengthB v = lengthA $ toA v
+
+data DA m a = DA Int
+data DB a = DB Int
+
+instance caDA :: CA DA a where
+  lengthA (DA i) = i
+
+instance cbDB :: (CA DA a) => CB DB DA a where
+  lengthB = defaultLengthB
+  fromA (DA a) = (DB a)
+  toA (DB a) = (DA a)
+
+main :: Effect Unit
+main = log (show (lengthB (fromA (DA 3))))

--- a/tests/purs/failing/3429-fsoikin.purs
+++ b/tests/purs/failing/3429-fsoikin.purs
@@ -1,0 +1,14 @@
+-- @shouldFailWith CycleInDictDeclaration
+-- Example submitted by fsoikin in issue #3488.
+module Main where
+
+import Prelude (class Ord, class Semiring, zero, (>))
+import Data.Array (filter)
+
+class C a where
+  f :: a -> Boolean
+  g :: Array a
+
+instance cInst :: (Ord a, Semiring a) => C a where
+  f i = i > zero
+  g = filter f []

--- a/tests/purs/failing/3429-nukisman.purs
+++ b/tests/purs/failing/3429-nukisman.purs
@@ -1,0 +1,16 @@
+-- @shouldFailWith CycleInDictDeclaration
+-- Example submitted by nukisman in issue #2975.
+-- Cf. passing/3429/nukisman.purs
+module Main where
+
+import Data.Foldable (class Foldable, foldrDefault, foldMapDefaultL)
+
+data Tree a
+  = Leaf
+  | Branch (Tree a) a (Tree a)
+
+instance foldableTree :: Foldable Tree where
+  foldl _ acc Leaf = acc
+  foldl f acc (Branch l e r) = acc -- Just for debug
+  foldr = foldrDefault
+  foldMap = foldMapDefaultL

--- a/tests/purs/failing/MissingEtaExpansion.purs
+++ b/tests/purs/failing/MissingEtaExpansion.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith MissingEtaExpansion
+-- Cf. passing/MissingEtaExpanson.purs and passing/UnifyInTypeInstanceLookup.purs
+module Main where
+
+f :: Int -> Int
+f = f

--- a/tests/purs/passing/3429.purs
+++ b/tests/purs/passing/3429.purs
@@ -1,0 +1,32 @@
+module Main where
+
+import Effect.Console (log)
+
+import Mod0
+import Mod1
+import Mod2
+import Mod3
+import Mod4
+import Mod5
+import Mod6
+import Mod7
+import Mod8
+import Mod9
+import Mod10
+import Mod11
+import Mod12
+import Mod13
+import Mod14
+import Mod15
+import Mod16
+import Mod17
+import Mod18
+import Mod19
+import Mod20
+import Mod21
+import Mod22
+import ChrisMShelton
+import HeytingAlgebra
+import Nukisman
+
+main = log "Done"

--- a/tests/purs/passing/3429/00.purs
+++ b/tests/purs/passing/3429/00.purs
@@ -1,0 +1,17 @@
+module Mod0 where
+
+import Prelude
+
+class C a where
+  c0 :: a
+  c1 :: Unit -> a
+
+instance cInt :: C Int where
+  c0 = 0
+  c1 _ = c0
+
+c :: Int
+c = c0
+
+f :: Unit -> Int
+f = c1

--- a/tests/purs/passing/3429/01.purs
+++ b/tests/purs/passing/3429/01.purs
@@ -1,0 +1,21 @@
+module Mod1 where
+
+import Prelude
+
+class B
+
+instance b :: B
+
+class C a where
+  c0 :: a
+  c1 :: Unit -> a
+
+instance cInt :: B => C Int where
+  c0 = 0
+  c1 _ = c0
+
+c :: Int
+c = c0
+
+f :: Unit -> Int
+f = c1

--- a/tests/purs/passing/3429/02.purs
+++ b/tests/purs/passing/3429/02.purs
@@ -1,0 +1,19 @@
+module Mod2 where
+
+class C0 a where
+  c0 :: a
+
+class C1 a where
+  c1 :: a
+
+instance c0Int :: C0 Int where
+  c0 = 0
+
+instance c1Int :: C1 Int where
+  c1 = 1
+
+d0 :: Int
+d0 = c0
+
+d1 :: Int
+d1 = c1

--- a/tests/purs/passing/3429/03.purs
+++ b/tests/purs/passing/3429/03.purs
@@ -1,0 +1,19 @@
+module Mod3 where
+
+class C0 a where
+  c0 :: a
+
+class C1 a where
+  c1 :: a
+
+instance c0Int :: C0 Int where
+  c0 = 0
+
+instance c1Int :: C1 Int where
+  c1 = c0
+
+d0 :: Int
+d0 = c0
+
+d1 :: Int
+d1 = c1

--- a/tests/purs/passing/3429/04.purs
+++ b/tests/purs/passing/3429/04.purs
@@ -1,0 +1,24 @@
+module Mod4 where
+
+class B
+
+instance b :: B
+
+class C0 a where
+  c0 :: a
+
+class C1 a where
+  c1 :: a
+
+instance c0Int :: C0 Int where
+  c0 :: B => Int
+  c0 = c1
+
+instance c1Int :: C1 Int where
+  c1 = 1
+
+d0 :: Int
+d0 = c0
+
+d1 :: Int
+d1 = c1

--- a/tests/purs/passing/3429/05.purs
+++ b/tests/purs/passing/3429/05.purs
@@ -1,0 +1,24 @@
+module Mod5 where
+
+class B
+
+instance b :: B
+
+class C0 a where
+  c0 :: a
+
+class C1 a where
+  c1 :: a
+
+instance c0Int :: B => C0 Int where
+  c0 = c1
+
+instance c1Int :: C1 Int where
+  c1 :: B => Int
+  c1 = 1
+
+d0 :: Int
+d0 = c0
+
+d1 :: Int
+d1 = c1

--- a/tests/purs/passing/3429/06.purs
+++ b/tests/purs/passing/3429/06.purs
@@ -1,0 +1,24 @@
+module Mod6 where
+
+class B
+
+instance b :: B
+
+class C0 a where
+  c0 :: a
+
+class C1 a where
+  c1 :: a
+
+instance c0Int :: B => C0 Int where
+  c0 = 0
+
+instance c1Int :: C1 Int where
+  c1 :: B => Int
+  c1 = c0
+
+d0 :: Int
+d0 = c0
+
+d1 :: Int
+d1 = c1

--- a/tests/purs/passing/3429/07.purs
+++ b/tests/purs/passing/3429/07.purs
@@ -1,0 +1,24 @@
+module Mod7 where
+
+class B
+
+instance b :: B
+
+class C0 a where
+  c0 :: a
+
+class C1 a where
+  c1 :: a
+
+instance c0Int :: B => C0 Int where
+  c0 = 0
+
+instance c1Int :: B => C1 Int where
+  c1 :: B => Int
+  c1 = c0
+
+d0 :: Int
+d0 = c0
+
+d1 :: Int
+d1 = c1

--- a/tests/purs/passing/3429/08.purs
+++ b/tests/purs/passing/3429/08.purs
@@ -1,0 +1,7 @@
+module Mod8 where
+
+class C a where
+  c :: Int -> a
+
+instance cInt :: C Int where
+  c i = c i

--- a/tests/purs/passing/3429/09.purs
+++ b/tests/purs/passing/3429/09.purs
@@ -1,0 +1,23 @@
+module Mod9 where
+
+import Prelude
+
+class B a where
+  x :: a
+
+instance bUnit :: B Unit where
+  x = unit
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cUnit :: C Unit where
+  c0 = unit
+  c1 = x
+
+d0 :: Unit
+d0 = c0
+
+d1 :: Unit
+d1 = c0

--- a/tests/purs/passing/3429/10.purs
+++ b/tests/purs/passing/3429/10.purs
@@ -1,0 +1,23 @@
+module Mod10 where
+
+import Prelude
+
+class B a where
+  x :: a
+
+instance bUnit :: B Unit where
+  x = unit
+
+class B a <= C a where
+  c0 :: a
+  c1 :: a
+
+instance cUnit :: C Unit where
+  c0 = unit
+  c1 = x
+
+d0 :: Unit
+d0 = c0
+
+d1 :: Unit
+d1 = c0

--- a/tests/purs/passing/3429/11.purs
+++ b/tests/purs/passing/3429/11.purs
@@ -1,0 +1,23 @@
+module Mod11 where
+
+import Prelude
+
+class B a where
+  x :: a
+
+instance bUnit :: B Unit where
+  x = unit
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cUnit :: B Unit => C Unit where
+  c0 = unit
+  c1 = x
+
+d0 :: Unit
+d0 = c0
+
+d1 :: Unit
+d1 = c0

--- a/tests/purs/passing/3429/12.purs
+++ b/tests/purs/passing/3429/12.purs
@@ -1,0 +1,19 @@
+module Mod12 where
+
+class B
+
+instance b :: B
+
+class C a where
+  c0 :: a
+  c1 :: B => a
+
+instance cInt :: C Int where
+  c0 = 0
+  c1 = c0
+
+d0 :: Int
+d0 = c0
+
+d1 :: Int
+d1 = c1

--- a/tests/purs/passing/3429/13.purs
+++ b/tests/purs/passing/3429/13.purs
@@ -1,0 +1,20 @@
+module Mod13 where
+
+class B
+
+instance b :: B
+
+class C a where
+  c0 :: a
+  c1 :: B => a
+
+instance cInt :: C Int where
+  c0 = 0
+  c1 :: B => Int
+  c1 = c0
+
+d0 :: Int
+d0 = c0
+
+d1 :: Int
+d1 = c1

--- a/tests/purs/passing/3429/14.purs
+++ b/tests/purs/passing/3429/14.purs
@@ -1,0 +1,21 @@
+module Mod14 where
+
+data D a = D0 | D1 a
+
+class C a where
+  c0 :: a
+  c1 :: a
+
+instance cInt :: C Int where
+  c0 = 0
+  c1 = 0
+
+instance cD :: C a => C (D a) where
+  c0 = D0
+  c1 = D1 c0
+
+d0 :: Int
+d0 = c0
+
+d1 :: Int
+d1 = c1

--- a/tests/purs/passing/3429/15.purs
+++ b/tests/purs/passing/3429/15.purs
@@ -1,0 +1,21 @@
+-- Cf. 18.purs and 21.purs
+module Mod15 where
+
+class B
+
+instance b :: B
+
+class C a where
+  c0 :: B => a
+  c1 :: B => a
+
+instance cInt :: C Int where
+  c0 = c1
+  c1 = c0
+
+-- The following two values induce endless looping.
+-- d0 :: Int
+-- d0 = c0
+--
+-- d1 :: Int
+-- d1 = c1

--- a/tests/purs/passing/3429/16.purs
+++ b/tests/purs/passing/3429/16.purs
@@ -1,0 +1,20 @@
+-- Cf. 17.purs and 20.purs
+module Mod16 where
+
+class B
+
+instance b :: B
+
+class C a where
+  c0 :: Int -> a
+  c1 :: Int -> a
+
+instance cInt :: C Int where
+  c0 i = c1 i
+  c1 i = c0 i
+
+d0 :: Int -> Int
+d0 = c0
+
+d1 :: Int -> Int
+d1 = c1

--- a/tests/purs/passing/3429/17.purs
+++ b/tests/purs/passing/3429/17.purs
@@ -1,0 +1,20 @@
+-- Cf. 19.purs
+module Mod17 where
+
+class B
+
+instance b :: B
+
+class C a where
+  c0 :: Int -> a
+  c1 :: Int -> a
+
+instance cInt :: C Int where
+  c0 = \_ -> c0 0
+  c1 = \_ -> c1 0
+
+d0 :: Int -> Int
+d0 = c0
+
+d1 :: Int -> Int
+d1 = c1

--- a/tests/purs/passing/3429/18.purs
+++ b/tests/purs/passing/3429/18.purs
@@ -1,0 +1,21 @@
+-- Cf. 17.purs
+module Mod18 where
+
+class B
+
+instance b :: B
+
+class C a where
+  c0 :: B => a
+  c1 :: B => a
+
+instance cInt :: C Int where
+  c0 = c0
+  c1 = c1
+
+-- The following two values induce endless looping.
+-- d0 :: Int
+-- d0 = c0
+--
+-- d1 :: Int
+-- d1 = c1

--- a/tests/purs/passing/3429/19.purs
+++ b/tests/purs/passing/3429/19.purs
@@ -1,0 +1,25 @@
+-- Cf. 20.purs and failing/3429-20.purs
+module Mod19 where
+
+class B
+
+instance b :: B
+
+class C0 a where
+  c0 :: B => a
+
+class C1 a where
+  c1 :: B => a
+
+instance c0Int :: C0 Int where
+  c0 = c1
+
+instance c1Int :: C1 Int where
+  c1 = c0
+
+-- The following two values induce endless looping.
+-- d0 :: Int
+-- d0 = c0
+--
+-- d1 :: Int
+-- d1 = c1

--- a/tests/purs/passing/3429/20.purs
+++ b/tests/purs/passing/3429/20.purs
@@ -1,0 +1,20 @@
+-- Cf. 19.purs, 21.purs, failing/3429-10.purs, failing/3429-20.purs
+module Mod20 where
+
+class C0 a where
+  c0 :: Int -> a
+
+class C1 a where
+  c1 :: Int -> a
+
+instance c0Int :: C0 Int where
+  c0 _ = c1 0
+
+instance c1Int :: C1 Int where
+  c1 _ = c0 0
+
+d0 :: Int -> Int
+d0 = c0
+
+d1 :: Int -> Int
+d1 = c1

--- a/tests/purs/passing/3429/21.purs
+++ b/tests/purs/passing/3429/21.purs
@@ -1,0 +1,20 @@
+-- Cf. 20.purs
+module Mod21 where
+
+class C0 a where
+  c0 :: Int -> a
+
+class C1 a where
+  c1 :: Int -> a
+
+instance c0Int :: C0 Int where
+  c0 = c1
+
+instance c1Int :: C1 Int where
+  c1 _ = c0 0
+
+d0 :: Int -> Int
+d0 = c0
+
+d1 :: Int -> Int
+d1 = c1

--- a/tests/purs/passing/3429/22.purs
+++ b/tests/purs/passing/3429/22.purs
@@ -1,0 +1,16 @@
+-- Cf. failing/3429-22.purs
+module Mod22 where
+
+class B
+
+instance b :: B
+
+class C a where
+  c :: B => a
+
+instance cInt :: C Int where
+  c = c
+
+-- The following value induces endless looping.
+-- c0 :: Int
+-- c0 = c

--- a/tests/purs/passing/3429/HeytingAlgebra.js
+++ b/tests/purs/passing/3429/HeytingAlgebra.js
@@ -1,0 +1,17 @@
+"use strict";
+
+exports.boolConj = function (b1) {
+  return function (b2) {
+    return b1 && b2;
+  };
+};
+
+exports.boolDisj = function (b1) {
+  return function (b2) {
+    return b1 || b2;
+  };
+};
+
+exports.boolNot = function (b) {
+  return !b;
+};

--- a/tests/purs/passing/3429/HeytingAlgebra.purs
+++ b/tests/purs/passing/3429/HeytingAlgebra.purs
@@ -1,0 +1,32 @@
+-- Cf. failing/3429-HeytingAlgebra.purs
+module HeytingAlgebra where
+
+class HeytingAlgebra a where
+  ff :: a
+  tt :: a
+  implies :: a -> a -> a
+  conj :: a -> a -> a
+  disj :: a -> a -> a
+  not :: a -> a
+
+infixr 2 disj as ||
+
+foreign import boolConj :: Boolean -> Boolean -> Boolean
+foreign import boolDisj :: Boolean -> Boolean -> Boolean
+foreign import boolNot :: Boolean -> Boolean
+
+-- | The definition of `heytingAlgebraBoolean` is self-referential
+-- | in that one of its components, `implies`, depends on two of the instance's
+-- | other members (namely, `not` and `disj`).
+-- | However, despite self-referencing, the following definition type-checks
+-- | because the terms `not` and `||` are within the body of an `Abs` expression
+-- | and therefore beyond the reach of the typechecker's current implementation
+-- | for cycle determination.
+-- | (Cf. tests/purs/failing/HeytingAlgebraBoolean.purs)
+instance heytingAlgebraBoolean :: HeytingAlgebra Boolean where
+  ff = false
+  tt = true
+  implies a b = not a || b
+  conj = boolConj
+  disj = boolDisj
+  not = boolNot

--- a/tests/purs/passing/3429/chrismshelton.purs
+++ b/tests/purs/passing/3429/chrismshelton.purs
@@ -1,0 +1,28 @@
+-- Example submitted by chrismshelton.
+-- Cf. failing/3429-chrismshelton.purs
+module ChrisMShelton where
+
+import Prelude
+
+class CA v a where
+  lengthA :: forall m . v m a -> Int
+
+class (CA w a) <= CB v w a | v a -> w, w a -> v where
+  lengthB :: v a -> Int
+  fromA :: forall m . w m a -> v a
+  toA   :: forall m . v a -> w m a
+
+defaultLengthB :: forall v w a . (CB v w a) => v a -> Int
+defaultLengthB v = lengthA $ toA v
+
+data DA m a = DA Int
+
+data DB a = DB Int
+
+instance caDA :: CA DA a where
+  lengthA (DA i) = i
+
+instance cbDB :: (CA DA a) => CB DB DA a where
+  lengthB x = defaultLengthB x
+  fromA (DA a) = (DB a)
+  toA (DB a) = (DA a)

--- a/tests/purs/passing/3429/nukisman.purs
+++ b/tests/purs/passing/3429/nukisman.purs
@@ -1,0 +1,19 @@
+-- Example submitted by nukisman in issue #2975.
+-- Cf. failing/3429-nukisman.purs
+module Nukisman where
+
+import Data.Foldable (class Foldable, foldrDefault, foldMapDefaultL)
+
+data Tree a
+  = Leaf
+  | Branch (Tree a) a (Tree a)
+
+instance foldableTree :: Foldable Tree where
+  foldl _ acc Leaf = acc
+  foldl f acc (Branch l e r) = acc -- Just for debug
+  foldr f = foldrDefault f
+  foldMap = foldMapDefaultL
+
+-- NOTE: `foldMap` doesn't need to be eta-expanded
+-- because, during elaboration, the `Monoid` constraint of `foldMapDefaultL`
+-- is transformed into an `Abs` node, which suppresses cycle checking.

--- a/tests/purs/passing/365.purs
+++ b/tests/purs/passing/365.purs
@@ -1,8 +1,8 @@
--- @shouldFailWith CycleInDictDeclaration
--- Cf. 3429-*.purs and passing/365.purs
+-- Cf. 3429/*.purs and failing/365.purs
 module Main where
 
 import Prelude
+import Effect.Console (log)
 
 class C a where
   f :: a -> a
@@ -10,6 +10,6 @@ class C a where
 
 instance cS :: C String where
   f s = s
-  g = f
+  g s = f s
 
-main = g "Done"
+main = log "Done"

--- a/tests/purs/passing/Foldable.purs
+++ b/tests/purs/passing/Foldable.purs
@@ -1,8 +1,8 @@
--- @shouldFailWith CycleInDictDeclaration
--- Cf. passing/Foldable.purs and 3429-*.purs
+-- Cf. failing/Foldable.purs and 3429/*.purs
 module Main where
 
 import Prelude
+import Effect.Console (log)
 
 class Foldable f where
   fold :: forall a b. (a -> b -> b) -> b -> f a -> b
@@ -13,6 +13,8 @@ data L a = C a (L a) | N
 instance foldableL :: Foldable L where
   fold _ z N = z
   fold f z (C x xs) = x `f` (fold f z xs)
-  size = fold (const ((+) 1.0)) 0.0
+  size i = fold (const ((+) 1.0)) 0.0 i
 
 x = size (C 1 (C 2 (C 3 N)))
+
+main = log "Done"

--- a/tests/purs/passing/MissingEtaExpansion.purs
+++ b/tests/purs/passing/MissingEtaExpansion.purs
@@ -1,0 +1,9 @@
+-- Cf. UnifyInTypeInstanceLookup.purs and failing/MissingEtaExpanson.purs
+module Main where
+
+import Effect.Console (log)
+
+f :: Int -> Int
+f i = f i
+
+main = log "Done"


### PR DESCRIPTION
Resolves #3429.

Previously, non-function members of constrained typeclass instances could reference each other. Because members also implicitly reference the overarching typeclass dictionary, the resulting cycle in a typeclass declaration between a dictionary and its members can cause runtime misbehavior.

For example, @LiamGoodacre, in #3429, documents the following problematic typeclass declarations:
```purescript
class Trivial
instance trivial :: Trivial

instance what :: Trivial => C Int where
  foo = 0
  bar = foo
```

Because `what` and `foo` reference each other in the following generated javascript, any invocation of `what` causes a stack-overflow error.
```javascript
var foo = function (dict) {
    return dict.foo;
};
var what = function (dictTrivial) {
    return new C(foo(what(dictTrivial)), 0);
};
```

The previously established procedure for preventing cycles in typeclass declarations fails in @LiamGoodacre's scenario because, in order to allow implementations of superclass methods to depend on subclass implementations (cf. `functorEffect` and `applicativeEffect`), the desugaring process in "Sugar/BindingGroups.hs" deliberately allows cyclical references if they occur inside lambda abstractions. And since, during type elaboration, constrained typeclass dictionaries are represented as abstractions, dictionary cycles fail to trigger a "CycleInDeclaration" error.

Code changes in this pull request fix issue #3429 by adding a new cycle check that is specific to typeclass value declarations. Unlike the primary check, it disallows self-reference even if it occurs within abstractions outside literal objects. Therefore, the implicit cycle in the `what` instance above (and the explicit cycle in the desugared "pseudo"-purescript representation below) induces an error.

```purescript
what :: Trivial -> C Int
what dictTrivial = { foo: 0, bar: (what dictTrivial).foo }
```

Like the primary cycle check, the new check permits self-reference if it occurs within a bare abstraction of an object member. For example, the following class and instance successfully compile.

```purescript
class C a where
  c0 :: Int
  c1 :: Unit -> Int

instance cInt :: C Int where
  c0 = 0
  c1 _ = c0
``` 

Or in pseudo-purescript:
```purescript
cInt :: C Int
cInt = { c0: 0, c1: \_ -> cInt.c0 }
```

However, unlike the primary cycle check, self-reference in purescript typeclass "IFFE"s is now considered invalid. This is designed to prevent the following scenario.

```purescript
class B
instance b :: B

class C a where
  c0 :: a
  c1 :: a

instance cInt :: C Int where
  c0 = 0
  c1 :: B => Int
  c1 = c0
```

The corresponding pseudo-purescript may make the reason for proscription clearer.
```purescript
b :: B
b = {}

cInt :: C Int
cInt = { c0: 0, c1: (\dictB -> cInt.c0) b }
```

Constrained typeclass members, like constrained typeclasses, are represented as abstractions. However, they are also immediately invoked, and so the same kind of deviant runtime behavior as documented by @LiamGoodacre can occur unless screened.

-------------------

Typeclass self-reference, even with the introduced cyclicality check, is still possible. The earlier case
```purescript
instance cInt :: C Int where
  c0 = 0
  c1 _ = c0
```
is one example. Other possibilities arise when the members of class declarations are constrained.

For instance, the following purescript

```purescript
class B
instance b :: B

class C a where
  c :: B => a

instance cInt :: C Int where
  c = c
```
or pseudo-purescript,
```purescript
type C a = { c :: B -> a }
cInt :: C Int
cInt = { c: \b -> cInt.c b }
```
despite its pronounced and unhelpful self-reference, compiles successfully. Unlike constrained instance members, constrained class members are not immediately invoked, and therefore, the abstraction exception for self-reference takes precedence.

This might be considered a distasteful loophole by the cyclicality screening procedure. Similar cases unrelated to constrained typeclasses already exist, however. Consider the following unconstrained instance.

```purescript
class C a where
  f :: a -> a

instance cInt :: C Int where
  f x = f x
```

Or even functions independent of typeclasses altogether like `g` below.
```purescript
g :: Int -> Int
g x = g x
```
-------------------

In addition to more robust cycle prevention, this pull request also improves error messages for end users.

Error messages for typeclasses now specify the individual members of an instance declaration that contribute to the error -- as well as the members' locations in source code.

For example,

```purescript
class C a where
  c0 :: a
  c1 :: a
  c2 :: a
  c3 :: a
  c4 :: a

instance cInt :: C Int where
  c0 = 0
  c1 = c0
  c2 = c0
  c3 = c0
  c4 = c0
```

induces an error message like the following.

```
Error 1 of 2:

  at src1/Module1.purs:20:1 - 20:52 (line 20, column 1 - line 20, column 52)

    The definition of instance cInt is invalid because of cyclical dependencies.

    In particular, its following members implicitly reference the instance itself.
      value "c1" at src1/Module1.purs:22:3 - 22:10 (line 22, column 3 - line 22, column 10)
      value "c2" at src1/Module1.purs:23:3 - 23:10 (line 23, column 3 - line 23, column 10)
      value "c3" at src1/Module1.purs:24:3 - 24:10 (line 24, column 3 - line 24, column 10)
      value "c4" at src1/Module1.purs:25:3 - 30:28 (line 25, column 3 - line 30, column 28)
```

Additionally, error messages distinguish between instance members that are functions and those that aren't in order to provide additional guidance to end users.

For example, the following

```purescript
class C a where
  c0 :: a -> a
  c1 :: a -> a

instance cInt :: C Int where
  c0 _ = 0
  c1 = c0
```

induces an error message like the following.

```
Error 2 of 2:

  at src1/Module2.purs:12:1 - 12:25 (line 12, column 1 - line 12, column 25)

    The definition of instance cInt is invalid because of cyclical dependencies.

    In particular, its member
      function "c0" at src1/Module2.purs:13:3 - 13:10 (line 13, column 3 - line 13, column 10)
    implicitly references the instance itself.

    Note that cycles in the member functions of cInt may lead to non-terminating runtime behavior.

    Consider replacing the functions' circular dependencies with independent terms.

    If their definitions cannot be rewritten, eta-expansion is necessary to accommodate purescript's non-strict style of evaluation.
```


