### PR TITLE
Make git consider *.out files as binary for the golden tests

### DIFF
--- a/tests/purs/layout/.gitattributes
+++ b/tests/purs/layout/.gitattributes
@@ -1,0 +1,1 @@
+*.out -merge -text


### PR DESCRIPTION
Fixes #3655 