### PR TITLE
Fix record-unification issue:

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -133,6 +133,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@jordanmartinez](https://github.com/jordanmartinez) | Jordan Martinez | [MIT license](http://opensource.org/licenses/MIT) |
 | [@Saulukass](https://github.com/Saulukass) | Saulius Skliutas | [MIT license](http://opensource.org/licenses/MIT) |
 | [@adnelson](https://github.com/adnelson) | Allen Nelson | [MIT license](http://opensource.org/licenses/MIT) |
+| [@matthew-hilty](https://github.com/matthew-hilty) | Matthew Hilty | [MIT license](http://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms
 

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -180,6 +180,13 @@ lookupTypeClassDictionariesForClass
   -> m (M.Map (Qualified Ident) (NEL.NonEmpty NamedDict))
 lookupTypeClassDictionariesForClass mn cn = fromMaybe M.empty . M.lookup cn <$> lookupTypeClassDictionaries mn
 
+-- | Generate the type class dictionary for a given constraint and CheckState.
+getTypeClassDictionary :: MonadState CheckState m => SourceConstraint -> m Expr
+getTypeClassDictionary con = do
+  dicts <- getTypeClassDictionaries
+  hints <- getHints
+  return $ TypeClassDictionary con dicts hints
+
 -- | Temporarily bind a collection of names to local variables
 bindLocalVariables
   :: (MonadState CheckState m)

--- a/tests/purs/passing/PolyTypedRowInArgToConstrainedFn.purs
+++ b/tests/purs/passing/PolyTypedRowInArgToConstrainedFn.purs
@@ -1,0 +1,23 @@
+module Main where
+
+import Prelude (class Functor, Unit, identity)
+import Effect (Effect)
+import Effect.Console (log)
+import Type.RowList (class RowToList, Cons, RLProxy(RLProxy), kind RowList)
+
+class GId (l :: RowList) (r :: # Type) | l -> r where
+  gId :: RLProxy l -> Record r -> Record r
+
+instance gIdCons :: GId (Cons s (va -> vb) l') r where
+  gId l record = record
+
+id :: forall l r. GId l r => RowToList r l => Record r -> Record r
+id = gId (RLProxy :: RLProxy l)
+
+x1 = id { a: (identity :: forall a. a -> a) }
+x2 = id ({ a: identity } :: { a :: forall a. a -> a })
+x3 = id ({ a: (identity :: forall a. a -> a) } :: { a :: forall a. a -> a })
+x4 = id { a: (identity :: forall a f. Functor f => f a -> f a) }
+
+main :: Effect Unit
+main = log "Done"

--- a/tests/purs/passing/VarForPolyTypedRowAsArgToConstrainedFn.purs
+++ b/tests/purs/passing/VarForPolyTypedRowAsArgToConstrainedFn.purs
@@ -1,0 +1,23 @@
+module Main where
+
+import Prelude (Unit, identity)
+import Effect (Effect)
+import Effect.Console (log)
+import Type.RowList (class RowToList, Cons, RLProxy(RLProxy), kind RowList)
+
+class GId (l :: RowList) (r :: # Type) | l -> r where
+  gId :: RLProxy l -> Record r -> Record r
+
+instance gIdCons :: GId (Cons s (va -> vb) l') r where
+  gId l record = record
+
+id :: forall l r. GId l r => RowToList r l => Record r -> Record r
+id = gId (RLProxy :: RLProxy l)
+
+x0 :: { a :: forall a. a -> a }
+x0 = { a: (identity :: forall a. a -> a) }
+
+x1 = id x0
+
+main :: Effect Unit
+main = log "Done"


### PR DESCRIPTION
* In type checking and subsumption, strip row types of 'ForAll' nodes, and replace type variables with unification variables so that later typeclass resolution can be accomplished.

Here are two examples for which the described changes are necessary:

```purescript
class GId (l :: RowList) (r :: # Type) | l -> r where
  gId :: RLProxy l -> Record r -> Record r

instance gIdCons :: GId (Cons s (va -> vb) l') r where
  gId l record = record

id :: forall l r. GId l r => RowToList r l => Record r -> Record r
id = gId (RLProxy :: RLProxy l)

example1 = id { a: (identity :: forall a. a -> a) }

x :: { a :: forall a. a -> a }
x = { a: (identity :: forall a. a -> a) }

example2 = id x
```