### PR TITLE
Update to GHC 8.6.5, lts 13.26

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -92,7 +92,7 @@ dependencies:
   - utf8-string >=1 && <2
   - vector
 build-tools:
-  - happy ==1.19.11
+  - happy ==1.19.9
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -62,7 +62,7 @@ dependencies:
   - fsnotify >=0.2.1
   - Glob >=0.9 && <0.10
   - haskeline >=0.7.0.0
-  - language-javascript >=0.6.0.9 && <0.7
+  - language-javascript >=0.6.0.13
   - lifted-async >=0.10.0.3 && <0.10.1
   - lifted-base >=0.2.3 && <0.2.4
   - microlens-platform >=0.3.9.0 && <0.4
@@ -92,7 +92,7 @@ dependencies:
   - utf8-string >=1 && <2
   - vector
 build-tools:
-  - happy ==1.19.9
+  - happy ==1.19.11
 
 library:
   source-dirs: src

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,8 +3,9 @@ pvp-bounds: upper
 packages:
 - '.'
 extra-deps:
-- network-3.0.1.1
+- happy-1.19.9
 - language-javascript-0.6.0.13
+- network-3.0.1.1
 nix:
   enable: false
   packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,10 @@
-resolver: lts-13.12
+resolver: lts-13.26
 pvp-bounds: upper
 packages:
 - '.'
 extra-deps:
 - network-3.0.1.1
+- language-javascript-0.6.0.13
 nix:
   enable: false
   packages:


### PR DESCRIPTION
I'm hoping this will fix an access violation seen in Windows CI:

    <https://travis-ci.org/purescript/purescript/jobs/549447718>

but updating things is probably a good idea in general anyway.

I've tightened the lower bound on language-javascript to 0.6.0.13,
because version 0.6.0.12 (the version in the snapshot we're now using)
has a bug where it does not consider `as` to be a valid identifier.