### PR TITLE
Fix #3727

### DIFF
--- a/tests/purs/bundle/3727.js
+++ b/tests/purs/bundle/3727.js
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.foo = 1;
+exports.bar = exports.foo;

--- a/tests/purs/bundle/3727.purs
+++ b/tests/purs/bundle/3727.purs
@@ -1,0 +1,13 @@
+module Main (main) where
+
+import Prelude
+import Effect (Effect)
+import Effect.Console (log)
+import Test.Assert (assert)
+
+main :: Effect Unit
+main = do
+  assert (bar == 1)
+  log "Done"
+
+foreign import bar :: Int


### PR DESCRIPTION
The bundler needs to track internal dependencies on exported symbols
during dead code elimination, not just on internal declarations.