### PR TITLE
Fix error with building haddocks

### DIFF
--- a/src/Language/PureScript/Bundle.hs
+++ b/src/Language/PureScript/Bundle.hs
@@ -297,7 +297,7 @@ withDeps (Module modulePath fn es) = Module modulePath fn (map expandDeps es)
       = ([(mid, nm', Public)], bn)
     toReference (JSIdentifier _ nm) bn
       | nm `elem` bn
-      -- ^ only add a dependency if this name is still in the list of names
+      -- only add a dependency if this name is still in the list of names
       -- bound to the module level (i.e., hasn't been shadowed by a function
       -- parameter)
       = ([(m, nm, Internal)], bn)
@@ -305,7 +305,7 @@ withDeps (Module modulePath fn es) = Module modulePath fn (map expandDeps es)
       = let
           shorthandNames =
             filter (`elem` bn) $
-            -- ^ only add a dependency if this name is still in the list of
+            -- only add a dependency if this name is still in the list of
             -- names bound to the module level (i.e., hasn't been shadowed by a
             -- function parameter)
             mapMaybe unPropertyIdentRef $
@@ -316,7 +316,7 @@ withDeps (Module modulePath fn es) = Module modulePath fn (map expandDeps es)
       = ([], bn \\ (mapMaybe unIdentifier $ commaList params))
     toReference e bn
       | Just nm <- exportsAccessor e
-      -- ^ exports.foo means there's a dependency on the public member "foo" of
+      -- exports.foo means there's a dependency on the public member "foo" of
       -- this module.
       = ([(m, nm, Public)], bn)
     toReference _ bn = ([], bn)


### PR DESCRIPTION
I was having trouble with `stack build --haddock` failing.  

When running `stack build --haddock`, I would get the following error during the haddock phase:

```
src/Language/PureScript/Bundle.hs:300:7: error:
    parse error on input ‘-- ^ only add a dependency if this name is still in the list of names
      -- bound to the module level (i.e., hasn't been shadowed by a function
      -- parameter)’        
    |                       
300 |       -- ^ only add a dependency if this name is still in the list of names
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Here's the full build log:

https://gist.github.com/cdepillabout/ae690a8349d6f448ac7fadf580df6669

--------------------------------------------------------------------------

This PR contains two commits:

- 646cbec corrects those Haskell comments so they don't cause `stack build --haddock` to fail.

- 96fc231 turns on building haddocks for CI, so these types of errors don't creep into the codebase again.

    However, looking back through the history, it appears that building haddocks was explicitly turned off, so I imagine there might be problems with turning this on: https://github.com/purescript/purescript/pull/3606

    I can remove this commit from this PR if needed.