### PR TITLE
Fix printing of tokens with string escapes

### DIFF
--- a/src/Language/PureScript/CST/Lexer.hs
+++ b/src/Language/PureScript/CST/Lexer.hs
@@ -495,9 +495,9 @@ token = peek >>= maybe (pure TokEof) k0
   escape = do
     ch <- peek
     case ch of
-      Just 't'  -> next $> ("\t", '\t')
-      Just 'r'  -> next $> ("\\r", '\r')
-      Just 'n'  -> next $> ("\\n", '\n')
+      Just 't'  -> next $> ("t", '\t')
+      Just 'r'  -> next $> ("r", '\r')
+      Just 'n'  -> next $> ("n", '\n')
       Just '"'  -> next $> ("\"", '"')
       Just '\'' -> next $> ("'", '\'')
       Just '\\' -> next $> ("\\", '\\')
@@ -508,7 +508,7 @@ token = peek >>= maybe (pure TokEof) k0
           go n acc _
             | n <= 0x10FFFF =
                 ksucc (Text.drop (length acc) inp)
-                  (Text.pack $ reverse acc, Char.chr n)
+                  ("x" <> Text.pack (reverse acc), Char.chr n)
             | otherwise =
                 kerr inp ErrCharEscape -- TODO
         go 0 [] $ Text.unpack $ Text.take 6 inp


### PR DESCRIPTION
- Modify generators so that string escapes are more likely to appear
- Clarify error message when a roundtrip fails (so that we can
  distinguish whether parsing failed the first or second time)
- Fix a bug where the lexer would include extra slashes in the raw
  component of string and char tokens