### PR TITLE
WIP: Print Functions as Arrow-Functions when generating JS

### DIFF
--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -204,7 +204,7 @@ moduleToJs (Module _ coms mn _ imps exps foreigns decls) foreign_ =
     extendObj obj sts
   valueToJs' e@(Abs (_, _, _, Just IsTypeClassConstructor) _ _) =
     let args = unAbs e
-    in return $ AST.Function Nothing Nothing (map identToJs args) (AST.Block Nothing $ map assign args)
+    in return $ AST.Constructor Nothing Nothing (map identToJs args) (AST.Block Nothing $ map assign args)
     where
     unAbs :: Expr Ann -> [Ident]
     unAbs (Abs _ arg val) = arg : unAbs val


### PR DESCRIPTION
Arrow Functions have the advantage of ~better performance~ (EDIT: actual performance gains are unclear) and are easier to read (especially with curried functions).

This PR is a PoC for using arrow functions where ever it is possible. If there is interest in implementing it in the compiler, I'll clean the code up.

- [x] tests are passing

### Changes
- Addition of `Constructor` to CoreImp AST
- prettyPrint for Constructor
- prettyPrint for Function

```purescript
module Test where

f as b cs = [as, b, cs]

c n = {n}

data Test = Test Int

testVal :: Test
testVal = Test 1

class ShowTest a where show :: a -> String

instance showTest ∷ ShowTest Test where show _ = "test"
```
now generates:
```js
"use strict";
var Test = (() => {
    function Test(value0) {
        this.value0 = value0;
    };
    Test.create = value0 => new Test(value0);
    return Test;
})();
var ShowTest = function (show) {
    this.show = show;
};
var testVal = new Test(1);
var showTest = new ShowTest(v => "test");
var show = dict => dict.show;
var f = as => b => cs => [ as, b, cs ];
var c = n => ({
    n: n
});
...
```

instead of:
```js
"use strict";
var Test = (function () {
    function Test(value0) {
        this.value0 = value0;
    };
    Test.create = function (value0) {
        return new Test(value0);
    };
    return Test;
})();
var ShowTest = function (show) {
    this.show = show;
};
var testVal = new Test(1);
var showTest = new ShowTest(function (v) {
    return "test";
});
var show = function (dict) {
    return dict.show;
};
var f = function (as) {
    return function (b) {
        return function (cs) {
            return [ as, b, cs ];
        };
    };
};
var c = function (n) {
    return {
        n: n
    };
};
...
```