### PR TITLE
Run golden tests in CI

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -29,6 +29,12 @@ else
   STACK_OPTS="$STACK_OPTS --fast"
 fi
 
+# Fail the build instead of creating missing golden test files. Note that using
+# the environment variable as opposed to the command line flag version of this
+# option prevents test executables that don't contain golden tests from failing
+# with an invalid option error.
+export TASTY_NO_CREATE=true
+
 # Install snapshot dependencies (since these will be cached globally and thus
 # can be reused during the sdist build step)
 $STACK build --only-snapshot $STACK_OPTS

--- a/lib/purescript-cst/package.yaml
+++ b/lib/purescript-cst/package.yaml
@@ -16,6 +16,7 @@ license: BSD3
 github: purescript/purescript
 homepage: http://www.purescript.org/
 extra-source-files:
+  - tests/purs/layout/*.out
   - tests/purs/layout/*.purs
   - README.md
 dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -178,6 +178,7 @@ tests:
       - hspec
       - hspec-discover
       - HUnit
+      - regex-base
     default-extensions:
       - NoImplicitPrelude
       - LambdaCase

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ extra-source-files:
   - tests/purs/**/*.js
   - tests/purs/**/*.purs
   - tests/purs/**/*.json
+  - tests/purs/**/*.out
   - tests/json-compat/**/*.json
   - tests/support/*.json
   - tests/support/setup-win.cmd

--- a/tests/purs/failing/DuplicateModule.out
+++ b/tests/purs/failing/DuplicateModule.out
@@ -1,5 +1,5 @@
 Error found:
-at tests/purs/failing/DuplicateModule/M1.purs:1:1 - 1:16 (line 1, column 1 - line 1, column 16)
+at tests/purs/failing/DuplicateModule.purs:2:1 - 2:16 (line 2, column 1 - line 2, column 16)
 
   Module [33mM1[0m has been defined multiple times
 


### PR DESCRIPTION
This commit adds the golden test expected output files to the source distributions, and fails tests in CI if an expected output file doesn't exist (instead of automatically creating it like a local build would).