### PR TITLE
Allow to label rows with roles annotations keywords

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -139,6 +139,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@matthew-hilty](https://github.com/matthew-hilty) | Matthew Hilty | [MIT license](http://opensource.org/licenses/MIT) |
 | [@woody88](https://github.com/woody88) | Woodson Delhia | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mhmdanas](https://github.com/mhmdanas) | Mohammed Anas | [MIT license](http://opensource.org/licenses/MIT) |
+| [@kl0tl](https://github.com/kl0tl) | Cyril Sobierajewicz | [MIT license](http://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms
 

--- a/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
@@ -264,6 +264,10 @@ label :: { Label }
   | 'true' { toLabel $1 }
   | 'type' { toLabel $1 }
   | 'where' { toLabel $1 }
+  | 'role' { toLabel $1 }
+  | 'nominal' { toLabel $1 }
+  | 'representational' { toLabel $1 }
+  | 'phantom' { toLabel $1 }
 
 hole :: { Name Ident }
   : LIT_HOLE {% toName Ident $1 }

--- a/tests/purs/passing/RolesAnnotationsKeywordsLabels.purs
+++ b/tests/purs/passing/RolesAnnotationsKeywordsLabels.purs
@@ -1,0 +1,12 @@
+module Main where
+
+import Effect.Console (log)
+
+type Row a =
+  ( role :: a
+  , nominal :: a
+  , representational :: a
+  , phantom :: a
+  )
+
+main = log "Done"


### PR DESCRIPTION
Compiling `purescript-react-basic@v13.0.0` fails with the following error otherwise:

```
Error found:
at .spago/react-basic/v13.0.0/src/React/Basic/DOM/Generated.purs:134:5 - 134:9 (line 134, column 5 - line 134, column 9)

  Unable to parse module:
  Unexpected token 'role'


See https://github.com/purescript/documentation/blob/master/errors/ErrorParsingModule.md for more information,
or to contribute content related to this error.
```