### PR TITLE
Suggest import for name causing a UnknownName error

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -205,6 +205,7 @@ data ErrorMessageHint
   | ErrorInTypeClassDeclaration (ProperName 'ClassName)
   | ErrorInForeignImport Ident
   | ErrorSolvingConstraint SourceConstraint
+  | ErrorMissingImport (NEL.NonEmpty (ModuleName, DeclarationRef)) -- List of possible import matching the expected name
   | PositionedError (NEL.NonEmpty SourceSpan)
   deriving (Show)
 

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -34,6 +34,7 @@ import           Language.PureScript.Environment
 import           Language.PureScript.Errors
 import           Language.PureScript.Externs
 import           Language.PureScript.Linter
+import           Language.PureScript.Suggest
 import           Language.PureScript.ModuleDependencies
 import           Language.PureScript.Names
 import           Language.PureScript.Renamer
@@ -125,7 +126,8 @@ make ma@MakeActions{..} ms = do
   results <- BuildPlan.collectResults buildPlan
 
   -- All threads have completed, rethrow any caught errors.
-  let errors = mapMaybe buildJobFailure $ M.elems results
+  let errors = decorateSuggestions (M.elems results) $ mapMaybe buildJobFailure $ M.elems results
+  
   unless (null errors) $ throwError (mconcat errors)
 
   -- Here we return all the ExternsFile in the ordering of the topological sort,

--- a/src/Language/PureScript/Suggest.hs
+++ b/src/Language/PureScript/Suggest.hs
@@ -1,0 +1,39 @@
+-- |
+-- This module implements a simple linting pass on the PureScript AST.
+--
+module Language.PureScript.Suggest where
+
+import Prelude.Compat
+
+import Data.Maybe (catMaybes, maybeToList)
+
+import qualified Data.List.NonEmpty as NEL
+
+import Language.PureScript.Make.BuildPlan
+import           Language.PureScript.Errors
+import           Language.PureScript.Externs
+import Language.PureScript.Names
+
+
+decorateSuggestions :: [BuildJobResult] -> [MultipleErrors] -> [MultipleErrors]
+decorateSuggestions jobs multipleErrors = decorateMultipleErrors <$> multipleErrors
+    where
+      compiledExterns :: [ExternsFile]
+      compiledExterns = snd <$> (catMaybes $ buildJobSuccess <$> jobs)
+
+      decorateMultipleErrors :: MultipleErrors -> MultipleErrors
+      decorateMultipleErrors (MultipleErrors errs) = MultipleErrors $ decorateErrorMessage <$> errs
+
+      decorateErrorMessage :: ErrorMessage -> ErrorMessage
+      decorateErrorMessage (ErrorMessage hints err@(UnknownName (Qualified Nothing name))) = ErrorMessage (hints ++ maybeToList (importHintsForModule name)) err
+      decorateErrorMessage others = others
+
+      importHintsForModule :: Name -> Maybe ErrorMessageHint
+      importHintsForModule name = ErrorMissingImport <$> NEL.nonEmpty qualifiedValues 
+        where qualifiedValues = findImportForName name 
+
+      findImportForName :: Name -> [(ModuleName, DeclarationRef)]
+      findImportForName name = 
+        filter ((==name) . declRefName . snd)
+        $ concat
+        $ (\extern -> (\decl -> (efModuleName extern, decl)) <$> efExports extern) <$> compiledExterns


### PR DESCRIPTION
This PR adds the adds a Hint to the UnknownName error, if a module exports the same name. It (should) support all names including types, type classes, values etc. 

## Changes
- addition of a new Hint for UnknownName
- renderning for the hint
- call to add these suggestions in `Make.make`
- add module for future suggestions

## ToDos
- [ ] Move from Hint to Field on UnknownName (to support JSON error suggestions)
- [ ] Check performance. If needed limit search / build map from Name to possible imports
- [ ] SourceSpans
- [ ] Reuse existing imports if possible: E.g. if `Prelude (map)` is already imported, suggest `Prelude (map, class Show)`

If there is interest in this, I'll implement these ToDos.
Ensuring, that the value has the correct type would be nice but seems quite involved, as none of the data structures available at the necessary places seem to have type information available.

Example:
```
Error 3 of 4:

  in module Data.DotLang.Attr.Edge
  at src/Data/DotLang/Attr/Edge.purs:22:1 - 23:21 (line 22, column 1 - line 23, column 21)

    Unknown type class Show

  Perhaps you want to add it to the import list? 2 possible imports were found:
                                 
    import Data.Show (class Show)
    import Prelude (class Show)  
                                 

  See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
  or to contribute content related to this error.
```