### PR TITLE
Add golden tests for Coercible

### DIFF
--- a/tests/purs/failing/CoercibleForeign.out
+++ b/tests/purs/failing/CoercibleForeign.out
@@ -1,0 +1,24 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleForeign.purs:11:20 - 11:26 (line 11, column 20 - line 11, column 26)
+
+  No type class instance was found for
+  [33m                                                 [0m
+  [33m  Prim.Coerce.Coercible (Foreign a0 b1)          [0m
+  [33m                        (Foreign (Id a0) (Id b1))[0m
+  [33m                                                 [0m
+
+while checking that type [33mforall a b. Coercible a b => a -> b[0m
+  is at least as general as type [33mForeign a0 b1 -> Foreign (Id a0) (Id b1)[0m
+while checking that expression [33mcoerce[0m
+  has type [33mForeign a0 b1 -> Foreign (Id a0) (Id b1)[0m
+in value declaration [33mforeignToForeign[0m
+
+where [33mb1[0m is a rigid type variable
+        bound at (line 11, column 20 - line 11, column 26)
+      [33ma0[0m is a rigid type variable
+        bound at (line 11, column 20 - line 11, column 26)
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/CoercibleNominal.out
+++ b/tests/purs/failing/CoercibleNominal.out
@@ -1,0 +1,26 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleNominal.purs:11:20 - 11:26 (line 11, column 20 - line 11, column 26)
+
+  No type class instance was found for
+  [33m                                       [0m
+  [33m  Prim.Coerce.Coercible (Nominal a0 c1)[0m
+  [33m                        (Nominal b2 c1)[0m
+  [33m                                       [0m
+
+while checking that type [33mforall a b. Coercible a b => a -> b[0m
+  is at least as general as type [33mNominal a0 c1 -> Nominal b2 c1[0m
+while checking that expression [33mcoerce[0m
+  has type [33mNominal a0 c1 -> Nominal b2 c1[0m
+in value declaration [33mnominalToNominal[0m
+
+where [33mc1[0m is a rigid type variable
+        bound at (line 11, column 20 - line 11, column 26)
+      [33mb2[0m is a rigid type variable
+        bound at (line 11, column 20 - line 11, column 26)
+      [33ma0[0m is a rigid type variable
+        bound at (line 11, column 20 - line 11, column 26)
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/CoercibleNominalTypeApp.out
+++ b/tests/purs/failing/CoercibleNominalTypeApp.out
@@ -1,0 +1,19 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleNominalTypeApp.purs:13:8 - 13:14 (line 13, column 8 - line 13, column 14)
+
+  No type class instance was found for
+  [33m                                        [0m
+  [33m  Prim.Coerce.Coercible (G Maybe Int)   [0m
+  [33m                        (G Maybe String)[0m
+  [33m                                        [0m
+
+while checking that type [33mforall a b. Coercible a b => a -> b[0m
+  is at least as general as type [33mG Maybe Int -> G Maybe String[0m
+while checking that expression [33mcoerce[0m
+  has type [33mG Maybe Int -> G Maybe String[0m
+in value declaration [33mgToG[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/CoercibleNominalWrapped.out
+++ b/tests/purs/failing/CoercibleNominalWrapped.out
@@ -1,0 +1,24 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleNominalWrapped.purs:15:14 - 15:20 (line 15, column 14 - line 15, column 20)
+
+  No type class instance was found for
+  [33m                                         [0m
+  [33m  Prim.Coerce.Coercible (Wrap a0 b1)     [0m
+  [33m                        (Wrap (Id a0) b1)[0m
+  [33m                                         [0m
+
+while checking that type [33mforall a b. Coercible a b => a -> b[0m
+  is at least as general as type [33mWrap a0 b1 -> Wrap (Id a0) b1[0m
+while checking that expression [33mcoerce[0m
+  has type [33mWrap a0 b1 -> Wrap (Id a0) b1[0m
+in value declaration [33mwrapToWrap[0m
+
+where [33mb1[0m is a rigid type variable
+        bound at (line 15, column 14 - line 15, column 20)
+      [33ma0[0m is a rigid type variable
+        bound at (line 15, column 14 - line 15, column 20)
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/CoercibleRepresentational.out
+++ b/tests/purs/failing/CoercibleRepresentational.out
@@ -1,0 +1,24 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleRepresentational.purs:11:20 - 11:26 (line 11, column 20 - line 11, column 26)
+
+  No type class instance was found for
+  [33m                          [0m
+  [33m  Prim.Coerce.Coercible a0[0m
+  [33m                        b1[0m
+  [33m                          [0m
+
+while checking that type [33mforall a b. Coercible a b => a -> b[0m
+  is at least as general as type [33mPhantom a0 -> Phantom b1[0m
+while checking that expression [33mcoerce[0m
+  has type [33mPhantom a0 -> Phantom b1[0m
+in value declaration [33mphantomToPhantom[0m
+
+where [33mb1[0m is a rigid type variable
+        bound at (line 11, column 20 - line 11, column 26)
+      [33ma0[0m is a rigid type variable
+        bound at (line 11, column 20 - line 11, column 26)
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/CoercibleRepresentational2.out
+++ b/tests/purs/failing/CoercibleRepresentational2.out
@@ -1,0 +1,19 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleRepresentational2.purs:9:14 - 9:20 (line 9, column 14 - line 9, column 20)
+
+  No type class instance was found for
+  [33m                              [0m
+  [33m  Prim.Coerce.Coercible Int   [0m
+  [33m                        String[0m
+  [33m                              [0m
+
+while checking that type [33mforall a b. Coercible a b => a -> b[0m
+  is at least as general as type [33mArr1 Int -> Arr1 String[0m
+while checking that expression [33mcoerce[0m
+  has type [33mArr1 Int -> Arr1 String[0m
+in value declaration [33marr1ToArr1[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/CoercibleRepresentational3.out
+++ b/tests/purs/failing/CoercibleRepresentational3.out
@@ -1,0 +1,19 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleRepresentational3.purs:9:14 - 9:20 (line 9, column 14 - line 9, column 20)
+
+  No type class instance was found for
+  [33m                              [0m
+  [33m  Prim.Coerce.Coercible Int   [0m
+  [33m                        String[0m
+  [33m                              [0m
+
+while checking that type [33mforall a b. Coercible a b => a -> b[0m
+  is at least as general as type [33mRec1 Int -> Rec1 String[0m
+while checking that expression [33mcoerce[0m
+  has type [33mRec1 Int -> Rec1 String[0m
+in value declaration [33marr1ToArr1[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+


### PR DESCRIPTION
Since both #3351 and #3774 were fairly recently merged, this is probably just an oversight. These are just the outputs currently generated by the existing tests; I've given them a cursory once-over but someone with more context on the Coercible PR (@lunaris? @hdgarrood?) should confirm that these are correct.

Blocks #3808.