### PR TITLE
Fix multiple "let"s in ado before the final "in"

### DIFF
--- a/src/Language/PureScript/CST/Layout.hs
+++ b/src/Language/PureScript/CST/Layout.hs
@@ -146,13 +146,15 @@ insertLayout src@(SourceToken tokAnn tok) nextPos stack =
       inP _ lyt    = isIndented lyt
 
     TokLowerName [] "let" ->
-      case stk of
+      state & insertKwProperty next
+      where
+      next state'@(stk', _) = case stk' of
         (p, LytDo) : _ | srcColumn p == srcColumn tokPos ->
-          state & insertKwProperty (insertStart LytLetStmt)
+          state' & insertStart LytLetStmt
         (p, LytAdo) : _ | srcColumn p == srcColumn tokPos ->
-          state & insertKwProperty (insertStart LytLetStmt)
+          state' & insertStart LytLetStmt
         _ ->
-          state & insertKwProperty (insertStart LytLet)
+          state' & insertStart LytLet
 
     TokLowerName _ "do" ->
       state & insertKwProperty (insertStart LytDo)

--- a/tests/purs/layout/AdoIn.out
+++ b/tests/purs/layout/AdoIn.out
@@ -10,5 +10,11 @@ test = ado {}in foo;
 test = ado{
   foo <- bar $ let {a = 42 }in a;
   baz <- b}
+  in bar;
+
+test = ado{
+  foo;
+  let {bar = let {a = 42 }in a};
+  let {baz = 42}}
   in bar}
 <eof>

--- a/tests/purs/layout/AdoIn.purs
+++ b/tests/purs/layout/AdoIn.purs
@@ -11,3 +11,9 @@ test = ado
   foo <- bar $ let a = 42 in a
   baz <- b
   in bar
+
+test = ado
+  foo
+  let bar = let a = 42 in a
+  let baz = 42
+  in bar


### PR DESCRIPTION
This failed because we were checking the layout stack before collapsing
it. Subsequent let statements were tagged as a normal LytLet context
instead of a LytLetStmt context because the previous LytLetStmt was on
top of the stack instead of LytAdo/LytDo. By collapsing first, it pops
the previous LytLetStmt, and we get the LytAdo/LytDo on top again.

Fixes #3675 