### PR TITLE
Added spans to ado desugaring

### DIFF
--- a/src/Language/PureScript/Sugar/AdoNotation.hs
+++ b/src/Language/PureScript/Sugar/AdoNotation.hs
@@ -40,29 +40,29 @@ desugarAdo d =
 
   replace :: SourceSpan -> Expr -> m Expr
   replace pos (Ado m els yield) = do
-    (func, args) <- foldM go (yield, []) (reverse els)
+    (func, args) <- foldM (go pos) (yield, []) (reverse els)
     return $ case args of
       [] -> App (pure' pos m) func
       hd : tl -> foldl' (\a b -> App (App (apply pos m) a) b) (App (App (map' pos m) func) hd) tl
   replace _ (PositionedValue pos com v) = PositionedValue pos com <$> rethrowWithPosition pos (replace pos v)
   replace _ other = return other
 
-  go :: (Expr, [Expr]) -> DoNotationElement -> m (Expr, [Expr])
-  go (yield, args) (DoNotationValue val) =
+  go :: SourceSpan -> (Expr, [Expr]) -> DoNotationElement -> m (Expr, [Expr])
+  go _ (yield, args) (DoNotationValue val) =
     return (Abs NullBinder yield, val : args)
-  go (yield, args) (DoNotationBind (VarBinder ss ident) val) =
+  go _ (yield, args) (DoNotationBind (VarBinder ss ident) val) =
     return (Abs (VarBinder ss ident) yield, val : args)
-  go (yield, args) (DoNotationBind binder val) = do
+  go ss (yield, args) (DoNotationBind binder val) = do
     ident <- freshIdent'
-    let abs = Abs (VarBinder nullSourceSpan ident)
-                  (Case [Var nullSourceSpan (Qualified Nothing ident)]
+    let abs = Abs (VarBinder ss ident)
+                  (Case [Var ss (Qualified Nothing ident)]
                         [CaseAlternative [binder] [MkUnguarded yield]])
     return (abs, val : args)
-  go (yield, args) (DoNotationLet ds) = do
+  go _ (yield, args) (DoNotationLet ds) = do
     return (Let FromLet ds yield, args)
-  go acc (PositionedDoNotationElement pos com el) =
+  go _ acc (PositionedDoNotationElement pos com el) =
     rethrowWithPosition pos $ do
-      (yield, args) <- go acc el
+      (yield, args) <- go pos acc el
       return $ case args of
         [] -> (PositionedValue pos com yield, args)
         (a : as) -> (yield, PositionedValue pos com a : as)

--- a/src/Language/PureScript/Sugar/AdoNotation.hs
+++ b/src/Language/PureScript/Sugar/AdoNotation.hs
@@ -25,26 +25,27 @@ desugarAdoModule (Module ss coms mn ds exts) = Module ss coms mn <$> parU ds des
 -- | Desugar a single ado statement
 desugarAdo :: forall m. (MonadSupply m, MonadError MultipleErrors m) => Declaration -> m Declaration
 desugarAdo d =
-  let (f, _, _) = everywhereOnValuesM return replace return
-  in f d
+  let ss = declSourceSpan d
+      (f, _, _) = everywhereOnValuesM return (replace ss) return
+  in rethrowWithPosition ss $ f d
   where
-  pure' :: Maybe ModuleName -> Expr
-  pure' m = Var nullSourceSpan (Qualified m (Ident C.pure'))
+  pure' :: SourceSpan -> Maybe ModuleName -> Expr
+  pure' ss m = Var ss (Qualified m (Ident C.pure'))
 
-  map' :: Maybe ModuleName -> Expr
-  map' m = Var nullSourceSpan (Qualified m (Ident C.map))
+  map' :: SourceSpan -> Maybe ModuleName -> Expr
+  map' ss m = Var ss (Qualified m (Ident C.map))
 
-  apply :: Maybe ModuleName -> Expr
-  apply m = Var nullSourceSpan (Qualified m (Ident C.apply))
+  apply :: SourceSpan -> Maybe ModuleName -> Expr
+  apply ss m = Var ss (Qualified m (Ident C.apply))
 
-  replace :: Expr -> m Expr
-  replace (Ado m els yield) = do
+  replace :: SourceSpan -> Expr -> m Expr
+  replace pos (Ado m els yield) = do
     (func, args) <- foldM go (yield, []) (reverse els)
     return $ case args of
-      [] -> App (pure' m) func
-      hd : tl -> foldl' (\a b -> App (App (apply m) a) b) (App (App (map' m) func) hd) tl
-  replace (PositionedValue pos com v) = PositionedValue pos com <$> rethrowWithPosition pos (replace v)
-  replace other = return other
+      [] -> App (pure' pos m) func
+      hd : tl -> foldl' (\a b -> App (App (apply pos m) a) b) (App (App (map' pos m) func) hd) tl
+  replace _ (PositionedValue pos com v) = PositionedValue pos com <$> rethrowWithPosition pos (replace pos v)
+  replace _ other = return other
 
   go :: (Expr, [Expr]) -> DoNotationElement -> m (Expr, [Expr])
   go (yield, args) (DoNotationValue val) =


### PR DESCRIPTION
This should fix  #3754.

I'm not sure if the `nullSourceSpan` passed to `VarBinder` and `Case` in the `go` function needs to be addressed.