### PR TITLE
Consider re-exports in unused kind warnings

### DIFF
--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -178,6 +178,7 @@ lintImports (Module _ _ mn mdecls (Just mexports)) env usedImps = do
       ++ extractByQual mne (importedDataConstructors scope) DctorName
       ++ extractByQual mne (importedValues scope) IdentName
       ++ extractByQual mne (importedValueOps scope) ValOpName
+      ++ extractByQual mne (importedKinds scope) KiName
     where
     go :: (ModuleName, Qualified Name) -> UsedImports -> UsedImports
     go (q, name) = M.alter (Just . maybe [name] (name :)) q

--- a/tests/purs/warning/KindReExport.purs
+++ b/tests/purs/warning/KindReExport.purs
@@ -1,0 +1,11 @@
+-- | This test is to ensure that we do not get an incorrect 'unused kind'
+-- | warning. See #3744
+module Main (main, module X) where
+
+import Prelude
+import Effect (Effect)
+import Effect.Console (log)
+import Prim.Ordering (kind Ordering) as X
+
+main :: Effect Unit
+main = log "Done"


### PR DESCRIPTION
Fixes #3744. This allows `purescript-st` to compile without warnings again (see https://travis-ci.org/purescript/purescript-st/jobs/606644430#L956 for an example of how it is now)