### PR TITLE
Generate correct arity failure case for some guarded matches

### DIFF
--- a/tests/purs/passing/Guards.purs
+++ b/tests/purs/passing/Guards.purs
@@ -34,6 +34,12 @@ clunky1 a b | x <- max a b
             = x
 clunky1 a _ = a
 
+clunky1_refutable :: Int -> Int -> Int
+clunky1_refutable 0 a | x <- max a a
+                      , x > 5
+                      = x
+clunky1_refutable a _ = a
+
 clunky2 :: Int -> Int -> Int
 clunky2 a b | x <- max a b
             , x > 5


### PR DESCRIPTION
Specifically when a multi-way case contains a pattern guard or multiple
guard expressions, the desugared case expression may contain a guard with
a different arity to the matched expressions. There's some requirement on pattern refutability to trigger this, I've added a case to the test suite.

This happens to work out OK with the current JS codegen, but produces CoreFn that I'd consider violates a constraint, that case expressions contain the same number of binders in each branch as the number of expressions in the case. The purerl backend ran afoul of this unexpected situation, though it's somewhat hard to spot with several contributing factors.

The commentary in CaseDeclarations describes the desugaring here:
```-- Consider an exhaustive case expression:
    --
    --   case e of
    --    (T s) | Just info <- Map.lookup s names
    --          , is_used info
    --          -> f info
    --    _     -> Nothing
    --
    -- desugars to:
    --
    --    case e of
    --      _ -> let
    --                v _ = Nothing
    --           in
    --             case e of
    --                (T s) -> case Map.lookup s names of
    --                          Just info -> f info
    --                          _ -> v true
    --                _  -> v true
```

But in the case of something more like 
```
case e1, e2 of
  (T s) _ | Just info <- Map.lookup s names
              , is_used info
             -> f info
  _  _     -> Nothing
```
we get a case clause something like this:
```case e1, e2 of
  (T s), _ -> case Map.lookup s names of
                      Just info -> f info
                      _ -> v true
  _  -> v true
```

This change defers the decision as to how many binders are required on that `-> v true` to the point of use - in this case it will be used twice with 1 and 2 ignored arguments.