### PR TITLE
Fix typos

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5060,7 +5060,7 @@ vector-algorithms LICENSE file:
   ------------------------------------------------------------------------------
 
   The code in Data.Array.Vector.Algorithms.Mutable.Optimal is adapted from a C
-  algorithm for the same purpose. The folowing is the copyright notice for said
+  algorithm for the same purpose. The following is the copyright notice for said
   C code:
 
   Copyright (c) 2004 Paul Hsieh

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -303,7 +303,7 @@ addImportForIdentifier fp ident qual filters = do
     -- This case comes up for newtypes and dataconstructors. Because values and
     -- types don't share a namespace we can get multiple matches from the same
     -- module. This also happens for parameterized types, as these generate both
-    -- a type aswell as a type synonym.
+    -- a type as well as a type synonym.
 
     ms@[Match (m1, d1), Match (m2, d2)] ->
       if m1 /= m2

--- a/src/Language/PureScript/Ide/Matcher.hs
+++ b/src/Language/PureScript/Ide/Matcher.hs
@@ -52,7 +52,7 @@ instance FromJSON (Matcher IdeDeclarationAnn) where
       Just _ -> mzero
       Nothing -> return mempty
 
--- | Matches any occurence of the search string with intersections
+-- | Matches any occurrence of the search string with intersections
 --
 -- The scoring measures how far the matches span the string where
 -- closer is better.

--- a/src/Language/PureScript/Interactive/Directive.hs
+++ b/src/Language/PureScript/Interactive/Directive.hs
@@ -12,7 +12,7 @@ import Data.Tuple (swap)
 import Language.PureScript.Interactive.Types
 
 -- |
--- List of all avaliable directives.
+-- List of all available directives.
 --
 directives :: [Directive]
 directives = map fst directiveStrings

--- a/src/Language/PureScript/Kinds.hs
+++ b/src/Language/PureScript/Kinds.hs
@@ -98,7 +98,7 @@ kindFromJSON defaultAnn annFromJSON = A.withObject "Kind" $ \o -> do
   go :: Value -> Parser (Kind a)
   go = kindFromJSON defaultAnn annFromJSON
 
--- These overlapping instances exist to preserve compatability for common
+-- These overlapping instances exist to preserve compatibility for common
 -- instances which have a sensible default for missing annotations.
 instance {-# OVERLAPPING #-} A.FromJSON (Kind SourceAnn) where
   parseJSON = kindFromJSON (pure NullSourceAnn) A.parseJSON

--- a/src/Language/PureScript/Sugar/Operators/Common.hs
+++ b/src/Language/PureScript/Sugar/Operators/Common.hs
@@ -96,7 +96,7 @@ matchOperators isBinOp extractOp fromOp reapply modOpTable ops = parseChains
   -- grouping them by shared precedence, then if any of the following conditions
   -- are met, we have something to report:
   --   1. any of the groups have mixed associativity
-  --   2. there is more than one occurance of a non-associative operator in a
+  --   2. there is more than one occurrence of a non-associative operator in a
   --      precedence group
   mkErrors :: Chain a -> [ErrorMessage]
   mkErrors chain =

--- a/src/Language/PureScript/TypeChecker/Skolems.hs
+++ b/src/Language/PureScript/TypeChecker/Skolems.hs
@@ -30,7 +30,7 @@ newSkolemConstant = do
   modify $ \st -> st { checkNextSkolem = s + 1 }
   return s
 
--- | Introduce skolem scope at every occurence of a ForAll
+-- | Introduce skolem scope at every occurrence of a ForAll
 introduceSkolemScope :: MonadState CheckState m => Type a -> m (Type a)
 introduceSkolemScope = everywhereOnTypesM go
   where

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -321,7 +321,7 @@ typeFromJSON defaultAnn annFromJSON = A.withObject "Type" $ \o -> do
   go :: A.Value -> A.Parser (Type a)
   go = typeFromJSON defaultAnn annFromJSON
 
--- These overlapping instances exist to preserve compatability for common
+-- These overlapping instances exist to preserve compatibility for common
 -- instances which have a sensible default for missing annotations.
 instance {-# OVERLAPPING #-} A.FromJSON (Type SourceAnn) where
   parseJSON = typeFromJSON (pure NullSourceAnn) A.parseJSON

--- a/tests/purs/warning/ScopeShadowing.purs
+++ b/tests/purs/warning/ScopeShadowing.purs
@@ -7,7 +7,7 @@ import Prelude
 data Unit = Unit
 
 -- This is only a warning as the `Prelude` import is implicit. If `Unit` was
--- named explicitly in an import list, then this refernce to `Unit`
+-- named explicitly in an import list, then this reference to `Unit`
 -- would be a `ScopeConflict` error instead.
 test :: Unit
 test = const Unit unit


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.