### PR TITLE
Disallow re-exporting class and type with the same name

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -562,7 +562,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderSimpleErrorMessage (DeclConflict new existing) =
       line $ "Declaration for " <> printName (Qualified Nothing new) <> " conflicts with an existing " <> nameType existing <> " of the same name."
     renderSimpleErrorMessage (ExportConflict new existing) =
-      line $ "Export for " <> printName new <> " conflicts with " <> runName existing
+      line $ "Export for " <> printName new <> " conflicts with " <> printName existing
     renderSimpleErrorMessage (DuplicateModule mn) =
       line $ "Module " <> markCode (runModuleName mn) <> " has been defined multiple times"
     renderSimpleErrorMessage (DuplicateTypeClass pn ss) =

--- a/src/Language/PureScript/Sugar/Names/Env.hs
+++ b/src/Language/PureScript/Sugar/Names/Env.hs
@@ -318,6 +318,10 @@ exportType ss exportMode exps name dctors src = do
           throwDeclConflict (DctorName dctor) (TyClassName (coerceProperName dctor))
     ReExport -> do
       let mn = exportSourceDefinedIn src
+      forM_ (coerceProperName name `M.lookup` exClasses) $ \src' ->
+        let mn' = exportSourceDefinedIn src' in
+        when (mn /= mn') $
+          throwExportConflict ss mn mn' (TyName name)
       forM_ (name `M.lookup` exTypes) $ \(_, src') ->
         let mn' = exportSourceDefinedIn src' in
         when (mn /= mn') $

--- a/src/Language/PureScript/Sugar/Names/Env.hs
+++ b/src/Language/PureScript/Sugar/Names/Env.hs
@@ -320,8 +320,7 @@ exportType ss exportMode exps name dctors src = do
       let mn = exportSourceDefinedIn src
       forM_ (coerceProperName name `M.lookup` exClasses) $ \src' ->
         let mn' = exportSourceDefinedIn src' in
-        when (mn /= mn') $
-          throwExportConflict ss mn mn' (TyName name)
+        throwExportConflict' ss mn mn' (TyName name) (TyClassName (coerceProperName name))
       forM_ (name `M.lookup` exTypes) $ \(_, src') ->
         let mn' = exportSourceDefinedIn src' in
         when (mn /= mn') $
@@ -462,8 +461,23 @@ throwExportConflict
   -> Name
   -> m a
 throwExportConflict ss new existing name =
+  throwExportConflict' ss new existing name name
+
+-- |
+-- Raises an error for when there are conflicting names in the exports. Allows
+-- different categories of names. E.g. class and type names conflicting.
+--
+throwExportConflict'
+  :: MonadError MultipleErrors m
+  => SourceSpan
+  -> ModuleName
+  -> ModuleName
+  -> Name
+  -> Name
+  -> m a
+throwExportConflict' ss new existing newName existingName =
   throwError . errorMessage' ss $
-    ExportConflict (Qualified (Just new) name) (Qualified (Just existing) name)
+    ExportConflict (Qualified (Just new) newName) (Qualified (Just existing) existingName)
 
 -- |
 -- Gets the exports for a module, or raise an error if the module doesn't exist.

--- a/tests/purs/failing/ExportConflictClassAndType.purs
+++ b/tests/purs/failing/ExportConflictClassAndType.purs
@@ -1,0 +1,5 @@
+-- @shouldFailWith ExportConflict
+module C (module A, module B) where
+
+import A as A
+import B as B

--- a/tests/purs/failing/ExportConflictClassAndType/A.purs
+++ b/tests/purs/failing/ExportConflictClassAndType/A.purs
@@ -1,0 +1,3 @@
+module A where
+
+class X

--- a/tests/purs/failing/ExportConflictClassAndType/B.purs
+++ b/tests/purs/failing/ExportConflictClassAndType/B.purs
@@ -1,0 +1,3 @@
+module B where
+
+data X

--- a/tests/support/bower.json
+++ b/tests/support/bower.json
@@ -24,7 +24,7 @@
     "purescript-newtype": "3.0.0",
     "purescript-nonempty": "5.0.0",
     "purescript-partial": "2.0.0",
-    "purescript-prelude": "4.0.0",
+    "purescript-prelude": "4.1.0",
     "purescript-proxy": "3.0.0",
     "purescript-psci-support": "4.0.0",
     "purescript-refs": "4.1.0",
@@ -33,7 +33,7 @@
     "purescript-tailrec": "4.0.0",
     "purescript-tuples": "5.0.0",
     "purescript-type-equality": "3.0.0",
-    "purescript-typelevel-prelude": "3.0.0",
+    "purescript-typelevel-prelude": "4.0.1",
     "purescript-unfoldable": "4.0.0",
     "purescript-unsafe-coerce": "4.0.0"
   }


### PR DESCRIPTION
Re: #3502.

This PR follows the suggestion of disallowing the re-export. Let me know if I missed anything or if anything needs to change!

The tests are currently failing because of https://github.com/purescript/purescript-typelevel-prelude/issues/43.