### PR TITLE
Docs: Write ctags and etags to filesystem instead of stdout.

### DIFF
--- a/app/Command/Docs.hs
+++ b/app/Command/Docs.hs
@@ -44,11 +44,9 @@ docgen (PSCDocsOptions fmt inputGlob) = do
   let ms = D.primModules ++ map snd fileMs
   case fmt of
     Etags -> do
-      let outputFilename = "TAGS" -- TODO: make this configurable
-      writeTagsToFile outputFilename $ dumpEtags fileMs
+      writeTagsToFile "TAGS" $ dumpEtags fileMs
     Ctags -> do
-      let outputFilename = "tags" -- TODO: make this configurable
-      writeTagsToFile outputFilename $ dumpCtags fileMs
+      writeTagsToFile "tags" $ dumpCtags fileMs
     Html -> do
       let outputDir = "./generated-docs/html" -- TODO: make this configurable
       let ext = compile "*.html"
@@ -83,9 +81,7 @@ docgen (PSCDocsOptions fmt inputGlob) = do
   writeTagsToFile outputFilename tags = do
     currentDir <- getCurrentDirectory
     let outputFile = currentDir </> outputFilename
-    let pattern = compile outputFilename
     let text = T.pack . unlines $ tags
-    globDir1 pattern currentDir >>= mapM_ removeFile
     writeUTF8FileT outputFile text
 
 inputFile :: Opts.Parser FilePath

--- a/app/Command/Docs.hs
+++ b/app/Command/Docs.hs
@@ -43,10 +43,8 @@ docgen (PSCDocsOptions fmt inputGlob) = do
   fileMs <- parseAndConvert input
   let ms = D.primModules ++ map snd fileMs
   case fmt of
-    Etags -> do
-      writeTagsToFile "TAGS" $ dumpEtags fileMs
-    Ctags -> do
-      writeTagsToFile "tags" $ dumpCtags fileMs
+    Etags -> writeTagsToFile "TAGS" $ dumpEtags fileMs
+    Ctags -> writeTagsToFile "tags" $ dumpCtags fileMs
     Html -> do
       let outputDir = "./generated-docs/html" -- TODO: make this configurable
       let ext = compile "*.html"


### PR DESCRIPTION
Fixes #3642.

When running `purs docs` with ctags or etags formats, write to the filesystem instead of writing to standard output.

CTags format will generate a file `generated-docs/tags`, while ETags format will generate a file `generated-docs/TAGS`. The naming convention is taken from the default filenames generated by the `ctags` and `etags` commands (see http://ctags.sourceforge.net/ctags.html).

Example output:
```
→ purs docs --format ctags example.purs 
→ purs docs --format etags example.purs

→ ls generated-docs/
> tags  TAGS

→ cat generated-docs/tags
> Bar	/home/ealmansi/dev/ealmansi/purescript/example.purs	6
> Foo	/home/ealmansi/dev/ealmansi/purescript/example.purs	5

```
