### PR TITLE
Improved build cache invalidation with content hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ TAGS
 *.prof
 *.ps
 *.svg
+tests/purs/make/

--- a/LICENSE
+++ b/LICENSE
@@ -17,6 +17,7 @@ PureScript uses the following Haskell library packages. Their license files foll
   Cabal
   Glob
   SHA
+  StateVar
   aeson
   aeson-better-errors
   aeson-pretty
@@ -33,6 +34,7 @@ PureScript uses the following Haskell library packages. Their license files foll
   base-orphans
   base64-bytestring
   basement
+  bifunctors
   binary
   blaze-builder
   blaze-html
@@ -48,10 +50,12 @@ PureScript uses the following Haskell library packages. Their license files foll
   cheapskate
   clock
   colour
+  comonad
   conduit
   conduit-extra
   constraints
   containers
+  contravariant
   cookie
   cryptonite
   css-text
@@ -63,6 +67,7 @@ PureScript uses the following Haskell library packages. Their license files foll
   data-ordlist
   deepseq
   directory
+  distributive
   dlist
   easy-file
   edit-distance
@@ -121,6 +126,8 @@ PureScript uses the following Haskell library packages. Their license files foll
   resourcet
   safe
   scientific
+  semialign
+  semigroupoids
   semigroups
   shelly
   simple-sendfile
@@ -139,6 +146,7 @@ PureScript uses the following Haskell library packages. Their license files foll
   terminfo
   text
   th-abstraction
+  these
   time
   time-locale-compat
   transformers
@@ -263,6 +271,38 @@ SHA LICENSE file:
   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+
+StateVar LICENSE file:
+
+  Copyright (c) 2014-2015, Edward Kmett
+  Copyright (c) 2009-2018, Sven Panne
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  3. Neither the name of the author nor the names of its contributors may be
+     used to endorse or promote products derived from this software without
+     specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 
 aeson LICENSE file:
@@ -842,6 +882,35 @@ basement LICENSE file:
   OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
   SUCH DAMAGE.
 
+bifunctors LICENSE file:
+
+  Copyright 2008-2016 Edward Kmett
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+
 binary LICENSE file:
 
   Copyright (c) Lennart Kolmodin
@@ -1317,6 +1386,36 @@ colour LICENSE file:
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 
+comonad LICENSE file:
+
+  Copyright 2008-2014 Edward Kmett
+  Copyright 2004-2008 Dave Menendez
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+
 conduit LICENSE file:
 
   Copyright (c) 2012 Michael Snoyman, http://www.yesodweb.com/
@@ -1425,6 +1524,39 @@ containers LICENSE file:
   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
   OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
   DAMAGE.
+
+contravariant LICENSE file:
+
+  Copyright 2007-2015 Edward Kmett
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  3. Neither the name of the author nor the names of his contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
 
 cookie LICENSE file:
 
@@ -1768,6 +1900,35 @@ directory LICENSE file:
     be a definition of the Haskell 98 Language.
 
   -----------------------------------------------------------------------------
+
+distributive LICENSE file:
+
+  Copyright 2011-2016 Edward Kmett
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
 
 dlist LICENSE file:
 
@@ -3695,6 +3856,68 @@ scientific LICENSE file:
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+semialign LICENSE file:
+
+  Copyright (c) 2012, C. McCann, 2015-2019 Oleg Grenrus
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+
+      * Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials provided
+        with the distribution.
+
+      * Neither the name of C. McCann nor the names of other
+        contributors may be used to endorse or promote products derived
+        from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+semigroupoids LICENSE file:
+
+  Copyright 2011-2015 Edward Kmett
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+
 semigroups LICENSE file:
 
   Copyright 2011-2015 Edward Kmett
@@ -4289,6 +4512,39 @@ th-abstraction LICENSE file:
   OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
   TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
   THIS SOFTWARE.
+
+these LICENSE file:
+
+  Copyright (c) 2012, C. McCann, 2015-2019 Oleg Grenrus
+
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+
+      * Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials provided
+        with the distribution.
+
+      * Neither the name of C. McCann nor the names of other
+        contributors may be used to endorse or promote products derived
+        from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 time LICENSE file:
 

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,7 @@ dependencies:
   - cheapskate >=0.1 && <0.2
   - clock
   - containers
+  - cryptonite >=0.25
   - data-ordlist >=0.4.7.0
   - deepseq
   - directory >=1.2.3
@@ -65,6 +66,7 @@ dependencies:
   - language-javascript >=0.6.0.13
   - lifted-async >=0.10.0.3 && <0.10.1
   - lifted-base >=0.2.3 && <0.2.4
+  - memory >=0.14 && <0.15
   - microlens-platform >=0.3.9.0 && <0.4
   - monad-control >=1.0.0.0 && <1.1
   - monad-logger >=0.3 && <0.4
@@ -78,12 +80,14 @@ dependencies:
   - safe >=0.3.9 && <0.4
   - scientific >=0.3.4.9 && <0.4
   - semigroups >=0.16.2 && <0.19
+  - semialign >=1 && <1.1
   - sourcemap >=0.1.6
   - split
   - stm >=0.2.4.0
   - stringsearch
   - syb
   - text
+  - these >= 1 && <1.1
   - time
   - transformers >=0.3.0 && <0.6
   - transformers-base >=0.4.0 && <0.5
@@ -105,6 +109,7 @@ library:
     - DeriveFoldable
     - DeriveTraversable
     - DeriveGeneric
+    - DerivingStrategies
     - EmptyDataDecls
     - FlexibleContexts
     - KindSignatures
@@ -173,6 +178,8 @@ tests:
       - HUnit
     default-extensions:
       - NoImplicitPrelude
+      - LambdaCase
+      - OverloadedStrings
 
 flags:
   release:

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -22,7 +22,7 @@ import           Data.Function (on)
 import           Data.Foldable (for_)
 import           Data.List (foldl', sortBy)
 import qualified Data.List.NonEmpty as NEL
-import           Data.Maybe (fromMaybe, mapMaybe)
+import           Data.Maybe (fromMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -41,6 +41,7 @@ import           Language.PureScript.Sugar
 import           Language.PureScript.TypeChecker
 import           Language.PureScript.Make.BuildPlan
 import qualified Language.PureScript.Make.BuildPlan as BuildPlan
+import qualified Language.PureScript.Make.Cache as Cache
 import           Language.PureScript.Make.Actions as Actions
 import           Language.PureScript.Make.Monad as Monad
 import qualified Language.PureScript.CoreFn as CF
@@ -99,18 +100,19 @@ rebuildModule MakeActions{..} externs m@(Module _ _ moduleName _ _) = do
 
 -- | Compiles in "make" mode, compiling each module separately to a @.js@ file and an @externs.json@ file.
 --
--- If timestamps have not changed, the externs file can be used to provide the module's types without
--- having to typecheck the module again.
+-- If timestamps or hashes have not changed, existing externs files can be used to provide upstream modules' types without
+-- having to typecheck those modules again.
 make :: forall m. (Monad m, MonadBaseControl IO m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
      => MakeActions m
      -> [CST.PartialResult Module]
      -> m [ExternsFile]
 make ma@MakeActions{..} ms = do
   checkModuleNames
+  cacheDb <- readCacheDb
 
   (sorted, graph) <- sortModules (moduleSignature . CST.resPartial) ms
 
-  buildPlan <- BuildPlan.construct ma (sorted, graph)
+  (buildPlan, newCacheDb) <- BuildPlan.construct ma cacheDb (sorted, graph)
 
   let toBeRebuilt = filter (BuildPlan.needsRebuild buildPlan . getModuleName . CST.resPartial) sorted
   for_ toBeRebuilt $ \m -> fork $ do
@@ -122,21 +124,31 @@ make ma@MakeActions{..} ms = do
       (deps `inOrderOf` map (getModuleName . CST.resPartial) sorted)
 
   -- Wait for all threads to complete, and collect results (and errors).
-  results <- BuildPlan.collectResults buildPlan
+  (failures, successes) <-
+    let
+      splitResults = \case
+        BuildJobSucceeded _ exts ->
+          Right exts
+        BuildJobFailed errs ->
+          Left errs
+        BuildJobSkipped ->
+          Left mempty
+    in
+      M.mapEither splitResults <$> BuildPlan.collectResults buildPlan
+
+  -- Write the updated build cache database to disk
+  writeCacheDb $ Cache.removeModules (M.keysSet failures) newCacheDb
 
   -- All threads have completed, rethrow any caught errors.
-  let errors = mapMaybe buildJobFailure $ M.elems results
+  let errors = M.elems failures
   unless (null errors) $ throwError (mconcat errors)
 
   -- Here we return all the ExternsFile in the ordering of the topological sort,
   -- so they can be folded into an Environment. This result is used in the tests
   -- and in PSCI.
   let lookupResult mn =
-        snd
-        . fromMaybe (internalError "make: module's build job did not succeed")
-        . buildJobSuccess
-        . fromMaybe (internalError "make: module not found in results")
-        $ M.lookup mn results
+        fromMaybe (internalError "make: module not found in results")
+        $ M.lookup mn successes
   return (map (lookupResult . getModuleName . CST.resPartial) sorted)
 
   where

--- a/src/Language/PureScript/Make/Cache.hs
+++ b/src/Language/PureScript/Make/Cache.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Language.PureScript.Make.Cache
+  ( ContentHash
+  , hash
+  , CacheDb
+  , CacheInfo
+  , checkChanged
+  , removeModules
+  ) where
+
+import Prelude
+
+import Control.Category ((>>>))
+import Control.Monad ((>=>))
+import Crypto.Hash (hashlazy, HashAlgorithm, Digest, SHA512, digestFromByteString)
+import qualified Data.Aeson as Aeson
+import Data.Align (align)
+import Data.ByteArray.Encoding (Base(Base16), convertToBase, convertFromBase)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Monoid (All(..))
+import Data.Set (Set)
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8, decodeUtf8)
+import Data.These (These(..))
+import Data.Time.Clock (UTCTime)
+import Data.Traversable (for)
+
+import Language.PureScript.Names (ModuleName)
+
+digestToHex :: Digest a -> Text
+digestToHex = decodeUtf8 . convertToBase Base16
+
+digestFromHex :: forall a. HashAlgorithm a => Text -> Maybe (Digest a)
+digestFromHex =
+  encodeUtf8
+  >>> either (const Nothing) Just . convertFromBase Base16
+  >=> (digestFromByteString :: BS.ByteString -> Maybe (Digest a))
+
+-- | Defines the hash algorithm we use for cache invalidation of input files.
+newtype ContentHash = ContentHash
+  { unContentHash :: Digest SHA512 }
+  deriving (Show, Eq, Ord)
+
+instance Aeson.ToJSON ContentHash where
+  toJSON = Aeson.toJSON . digestToHex . unContentHash
+
+instance Aeson.FromJSON ContentHash where
+  parseJSON x = do
+    str <- Aeson.parseJSON x
+    case digestFromHex str of
+      Just digest ->
+        pure $ ContentHash digest
+      Nothing ->
+        fail "Unable to decode ContentHash"
+
+hash :: BSL.ByteString -> ContentHash
+hash = ContentHash . hashlazy
+
+type CacheDb = Map ModuleName CacheInfo
+
+-- | A CacheInfo contains all of the information we need to store about a
+-- particular module in the cache database.
+newtype CacheInfo = CacheInfo
+  { unCacheInfo :: Map FilePath (UTCTime, ContentHash) }
+  deriving stock (Show)
+  deriving newtype (Eq, Ord, Semigroup, Monoid, Aeson.FromJSON, Aeson.ToJSON)
+
+-- | Given a module name, and a map containing the associated input files
+-- together with current metadata i.e. timestamps and hashes, check whether the
+-- input files have changed, based on comparing with the database stored in the
+-- monadic state.
+--
+-- The CacheInfo in the return value should be stored in the cache for future
+-- builds.
+--
+-- The Bool in the return value indicates whether it is safe to use existing
+-- build artifacts for this module, at least based on the timestamps and hashes
+-- of the module's input files.
+--
+-- If the timestamps are the same as those in the database, assume the file is
+-- unchanged, and return True without checking hashes.
+--
+-- If any of the timestamps differ from what is in the database, check the
+-- hashes of those files. In this case, update the database with any changed
+-- timestamps and hashes, and return True if and only if all of the hashes are
+-- unchanged.
+checkChanged
+  :: Monad m
+  => CacheDb
+  -> ModuleName
+  -> Map FilePath (UTCTime, m ContentHash)
+  -> m (CacheInfo, Bool)
+checkChanged cacheDb mn currentInfo = do
+  let dbInfo = unCacheInfo $ fromMaybe mempty (Map.lookup mn cacheDb)
+  (newInfo, isUpToDate) <-
+    fmap mconcat $
+      for (Map.toList (align dbInfo currentInfo)) $ \(fp, aligned) -> do
+        case aligned of
+          This _ -> do
+            -- One of the input files listed in the cache no longer exists;
+            -- remove that file from the cache and note that the module needs
+            -- rebuilding
+            pure (Map.empty, All False)
+          That (timestamp, getHash) -> do
+            -- The module has a new input file; add it to the cache and
+            -- note that the module needs rebuilding.
+            newHash <- getHash
+            pure (Map.singleton fp (timestamp, newHash), All False)
+          These db@(dbTimestamp, _) (newTimestamp, _) | dbTimestamp == newTimestamp -> do
+            -- This file exists both currently and in the cache database,
+            -- and the timestamp is unchanged, so we skip checking the
+            -- hash.
+            pure (Map.singleton fp db, mempty)
+          These (_, dbHash) (newTimestamp, getHash) -> do
+            -- This file exists both currently and in the cache database,
+            -- but the timestamp has changed, so we need to check the hash.
+            newHash <- getHash
+            pure (Map.singleton fp (newTimestamp, newHash), All (dbHash == newHash))
+
+  pure (CacheInfo newInfo, getAll isUpToDate)
+
+-- | Remove any modules from the given set from the cache database; used when
+-- they failed to build.
+removeModules :: Set ModuleName -> CacheDb -> CacheDb
+removeModules moduleNames = flip Map.withoutKeys moduleNames

--- a/src/Language/PureScript/Names.hs
+++ b/src/Language/PureScript/Names.hs
@@ -12,6 +12,7 @@ import Prelude.Compat
 
 import Control.Monad.Supply.Class
 import Control.DeepSeq (NFData)
+import Data.Functor.Contravariant (contramap)
 
 import GHC.Generics (Generic)
 import Data.Aeson
@@ -243,3 +244,9 @@ isQualifiedWith _ _ = False
 $(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''Qualified)
 $(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''Ident)
 $(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''ModuleName)
+
+instance ToJSONKey ModuleName where
+  toJSONKey = contramap runModuleName toJSONKey
+
+instance FromJSONKey ModuleName where
+  fromJSONKey = fmap moduleNameFromString fromJSONKey

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,8 @@ extra-deps:
 - happy-1.19.9
 - language-javascript-0.6.0.13
 - network-3.0.1.1
+- these-1.0.1
+- semialign-1
 nix:
   enable: false
   packages:
@@ -17,3 +19,6 @@ nix:
 flags:
   aeson-pretty:
     lib-only: true
+  these:
+    assoc: false
+    quickcheck: false

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -20,6 +20,7 @@ import qualified TestPsci
 import qualified TestIde
 import qualified TestPscPublish
 import qualified TestBundle
+import qualified TestMake
 import qualified TestUtils
 
 import System.IO (hSetEncoding, stdout, stderr, utf8)
@@ -35,6 +36,7 @@ main = do
   cstTests <- TestCst.main
   ideTests <- TestIde.main
   compilerTests <- TestCompiler.main
+  makeTests <- TestMake.main
   psciTests <- TestPsci.main
   pscBundleTests <- TestBundle.main
   coreFnTests <- TestCoreFn.main
@@ -48,6 +50,7 @@ main = do
       "Tests"
       [ cstTests
       , compilerTests
+      , makeTests
       , psciTests
       , pscBundleTests
       , ideTests

--- a/tests/TestMake.hs
+++ b/tests/TestMake.hs
@@ -1,0 +1,216 @@
+-- Tests for the compiler's handling of incremental builds, i.e. the code in
+-- Language.PureScript.Make.
+
+module TestMake where
+
+import Prelude ()
+import Prelude.Compat
+
+import qualified Language.PureScript as P
+import qualified Language.PureScript.CST as CST
+
+import Control.Monad
+import Control.Exception (tryJust)
+import Control.Monad.IO.Class (liftIO)
+import Control.Concurrent.MVar (readMVar, newMVar, modifyMVar_)
+import Data.Time.Calendar
+import Data.Time.Clock
+import qualified Data.Text as T
+import Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.Map as M
+
+import System.FilePath
+import System.Directory
+import System.IO.Error (isDoesNotExistError)
+import System.IO.UTF8 (readUTF8FilesT, writeUTF8FileT)
+
+import Test.Tasty
+import Test.Tasty.Hspec
+
+utcMidnightOnDate :: Integer -> Int -> Int -> UTCTime
+utcMidnightOnDate day month year = UTCTime (fromGregorian day month year) (secondsToDiffTime 0)
+
+timestampA, timestampB, timestampC, timestampD, timestampE, timestampF :: UTCTime
+timestampA = utcMidnightOnDate 2019 1 1
+timestampB = utcMidnightOnDate 2019 1 2
+timestampC = utcMidnightOnDate 2019 1 3
+timestampD = utcMidnightOnDate 2019 1 4
+timestampE = utcMidnightOnDate 2019 1 5
+timestampF = utcMidnightOnDate 2019 1 6
+
+main :: IO TestTree
+main = testSpec "make" spec
+
+spec :: Spec
+spec = do
+  let sourcesDir = "tests/purs/make"
+  let moduleNames = Set.fromList . map P.moduleNameFromString
+  before_ (rimraf modulesDir >> rimraf sourcesDir >> createDirectory sourcesDir) $ do
+    it "does not recompile if there are no changes" $ do
+      let modulePath = sourcesDir </> "Module.purs"
+
+      writeFileWithTimestamp modulePath timestampA "module Module where\nfoo = 0\n"
+      compile [modulePath] `shouldReturn` moduleNames ["Module"]
+      compile [modulePath] `shouldReturn` moduleNames []
+
+    it "recompiles if files have changed" $ do
+      let modulePath = sourcesDir </> "Module.purs"
+
+      writeFileWithTimestamp modulePath timestampA "module Module where\nfoo = 0\n"
+      compile [modulePath] `shouldReturn` moduleNames ["Module"]
+      writeFileWithTimestamp modulePath timestampB "module Module where\nfoo = 1\n"
+      compile [modulePath] `shouldReturn` moduleNames ["Module"]
+
+    it "does not recompile if hashes have not changed" $ do
+      let modulePath = sourcesDir </> "Module.purs"
+          moduleContent = "module Module where\nfoo = 0\n"
+
+      writeFileWithTimestamp modulePath timestampA moduleContent
+      compile [modulePath] `shouldReturn` moduleNames ["Module"]
+      writeFileWithTimestamp modulePath timestampB moduleContent
+      compile [modulePath] `shouldReturn` moduleNames []
+
+    it "recompiles if the file path for a module has changed" $ do
+      let modulePath1 = sourcesDir </> "Module1.purs"
+          modulePath2 = sourcesDir </> "Module2.purs"
+          moduleContent = "module Module where\nfoo = 0\n"
+
+      writeFileWithTimestamp modulePath1 timestampA moduleContent
+      writeFileWithTimestamp modulePath2 timestampA moduleContent
+
+      compile [modulePath1] `shouldReturn` moduleNames ["Module"]
+      compile [modulePath2] `shouldReturn` moduleNames ["Module"]
+
+    it "recompiles if an FFI file was added" $ do
+      let moduleBasePath = sourcesDir </> "Module"
+          modulePath = moduleBasePath ++ ".purs"
+          moduleFFIPath = moduleBasePath ++ ".js"
+          moduleContent = "module Module where\nfoo = 0\n"
+
+      writeFileWithTimestamp modulePath timestampA moduleContent
+      compile [modulePath] `shouldReturn` moduleNames ["Module"]
+
+      writeFileWithTimestamp moduleFFIPath timestampB "exports.bar = 1;\n"
+      compile [modulePath] `shouldReturn` moduleNames ["Module"]
+
+    it "recompiles if an FFI file was removed" $ do
+      let moduleBasePath = sourcesDir </> "Module"
+          modulePath = moduleBasePath ++ ".purs"
+          moduleFFIPath = moduleBasePath ++ ".js"
+          moduleContent = "module Module where\nfoo = 0\n"
+
+      writeFileWithTimestamp modulePath timestampA moduleContent
+      writeFileWithTimestamp moduleFFIPath timestampB "exports.bar = 1;\n"
+      compile [modulePath] `shouldReturn` moduleNames ["Module"]
+
+      removeFile moduleFFIPath
+      compile [modulePath] `shouldReturn` moduleNames ["Module"]
+
+    it "recompiles downstream modules when a module is rebuilt" $ do
+      let moduleAPath = sourcesDir </> "A.purs"
+          moduleBPath = sourcesDir </> "B.purs"
+          moduleAContent1 = "module A where\nfoo = 0\n"
+          moduleAContent2 = "module A where\nfoo = 1\n"
+          moduleBContent = "module B where\nimport A (foo)\nbar = foo\n"
+
+      writeFileWithTimestamp moduleAPath timestampA moduleAContent1
+      writeFileWithTimestamp moduleBPath timestampB moduleBContent
+      compile [moduleAPath, moduleBPath] `shouldReturn` moduleNames ["A", "B"]
+
+      writeFileWithTimestamp moduleAPath timestampC moduleAContent2
+      compile [moduleAPath, moduleBPath] `shouldReturn` moduleNames ["A", "B"]
+
+    it "only recompiles downstream modules when a module is rebuilt" $ do
+      let moduleAPath = sourcesDir </> "A.purs"
+          moduleBPath = sourcesDir </> "B.purs"
+          moduleCPath = sourcesDir </> "C.purs"
+          modulePaths = [moduleAPath, moduleBPath, moduleCPath]
+          moduleAContent1 = "module A where\nfoo = 0\n"
+          moduleAContent2 = "module A where\nfoo = 1\n"
+          moduleBContent = "module B where\nimport A (foo)\nbar = foo\n"
+          moduleCContent = "module C where\nbaz = 3\n"
+
+      writeFileWithTimestamp moduleAPath timestampA moduleAContent1
+      writeFileWithTimestamp moduleBPath timestampB moduleBContent
+      writeFileWithTimestamp moduleCPath timestampC moduleCContent
+      compile modulePaths `shouldReturn` moduleNames ["A", "B", "C"]
+
+      writeFileWithTimestamp moduleAPath timestampD moduleAContent2
+      compile modulePaths `shouldReturn` moduleNames ["A", "B"]
+
+    it "does not necessarily recompile modules which were not part of the previous batch" $ do
+      let moduleAPath = sourcesDir </> "A.purs"
+          moduleBPath = sourcesDir </> "B.purs"
+          moduleCPath = sourcesDir </> "C.purs"
+          modulePaths = [moduleAPath, moduleBPath, moduleCPath]
+          batch1 = [moduleAPath, moduleBPath]
+          batch2 = [moduleAPath, moduleCPath]
+          moduleAContent = "module A where\nfoo = 0\n"
+          moduleBContent = "module B where\nimport A (foo)\nbar = foo\n"
+          moduleCContent = "module C where\nbaz = 3\n"
+
+      writeFileWithTimestamp moduleAPath timestampA moduleAContent
+      writeFileWithTimestamp moduleBPath timestampB moduleBContent
+      writeFileWithTimestamp moduleCPath timestampC moduleCContent
+      compile modulePaths `shouldReturn` moduleNames ["A", "B", "C"]
+
+      compile batch1 `shouldReturn` moduleNames []
+      compile batch2 `shouldReturn` moduleNames []
+
+    it "recompiles if a module fails to compile" $ do
+      let modulePath = sourcesDir </> "Module.purs"
+          moduleContent = "module Module where\nfoo :: Int\nfoo = \"not an int\"\n"
+
+      writeFileWithTimestamp modulePath timestampA moduleContent
+      compileAllowingFailures [modulePath] `shouldReturn` moduleNames ["Module"]
+      compileAllowingFailures [modulePath] `shouldReturn` moduleNames ["Module"]
+
+rimraf :: FilePath -> IO ()
+rimraf =
+  void . tryJust (guard . isDoesNotExistError) . removeDirectoryRecursive
+
+-- | Returns a set of the modules for which a rebuild was attempted, including
+-- the make result.
+compileWithResult :: [FilePath] -> IO (Either P.MultipleErrors [P.ExternsFile], Set P.ModuleName)
+compileWithResult input = do
+  recompiled <- newMVar Set.empty
+  moduleFiles <- readUTF8FilesT input
+  (makeResult, _) <- P.runMake P.defaultOptions $ do
+    ms <- CST.parseModulesFromFiles id moduleFiles
+    let filePathMap = M.fromList $ map (\(fp, pm) -> (P.getModuleName $ CST.resPartial pm, Right fp)) ms
+    foreigns <- P.inferForeignModules filePathMap
+    let makeActions =
+          (P.buildMakeActions modulesDir filePathMap foreigns True)
+            { P.progress = \(P.CompilingModule mn) ->
+                liftIO $ modifyMVar_ recompiled (return . Set.insert mn)
+            }
+    P.make makeActions (map snd ms)
+
+  recompiledModules <- readMVar recompiled
+  pure (makeResult, recompiledModules)
+
+-- | Compile, returning the set of modules which were rebuilt, and failing if
+-- any errors occurred.
+compile :: [FilePath] -> IO (Set P.ModuleName)
+compile input = do
+  (result, recompiled) <- compileWithResult input
+  case result of
+    Left errs ->
+      fail (P.prettyPrintMultipleErrors P.defaultPPEOptions errs)
+    Right _ ->
+      pure recompiled
+
+compileAllowingFailures :: [FilePath] -> IO (Set P.ModuleName)
+compileAllowingFailures input = fmap snd (compileWithResult input)
+
+writeFileWithTimestamp :: FilePath -> UTCTime -> T.Text -> IO ()
+writeFileWithTimestamp path mtime contents = do
+  writeUTF8FileT path contents
+  setModificationTime path mtime
+
+-- | Use a different output directory to ensure that we don't get interference
+-- from other test results
+modulesDir :: FilePath
+modulesDir = ".test_modules" </> "make"
+

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -198,13 +198,13 @@ checkMain ms =
 
 makeActions :: [P.Module] -> M.Map P.ModuleName FilePath -> P.MakeActions P.Make
 makeActions modules foreigns = (P.buildMakeActions modulesDir (P.internalError "makeActions: input file map was read.") foreigns False)
-                               { P.getInputTimestamp = getInputTimestamp
+                               { P.getInputTimestampsAndHashes = getInputTimestampsAndHashes
                                , P.getOutputTimestamp = getOutputTimestamp
                                , P.progress = const (pure ())
                                }
   where
-  getInputTimestamp :: P.ModuleName -> P.Make (Either P.RebuildPolicy (Maybe UTCTime))
-  getInputTimestamp mn
+  getInputTimestampsAndHashes :: P.ModuleName -> P.Make (Either P.RebuildPolicy a)
+  getInputTimestampsAndHashes mn
     | isSupportModule (P.runModuleName mn) = return (Left P.RebuildNever)
     | otherwise = return (Left P.RebuildAlways)
     where


### PR DESCRIPTION
Fixes #3145.

The current build cache invalidation algorithm compares the input
timestamps to the output timestamps, and only triggers a rebuild if the
input timestamps are newer than the output timestamps. However, this
does not appear to be sufficient: as discussed in #3145, we think that
the reason that doing `rm -r output` often fixes weird compile errors is
that we should really be considering the input file to have changed if
its timestamp is _different_ to what it was at the last successful
build, regardless of whether it is before or after the output timestamp.
Essentially, timestamps on input files can't be trusted to the extent
that we do for cache invalidation, because of things like switching
between different versions of dependencies or switching branches;
sometimes you can have an input file's contents and timestamp both
change, but have the timestamp still be older than the output timestamp.

This commit implements a slightly different cache invalidation
algorithm, where we make a note of the timestamps of all input files at
the start of each build, and we consider files to have changed in
subsequent builds if their input timestamps have changed at all
(regardless of whether the new input timestamps are before or after the
output timestamps).

The timestamps are stored in a json file `cache-db.json` in the output
directory; I also considered putting the timestamps in the externs
files, but I think having them stored separately is preferable because
then we don't have to update the module's externs file if its input file
timestamp changes but its hash doesn't, which means that we don't force
a rebuild for downstream modules.

As an additional enhancement, we also make note of file content hashes
and store them in the `cache-db.json` file. On subsequent builds, if
timestamps have changed, we compare the previous hash to the new hash,
and if they are identical, we can skip rebuilding the module. This means
that e.g. touching a file no longer forces a rebuild. Note that we only
compute hashes in the case where timestamps differ to avoid doing extra
unnecessary work. This scheme of checking timestamps and then hashes was
inspired by Shake, which provides this mechanism as one of its options
for Change; see https://github.com/purescript/purescript/issues/3145#issuecomment-491639339

I've also added some tests so that we can make changes to this part of
the compiler a little more confidently.

I'm using the latest version of `these` (which is not in our Stack
snapshot) because it doesn't incur a `lens` dependency, whereas earlier
versions do.