### PR TITLE
Add upper bound on Protolude

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -75,7 +75,7 @@ dependencies:
   - parsec >=3.1.10
   - pattern-arrows >=0.0.2 && <0.1
   - process >=1.2.0 && <1.7
-  - protolude >=0.1.6
+  - protolude >=0.1.6 && <0.2.4
   - regex-tdfa
   - safe >=0.3.9 && <0.4
   - scientific >=0.3.4.9 && <0.4


### PR DESCRIPTION
The compiler does not currently compile with Protolude 0.2.4, because of
an import conflict. This commit addresses the issue by adding an upper
bound which prevents Protolude 0.2.4 from being selected.

I already made the revision on Hackage for this (see http://hackage.haskell.org/package/purescript-0.13.4/revisions/) but I forgot to make a PR here until just now. Sorry!