### PR TITLE
Tighten base lower bound

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -40,7 +40,7 @@ dependencies:
   - aeson-better-errors >=0.8
   - ansi-terminal >=0.7.1 && <0.9
   - array
-  - base >=4.8 && <4.13
+  - base >=4.11 && <4.13
   - base-compat >=0.6.0
   - blaze-html >=0.8.1 && <0.10
   - bower-json >=1.0.0.1 && <1.1


### PR DESCRIPTION
Refs #3654. The PureScript compiler does not build on earlier versions
of `base`; see e.g. https://matrix.hackage.haskell.org/#/package/purescript/0.12.5/ghc-8.2.2@1559223206