### PR TITLE
Update language-javascript to 0.7.0.0

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -63,7 +63,7 @@ dependencies:
   - fsnotify >=0.2.1
   - Glob >=0.9 && <0.10
   - haskeline >=0.7.0.0
-  - language-javascript >=0.6.0.14
+  - language-javascript >=0.7.0.0
   - lifted-async >=0.10.0.3 && <0.10.1
   - lifted-base >=0.2.3 && <0.2.4
   - memory >=0.14 && <0.15

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
 - '.'
 extra-deps:
 - happy-1.19.9
-- language-javascript-0.6.0.14
+- language-javascript-0.7.0.0
 - network-3.0.1.1
 - these-1.0.1
 - semialign-1


### PR DESCRIPTION
0.7.0.0 is the same as 0.6.0.14 (which is currently in our package
configuration), except the latter has been deprecated, because it
contained breaking changes but was released as a patch level change.