### PR TITLE
Fixes to allow building with Cabal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ dist
 cabal-dev
 .cabal-sandbox
 cabal.sandbox.config
+dist-newstyle/
+cabal.project.local*
 *.o
 *.hi
 *.chi

--- a/package.yaml
+++ b/package.yaml
@@ -89,6 +89,8 @@ dependencies:
   - unordered-containers
   - utf8-string >=1 && <2
   - vector
+build-tools:
+  - happy ==1.19.9
 
 library:
   source-dirs: src


### PR DESCRIPTION
Fixes #3654 by specifying the same version of happy that we are using
via the Stack snapshot. Also add .gitignore entries for new-style cabal
projects.