### PR TITLE
Fix parsing of comma-separated guards in let statements

### DIFF
--- a/src/Language/PureScript/CST/Layout.hs
+++ b/src/Language/PureScript/CST/Layout.hs
@@ -236,9 +236,10 @@ insertLayout src@(SourceToken tokAnn tok) nextPos stack =
         _ ->
           state & insertDefault
       where
-      equalsP _ LytWhere = True
-      equalsP _ LytLet   = True
-      equalsP _ _        = False
+      equalsP _ LytWhere   = True
+      equalsP _ LytLet     = True
+      equalsP _ LytLetStmt = True
+      equalsP _ _          = False
 
     -- Guards need masking because of commas.
     TokPipe ->
@@ -246,6 +247,8 @@ insertLayout src@(SourceToken tokAnn tok) nextPos stack =
         state'@((_, LytOf) : _, _) ->
           state' & pushStack tokPos LytCaseGuard & insertToken src
         state'@((_, LytLet) : _, _) ->
+          state' & pushStack tokPos LytDeclGuard & insertToken src
+        state'@((_, LytLetStmt) : _, _) ->
           state' & pushStack tokPos LytDeclGuard & insertToken src
         state'@((_, LytWhere) : _, _) ->
           state' & pushStack tokPos LytDeclGuard & insertToken src

--- a/tests/purs/layout/LetGuards.out
+++ b/tests/purs/layout/LetGuards.out
@@ -1,0 +1,30 @@
+module Test where{
+
+test =
+  let{
+    foo
+      | bar
+      , baz =
+        42
+      | otherwise = 100}
+  in
+    foo;
+
+test = do{
+  let{
+    foo
+      | bar
+      , baz =
+        42
+      | otherwise = 100};
+  foo};
+
+test = ado{
+  let{
+    foo
+      | bar
+      , baz =
+        42
+      | otherwise = 100};
+  foo}}
+<eof>

--- a/tests/purs/layout/LetGuards.purs
+++ b/tests/purs/layout/LetGuards.purs
@@ -1,0 +1,29 @@
+module Test where
+
+test =
+  let
+    foo
+      | bar
+      , baz =
+        42
+      | otherwise = 100
+  in
+    foo
+
+test = do
+  let
+    foo
+      | bar
+      , baz =
+        42
+      | otherwise = 100
+  foo
+
+test = ado
+  let
+    foo
+      | bar
+      , baz =
+        42
+      | otherwise = 100
+  foo


### PR DESCRIPTION
Parsing was failing in do/let guards if a comma was inserted. It was prematurely inserting closing layout delimiters before the comma due to the missing cases for `LytLetStmt`.