### PR TITLE
Add versions bounds

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -48,7 +48,7 @@ dependencies:
   - bower-json >=1.0.0.1 && <1.1
   - boxes >=0.1.4 && <0.2.0
   - bytestring
-  - Cabal >= 2.2
+  - Cabal >= 2.2 && <3.0
   - cheapskate >=0.1 && <0.2
   - clock
   - containers
@@ -62,7 +62,7 @@ dependencies:
   - filepath
   - fsnotify >=0.2.1
   - Glob >=0.9 && <0.10
-  - haskeline >=0.7.0.0
+  - haskeline >=0.7.0.0 && <0.8.0.0
   - language-javascript >=0.7.0.0
   - lifted-async >=0.10.0.3 && <0.10.1
   - lifted-base >=0.2.3 && <0.2.4


### PR DESCRIPTION
The version bounds are too relaxed.  Cabal needs to be constraint with
`<3.0` and haskeline with `<0.8` version bounds.