### PR TITLE
Fix DuplicateModule.purs golden test

### DIFF
--- a/tests/TestCompiler.hs
+++ b/tests/TestCompiler.hs
@@ -226,7 +226,8 @@ printErrorOrWarning
   -> [FilePath]
   -> IO String
 printErrorOrWarning supportModules supportExterns supportForeigns inputFiles = do
-  (e, w) <- compile supportModules supportExterns supportForeigns inputFiles noPreCheck
+  -- Sorting the input files makes some messages (e.g., duplicate module) deterministic
+  (e, w) <- compile supportModules supportExterns supportForeigns (sort inputFiles) noPreCheck
   case (const w <$> e) of
     Left errs ->
       return $ P.prettyPrintMultipleErrors P.defaultPPEOptions $ errs


### PR DESCRIPTION
`System.FilePath.Glob` explicitly states that the results of a glob are not in any defined order. However, the order of the files provided to `L.P.Make.make` determines which file is reported as having a duplicate module. So in order to make the output of `DuplicateModule.purs` deterministic (and possibly other error messages as well), the test framework sorts the input files passed to `make` when testing the text of warnings and errors.

Fixes #3809.