### PR TITLE
Add --debug flag to bundle command

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -38,6 +38,7 @@ extra-source-files:
 dependencies:
   - aeson >=1.0 && <1.5
   - aeson-better-errors >=0.8
+  - aeson-pretty
   - ansi-terminal >=0.7.1 && <0.9
   - array
   - base >=4.11 && <4.13

--- a/src/Language/PureScript/Bundle.hs
+++ b/src/Language/PureScript/Bundle.hs
@@ -14,6 +14,7 @@ module Language.PureScript.Bundle
   , ErrorMessage(..)
   , printErrorMessage
   , getExportedIdentifiers
+  , Module
   ) where
 
 import Prelude.Compat
@@ -23,6 +24,7 @@ import Control.Monad
 import Control.Monad.Error.Class
 import Control.Arrow ((&&&))
 
+import Data.Aeson ((.=))
 import Data.Array ((!))
 import Data.Char (chr, digitToInt)
 import Data.Foldable (fold)
@@ -31,6 +33,7 @@ import Data.Graph
 import Data.List (stripPrefix)
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import Data.Version (showVersion)
+import qualified Data.Aeson as A
 import qualified Data.Map as M
 import qualified Data.Set as S
 
@@ -68,6 +71,12 @@ showModuleType Foreign = "Foreign"
 
 -- | A module is identified by its module name and its type.
 data ModuleIdentifier = ModuleIdentifier String ModuleType deriving (Show, Eq, Ord)
+
+instance A.ToJSON ModuleIdentifier where
+  toJSON (ModuleIdentifier name mt) =
+    A.object [ "name" .= name
+             , "type" .= show mt
+             ]
 
 moduleName :: ModuleIdentifier -> String
 moduleName (ModuleIdentifier name _) = name
@@ -110,8 +119,61 @@ data ModuleElement
   | Skip JSStatement
   deriving (Show)
 
+instance A.ToJSON ModuleElement where
+  toJSON = \case
+    (Require _ name (Right target)) ->
+      A.object [ "type"   .= A.String "Require"
+               , "name"   .= name
+               , "target" .= target
+               ]
+    (Require _ name (Left targetPath)) ->
+      A.object [ "type"       .= A.String "Require"
+               , "name"       .= name
+               , "targetPath" .= targetPath
+               ]
+    (Member _ public name _ dependsOn) ->
+      A.object [ "type"       .= A.String "Member"
+               , "name"       .= name
+               , "visibility" .= A.String (if public then "Public" else "Internal")
+               , "dependsOn"  .= map keyToJSON dependsOn
+               ]
+    (ExportsList exports) ->
+      A.object [ "type"    .= A.String "ExportsList"
+               , "exports" .= map exportToJSON exports
+               ]
+    (Other _) ->
+      A.object [ "type" .= A.String "Other" ]
+    (Skip _) ->
+      A.object [ "type" .= A.String "Skip" ]
+
+    where
+
+    keyToJSON (mid, member) =
+      A.object [ "module" .= mid
+               , "member" .= member
+               ]
+
+    exportToJSON (RegularExport sourceName, name, _, dependsOn) =
+      A.object [ "type"       .= A.String "RegularExport"
+               , "name"       .= name
+               , "sourceName" .= sourceName
+               , "dependsOn"  .= map keyToJSON dependsOn
+               ]
+    exportToJSON (ForeignReexport, name, _, dependsOn) =
+      A.object [ "type"      .= A.String "ForeignReexport"
+               , "name"      .= name
+               , "dependsOn" .= map keyToJSON dependsOn
+               ]
+
 -- | A module is just a list of elements of the types listed above.
 data Module = Module ModuleIdentifier (Maybe FilePath) [ModuleElement] deriving (Show)
+
+instance A.ToJSON Module where
+  toJSON (Module moduleId filePath elements) =
+    A.object [ "moduleId" .= moduleId
+             , "filePath" .= filePath
+             , "elements" .= elements
+             ]
 
 -- | Prepare an error message for consumption by humans.
 printErrorMessage :: ErrorMessage -> [String]
@@ -730,8 +792,9 @@ bundleSM :: (MonadError ErrorMessage m)
        -> Maybe String -- ^ An optional main module.
        -> String -- ^ The namespace (e.g. PS).
        -> Maybe FilePath -- ^ The output file name (if there is one - in which case generate source map)
+       -> Maybe ([Module] -> m ()) -- ^ Optionally report the parsed modules prior to DCE -- used by "bundle --debug"
        -> m (Maybe SourceMapping, String)
-bundleSM inputStrs entryPoints mainModule namespace outFilename = do
+bundleSM inputStrs entryPoints mainModule namespace outFilename reportRawModules = do
   let mid (a,_,_) = a
   forM_ mainModule $ \mname ->
     when (mname `notElem` map (moduleName . mid) inputStrs) (throwError (MissingMainModule mname))
@@ -744,6 +807,8 @@ bundleSM inputStrs entryPoints mainModule namespace outFilename = do
   let mids = S.fromList (map (moduleName . mid) input)
 
   modules <- traverse (fmap withDeps . (\(a,fn,c) -> toModule mids a fn c)) input
+
+  forM_ reportRawModules ($ modules)
 
   let compiled = compile modules entryPoints
       sorted   = sortModules (filter (not . isModuleEmpty) compiled)
@@ -759,4 +824,4 @@ bundle :: (MonadError ErrorMessage m)
        -> Maybe String -- ^ An optional main module.
        -> String -- ^ The namespace (e.g. PS).
        -> m String
-bundle inputStrs entryPoints mainModule namespace = snd <$> bundleSM (map (\(a,b) -> (a,Nothing,b)) inputStrs) entryPoints mainModule namespace Nothing
+bundle inputStrs entryPoints mainModule namespace = snd <$> bundleSM (map (\(a,b) -> (a,Nothing,b)) inputStrs) entryPoints mainModule namespace Nothing Nothing

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,3 +12,6 @@ nix:
   - nodejs
   - nodePackages.npm
   - nodePackages.bower
+flags:
+  aeson-pretty:
+    lib-only: true

--- a/tests/TestBundle.hs
+++ b/tests/TestBundle.hs
@@ -74,7 +74,7 @@ assertBundles supportModules supportExterns supportForeigns inputFiles outputFil
             js <- liftIO $ readUTF8File filename
             mid <- guessModuleIdentifier filename
             length js `seq` return (mid, Just filename, js) 
-          bundleSM input entryModule (Just $ "Main") "PS" (Just entryPoint)
+          bundleSM input entryModule (Just $ "Main") "PS" (Just entryPoint) Nothing
         case bundled of
             Right (_, js) -> do
               writeUTF8File entryPoint js


### PR DESCRIPTION
This flag causes an optimized-for-humans JSON representation of the
modules being bundled to be dumped to stderr, prior to dead code
elimination.  This feature was requested in the review of #3562.

---

*<waves at @hdgarrood>*

[Here's some sample output](https://gist.github.com/rhendric/8ace4d8280972bc5b596c5537d8b0a90), generated by running `bundle --debug` on `Data.Functor*`.