### PR TITLE
Setup `hlint` to run in the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin
 dist
 cabal-dev
 .cabal-sandbox

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.build
 bin
 dist
 cabal-dev

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,114 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
+
+
+# Warnings currently triggered by your code
+- ignore: {name: "Unused LANGUAGE pragma"}
+- ignore: {name: "Redundant =="}
+- ignore: {name: "Use infix"}
+- ignore: {name: "Redundant do"}
+- ignore: {name: "Use newtype instead of data"}
+- ignore: {name: "Redundant bracket"}
+- ignore: {name: "Use join"}
+- ignore: {name: "Fuse foldr/map"}
+- ignore: {name: "Eta reduce"}
+- ignore: {name: "Use notElem"}
+- ignore: {name: "Use lambda-case"}
+- ignore: {name: "Avoid lambda"}
+- ignore: {name: "Use tuple-section"}
+- ignore: {name: "Use sortOn"}
+- ignore: {name: "Redundant $"}
+- ignore: {name: "Use record patterns"}
+- ignore: {name: "Use String"}
+- ignore: {name: "Use isDigit"}
+- ignore: {name: "Use list literal pattern"}
+- ignore: {name: "Use unless"}
+- ignore: {name: "Move brackets to avoid $"}
+- ignore: {name: "Use section"}
+- ignore: {name: "Use &&"}
+- ignore: {name: "Use <$>"}
+- ignore: {name: "Use ."}
+- ignore: {name: "Redundant if"}
+- ignore: {name: "Use traverse_"}
+- ignore: {name: "Use :"}
+- ignore: {name: "Parse error"}
+- ignore: {name: "Avoid reverse"}
+- ignore: {name: "Use Just"}
+- ignore: {name: "Use /="}
+- ignore: {name: "Reduce duplication"}
+- ignore: {name: "Use fewer imports"}
+- ignore: {name: "Use camelCase"}
+- ignore: {name: "Use ++"}
+- ignore: {name: "Hoist not"}
+- ignore: {name: "Functor law"}
+- ignore: {name: "Use $>"}
+- ignore: {name: "Redundant fmap"}
+- ignore: {name: "Use =<<"}
+- ignore: {name: "Use maybe"}
+- ignore: {name: "Use zipWithM_"}
+- ignore: {name: "Use fromMaybe"}
+- ignore: {name: "Use gets"}
+- ignore: {name: "Use unwords"}
+- ignore: {name: "Use fmap"}
+- ignore: {name: "Avoid lambda using `infix`"}
+- ignore: {name: "Use <$"}
+- ignore: {name: "Use const"}
+- ignore: {name: "Fuse mapM/map"}
+
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+# - group: {name: generalise, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,7 @@ install:
     export CI_RELEASE=true
   fi
 script:
+- make lint
 # Set a timeout of 35 minutes. We could use travis_wait here, but travis_wait
 # doesn't produce any output until the command finishes, and also doesn't
 # always show all of the command's output.

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,10 @@ install:
   tar -xzf stack.tar.gz --strip-components=1
   mv stack "$HOME/.local/bin/"
   popd
+- | # Install hlint.
+  BUILD_DIR="$HOME/hlint"
+  BIN_DIR="$HOME/.local/bin/"
+  ci/install-hlint.sh
 - | # Set up the timeout command
   if which timeout >/dev/null
   then
@@ -97,7 +101,7 @@ install:
     export CI_RELEASE=true
   fi
 script:
-- make lint
+- hlint --git
 # Set a timeout of 35 minutes. We could use travis_wait here, but travis_wait
 # doesn't produce any output until the command finishes, and also doesn't
 # always show all of the command's output.

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,7 @@ install:
   mv stack "$HOME/.local/bin/"
   popd
 - | # Install hlint.
-  BUILD_DIR="$HOME/hlint"
-  BIN_DIR="$HOME/.local/bin/"
-  ci/install-hlint.sh
+  BIN_DIR="$HOME/.local/bin/" BUILD_DIR="$HOME/hlint" ci/install-hlint.sh
 - | # Set up the timeout command
   if which timeout >/dev/null
   then

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
+bindir = bin
 package = purescript
 exe_target = purs
 stack_yaml = STACK_YAML="stack.yaml"
 stack = $(stack_yaml) stack
+
+.DEFAULT_GOAL := help
+
+$(bindir)/hlint: ci/install-hlint.sh
+	$<
+	touch $@
+
+clean: ## Remove build artifacts
+	rm -fr $(bindir)
 
 help: ## Print documentation
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -59,4 +69,9 @@ dev-deps: ## Install helpful development tools.
 license-generator: ## Update dependencies in LICENSE
 	$(stack) ls dependencies purescript --flag purescript:RELEASE | stack license-generator/generate.hs > LICENSE
 
-.PHONY : build build-dirty run install ghci test test-ghci test-profiling ghcid dev-deps license-generator
+lint: lint-hlint ## Check project adheres to standards
+
+lint-hlint: $(bindir)/hlint ## Check project adheres to hlint standards
+	$< --git
+
+.PHONY : build build-dirty run install ghci test test-ghci test-profiling ghcid dev-deps license-generator clean lint lint-hlint

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-bindir = bin
+bin_dir = bin
+build_dir = .build
 package = purescript
 exe_target = purs
 stack_yaml = STACK_YAML="stack.yaml"
@@ -6,12 +7,13 @@ stack = $(stack_yaml) stack
 
 .DEFAULT_GOAL := help
 
-$(bindir)/hlint: ci/install-hlint.sh
-	$<
+$(bin_dir)/hlint: ci/install-hlint.sh
+	BIN_DIR=$(bin_dir) BUILD_DIR=$(build_dir) $<
 	touch $@
 
 clean: ## Remove build artifacts
-	rm -fr $(bindir)
+	rm -fr $(bin_dir)
+	rm -fr $(build_dir)
 
 help: ## Print documentation
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -71,7 +73,7 @@ license-generator: ## Update dependencies in LICENSE
 
 lint: lint-hlint ## Check project adheres to standards
 
-lint-hlint: $(bindir)/hlint ## Check project adheres to hlint standards
+lint-hlint: $(bin_dir)/hlint ## Check project adheres to hlint standards
 	$< --git
 
 .PHONY : build build-dirty run install ghci test test-ghci test-profiling ghcid dev-deps license-generator clean lint lint-hlint

--- a/ci/install-hlint.sh
+++ b/ci/install-hlint.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+IFS=$'\n\t'
+
+readonly hlint_version=2.2.11
+readonly temporary_dir="$(mktemp --directory -t "install-hlint.XXXXXXXXXX")"
+
+function cleanup() {
+    local exit_code="${?}"
+
+    rm --force --recursive "${temporary_dir}"
+
+    exit "${exit_code}"
+}
+
+trap cleanup EXIT
+
+function download_for_unix() {
+    local os="${1}"
+    local url="https://github.com/ndmitchell/hlint/releases/download/v${hlint_version}/hlint-${hlint_version}-x86_64-${os}.tar.gz"
+
+    pushd "${temporary_dir}"
+    curl --location "${url}" --output hlint.tar.gz
+    tar -xzf hlint.tar.gz --strip-components=1
+    popd
+
+    mkdir -p bin/data
+    cp -r "${temporary_dir}/data" bin
+    cp "${temporary_dir}/hlint" bin
+}
+
+function download_for_windows() {
+    local url="https://github.com/ndmitchell/hlint/releases/download/v${hlint_version}/hlint-${hlint_version}-x86_64-windows.zip"
+
+    pushd "${temporary_dir}"
+    curl --location "${url}" --output hlint.zip
+    7z e -r hlint.zip
+    popd
+
+    mkdir -p bin/data
+    cp -r "${temporary_dir}/data" bin
+    cp "${temporary_dir}/hlint.exe" bin
+}
+
+function main() {
+    # The OS environment variable is set to 'Windows_NT' on Windows NT systems.
+    # This should work for all recent Windows versions including:
+    # NT, 2000, XP, Server, Vista, 7, 8, 8.1, and 10.
+    case "${OS:-$(uname)}" in
+        'Darwin')
+            download_for_unix 'osx';;
+        'Linux')
+            download_for_unix 'linux';;
+        'Windows_NT')
+            download_for_windows;;
+        *)
+            echo 'Unknown Platform. Only Linux, macOS, and Windows are supported';
+            exit 1;;
+    esac
+}
+
+main

--- a/ci/install-hlint.sh
+++ b/ci/install-hlint.sh
@@ -6,12 +6,11 @@ set -o pipefail
 IFS=$'\n\t'
 
 readonly hlint_version=2.2.11
-readonly temporary_dir="$(mktemp --directory -t "install-hlint.XXXXXXXXXX")"
+readonly build_dir="${BUILD_DIR:?Must provide a directory to build in}"
+readonly bin_dir="${BIN_DIR:?Must provide a directory to install binaries}"
 
 function cleanup() {
     local exit_code="${?}"
-
-    rm --force --recursive "${temporary_dir}"
 
     exit "${exit_code}"
 }
@@ -22,27 +21,29 @@ function download_for_unix() {
     local os="${1}"
     local url="https://github.com/ndmitchell/hlint/releases/download/v${hlint_version}/hlint-${hlint_version}-x86_64-${os}.tar.gz"
 
-    pushd "${temporary_dir}"
+    mkdir -p "${build_dir}"
+    pushd "${build_dir}"
     curl --location "${url}" --output hlint.tar.gz
     tar -xzf hlint.tar.gz --strip-components=1
     popd
 
-    mkdir -p bin/data
-    cp -r "${temporary_dir}/data" bin
-    cp "${temporary_dir}/hlint" bin
+    mkdir -p "${bin_dir}/data"
+    cp -r "${build_dir}/data" "${bin_dir}"
+    cp "${build_dir}/hlint" "${bin_dir}"
 }
 
 function download_for_windows() {
     local url="https://github.com/ndmitchell/hlint/releases/download/v${hlint_version}/hlint-${hlint_version}-x86_64-windows.zip"
 
-    pushd "${temporary_dir}"
+    mkdir -p "${build_dir}"
+    pushd "${build_dir}"
     curl --location "${url}" --output hlint.zip
     7z e -r hlint.zip
     popd
 
-    mkdir -p bin/data
-    cp -r "${temporary_dir}/data" bin
-    cp "${temporary_dir}/hlint.exe" bin
+    mkdir -p "${bin_dir}/data"
+    cp -r "${build_dir}/data" "${bin_dir}"
+    cp "${build_dir}/hlint.exe" "${bin_dir}"
 }
 
 function main() {


### PR DESCRIPTION
As the first step in [cleaning up language extensions](https://github.com/purescript/purescript/issues/3805#issuecomment-599297787), we're setting up `hlint`. Assuming this approach works, we'll then use hlint to [restrict which language extensions can be used](https://github.com/ndmitchell/hlint/tree/9f1e23655c4fac537446a2600dd2f5d89825406c#restricting-items).