### PR TITLE
Add support for local type synonyms

### DIFF
--- a/lib/purescript-cst/src/Language/PureScript/CST/Convert.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Convert.hs
@@ -224,6 +224,13 @@ convertLetBinding fileName = \case
   binding@(LetBindingPattern _ a _ b) -> do
     let ann = uncurry (sourceAnnCommented fileName) $ letBindingRange binding
     AST.BoundValueDeclaration ann (convertBinder fileName a) (convertWhere fileName b)
+  binding@(LetBindingType _ (DataHead _ a vars) _ bd) -> do
+    let ann = uncurry (sourceAnnCommented fileName) $ letBindingRange binding
+    AST.TypeSynonymDeclaration ann (nameValue a) (goTypeVar <$> vars) (convertType fileName bd)
+  where
+  goTypeVar = \case
+    TypeVarKinded (Wrapped _ (Labeled x _ y) _) -> (getIdent $ nameValue x, Just $ convertType fileName y)
+    TypeVarName x -> (getIdent $ nameValue x, Nothing)
 
 convertExpr :: forall a. String -> Expr a -> AST.Expr
 convertExpr fileName = go

--- a/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
@@ -457,6 +457,7 @@ letBinding :: { LetBinding () }
   | ident guardedDecl { LetBindingName () (ValueBindingFields $1 [] $2) }
   | ident many(binderAtom) guardedDecl { LetBindingName () (ValueBindingFields $1 (NE.toList $2) $3) }
   | binder1 '=' exprWhere { LetBindingPattern () $1 $2 $3 }
+  | typeHead '=' type {% checkNoWildcards $3 *> pure (LetBindingType () $1 $2 $3) }
 
 caseBranch :: { (Separated (Binder ()), Guarded ()) }
   : sep(binder1, ',') guardedCase { ($1, $2) }

--- a/lib/purescript-cst/src/Language/PureScript/CST/Positions.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Positions.hs
@@ -307,6 +307,7 @@ letBindingRange = \case
   LetBindingSignature _ (Labeled a _ b) -> (nameTok a, snd $ typeRange b)
   LetBindingName _ a -> valueBindingFieldsRange a
   LetBindingPattern _ a _ b -> (fst $ binderRange a, snd $ whereRange b)
+  LetBindingType _ a _ b -> (fst $ dataHeadRange a, snd $ typeRange b)
 
 doStatementRange :: DoStatement a -> TokenRange
 doStatementRange = \case

--- a/lib/purescript-cst/src/Language/PureScript/CST/Types.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Types.hs
@@ -402,6 +402,7 @@ data LetBinding a
   = LetBindingSignature a (Labeled (Name Ident) (Type a))
   | LetBindingName a (ValueBindingFields a)
   | LetBindingPattern a (Binder a) SourceToken (Where a)
+  | LetBindingType a (DataHead a) SourceToken (Type a)
   deriving (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
 
 data DoBlock a = DoBlock

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -754,7 +754,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
                 ]
     renderSimpleErrorMessage (CycleInTypeSynonym name) =
       paras [ line $ case name of
-                       Just pn -> "A cycle appears in the definition of type synonym " <> markCode (runProperName pn)
+                       Just pn -> "A cycle appears in the definition of type synonym " <> markCode (showTypeSynonymName pn)
                        Nothing -> "A cycle appears in a set of type synonym definitions."
             , line "Cycles are disallowed because they can lead to loops in the type checker."
             , line "Consider using a 'newtype' instead."
@@ -778,7 +778,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderSimpleErrorMessage (UndefinedTypeVariable name) =
       line $ "Type variable " <> markCode (runProperName name) <> " is undefined."
     renderSimpleErrorMessage (PartiallyAppliedSynonym name) =
-      paras [ line $ "Type synonym " <> markCode (showQualified runProperName name) <> " is partially applied."
+      paras [ line $ "Type synonym " <> markCode (showQualifiedTypeSynonymName name) <> " is partially applied."
             , line "Type synonyms must be applied to all of their type arguments."
             ]
     renderSimpleErrorMessage (EscapedSkolem name Nothing ty) =
@@ -1394,7 +1394,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             ]
     renderHint (ErrorInTypeSynonym name) detail =
       paras [ detail
-            , line $ "in type synonym " <> markCode (runProperName name)
+            , line $ "in type synonym " <> markCode (showTypeSynonymName name)
             ]
     renderHint (ErrorInValueDeclaration n) detail =
       paras [ detail

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -202,7 +202,7 @@ moduleToExternsFile (Module ss _ mn ds (Just exps)) env = ExternsFile{..}
   where
   efVersion       = T.pack (showVersion Paths.version)
   efModuleName    = mn
-  efExports       = exps
+  efExports       = filter isVisible exps
   efImports       = mapMaybe importDecl ds
   efFixities      = mapMaybe fixityDecl ds
   efTypeFixities  = mapMaybe typeFixityDecl ds
@@ -265,6 +265,9 @@ moduleToExternsFile (Module ss _ mn ds (Just exps)) env = ExternsFile{..}
       , TypeClassDictionaryInScope{..} <- NEL.toList nel
       ]
   toExternsDeclaration _ = []
+
+  isVisible (TypeRef _ pn _) = not $ isLocalSynonymName pn
+  isVisible _ = True
 
 externsFileName :: FilePath
 externsFileName = "externs.cbor"

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -20,6 +20,7 @@ import Language.PureScript.Sugar.CaseDeclarations as S
 import Language.PureScript.Sugar.DoNotation as S
 import Language.PureScript.Sugar.AdoNotation as S
 import Language.PureScript.Sugar.LetPattern as S
+import Language.PureScript.Sugar.LocalTypeSynonyms as S
 import Language.PureScript.Sugar.Names as S
 import Language.PureScript.Sugar.ObjectWildcards as S
 import Language.PureScript.Sugar.Operators as S
@@ -44,6 +45,8 @@ import Language.PureScript.Sugar.TypeDeclarations as S
 --
 --  * Desugar type declarations into value declarations with explicit type annotations
 --
+--  * Hoist all local type synonyms
+--
 --  * Qualify any unqualified names and types
 --
 --  * Rebracket user-defined binary operators
@@ -66,6 +69,7 @@ desugar env externs =
     >=> map desugarLetPatternModule
     >>> traverse desugarCasesModule
     >=> traverse desugarTypeDeclarationsModule
+    >=> traverse desugarLocalTypeSynonymsModule
     >=> desugarImports env
     >=> rebracket externs
     >=> traverse checkFixityExports

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -148,25 +148,16 @@ usedImmediateIdents moduleName =
 usedTypeNames :: ModuleName -> Declaration -> [ProperName 'TypeName]
 usedTypeNames moduleName = go
   where
-  (f, _, _, _, _) = accumTypes (everythingOnTypes (++) usedNames)
+  (f, _, _, _, _) = accumTypes (usedTypeNamesFromModule (Just moduleName))
 
   go :: Declaration -> [ProperName 'TypeName]
   go decl = ordNub (f decl <> usedNamesForTypeClassDeps decl)
 
-  usedNames :: SourceType -> [ProperName 'TypeName]
-  usedNames (ConstrainedType _ con _) = usedConstraint con
-  usedNames (TypeConstructor _ (Qualified (Just moduleName') name))
-    | moduleName == moduleName' = [name]
-  usedNames _ = []
-
-  usedConstraint :: SourceConstraint -> [ProperName 'TypeName]
-  usedConstraint (Constraint _ (Qualified (Just moduleName') name) _ _ _)
-    | moduleName == moduleName' = [coerceProperName name]
-  usedConstraint _ = []
-
   usedNamesForTypeClassDeps :: Declaration -> [ProperName 'TypeName]
   usedNamesForTypeClassDeps (TypeClassDeclaration _ _ _ deps _ _) = foldMap usedConstraint deps
   usedNamesForTypeClassDeps _ = []
+
+  usedConstraint = usedConstraintFromModule (Just moduleName)
 
 declTypeName :: Declaration -> ProperName 'TypeName
 declTypeName (DataDeclaration _ _ pn _ _) = pn

--- a/src/Language/PureScript/Sugar/LocalTypeSynonyms.hs
+++ b/src/Language/PureScript/Sugar/LocalTypeSynonyms.hs
@@ -1,0 +1,175 @@
+module Language.PureScript.Sugar.LocalTypeSynonyms
+  ( desugarLocalTypeSynonymsModule
+  ) where
+
+import Prelude.Compat
+
+import Control.Applicative (liftA2)
+import Control.Arrow (first, second, (&&&))
+import Control.Monad.Error.Class (MonadError)
+import Control.Monad.Identity
+import Control.Monad.Supply.Class (MonadSupply, freshName)
+import Control.Monad.Writer
+
+import Data.Graph (flattenSCC, stronglyConnCompR)
+import Data.Foldable (fold, foldl')
+import Data.Functor (($>), (<&>))
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Map as M
+import qualified Data.Set as S
+
+import Language.PureScript.AST
+import Language.PureScript.Crash
+import Language.PureScript.Errors
+import Language.PureScript.Names
+import Language.PureScript.Traversals
+import Language.PureScript.TypeChecker.Synonyms
+import Language.PureScript.Types
+
+desugarLocalTypeSynonymsModule :: (MonadError MultipleErrors m, MonadSupply m) => Module -> m Module
+desugarLocalTypeSynonymsModule = desugarModule
+  where
+  desugarModule (Module modSS coms mn decls exps) = Module modSS coms mn <$> prependHoisted (parU decls go) <*> pure exps
+  go = go2 . runIdentity . go1
+  (go1, _, _, _, _) = everywhereWithContextOnValuesM (UnshadowContext M.empty S.empty) defS unshadowStep defS defS defS
+  (go2, _, _, _, _) = everywhereWithContextOnValuesM (HoistContext M.empty M.empty []) defS hoistStepE hoistStepB defS defS
+
+  prependHoisted :: Monad m => WriterT [Declaration] m [Declaration] -> m [Declaration]
+  prependHoisted = fmap (uncurry (++)) . runWriterT
+
+-- Step 1: Any type variables that shadow outer variables need to be renamed
+-- so the shadowed variables are always available to be given as parameters to
+-- the desugared type synonyms.
+
+data UnshadowContext = UnshadowContext { bindings :: M.Map Text Text, usedNames :: S.Set Text }
+
+-- |
+-- Adds a name and its unique replacement to an UnshadowContext.
+--
+updateUnshadowContext :: UnshadowContext -> Text -> Text -> UnshadowContext
+updateUnshadowContext UnshadowContext{..} n un =
+  UnshadowContext
+    { bindings = M.insert n un bindings
+    , usedNames = S.insert un usedNames
+    }
+
+unshadowStep :: UnshadowContext -> Expr -> Identity (UnshadowContext, Expr)
+unshadowStep c = Identity . \case
+  (TypedValue check v ty) -> TypedValue check v <$> renameVarsInType c ty
+  (Let prov decls expr) -> (c, (Let prov (map (alphaConvertSynonym c) decls) expr))
+  other -> (c, other)
+
+renameVarsInType :: UnshadowContext -> SourceType -> (UnshadowContext, SourceType)
+renameVarsInType c = \case
+  (ForAll ann tv mbK ty sco) ->
+    let tv' = if tv `M.member` (bindings c) then genName (`S.member` usedNames c) tv else tv
+        (c', ty') = renameVarsInType (updateUnshadowContext c tv tv') ty
+    in (c', ForAll ann tv' mbK ty' sco)
+  other ->
+    let rename t@(TypeVar ann v) = fromMaybe t (TypeVar ann <$> M.lookup v (bindings c))
+        rename other' = other'
+    in (c, everywhereOnTypes rename other)
+
+alphaConvertSynonym :: UnshadowContext -> Declaration -> Declaration
+alphaConvertSynonym c = \case
+  (TypeSynonymDeclaration ann name params ty) -> TypeSynonymDeclaration ann name params' ty'
+    where
+    pnames = map fst params
+    pnames' = map (genName (`S.member` (usedNames c))) pnames
+    ty' = replaceAllTypeVars (zip pnames (map srcTypeVar pnames')) ty
+    params' = zip pnames' (map snd params)
+  other -> other
+
+-- Step 2: Hoist all local type synonyms to top-level type synonyms, adding
+-- one extra type parameter for each type variable in scope that is used in the
+-- synonym. (Adding unused type parameters can cause problems with kind
+-- inference, because all unused parameters are assumed to have kind `Type`.)
+-- Replace all uses of local type synonyms with uses of the hoisted synonyms.
+
+type SynonymParameter = (Text, Maybe (Type SourceAnn))
+type SynonymData = (SourceSpan, [SynonymParameter], SourceType)
+type SynonymBindingGroup = M.Map (ProperName 'TypeName) SynonymData
+
+data HoistContext =
+  HoistContext
+    { synonymMap :: SynonymMap
+    , typeVarUseMap :: M.Map (ProperName 'TypeName) (S.Set Text)
+    , typeVarsInScope :: [SynonymParameter]
+    }
+
+-- |
+-- Prepends any quantified type variables into a HoistContext's
+-- typeVarsInScope.
+--
+addTypeVars :: HoistContext -> SourceType -> HoistContext
+addTypeVars c t0 = c{ typeVarsInScope = go t0 }
+  where
+  go (ForAll _ v k t _) = (v, k) : go t
+  go _ = typeVarsInScope c
+
+-- |
+-- Inserts a new entry into a HoistContext's synonymMap.
+--
+addSynonym :: Text -> HoistContext -> ProperName 'TypeName -> HoistContext
+addSynonym scope c name = c{ synonymMap = M.insert (Qualified Nothing name) ([], hoistedRef) (synonymMap c) }
+  where
+  args = map srcTypeVar $ filter (`S.member` lookupUsedVars name c) $ map fst $ typeVarsInScope c
+  ctor = srcTypeConstructor $ Qualified Nothing $ makeLocalSynonymName scope (length args) name
+  hoistedRef = foldr (flip srcTypeApp) ctor args
+
+-- |
+-- Updates a HoistContext's typeVarUseMap with the type variables used
+-- (transitively) by a collection of local type synonyms.
+--
+addUsedVars :: HoistContext -> SynonymBindingGroup -> HoistContext
+addUsedVars c synGroup = c{ typeVarUseMap = foldl' step typeVarUseMap0 components }
+  where
+  typeVarUseMap0 = typeVarUseMap c
+  findDependencies = filter (liftA2 (||) (`M.member` synGroup) (`M.member` typeVarUseMap0)) . usedTypeNamesFromModule Nothing
+  toGraphNode name (_, ps, ty) = (S.fromList $ filter (`notElem` (map fst ps)) $ freeTypeVariables ty, name, findDependencies ty)
+  components = map flattenSCC $ stronglyConnCompR $ map (uncurry toGraphNode) $ M.toList synGroup
+  step useMap component = foldr (\(_, name, _) -> M.insert name componentVars) useMap component
+    where
+    componentVars = foldMap (\(vars, _, deps) -> vars <> foldMap (fold . (`M.lookup` useMap)) deps) component
+    -- If the component is cyclic, the above lookup may return Nothing; unlike
+    -- in lookupUsedVars, this doesn't indicate an internal error. (The user
+    -- will get an error about the cyclic type synonym definition later.)
+
+-- |
+-- Retrieves the set of type variable names used by a local type synonym from
+-- a HoistContext, or crashes if typeVarUseMap hasn't already been updated with
+-- the type synonym. (It might be tempting to play it safe and return S.empty,
+-- but that would be likely to produce less scrutable errors down the road.)
+--
+lookupUsedVars :: ProperName 'TypeName -> HoistContext -> S.Set Text
+lookupUsedVars k = fromMaybe (internalError "Sugar.LocalTypeSynonyms: name missing from typeVarUseMap") . M.lookup k . typeVarUseMap
+
+hoistStepE :: (MonadError MultipleErrors m, MonadSupply m) => HoistContext -> Expr -> WriterT [Declaration] m (HoistContext, Expr)
+hoistStepE c = \case
+  (Let prov decls expr) -> do
+    scope <- freshName
+    let (synGroup, decls') = extractSynonyms decls
+        c' = foldl' (addSynonym scope) (addUsedVars c synGroup) (M.keys synGroup)
+    M.traverseWithKey (hoistDeclaration scope c') synGroup $> (c', Let prov decls' expr)
+  (TypedValue check v ty) ->
+    replaceAllTypeSynonymsM (synonymMap c) M.empty ty <&> (addTypeVars c &&& TypedValue check v)
+  other -> pure (c, other)
+
+hoistStepB :: (MonadError MultipleErrors m) => HoistContext -> Binder -> WriterT [Declaration] m (HoistContext, Binder)
+hoistStepB c = \case
+  (TypedBinder ty b) -> replaceAllTypeSynonymsM (synonymMap c) M.empty ty <&> (\ty' -> (c, TypedBinder ty' b))
+  other -> pure (c, other)
+
+extractSynonyms :: [Declaration] -> (SynonymBindingGroup, [Declaration])
+extractSynonyms = flip foldr mempty $ \case
+  (TypeSynonymDeclaration (ss, _) name params ty) -> first $ M.insert name (ss, params, ty)
+  other                                           -> second (other :)
+
+hoistDeclaration :: (MonadError MultipleErrors m) => Text -> HoistContext -> ProperName 'TypeName -> SynonymData -> WriterT [Declaration] m ()
+hoistDeclaration scope c name (ss, params, ty) = do
+  let scopeParams = filter ((`S.member` lookupUsedVars name c) . fst) (typeVarsInScope c)
+  let rewriteTypes = replaceAllTypeSynonymsM (synonymMap c) M.empty
+  ty' <- rewriteTypes ty
+  params' <- traverse (\(pn, pk) -> (pn,) <$> traverse rewriteTypes pk) params
+  tell [TypeSynonymDeclaration (ss, []) (makeLocalSynonymName scope (length scopeParams) name) (foldl' (flip (:)) params' scopeParams) ty']

--- a/tests/purs/failing/LocalTypeSynonyms.out
+++ b/tests/purs/failing/LocalTypeSynonyms.out
@@ -1,0 +1,11 @@
+Error found:
+at tests/purs/failing/LocalTypeSynonyms.purs:7:3 - 7:21 (line 7, column 3 - line 7, column 21)
+
+  A cycle appears in a set of type synonym definitions.
+  Cycles are disallowed because they can lead to loops in the type checker.
+  Consider using a 'newtype' instead.
+
+
+See https://github.com/purescript/documentation/blob/master/errors/CycleInTypeSynonym.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/LocalTypeSynonyms.purs
+++ b/tests/purs/failing/LocalTypeSynonyms.purs
@@ -1,0 +1,9 @@
+-- @shouldFailWith CycleInTypeSynonym
+module LocalTypeSynonyms where
+
+foo :: Int
+foo = result
+  where
+  type T1 = Array T2
+  type T2 = T1
+  result = 0

--- a/tests/purs/failing/LocalTypeSynonyms2.out
+++ b/tests/purs/failing/LocalTypeSynonyms2.out
@@ -1,0 +1,11 @@
+Error found:
+at tests/purs/failing/LocalTypeSynonyms2.purs:7:3 - 7:21 (line 7, column 3 - line 7, column 21)
+
+  A cycle appears in the definition of type synonym [33mT1[0m
+  Cycles are disallowed because they can lead to loops in the type checker.
+  Consider using a 'newtype' instead.
+
+
+See https://github.com/purescript/documentation/blob/master/errors/CycleInTypeSynonym.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/LocalTypeSynonyms2.purs
+++ b/tests/purs/failing/LocalTypeSynonyms2.purs
@@ -1,0 +1,8 @@
+-- @shouldFailWith CycleInTypeSynonym
+module LocalTypeSynonyms2 where
+
+foo :: Int
+foo = result
+  where
+  type T1 = Array T1
+  result = 0

--- a/tests/purs/failing/LocalTypeSynonyms3.out
+++ b/tests/purs/failing/LocalTypeSynonyms3.out
@@ -1,0 +1,12 @@
+Error found:
+in module [33mLocalTypeSynonyms3[0m
+at tests/purs/failing/LocalTypeSynonyms3.purs:10:3 - 10:17 (line 10, column 3 - line 10, column 17)
+
+  Type synonym [33mF[0m is partially applied.
+  Type synonyms must be applied to all of their type arguments.
+
+in type synonym [33mG[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/LocalTypeSynonyms3.purs
+++ b/tests/purs/failing/LocalTypeSynonyms3.purs
@@ -1,0 +1,12 @@
+-- @shouldFailWith PartiallyAppliedSynonym
+module LocalTypeSynonyms3 where
+
+import Prelude
+
+foo :: String
+foo = f identity
+  where
+  type F x y = x -> y
+  type G x = F x
+  f :: G String String -> String
+  f k = k "Done"

--- a/tests/purs/failing/LocalTypeSynonyms4.out
+++ b/tests/purs/failing/LocalTypeSynonyms4.out
@@ -1,0 +1,30 @@
+Error found:
+in module [33mLocalTypeSynonyms4[0m
+at tests/purs/failing/LocalTypeSynonyms4.purs:8:13 - 8:16 (line 8, column 13 - line 8, column 16)
+
+  Could not match kind
+  [33m      [0m
+  [33m  Type[0m
+  [33m      [0m
+  with kind
+  [33m          [0m
+  [33m  Row Type[0m
+  [33m          [0m
+
+while checking that type [33ma0[0m
+  has kind [33mRow Type[0m
+while inferring the kind of [33mT a0[0m
+while checking that expression [33mresult                   [0m
+                               [33m  where                  [0m
+                               [33m  result = { wrapped: ...[0m
+                               [33m           }             [0m
+  has type [33m{ wrapped :: a0[0m
+           [33m}              [0m
+in value declaration [33mwrap[0m
+
+where [33ma0[0m is a rigid type variable
+        bound at (line 0, column 0 - line 0, column 0)
+
+See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/LocalTypeSynonyms4.purs
+++ b/tests/purs/failing/LocalTypeSynonyms4.purs
@@ -1,0 +1,9 @@
+-- @shouldFailWith KindsDoNotUnify
+module LocalTypeSynonyms4 where
+
+wrap :: forall a. a -> { wrapped :: a }
+wrap a = result
+  where
+  type T r = { wrapped :: a | r }
+  result :: T a
+  result = { wrapped: a }

--- a/tests/purs/failing/LocalTypeSynonyms5.out
+++ b/tests/purs/failing/LocalTypeSynonyms5.out
@@ -1,0 +1,25 @@
+Error found:
+in module [33mLocalTypeSynonyms5[0m
+at tests/purs/failing/LocalTypeSynonyms5.purs:18:34 - 18:35 (line 18, column 34 - line 18, column 35)
+
+  Could not match type
+  [33m                  [0m
+  [33m  { wrapped :: Int[0m
+  [33m  }               [0m
+  [33m                  [0m
+  with type
+  [33m     [0m
+  [33m  Int[0m
+  [33m     [0m
+
+while checking that type [33mInt[0m
+  is at least as general as type [33m{ wrapped :: Int[0m
+                                 [33m}               [0m
+while checking that expression [33m0[0m
+  has type [33m{ wrapped :: Int[0m
+           [33m}               [0m
+in value declaration [33mfoo[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/LocalTypeSynonyms5.purs
+++ b/tests/purs/failing/LocalTypeSynonyms5.purs
@@ -1,0 +1,18 @@
+-- @shouldFailWith TypesDoNotUnify
+module LocalTypeSynonyms5 where
+
+import Prelude
+
+-- Test that the inferred type doesn't leak the local type synonym in the
+-- produced error message.
+
+intentionallyUntyped = wrap thing
+  where
+  type Wrapped a = { wrapped :: a }
+  wrap :: forall a. a -> Wrapped a
+  wrap wrapped = { wrapped }
+  thing :: Int
+  thing = 0
+
+foo :: Int
+foo = if intentionallyUntyped == 0 then 0 else 1

--- a/tests/purs/failing/LocalTypeSynonyms6.out
+++ b/tests/purs/failing/LocalTypeSynonyms6.out
@@ -1,0 +1,23 @@
+Error found:
+in module [33mLocalTypeSynonyms6[0m
+at tests/purs/failing/LocalTypeSynonyms6.purs:24:14 - 24:34 (line 24, column 14 - line 24, column 34)
+
+  Could not match type
+  [33m        [0m
+  [33m  Record[0m
+  [33m        [0m
+  with type
+  [33m         [0m
+  [33m  Wrapped[0m
+  [33m         [0m
+
+while trying to match type [33m{ wrapped :: Int[0m
+                           [33m}               [0m
+  with type [33mWrapped Int[0m
+while checking that expression [33mintentionallyUntyped[0m
+  has type [33mWrapped Int[0m
+in value declaration [33mfoo[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/LocalTypeSynonyms6.purs
+++ b/tests/purs/failing/LocalTypeSynonyms6.purs
@@ -1,0 +1,24 @@
+-- @shouldFailWith TypesDoNotUnify
+module LocalTypeSynonyms6 where
+
+import Prelude
+
+-- Test that the inferred type doesn't leak and unify with the shadowed type
+-- with the same name, and also that the error message doesn't include the
+-- local type synonym.
+
+data Wrapped a = Wrapped a
+
+intentionallyUntyped = wrap thing
+  where
+  type Wrapped a = { wrapped :: a }
+  wrap :: forall a. a -> Wrapped a
+  wrap wrapped = { wrapped }
+  thing :: Int
+  thing = 0
+
+unwrap :: Wrapped Int -> Int
+unwrap (Wrapped w) = w
+
+foo :: Int
+foo = unwrap intentionallyUntyped

--- a/tests/purs/passing/LocalTypeSynonyms.purs
+++ b/tests/purs/passing/LocalTypeSynonyms.purs
@@ -1,0 +1,52 @@
+module Main where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Console (log)
+
+foo :: forall a. a -> { left :: Int, right :: a }
+foo a = result
+  where
+  result = result'
+    where
+    type Bravo a = { left :: a, right :: Alpha }
+    result' :: Bravo Int
+    result' = { left: 0, right: a }
+  type Alpha = a
+
+bar :: Effect Int
+bar = do
+  log "hello"
+  let type Alpha = Int
+  pure (1 :: Alpha)
+
+baz :: forall r a. { a :: a | r } -> { a :: a, b :: Int }
+baz = f
+  where
+  type In = { a :: a | r }
+  type Out = { a :: a, b :: Int }
+  f :: In -> Out
+  f { a } = { a, b: 0 }
+
+kinded :: Effect Int
+kinded = do
+  let type Alpha (a :: Type) = Type
+  let type Bravo (a :: Alpha String -> Type) = a Unit
+  let type Charlie (a :: Alpha String) = Int
+  pure (1 :: Bravo Charlie)
+
+
+intentionallyUntyped = wrap thing
+  where
+  type Wrapped a = { wrapped :: a }
+  wrap :: forall a. a -> Wrapped a
+  wrap wrapped = { wrapped }
+  thing :: Int
+  thing = 0
+
+
+main :: Effect Unit
+main = if intentionallyUntyped.wrapped == 0
+  then log "Done"
+  else log "Fail"


### PR DESCRIPTION
This implements `type X = Y` synonyms as another form of let binding,
valid inside `let` expressions, `where` clauses, and `do` notation.
These synonyms are hoisted to the top level during desugaring.

---

This is a complete attempt at #3708, but subject to change if there's feedback on that feature request. Feedback on this specific implementation is welcome here; feedback on the concept of local type synonyms should probably go there.

The biggest sin I have to confess here is using the hoisted type synonym name mangling to store data, as opposed to just being a unique string. The excuses I offer are that the data are only retrieved by reporting code in `Language.PureScript.Errors` and `Language.PureScript.Pretty`, not anywhere ‘important’, and there only through functions defined alongside the name mangling code so that the ‘magic string’ logic stays local; and that the alternative would involve changing `ProperName`, changing `TypeSynonymDeclaration`, or adding a new constructor alongside `TypeSynonymDeclaration`, any of which would likely require refactoring code in a much wider scope than this PR currently targets—an outcome worth avoiding not only because I'm lazy, but also because I figured you would prefer it if I kept my grubby noob hands out of the typechecker. :smile: As always, I'm happy to do the work if I'm wrong.

Closes #3708.