### PR TITLE
Relax `purescript-ast` dependency to `microlens`

### DIFF
--- a/lib/purescript-ast/package.yaml
+++ b/lib/purescript-ast/package.yaml
@@ -25,7 +25,7 @@ dependencies:
   - containers
   - deepseq
   - filepath
-  - microlens-platform >=0.3.9.0 && <0.4
+  - microlens >=0.4.10 && <0.5
   - mtl >=2.1.0 && <2.3.0
   - protolude >=0.1.6 && <0.2.4
   - scientific >=0.3.4.9 && <0.4

--- a/lib/purescript-ast/src/Language/PureScript/Types.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Types.hs
@@ -29,7 +29,7 @@ import "this" Language.PureScript.Names
 import "this" Language.PureScript.Label (Label)
 import "this" Language.PureScript.PSString (PSString)
 
-import "microlens-platform" Lens.Micro.Platform (Lens', (^.), set)
+import "microlens" Lens.Micro (Lens', (^.), set)
 
 type SourceType = Type SourceAnn
 type SourceConstraint = Constraint SourceAnn


### PR DESCRIPTION
`microlens-platform` is made to bring in a bunch of other dependencies so working with a small lens package isn't tedious. It's made for an application. `microlens` is made to be as minimal as possible. It's made so it doesn't increase the footprint of a package onto everyone that depends on that package. Now that `purescript-ast` is its own package, we drop the dependency down to `microlens` instead of `microlens-platform`, removing transitive dependencies in the process.

There should be no noticeable changes as far as API goes.