### PR TITLE
[purs ide] Resets IDE state before performing a full reload

### DIFF
--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -51,7 +51,8 @@ handleCommand
   -> m Success
 handleCommand c = case c of
   Load [] ->
-    findAvailableExterns >>= loadModulesAsync
+    -- Clearing the State before populating it to avoid a space leak
+    resetIdeState *> findAvailableExterns >>= loadModulesAsync
   Load modules ->
     loadModulesAsync modules
   LoadSync [] ->


### PR DESCRIPTION
This way we're avoiding a space leak. (There might be more but this is
good enough for the common case)

Fixes #3753

/cc @zyla 