### PR TITLE
Configure the 'shell-file' option in stack.yaml.

### DIFF
--- a/nix/init.nix
+++ b/nix/init.nix
@@ -1,0 +1,38 @@
+{ ghc }:
+let
+  bootstrap = import <nixpkgs> { };
+
+  nixpkgsConfig = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+
+  src = bootstrap.fetchFromGitHub {
+    owner = "NixOS";
+    repo  = "nixpkgs";
+    inherit (nixpkgsConfig) rev sha256;
+  };
+
+  pinned-nixpkgs = import src { };
+
+  pinned-ghc = pinned-nixpkgs.haskell.compiler.ghc864;
+
+  stack-inputs = with pinned-nixpkgs;
+    [ pinned-ghc
+      git
+      gcc
+      gmp
+    ];
+
+  project-inputs = with pinned-nixpkgs;
+    [ zlib
+      nodejs
+      nodePackages.npm
+      nodePackages.bower
+    ];
+
+  buildInputs = stack-inputs ++ project-inputs;
+
+in
+  pinned-nixpkgs.haskell.lib.buildStackProject {
+    inherit buildInputs;
+    name = "myEnv";
+    ghc = pinned-ghc;
+  }

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/NixOS/nixpkgs.git",
+  "rev": "bea8ead3c84f08fa60fded818e23bfc78dd9c656",
+  "date": "2019-05-13T10:49:18-04:00",
+  "sha256": "1n23z0gh7caxrkc4wb6nzrn8blz6mdlfaj8llmcx4wnzx8xhpgk5",
+  "fetchSubmodules": false
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,9 +5,5 @@ extra-deps:
 - network-3.0.1.1
 nix:
   enable: false
-  packages:
-  - zlib
-  # Test dependencies
-  - nodejs
-  - nodePackages.npm
-  - nodePackages.bower
+  shell-file: nix/init.nix
+  add-gc-roots: true


### PR DESCRIPTION
This accomplishes multiple purposes:
* It pins nixpkgs and ghc to specific versions, making builds faster and more predictable.
* It invokes 'buildStackProject', which sets the LANG env variable to 'en_US.UTF-8',
  thereby preventing an odd error caused by the conjunction of NixOS and Happy,
  while allowing stack to otherwise instantiate a pure env-less shell.
* It makes command-line stack use on NixOS easier, since using the --no-nix-pure
  flag and setting the NIX_PATH env variable are made unnecessary.
* It adds nix dependencies as nix gc roots, thereby hastening builds.