### PR TITLE
Ambiguous variable check: take closure of fundeps across constraints

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -113,7 +113,7 @@ data SimpleErrorMessage
   | ConstrainedTypeUnified SourceType SourceType
   | OverlappingInstances (Qualified (ProperName 'ClassName)) [SourceType] [Qualified Ident]
   | NoInstanceFound SourceConstraint
-  | AmbiguousTypeVariables SourceType SourceConstraint
+  | AmbiguousTypeVariables SourceType [Int]
   | UnknownClass (Qualified (ProperName 'ClassName))
   | PossiblyInfiniteInstance (Qualified (ProperName 'ClassName)) [SourceType]
   | CannotDerive (Qualified (ProperName 'ClassName)) [SourceType]

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -287,7 +287,7 @@ onTypesInErrorMessageM f (ErrorMessage hints simple) = ErrorMessage <$> traverse
   gSimple (ExprDoesNotHaveType e t) = ExprDoesNotHaveType e <$> f t
   gSimple (InvalidInstanceHead t) = InvalidInstanceHead <$> f t
   gSimple (NoInstanceFound con) = NoInstanceFound <$> overConstraintArgs (traverse f) con
-  gSimple (AmbiguousTypeVariables t con) = AmbiguousTypeVariables <$> f t <*> pure con
+  gSimple (AmbiguousTypeVariables t us) = AmbiguousTypeVariables <$> f t <*> pure us
   gSimple (OverlappingInstances cl ts insts) = OverlappingInstances cl <$> traverse f ts <*> pure insts
   gSimple (PossiblyInfiniteInstance cl ts) = PossiblyInfiniteInstance cl <$> traverse f ts
   gSimple (CannotDerive cl ts) = CannotDerive cl <$> traverse f ts
@@ -688,10 +688,16 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
         where
         go TUnknown{} = True
         go _ = False
-    renderSimpleErrorMessage (AmbiguousTypeVariables t _) =
+    renderSimpleErrorMessage (AmbiguousTypeVariables t us) =
       paras [ line "The inferred type"
             , markCodeBox $ indent $ typeAsBox prettyDepth t
-            , line "has type variables which are not mentioned in the body of the type. Consider adding a type annotation."
+            , line "has type variables which are not determined by those mentioned in the body of the type:"
+            , indent $ Box.hsep 1 Box.left
+              [ Box.vcat Box.left
+                [ line $ markCode ("t" <> T.pack (show u)) <> " could not be determined"
+                | u <- us ]
+              ]
+            , line "Consider adding a type annotation."
             ]
     renderSimpleErrorMessage (PossiblyInfiniteInstance nm ts) =
       paras [ line "Type class instance for"

--- a/tests/purs/passing/3238.purs
+++ b/tests/purs/passing/3238.purs
@@ -1,0 +1,14 @@
+module Main where
+
+import Effect.Console (log)
+
+class C a
+
+class FD a b | a -> b
+
+fn1 :: forall a b. FD a b => C b => a -> String
+fn1 _ = ""
+
+fn2 x = fn1 x
+
+main = log "Done"


### PR DESCRIPTION
Fixes #3238

Previously the check (which occurs when generalizing types) only took into account each class individually and would miss variables that were determined from the interaction of multiple constraints.

I also updated the error message to say which variables could not be determined, especially since that information is readily available now.

Feedback:
- Is `Protolude.atMay` the proper function to use to handle partiality? I couldn't really find one …
- Does the error message look okay?

```
Error found:
in module Data.Record.Operations
at test/Operations.purs:146:1 - 146:99 (line 146, column 1 - line 146, column 99)

  The inferred type
                                                                                                                                                                                                                                                                                                                                                                                                        
    forall t40 t41 t43 t44 t48 t49 t51 t52 t55 t56. RowToList t44 t41 => Lacks "onMouseEnter" t41 t55 => AppendCase t55 "onMouseEnter" String (Cons "onMouseLeave" String Nil) t41 t40 => ListToRow t40 t43 => RowToList t52 t49 => Lacks "onMouseLeave" t49 t56 => AppendCase t56 "onMouseLeave" String Nil t49 t48 => ListToRow t48 t51 => Tuple (Record t44 -> Record t43) (Record t52 -> Record t51)
                                                                                                                                                                                                                                                                                                                                                                                                        
  has type variables which are not determined by those mentioned in the body of the type:

    t40 could not be determined
    t48 could not be determined

  Consider adding a type annotation.

in value declaration e2
```