### PR TITLE
Throw a parse error (not internal error) when using quoted labels as puns

### DIFF
--- a/src/Language/PureScript/CST/Errors.hs
+++ b/src/Language/PureScript/CST/Errors.hs
@@ -33,6 +33,7 @@ data ParserErrorType
   | ErrGuardInLetBinder
   | ErrKeywordVar
   | ErrKeywordSymbol
+  | ErrQuotedPun
   | ErrToken
   | ErrLineFeedInString
   | ErrAstralCodePointInChar
@@ -103,6 +104,8 @@ prettyPrintErrorMessage (ParserError {..}) = case errType of
     "Expected variable, saw keyword"
   ErrKeywordSymbol ->
     "Expected symbol, saw reserved symbol"
+  ErrQuotedPun ->
+    "Unexpected quoted label in record pun, perhaps due to a missing ':'"
   ErrEof ->
     "Unexpected end of input"
   ErrLexeme (Just (hd : _)) _ | isSpace hd ->

--- a/src/Language/PureScript/CST/Utils.hs
+++ b/src/Language/PureScript/CST/Utils.hs
@@ -107,6 +107,8 @@ toName k tok = case tokValue tok of
   TokLowerName [] a
     | not (Set.member a reservedNames) -> pure $ Name tok (k a)
     | otherwise -> addFailure [tok] ErrKeywordVar $> Name tok (k "<unexpected>")
+  TokString _ _ -> parseFail tok ErrQuotedPun
+  TokRawString _ -> parseFail tok ErrQuotedPun
   TokUpperName [] a  -> pure $ Name tok (k a)
   TokSymbolName [] a -> pure $ Name tok (k a)
   TokOperator [] a   -> pure $ Name tok (k a)

--- a/tests/purs/failing/3689.purs
+++ b/tests/purs/failing/3689.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith ErrorParsingModule
+module Main where
+
+test =
+  { "bad"
+  }


### PR DESCRIPTION
Fixes #3689