### PR TITLE
Add upper bounds when producing source distributions

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
 resolver: lts-13.12
+pvp-bounds: upper
 packages:
 - '.'
 extra-deps:


### PR DESCRIPTION
This change means that stack will add upper bounds to our cabal file
when producing source distributions (e.g. for uploading to Hackage),
which means that we are less likely to run into solving/building
difficulties if new versions of our dependencies get released in the
meantime.

Comparing a `build-depends` section of the purescript.cabal file in a
source distribution before and after this change:

Before
```
      Cabal >=2.2
    , Glob >=0.9 && <0.10
    , aeson >=1.0 && <1.5
    , aeson-better-errors >=0.8
    , ansi-terminal >=0.7.1 && <0.9
    , array
    , base >=4.11 && <4.13
    , base-compat >=0.6.0
    , blaze-html >=0.8.1 && <0.10
    , bower-json >=1.0.0.1 && <1.1
    , boxes >=0.1.4 && <0.2.0
    , bytestring
    , cheapskate >=0.1 && <0.2
    , clock
    , containers
    , data-ordlist >=0.4.7.0
    , deepseq
    , directory >=1.2.3
    , dlist

```

After
```
        Cabal >=2.2 && <2.5,
        Glob ==0.9.*,
        aeson >=1.0 && <1.5,
        aeson-better-errors >=0.8 && <0.10,
        ansi-terminal >=0.7.1 && <0.9,
        array <0.6,
        base >=4.11 && <4.13,
        base-compat >=0.6.0 && <0.11,
        blaze-html >=0.8.1 && <0.10,
        bower-json >=1.0.0.1 && <1.1,
        boxes >=0.1.4 && <0.2.0,
        bytestring <0.11,
        cheapskate ==0.1.*,
        clock <0.8,
        containers <0.7,
        data-ordlist >=0.4.7.0 && <0.5,
        deepseq <1.5,
        directory >=1.2.3 && <1.4,
        dlist <0.9,
```

Note in particular that e.g. `array` (no bounds) becomes `array <0.6`,
and `Cabal >=2.2` becomes `Cabal >=2.2 && <2.5`.

The `purescript.cabal` file generated by hpack for local development
is unchanged. I think this is fine, because if our version bounds turn
out to be wrong during local development we can just fix them then and
there.