### PR TITLE
Better reporting of IO errors

### DIFF
--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -75,9 +75,7 @@ data SimpleErrorMessage
   | MissingFFIImplementations ModuleName [Ident]
   | UnusedFFIImplementations ModuleName [Ident]
   | InvalidFFIIdentifier ModuleName Text
-  | CannotGetFileInfo FilePath
-  | CannotReadFile FilePath
-  | CannotWriteFile FilePath
+  | FileIOError Text IOError -- ^ A description of what we were trying to do, and the error which occurred
   | InfiniteType SourceType
   | InfiniteKind SourceKind
   | MultipleValueOpFixities (OpName 'ValueOpName)

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -10,6 +10,7 @@ import           Prelude.Compat
 import           Protolude (ordNub)
 
 import           Control.Arrow ((&&&))
+import           Control.Exception (displayException)
 import           Control.Monad
 import           Control.Monad.Error.Class (MonadError(..))
 import           Control.Monad.Trans.State.Lazy
@@ -85,9 +86,7 @@ errorCode em = case unwrapErrorMessage em of
   MissingFFIImplementations{} -> "MissingFFIImplementations"
   UnusedFFIImplementations{} -> "UnusedFFIImplementations"
   InvalidFFIIdentifier{} -> "InvalidFFIIdentifier"
-  CannotGetFileInfo{} -> "CannotGetFileInfo"
-  CannotReadFile{} -> "CannotReadFile"
-  CannotWriteFile{} -> "CannotWriteFile"
+  FileIOError{} -> "FileIOError"
   InfiniteType{} -> "InfiniteType"
   InfiniteKind{} -> "InfiniteKind"
   MultipleValueOpFixities{} -> "MultipleValueOpFixities"
@@ -465,17 +464,9 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
                   else
                     "Make sure the source file exists, and that it has been provided as an input to the compiler."
             ]
-    renderSimpleErrorMessage (CannotGetFileInfo path) =
-      paras [ line "Unable to read file info: "
-            , indent . lineS $ path
-            ]
-    renderSimpleErrorMessage (CannotReadFile path) =
-      paras [ line "Unable to read file: "
-            , indent . lineS $ path
-            ]
-    renderSimpleErrorMessage (CannotWriteFile path) =
-      paras [ line "Unable to write file: "
-            , indent . lineS $ path
+    renderSimpleErrorMessage (FileIOError doWhat err) =
+      paras [ line $ "I/O error while trying to " <> doWhat
+            , indent . lineS $ displayException err
             ]
     renderSimpleErrorMessage (ErrorParsingFFIModule path extra) =
       paras $ [ line "Unable to parse foreign module:"

--- a/src/Language/PureScript/Make/Monad.hs
+++ b/src/Language/PureScript/Make/Monad.hs
@@ -5,11 +5,19 @@ module Language.PureScript.Make.Monad
     Make(..)
   , runMake
   , makeIO
+  , getTimestamp
+  , getTimestampMaybe
   , readTextFile
+  , readTextFileMaybe
+  , readJSONFile
+  , writeTextFile
+  , writeJSONFile
   ) where
 
 import           Prelude
 
+import           Control.Exception (tryJust)
+import           Control.Monad (join, guard)
 import           Control.Monad.Base (MonadBase(..))
 import           Control.Monad.Error.Class (MonadError(..))
 import           Control.Monad.IO.Class
@@ -18,11 +26,17 @@ import           Control.Monad.Reader (MonadReader(..), ReaderT(..))
 import           Control.Monad.Trans.Control (MonadBaseControl(..))
 import           Control.Monad.Trans.Except
 import           Control.Monad.Writer.Class (MonadWriter(..))
+import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as B
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import           Data.Time.Clock (UTCTime)
 import           Language.PureScript.AST
 import           Language.PureScript.Errors
 import           Language.PureScript.Options
-import           System.IO.Error (tryIOError)
+import           System.Directory (createDirectoryIfMissing, getModificationTime)
+import           System.FilePath (takeDirectory)
+import           System.IO.Error (tryIOError, isDoesNotExistError)
 
 -- | A monad for running make actions
 newtype Make a = Make
@@ -41,14 +55,71 @@ instance MonadBaseControl IO Make where
 runMake :: Options -> Make a -> IO (Either MultipleErrors a, MultipleErrors)
 runMake opts = runLogger' . runExceptT . flip runReaderT opts . unMake
 
--- | Run an 'IO' action in the 'Make' monad, by specifying how IO errors should
--- be rendered as 'ErrorMessage' values.
-makeIO :: (IOError -> ErrorMessage) -> IO a -> Make a
-makeIO f io = do
+-- | Run an 'IO' action in the 'Make' monad. The 'String' argument should
+-- describe what we were trying to do; it is used for rendering errors in the
+-- case that an IOException is thrown.
+makeIO :: Text -> IO a -> Make a
+makeIO description io = do
   e <- liftIO $ tryIOError io
-  either (throwError . singleError . f) return e
+  either (throwError . singleError . ErrorMessage [] . FileIOError description) return e
+
+-- | Get a file's modification time in the 'Make' monad, capturing any errors
+-- using the 'MonadError' instance.
+getTimestamp :: FilePath -> Make UTCTime
+getTimestamp path =
+  makeIO ("get a timestamp for file: " <> Text.pack path) $ getModificationTime path
+
+-- | Get a file's modification time in the 'Make' monad, returning Nothing if
+-- the file does not exist.
+getTimestampMaybe :: FilePath -> Make (Maybe UTCTime)
+getTimestampMaybe path =
+  makeIO ("get a timestamp for file: " <> Text.pack path) $ catchDoesNotExist $ getModificationTime path
 
 -- | Read a text file in the 'Make' monad, capturing any errors using the
 -- 'MonadError' instance.
 readTextFile :: FilePath -> Make B.ByteString
-readTextFile path = makeIO (const (ErrorMessage [] $ CannotReadFile path)) $ B.readFile path
+readTextFile path =
+  makeIO ("read file: " <> Text.pack path) $ B.readFile path
+
+-- | Read a text file in the 'Make' monad, or return 'Nothing' if the file does
+-- not exist. Errors are captured using the 'MonadError' instance.
+readTextFileMaybe :: FilePath -> Make (Maybe B.ByteString)
+readTextFileMaybe path =
+  makeIO ("read file: " <> Text.pack path) $ catchDoesNotExist $ B.readFile path
+
+-- | Read a JSON file in the 'Make' monad, returning 'Nothing' if the file does
+-- not exist or could not be parsed. Errors are captured using the 'MonadError'
+-- instance.
+readJSONFile :: Aeson.FromJSON a => FilePath -> Make (Maybe a)
+readJSONFile path =
+  makeIO ("read JSON file: " <> Text.pack path) $ do
+    r <- catchDoesNotExist $ Aeson.decodeFileStrict' path
+    return $ join r
+
+-- | If the provided action threw an 'isDoesNotExist' error, catch it and
+-- return Nothing. Otherwise return Just the result of the inner action.
+catchDoesNotExist :: IO a -> IO (Maybe a)
+catchDoesNotExist inner = do
+  r <- tryJust (guard . isDoesNotExistError) inner
+  case r of
+    Left () ->
+      return Nothing
+    Right x ->
+      return (Just x)
+
+-- | Write a text file in the 'Make' monad, capturing any errors using the
+-- 'MonadError' instance.
+writeTextFile :: FilePath -> B.ByteString -> Make ()
+writeTextFile path text = makeIO ("write file: " <> Text.pack path) $ do
+  createParentDirectory path
+  B.writeFile path text
+
+-- | Write a JSON file in the 'Make' monad, capturing any errors using the
+-- 'MonadError' instance.
+writeJSONFile :: Aeson.ToJSON a => FilePath -> a -> Make ()
+writeJSONFile path value = makeIO ("write JSON file: " <> Text.pack path) $ do
+  createParentDirectory path
+  Aeson.encodeFile path value
+
+createParentDirectory :: FilePath -> IO ()
+createParentDirectory = createDirectoryIfMissing True . takeDirectory


### PR DESCRIPTION
This commit fixes two issues with the way we read and write files inside
Language.PureScript.Make:

1. We use `doesFileExist` to check for file existence before attempting
to do something with a file. This can cause race conditions; it's better
to just attempt to do the thing and catch the "does not exist" error if
we get one.

2. We discard the IOException which actually tells you what has gone
wrong before we print the error message. This means that the error
message often does not include the most important information. For
example, here's the error I get when I try to build a project on a disk
which does not have enough remaining space to accommodate all of the
compiler output:

Before:

```
Compiling Data.Ord
Compiling Data.DivisionRing
[1/2 CannotWriteFile] (unknown module)

  Unable to write file:

    ./output/Data.DivisionRing/externs.json

[2/2 CannotWriteFile] (unknown module)

  Unable to write file:

    ./output/Data.Ord/foreign.js
```

After:

```
Compiling Data.Ord
Compiling Data.DivisionRing
[1/1 FileIOError] (unknown module)

  I/O error while trying to write JSON file: ./output/cache-db.json

    ./output/cache-db.json: hClose: resource exhausted (No space left on device)
```

We will need to update the documentation repo appropriately, because the
`CannotReadFile`, `CannotWriteFile`, and `CannotGetFileInfo` error codes
have been removed.