### PR TITLE
Keep Parser.y ASCII to avoid happy locale issues

### DIFF
--- a/src/Language/PureScript/CST/Parser.y
+++ b/src/Language/PureScript/CST/Parser.y
@@ -58,7 +58,7 @@ import Language.PureScript.PSString (PSString)
   '\;'            { SourceToken _ TokLayoutSep }
   '<-'            { SourceToken _ (TokLeftArrow _) }
   '->'            { SourceToken _ (TokRightArrow _) }
-  '<='            { SourceToken _ (TokOperator [] sym) | sym == "<=" || sym == "⇐" }
+  '<='            { SourceToken _ (TokOperator [] sym) | isLeftFatArrow sym }
   '=>'            { SourceToken _ (TokRightFatArrow _) }
   ':'             { SourceToken _ (TokOperator [] ":") }
   '::'            { SourceToken _ (TokDoubleColon _) }

--- a/src/Language/PureScript/CST/Utils.hs
+++ b/src/Language/PureScript/CST/Utils.hs
@@ -304,3 +304,10 @@ reservedNames = Set.fromList
 
 isValidModuleNamespace :: Text -> Bool
 isValidModuleNamespace = Text.null . snd . Text.span (\c -> c /= '_' && c /= '\'')
+
+-- | This is to keep the @Parser.y@ file ASCII, otherwise @happy@ will break
+-- in non-unicode locales.
+--
+-- Related GHC issue: https://gitlab.haskell.org/ghc/ghc/issues/8167
+isLeftFatArrow :: Text -> Bool
+isLeftFatArrow str = str == "<=" || str == "⇐"


### PR DESCRIPTION
Small change to fix some weird locale issues I've ran into with NixOS. 

Despite `locale` reporting a utf-8 locale, when I `stack build` that locale is lost and happy crashes with an encoding error. Probably something to do with how stack manages Nix, but in any case this seems like a straightforward way of avoiding similar issues in future. 