### PR TITLE
Bump to v0.13.1

### DIFF
--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "license": "ISC",
   "description": "PureScript wrapper that makes it available as a local dependency",
   "author": {
@@ -42,7 +42,7 @@
     "wrapper"
   ],
   "scripts": {
-    "postinstall": "install-purescript --purs-ver=0.13.0",
+    "postinstall": "install-purescript --purs-ver=0.13.1",
     "test": "echo 'Error: no test specified' && exit 1"
   }
 }

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: purescript
-version: '0.13.0'
+version: '0.13.1'
 synopsis: PureScript Programming Language Compiler
 description: A small strongly, statically typed programming language with expressive
   types, inspired by Haskell and compiling to JavaScript.


### PR DESCRIPTION
I would like to cut a new release because people keep tripping over the node 10 requirement for `npm install purescript`, and this allows us to use the new npm-installer which works with node 8. Any objections?