### PR TITLE
Ignore duplicate file inputs to compile command (#3653)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -133,6 +133,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@jordanmartinez](https://github.com/jordanmartinez) | Jordan Martinez | [MIT license](http://opensource.org/licenses/MIT) |
 | [@Saulukass](https://github.com/Saulukass) | Saulius Skliutas | [MIT license](http://opensource.org/licenses/MIT) |
 | [@adnelson](https://github.com/adnelson) | Allen Nelson | [MIT license](http://opensource.org/licenses/MIT) |
+| [@dyerw](https://github.com/dyerw) | Liam Dyer | [MIT license](http://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms
 

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 
 module Command.Compile (command) where
 
@@ -11,10 +10,9 @@ import           Control.Monad
 import qualified Data.Aeson as A
 import           Data.Bool (bool)
 import qualified Data.ByteString.Lazy.UTF8 as LBU8
-import           Data.List (intercalate, nub)
+import           Data.List (intercalate)
 import qualified Data.Map as M
 import qualified Data.Set as S
-import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Traversable (for)
 import qualified Language.PureScript as P
@@ -27,7 +25,7 @@ import           System.Exit (exitSuccess, exitFailure)
 import           System.Directory (getCurrentDirectory)
 import           System.FilePath.Glob (glob)
 import           System.IO (hPutStr, hPutStrLn, stderr)
-import           System.IO.UTF8 (readUTF8FileT)
+import           System.IO.UTF8 (readUTF8FilesTUnique)
 
 data PSCMakeOptions = PSCMakeOptions
   { pscmInput        :: [FilePath]
@@ -64,7 +62,7 @@ compile PSCMakeOptions{..} = do
                              , "Usage: For basic information, try the `--help' option."
                              ]
     exitFailure
-  moduleFiles <- readInput (nub input)
+  moduleFiles <- readUTF8FilesTUnique input
   (makeErrors, makeWarnings) <- runMake pscmOpts $ do
     ms <- CST.parseModulesFromFiles id moduleFiles
     let filePathMap = M.fromList $ map (\(fp, pm) -> (P.getModuleName $ CST.resPartial pm, Right fp)) ms
@@ -85,9 +83,6 @@ globWarningOnMisses warn = concatMapM globWithWarning
     when (null paths) $ warn pattern'
     return paths
   concatMapM f = fmap concat . mapM f
-
-readInput :: [FilePath] -> IO [(FilePath, Text)]
-readInput inputFiles = forM inputFiles $ \inFile -> (inFile, ) <$> readUTF8FileT inFile
 
 inputFile :: Opts.Parser FilePath
 inputFile = Opts.strArgument $

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -25,7 +25,7 @@ import           System.Exit (exitSuccess, exitFailure)
 import           System.Directory (getCurrentDirectory)
 import           System.FilePath.Glob (glob)
 import           System.IO (hPutStr, hPutStrLn, stderr)
-import           System.IO.UTF8 (readUTF8FilesTUnique)
+import           System.IO.UTF8 (readUTF8FilesT)
 
 data PSCMakeOptions = PSCMakeOptions
   { pscmInput        :: [FilePath]
@@ -62,7 +62,7 @@ compile PSCMakeOptions{..} = do
                              , "Usage: For basic information, try the `--help' option."
                              ]
     exitFailure
-  moduleFiles <- readUTF8FilesTUnique input
+  moduleFiles <- readUTF8FilesT input
   (makeErrors, makeWarnings) <- runMake pscmOpts $ do
     ms <- CST.parseModulesFromFiles id moduleFiles
     let filePathMap = M.fromList $ map (\(fp, pm) -> (P.getModuleName $ CST.resPartial pm, Right fp)) ms

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -11,7 +11,7 @@ import           Control.Monad
 import qualified Data.Aeson as A
 import           Data.Bool (bool)
 import qualified Data.ByteString.Lazy.UTF8 as LBU8
-import           Data.List (intercalate)
+import           Data.List (intercalate, nub)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import           Data.Text (Text)
@@ -37,7 +37,7 @@ data PSCMakeOptions = PSCMakeOptions
   , pscmJSONErrors   :: Bool
   }
 
--- | Argumnets: verbose, use JSON, warnings, errors
+-- | Arguments: verbose, use JSON, warnings, errors
 printWarningsAndErrors :: Bool -> Bool -> P.MultipleErrors -> Either P.MultipleErrors a -> IO ()
 printWarningsAndErrors verbose False warnings errors = do
   pwd <- getCurrentDirectory
@@ -64,7 +64,7 @@ compile PSCMakeOptions{..} = do
                              , "Usage: For basic information, try the `--help' option."
                              ]
     exitFailure
-  moduleFiles <- readInput input
+  moduleFiles <- readInput (nub input)
   (makeErrors, makeWarnings) <- runMake pscmOpts $ do
     ms <- CST.parseModulesFromFiles id moduleFiles
     let filePathMap = M.fromList $ map (\(fp, pm) -> (P.getModuleName $ CST.resPartial pm, Right fp)) ms

--- a/app/Command/Hierarchy.hs
+++ b/app/Command/Hierarchy.hs
@@ -30,7 +30,7 @@ import           System.FilePath ((</>))
 import           System.FilePath.Glob (glob)
 import           System.Exit (exitFailure, exitSuccess)
 import           System.IO (hPutStr, stderr)
-import           System.IO.UTF8 (readUTF8FilesTUnique)
+import           System.IO.UTF8 (readUTF8FilesT)
 import qualified Language.PureScript as P
 import qualified Language.PureScript.CST as CST
 import           Language.PureScript.Hierarchy (Graph(..), _unDigraph, _unGraphName, typeClasses)
@@ -42,7 +42,7 @@ data HierarchyOptions = HierarchyOptions
 
 parseInput :: [FilePath] -> IO (Either P.MultipleErrors [P.Module])
 parseInput paths = do
-  content <- readUTF8FilesTUnique paths
+  content <- readUTF8FilesT paths
   return $ map snd <$> CST.parseFromFiles id content
 
 compile :: HierarchyOptions -> IO ()

--- a/app/Command/Hierarchy.hs
+++ b/app/Command/Hierarchy.hs
@@ -13,7 +13,6 @@
 --
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE DataKinds #-}
 
 module Command.Hierarchy (command) where
@@ -31,7 +30,7 @@ import           System.FilePath ((</>))
 import           System.FilePath.Glob (glob)
 import           System.Exit (exitFailure, exitSuccess)
 import           System.IO (hPutStr, stderr)
-import           System.IO.UTF8 (readUTF8FileT)
+import           System.IO.UTF8 (readUTF8FilesTUnique)
 import qualified Language.PureScript as P
 import qualified Language.PureScript.CST as CST
 import           Language.PureScript.Hierarchy (Graph(..), _unDigraph, _unGraphName, typeClasses)
@@ -41,15 +40,15 @@ data HierarchyOptions = HierarchyOptions
   , _hierarchyOutput :: Maybe FilePath
   }
 
-readInput :: [FilePath] -> IO (Either P.MultipleErrors [P.Module])
-readInput paths = do
-  content <- mapM (\path -> (path, ) <$> readUTF8FileT path) paths
+parseInput :: [FilePath] -> IO (Either P.MultipleErrors [P.Module])
+parseInput paths = do
+  content <- readUTF8FilesTUnique paths
   return $ map snd <$> CST.parseFromFiles id content
 
 compile :: HierarchyOptions -> IO ()
 compile (HierarchyOptions inputGlob mOutput) = do
   input <- glob inputGlob
-  modules <- readInput input
+  modules <- parseInput input
   case modules of
     Left errs -> hPutStr stderr (P.prettyPrintMultipleErrors P.defaultPPEOptions errs) >> exitFailure
     Right ms -> do

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ dependencies:
   - directory >=1.2.3
   - dlist
   - edit-distance
+  - extra
   - file-embed
   - filepath
   - fsnotify >=0.2.1

--- a/package.yaml
+++ b/package.yaml
@@ -57,7 +57,6 @@ dependencies:
   - directory >=1.2.3
   - dlist
   - edit-distance
-  - extra
   - file-embed
   - filepath
   - fsnotify >=0.2.1

--- a/src/Language/PureScript/Docs/Collect.hs
+++ b/src/Language/PureScript/Docs/Collect.hs
@@ -13,7 +13,7 @@ import Data.String (String)
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import System.FilePath ((</>))
-import System.IO.UTF8 (readUTF8FileT, readUTF8FilesTUnique)
+import System.IO.UTF8 (readUTF8FileT, readUTF8FilesT)
 
 import Language.PureScript.Docs.Convert.ReExports (updateReExports)
 import Language.PureScript.Docs.Prim (primModules)
@@ -89,7 +89,7 @@ compileForDocs ::
   m [P.ExternsFile]
 compileForDocs outputDir inputFiles = do
   result <- liftIO $ do
-    moduleFiles <- readUTF8FilesTUnique inputFiles
+    moduleFiles <- readUTF8FilesT inputFiles
     fmap fst $ P.runMake testOptions $ do
       ms <- P.parseModulesFromFiles identity moduleFiles
       let filePathMap = Map.fromList $ map (\(fp, pm) -> (P.getModuleName $ P.resPartial pm, Right fp)) ms

--- a/src/Language/PureScript/Docs/Collect.hs
+++ b/src/Language/PureScript/Docs/Collect.hs
@@ -13,7 +13,7 @@ import Data.String (String)
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import System.FilePath ((</>))
-import System.IO.UTF8 (readUTF8FileT)
+import System.IO.UTF8 (readUTF8FileT, readUTF8FilesTUnique)
 
 import Language.PureScript.Docs.Convert.ReExports (updateReExports)
 import Language.PureScript.Docs.Prim (primModules)
@@ -89,7 +89,7 @@ compileForDocs ::
   m [P.ExternsFile]
 compileForDocs outputDir inputFiles = do
   result <- liftIO $ do
-    moduleFiles <- readInput inputFiles
+    moduleFiles <- readUTF8FilesTUnique inputFiles
     fmap fst $ P.runMake testOptions $ do
       ms <- P.parseModulesFromFiles identity moduleFiles
       let filePathMap = Map.fromList $ map (\(fp, pm) -> (P.getModuleName $ P.resPartial pm, Right fp)) ms
@@ -105,10 +105,6 @@ compileForDocs outputDir inputFiles = do
   renderProgressMessage :: P.ProgressMessage -> String
   renderProgressMessage (P.CompilingModule mn) =
     "Compiling documentation for " ++ T.unpack (P.runModuleName mn)
-
-  readInput :: [FilePath] -> IO [(FilePath, Text)]
-  readInput files =
-    forM files $ \inFile -> (inFile, ) <$> readUTF8FileT inFile
 
   testOptions :: P.Options
   testOptions = P.defaultOptions { P.optionsCodegenTargets = Set.singleton P.Docs }

--- a/src/Language/PureScript/Interactive/Module.hs
+++ b/src/Language/PureScript/Interactive/Module.hs
@@ -7,7 +7,7 @@ import qualified Language.PureScript.CST as CST
 import           Language.PureScript.Interactive.Types
 import           System.Directory (getCurrentDirectory)
 import           System.FilePath (pathSeparator, makeRelative)
-import           System.IO.UTF8 (readUTF8FileT, readUTF8FilesTUnique)
+import           System.IO.UTF8 (readUTF8FileT, readUTF8FilesT)
 
 -- * Support Module
 
@@ -34,7 +34,7 @@ loadModule filename = do
 loadAllModules :: [FilePath] -> IO (Either P.MultipleErrors [(FilePath, P.Module)])
 loadAllModules files = do
   pwd <- getCurrentDirectory
-  filesAndContent <- readUTF8FilesTUnique files
+  filesAndContent <- readUTF8FilesT files
   return $ CST.parseFromFiles (makeRelative pwd) filesAndContent
 
 -- |

--- a/src/Language/PureScript/Interactive/Module.hs
+++ b/src/Language/PureScript/Interactive/Module.hs
@@ -2,13 +2,12 @@ module Language.PureScript.Interactive.Module where
 
 import           Prelude.Compat
 
-import           Control.Monad
 import qualified Language.PureScript as P
 import qualified Language.PureScript.CST as CST
 import           Language.PureScript.Interactive.Types
 import           System.Directory (getCurrentDirectory)
 import           System.FilePath (pathSeparator, makeRelative)
-import           System.IO.UTF8 (readUTF8FileT)
+import           System.IO.UTF8 (readUTF8FileT, readUTF8FilesTUnique)
 
 -- * Support Module
 
@@ -35,9 +34,7 @@ loadModule filename = do
 loadAllModules :: [FilePath] -> IO (Either P.MultipleErrors [(FilePath, P.Module)])
 loadAllModules files = do
   pwd <- getCurrentDirectory
-  filesAndContent <- forM files $ \filename -> do
-    content <- readUTF8FileT filename
-    return (filename, content)
+  filesAndContent <- readUTF8FilesTUnique files
   return $ CST.parseFromFiles (makeRelative pwd) filesAndContent
 
 -- |

--- a/src/System/IO/UTF8.hs
+++ b/src/System/IO/UTF8.hs
@@ -4,25 +4,22 @@ module System.IO.UTF8 where
 
 import Prelude.Compat
 
-import           Control.Monad
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Search as BSS
 import qualified Data.ByteString.UTF8 as UTF8
-import           Data.List.Extra (nubOrd)
 import           Data.Text (Text)
 import qualified Data.Text.Encoding as TE
+import           Protolude (ordNub)
 
 -- | Unfortunately ByteString's readFile does not convert line endings on
 -- Windows, so we have to do it ourselves
 fixCRLF :: BS.ByteString -> BS.ByteString
 fixCRLF = BSL.toStrict . BSS.replace "\r\n" ("\n" :: BS.ByteString)
 
-readUTF8FilesTUnique :: [FilePath] -> IO [(FilePath, Text)]
-readUTF8FilesTUnique =  readUTF8FilesT . nubOrd
-
 readUTF8FilesT :: [FilePath] -> IO [(FilePath, Text)]
-readUTF8FilesT inputFiles = forM inputFiles $ \inFile -> (inFile, ) <$> readUTF8FileT inFile
+readUTF8FilesT =
+  traverse (\inFile -> (inFile, ) <$> readUTF8FileT inFile) . ordNub
 
 readUTF8FileT :: FilePath -> IO Text
 readUTF8FileT inFile =

--- a/src/System/IO/UTF8.hs
+++ b/src/System/IO/UTF8.hs
@@ -1,11 +1,15 @@
+{-# LANGUAGE TupleSections #-}
+
 module System.IO.UTF8 where
 
 import Prelude.Compat
 
+import           Control.Monad
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Search as BSS
 import qualified Data.ByteString.UTF8 as UTF8
+import           Data.List.Extra (nubOrd)
 import           Data.Text (Text)
 import qualified Data.Text.Encoding as TE
 
@@ -13,6 +17,12 @@ import qualified Data.Text.Encoding as TE
 -- Windows, so we have to do it ourselves
 fixCRLF :: BS.ByteString -> BS.ByteString
 fixCRLF = BSL.toStrict . BSS.replace "\r\n" ("\n" :: BS.ByteString)
+
+readUTF8FilesTUnique :: [FilePath] -> IO [(FilePath, Text)]
+readUTF8FilesTUnique =  readUTF8FilesT . nubOrd
+
+readUTF8FilesT :: [FilePath] -> IO [(FilePath, Text)]
+readUTF8FilesT inputFiles = forM inputFiles $ \inFile -> (inFile, ) <$> readUTF8FileT inFile
 
 readUTF8FileT :: FilePath -> IO Text
 readUTF8FileT inFile =


### PR DESCRIPTION
Resolves #3653 

If we should do the `nub` call in the `readInput` function that'd be fine too. But this is the only place it's called. Not sure if it matters if that's the behavior of `compile` specifically or `readInput`.

I couldn't find tests for the command line interface but if there are some I'm happy to add one.

Also fixed a spelling mistake =P