### PR TITLE
Remove PackageImports

### DIFF
--- a/lib/purescript-ast/package.yaml
+++ b/lib/purescript-ast/package.yaml
@@ -52,7 +52,6 @@ library:
     - LambdaCase
     - MultiParamTypeClasses
     - NoImplicitPrelude
-    - PackageImports
     - PatternGuards
     - PatternSynonyms
     - RankNTypes

--- a/lib/purescript-ast/src/Control/Monad/Supply.hs
+++ b/lib/purescript-ast/src/Control/Monad/Supply.hs
@@ -3,15 +3,15 @@
 --
 module Control.Monad.Supply where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
-import "base" Control.Applicative
-import "mtl" Control.Monad.Error.Class (MonadError(..))
-import "mtl" Control.Monad.Reader
-import "mtl" Control.Monad.State
-import "mtl" Control.Monad.Writer
+import Control.Applicative
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Reader
+import Control.Monad.State
+import Control.Monad.Writer
 
-import "base" Data.Functor.Identity
+import Data.Functor.Identity
 
 newtype SupplyT m a = SupplyT { unSupplyT :: StateT Integer m a }
   deriving (Functor, Applicative, Monad, MonadTrans, MonadError e, MonadWriter w, MonadReader r, Alternative, MonadPlus)

--- a/lib/purescript-ast/src/Control/Monad/Supply/Class.hs
+++ b/lib/purescript-ast/src/Control/Monad/Supply/Class.hs
@@ -4,12 +4,12 @@
 
 module Control.Monad.Supply.Class where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
-import "this" Control.Monad.Supply
-import "mtl" Control.Monad.State
-import "mtl" Control.Monad.Writer
-import "text" Data.Text (Text, pack)
+import Control.Monad.Supply
+import Control.Monad.State
+import Control.Monad.Writer
+import Data.Text (Text, pack)
 
 class Monad m => MonadSupply m where
   fresh :: m Integer

--- a/lib/purescript-ast/src/Language/PureScript/AST.hs
+++ b/lib/purescript-ast/src/Language/PureScript/AST.hs
@@ -5,10 +5,10 @@ module Language.PureScript.AST (
     module AST
 ) where
 
-import "this" Language.PureScript.AST.Binders as AST
-import "this" Language.PureScript.AST.Declarations as AST
-import "this" Language.PureScript.AST.Exported as AST
-import "this" Language.PureScript.AST.Literals as AST
-import "this" Language.PureScript.AST.Operators as AST
-import "this" Language.PureScript.AST.SourcePos as AST
-import "this" Language.PureScript.AST.Traversals as AST
+import Language.PureScript.AST.Binders as AST
+import Language.PureScript.AST.Declarations as AST
+import Language.PureScript.AST.Exported as AST
+import Language.PureScript.AST.Literals as AST
+import Language.PureScript.AST.Operators as AST
+import Language.PureScript.AST.SourcePos as AST
+import Language.PureScript.AST.Traversals as AST

--- a/lib/purescript-ast/src/Language/PureScript/AST/Binders.hs
+++ b/lib/purescript-ast/src/Language/PureScript/AST/Binders.hs
@@ -3,13 +3,13 @@
 --
 module Language.PureScript.AST.Binders where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
-import "this" Language.PureScript.AST.SourcePos
-import "this" Language.PureScript.AST.Literals
-import "this" Language.PureScript.Names
-import "this" Language.PureScript.Comments
-import "this" Language.PureScript.Types
+import Language.PureScript.AST.SourcePos
+import Language.PureScript.AST.Literals
+import Language.PureScript.Names
+import Language.PureScript.Comments
+import Language.PureScript.Types
 
 -- |
 -- Data type for binders

--- a/lib/purescript-ast/src/Language/PureScript/AST/Declarations.hs
+++ b/lib/purescript-ast/src/Language/PureScript/AST/Declarations.hs
@@ -6,30 +6,30 @@
 --
 module Language.PureScript.AST.Declarations where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
-import "deepseq" Control.DeepSeq (NFData)
-import "base" Data.Functor.Identity
+import Control.DeepSeq (NFData)
+import Data.Functor.Identity
 
-import "aeson" Data.Aeson.TH
-import qualified "containers" Data.Map as M
-import "text" Data.Text (Text)
-import qualified "base" Data.List.NonEmpty as NEL
-import "base" GHC.Generics (Generic)
+import Data.Aeson.TH
+import qualified Data.Map as M
+import Data.Text (Text)
+import qualified Data.List.NonEmpty as NEL
+import GHC.Generics (Generic)
 
-import "this" Language.PureScript.AST.Binders
-import "this" Language.PureScript.AST.Literals
-import "this" Language.PureScript.AST.Operators
-import "this" Language.PureScript.AST.SourcePos
-import "this" Language.PureScript.Types
-import "this" Language.PureScript.PSString (PSString)
-import "this" Language.PureScript.Label (Label)
-import "this" Language.PureScript.Names
-import "this" Language.PureScript.Roles
-import "this" Language.PureScript.TypeClassDictionaries
-import "this" Language.PureScript.Comments
-import "this" Language.PureScript.Environment
-import qualified "this" Language.PureScript.Constants.Prim as C
+import Language.PureScript.AST.Binders
+import Language.PureScript.AST.Literals
+import Language.PureScript.AST.Operators
+import Language.PureScript.AST.SourcePos
+import Language.PureScript.Types
+import Language.PureScript.PSString (PSString)
+import Language.PureScript.Label (Label)
+import Language.PureScript.Names
+import Language.PureScript.Roles
+import Language.PureScript.TypeClassDictionaries
+import Language.PureScript.Comments
+import Language.PureScript.Environment
+import qualified Language.PureScript.Constants.Prim as C
 
 -- | A map of locally-bound names in scope.
 type Context = [(Ident, SourceType)]

--- a/lib/purescript-ast/src/Language/PureScript/AST/Exported.hs
+++ b/lib/purescript-ast/src/Language/PureScript/AST/Exported.hs
@@ -3,17 +3,17 @@ module Language.PureScript.AST.Exported
   , isExported
   ) where
 
-import "base-compat" Prelude.Compat
-import "protolude" Protolude (sortBy, on)
+import Prelude.Compat
+import Protolude (sortBy, on)
 
-import "base" Control.Category ((>>>))
+import Control.Category ((>>>))
 
-import "base" Data.Maybe (mapMaybe)
-import qualified "containers" Data.Map as M
+import Data.Maybe (mapMaybe)
+import qualified Data.Map as M
 
-import "this" Language.PureScript.AST.Declarations
-import "this" Language.PureScript.Types
-import "this" Language.PureScript.Names
+import Language.PureScript.AST.Declarations
+import Language.PureScript.Types
+import Language.PureScript.Names
 
 -- |
 -- Return a list of all declarations which are exported from a module.

--- a/lib/purescript-ast/src/Language/PureScript/AST/Literals.hs
+++ b/lib/purescript-ast/src/Language/PureScript/AST/Literals.hs
@@ -3,8 +3,8 @@
 --
 module Language.PureScript.AST.Literals where
 
-import "base-compat" Prelude.Compat
-import "this" Language.PureScript.PSString (PSString)
+import Prelude.Compat
+import Language.PureScript.PSString (PSString)
 
 -- |
 -- Data type for literal values. Parameterised so it can be used for Exprs and

--- a/lib/purescript-ast/src/Language/PureScript/AST/Operators.hs
+++ b/lib/purescript-ast/src/Language/PureScript/AST/Operators.hs
@@ -3,14 +3,14 @@
 --
 module Language.PureScript.AST.Operators where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
-import "base" GHC.Generics (Generic)
-import "deepseq" Control.DeepSeq (NFData)
-import "aeson" Data.Aeson ((.=))
-import qualified "aeson" Data.Aeson as A
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
+import Data.Aeson ((.=))
+import qualified Data.Aeson as A
 
-import "this" Language.PureScript.Crash
+import Language.PureScript.Crash
 
 -- |
 -- A precedence level for an infix operator

--- a/lib/purescript-ast/src/Language/PureScript/AST/SourcePos.hs
+++ b/lib/purescript-ast/src/Language/PureScript/AST/SourcePos.hs
@@ -3,16 +3,16 @@
 --
 module Language.PureScript.AST.SourcePos where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
-import "deepseq" Control.DeepSeq (NFData)
-import "aeson" Data.Aeson ((.=), (.:))
-import "text" Data.Text (Text)
-import "base" GHC.Generics (Generic)
-import "this" Language.PureScript.Comments
-import qualified "aeson" Data.Aeson as A
-import qualified "text" Data.Text as T
-import "filepath" System.FilePath (makeRelative)
+import Control.DeepSeq (NFData)
+import Data.Aeson ((.=), (.:))
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Language.PureScript.Comments
+import qualified Data.Aeson as A
+import qualified Data.Text as T
+import System.FilePath (makeRelative)
 
 -- | Source annotation - position information and comments.
 type SourceAnn = (SourceSpan, [Comment])

--- a/lib/purescript-ast/src/Language/PureScript/AST/Traversals.hs
+++ b/lib/purescript-ast/src/Language/PureScript/AST/Traversals.hs
@@ -3,24 +3,24 @@
 --
 module Language.PureScript.AST.Traversals where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
-import "base" Control.Monad
+import Control.Monad
 
-import "base" Data.Foldable (fold)
-import "base" Data.List (mapAccumL)
-import "base" Data.Maybe (mapMaybe)
-import qualified "base" Data.List.NonEmpty as NEL
-import qualified "containers" Data.Map as M
-import qualified "containers" Data.Set as S
+import Data.Foldable (fold)
+import Data.List (mapAccumL)
+import Data.Maybe (mapMaybe)
+import qualified Data.List.NonEmpty as NEL
+import qualified Data.Map as M
+import qualified Data.Set as S
 
-import "this" Language.PureScript.AST.Binders
-import "this" Language.PureScript.AST.Declarations
-import "this" Language.PureScript.AST.Literals
-import "this" Language.PureScript.Names
-import "this" Language.PureScript.Traversals
-import "this" Language.PureScript.TypeClassDictionaries (TypeClassDictionaryInScope(..))
-import "this" Language.PureScript.Types
+import Language.PureScript.AST.Binders
+import Language.PureScript.AST.Declarations
+import Language.PureScript.AST.Literals
+import Language.PureScript.Names
+import Language.PureScript.Traversals
+import Language.PureScript.TypeClassDictionaries (TypeClassDictionaryInScope(..))
+import Language.PureScript.Types
 
 guardedExprM :: Applicative m
              => (Guard -> m Guard)

--- a/lib/purescript-ast/src/Language/PureScript/Comments.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Comments.hs
@@ -5,12 +5,12 @@
 --
 module Language.PureScript.Comments where
 
-import "base-compat" Prelude.Compat
-import "deepseq" Control.DeepSeq (NFData)
-import "text" Data.Text (Text)
-import "base" GHC.Generics (Generic)
+import Prelude.Compat
+import Control.DeepSeq (NFData)
+import Data.Text (Text)
+import GHC.Generics (Generic)
 
-import "aeson" Data.Aeson.TH
+import Data.Aeson.TH
 
 data Comment
   = LineComment Text

--- a/lib/purescript-ast/src/Language/PureScript/Constants/Prim.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Constants/Prim.hs
@@ -1,10 +1,10 @@
 -- | Various constants which refer to things in Prim
 module Language.PureScript.Constants.Prim where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
-import "base" Data.String (IsString)
-import "this" Language.PureScript.Names
+import Data.String (IsString)
+import Language.PureScript.Names
 
 -- Prim values
 

--- a/lib/purescript-ast/src/Language/PureScript/Crash.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Crash.hs
@@ -3,9 +3,9 @@
 
 module Language.PureScript.Crash where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
-import qualified "base" GHC.Stack
+import qualified GHC.Stack
 
 -- | A compatibility wrapper for the @GHC.Stack.HasCallStack@ constraint.
 #if __GLASGOW_HASKELL__ >= 800
@@ -13,7 +13,7 @@ type HasCallStack = GHC.Stack.HasCallStack
 #elif MIN_VERSION_GLASGOW_HASKELL(7,10,2,0)
 type HasCallStack = (?callStack :: GHC.Stack.CallStack)
 #else
-import "base" GHC.Exts (Constraint)
+import GHC.Exts (Constraint)
 -- CallStack wasn't present in GHC 7.10.1
 type HasCallStack = (() :: Constraint)
 #endif

--- a/lib/purescript-ast/src/Language/PureScript/Environment.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Environment.hs
@@ -1,29 +1,29 @@
 module Language.PureScript.Environment where
 
-import "base-compat" Prelude.Compat
-import "protolude" Protolude (ordNub)
+import Prelude.Compat
+import Protolude (ordNub)
 
-import "base" GHC.Generics (Generic)
-import "deepseq" Control.DeepSeq (NFData)
-import "aeson" Data.Aeson ((.=), (.:))
-import qualified "aeson" Data.Aeson as A
-import qualified "containers" Data.Map as M
-import qualified "containers" Data.Set as S
-import "base" Data.Maybe (fromMaybe, mapMaybe)
-import "text" Data.Text (Text)
-import qualified "text" Data.Text as T
-import "containers" Data.Tree (Tree, rootLabel)
-import qualified "containers" Data.Graph as G
-import "base" Data.Foldable (toList)
-import qualified "base" Data.List.NonEmpty as NEL
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
+import Data.Aeson ((.=), (.:))
+import qualified Data.Aeson as A
+import qualified Data.Map as M
+import qualified Data.Set as S
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Tree (Tree, rootLabel)
+import qualified Data.Graph as G
+import Data.Foldable (toList)
+import qualified Data.List.NonEmpty as NEL
 
-import "this" Language.PureScript.AST.SourcePos
-import "this" Language.PureScript.Crash
-import "this" Language.PureScript.Names
-import "this" Language.PureScript.Roles
-import "this" Language.PureScript.TypeClassDictionaries
-import "this" Language.PureScript.Types
-import qualified "this" Language.PureScript.Constants.Prim as C
+import Language.PureScript.AST.SourcePos
+import Language.PureScript.Crash
+import Language.PureScript.Names
+import Language.PureScript.Roles
+import Language.PureScript.TypeClassDictionaries
+import Language.PureScript.Types
+import qualified Language.PureScript.Constants.Prim as C
 
 -- | The @Environment@ defines all values and types which are currently in scope:
 data Environment = Environment

--- a/lib/purescript-ast/src/Language/PureScript/Label.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Label.hs
@@ -1,13 +1,13 @@
 module Language.PureScript.Label (Label(..)) where
 
-import "base-compat" Prelude.Compat hiding (lex)
-import "base" GHC.Generics (Generic)
-import "deepseq" Control.DeepSeq (NFData)
-import "base" Data.Monoid ()
-import "base" Data.String (IsString(..))
-import qualified "aeson" Data.Aeson as A
+import Prelude.Compat hiding (lex)
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
+import Data.Monoid ()
+import Data.String (IsString(..))
+import qualified Data.Aeson as A
 
-import "this" Language.PureScript.PSString (PSString)
+import Language.PureScript.PSString (PSString)
 
 -- |
 -- Labels are used as record keys and row entry names. Labels newtype PSString

--- a/lib/purescript-ast/src/Language/PureScript/Names.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Names.hs
@@ -5,17 +5,17 @@
 --
 module Language.PureScript.Names where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
-import "this" Control.Monad.Supply.Class
-import "deepseq" Control.DeepSeq (NFData)
-import "base" Data.Functor.Contravariant (contramap)
+import Control.Monad.Supply.Class
+import Control.DeepSeq (NFData)
+import Data.Functor.Contravariant (contramap)
 
-import "base" GHC.Generics (Generic)
-import "aeson" Data.Aeson
-import "aeson" Data.Aeson.TH
-import "text" Data.Text (Text)
-import qualified "text" Data.Text as T
+import GHC.Generics (Generic)
+import Data.Aeson
+import Data.Aeson.TH
+import Data.Text (Text)
+import qualified Data.Text as T
 
 -- | A sum of the possible name types, useful for error and lint messages.
 data Name

--- a/lib/purescript-ast/src/Language/PureScript/PSString.hs
+++ b/lib/purescript-ast/src/Language/PureScript/PSString.hs
@@ -9,28 +9,28 @@ module Language.PureScript.PSString
   , mkString
   ) where
 
-import "base-compat" Prelude.Compat
-import "base" GHC.Generics (Generic)
-import "deepseq" Control.DeepSeq (NFData)
-import "base" Control.Exception (try, evaluate)
-import "base" Control.Applicative ((<|>))
-import qualified "base" Data.Char as Char
-import "base" Data.Bits (shiftR)
-import "base" Data.List (unfoldr)
-import "scientific" Data.Scientific (toBoundedInteger)
-import "base" Data.String (IsString(..))
-import "bytestring" Data.ByteString (ByteString)
-import qualified "bytestring" Data.ByteString as BS
-import "text" Data.Text (Text)
-import qualified "text" Data.Text as T
-import "text" Data.Text.Encoding (decodeUtf16BE)
-import "text" Data.Text.Encoding.Error (UnicodeException)
-import qualified "vector" Data.Vector as V
-import "base" Data.Word (Word16, Word8)
-import "base" Numeric (showHex)
-import "base" System.IO.Unsafe (unsafePerformIO)
-import qualified "aeson" Data.Aeson as A
-import qualified "aeson" Data.Aeson.Types as A
+import Prelude.Compat
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
+import Control.Exception (try, evaluate)
+import Control.Applicative ((<|>))
+import qualified Data.Char as Char
+import Data.Bits (shiftR)
+import Data.List (unfoldr)
+import Data.Scientific (toBoundedInteger)
+import Data.String (IsString(..))
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf16BE)
+import Data.Text.Encoding.Error (UnicodeException)
+import qualified Data.Vector as V
+import Data.Word (Word16, Word8)
+import Numeric (showHex)
+import System.IO.Unsafe (unsafePerformIO)
+import qualified Data.Aeson as A
+import qualified Data.Aeson.Types as A
 
 -- |
 -- Strings in PureScript are sequences of UTF-16 code units, which do not

--- a/lib/purescript-ast/src/Language/PureScript/Roles.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Roles.hs
@@ -7,12 +7,12 @@ module Language.PureScript.Roles
   ( Role(..)
   ) where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
-import "deepseq" Control.DeepSeq (NFData)
-import qualified "aeson" Data.Aeson as A
-import qualified "aeson" Data.Aeson.TH as A
-import "base" GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
+import qualified Data.Aeson as A
+import qualified Data.Aeson.TH as A
+import GHC.Generics (Generic)
 
 -- |
 -- The role of a type constructor's parameter.

--- a/lib/purescript-ast/src/Language/PureScript/Traversals.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Traversals.hs
@@ -1,7 +1,7 @@
 -- | Common functions for implementing generic traversals
 module Language.PureScript.Traversals where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
 fstM :: (Functor f) => (a -> f c) -> (a, b) -> f (c, b)
 fstM f (a, b) = flip (,) b <$> f a

--- a/lib/purescript-ast/src/Language/PureScript/TypeClassDictionaries.hs
+++ b/lib/purescript-ast/src/Language/PureScript/TypeClassDictionaries.hs
@@ -1,13 +1,13 @@
 module Language.PureScript.TypeClassDictionaries where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
-import "base" GHC.Generics (Generic)
-import "deepseq" Control.DeepSeq (NFData)
-import "text" Data.Text (Text, pack)
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
+import Data.Text (Text, pack)
 
-import "this" Language.PureScript.Names
-import "this" Language.PureScript.Types
+import Language.PureScript.Names
+import Language.PureScript.Types
 
 --
 -- Data representing a type class dictionary which is in scope

--- a/lib/purescript-ast/src/Language/PureScript/Types.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Types.hs
@@ -3,33 +3,33 @@
 --
 module Language.PureScript.Types where
 
-import "base-compat" Prelude.Compat
-import "protolude" Protolude (ordNub)
+import Prelude.Compat
+import Protolude (ordNub)
 
-import "base" Control.Applicative ((<|>))
-import "base" Control.Arrow (first, second)
-import "deepseq" Control.DeepSeq (NFData)
-import "base" Control.Monad ((<=<), (>=>))
-import "aeson" Data.Aeson ((.:), (.:?), (.!=), (.=))
-import qualified "aeson" Data.Aeson as A
-import qualified "aeson" Data.Aeson.Types as A
-import "base" Data.Foldable (fold)
-import qualified "containers" Data.IntSet as IS
-import "base" Data.List (sort, sortBy)
-import "base" Data.Ord (comparing)
-import "base" Data.Maybe (fromMaybe, isJust)
-import qualified "containers" Data.Set as S
-import "text" Data.Text (Text)
-import qualified "text" Data.Text as T
-import "base" GHC.Generics (Generic)
+import Control.Applicative ((<|>))
+import Control.Arrow (first, second)
+import Control.DeepSeq (NFData)
+import Control.Monad ((<=<), (>=>))
+import Data.Aeson ((.:), (.:?), (.!=), (.=))
+import qualified Data.Aeson as A
+import qualified Data.Aeson.Types as A
+import Data.Foldable (fold)
+import qualified Data.IntSet as IS
+import Data.List (sort, sortBy)
+import Data.Ord (comparing)
+import Data.Maybe (fromMaybe, isJust)
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import GHC.Generics (Generic)
 
-import "this" Language.PureScript.AST.SourcePos
-import qualified "this" Language.PureScript.Constants.Prim as C
-import "this" Language.PureScript.Names
-import "this" Language.PureScript.Label (Label)
-import "this" Language.PureScript.PSString (PSString)
+import Language.PureScript.AST.SourcePos
+import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Names
+import Language.PureScript.Label (Label)
+import Language.PureScript.PSString (PSString)
 
-import "microlens-platform" Lens.Micro.Platform (Lens', (^.), set)
+import Lens.Micro.Platform (Lens', (^.), set)
 
 type SourceType = Type SourceAnn
 type SourceConstraint = Constraint SourceAnn

--- a/lib/purescript-ast/src/Language/PureScript/Types.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Types.hs
@@ -29,7 +29,7 @@ import Language.PureScript.Names
 import Language.PureScript.Label (Label)
 import Language.PureScript.PSString (PSString)
 
-import Lens.Micro.Platform (Lens', (^.), set)
+import Lens.Micro (Lens', (^.), set)
 
 type SourceType = Type SourceAnn
 type SourceConstraint = Constraint SourceAnn

--- a/lib/purescript-cst/package.yaml
+++ b/lib/purescript-cst/package.yaml
@@ -49,7 +49,6 @@ library:
     - MultiParamTypeClasses
     - NamedFieldPuns
     - NoImplicitPrelude
-    - PackageImports
     - PatternGuards
     - PatternSynonyms
     - RankNTypes

--- a/lib/purescript-cst/src/Language/PureScript/CST/Convert.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Convert.hs
@@ -15,26 +15,26 @@ module Language.PureScript.CST.Convert
   , comments
   ) where
 
-import "base" Prelude
+import Prelude
 
-import "base" Data.Bifunctor (bimap, first)
-import "base" Data.Foldable (foldl', toList)
-import "base" Data.Functor (($>))
-import qualified "base" Data.List.NonEmpty as NE
-import "base" Data.Maybe (isJust, fromJust, mapMaybe)
-import qualified "text" Data.Text as Text
-import qualified "purescript-ast" Language.PureScript.AST as AST
-import qualified "purescript-ast" Language.PureScript.AST.SourcePos as Pos
-import qualified "purescript-ast" Language.PureScript.Comments as C
-import "purescript-ast" Language.PureScript.Crash (internalError)
-import qualified "purescript-ast" Language.PureScript.Environment as Env
-import qualified "purescript-ast" Language.PureScript.Label as L
-import qualified "purescript-ast" Language.PureScript.Names as N
-import "purescript-ast" Language.PureScript.PSString (mkString)
-import qualified "purescript-ast" Language.PureScript.Types as T
-import "this" Language.PureScript.CST.Positions
-import "this" Language.PureScript.CST.Print (printToken)
-import "this" Language.PureScript.CST.Types
+import Data.Bifunctor (bimap, first)
+import Data.Foldable (foldl', toList)
+import Data.Functor (($>))
+import qualified Data.List.NonEmpty as NE
+import Data.Maybe (isJust, fromJust, mapMaybe)
+import qualified Data.Text as Text
+import qualified Language.PureScript.AST as AST
+import qualified Language.PureScript.AST.SourcePos as Pos
+import qualified Language.PureScript.Comments as C
+import Language.PureScript.Crash (internalError)
+import qualified Language.PureScript.Environment as Env
+import qualified Language.PureScript.Label as L
+import qualified Language.PureScript.Names as N
+import Language.PureScript.PSString (mkString)
+import qualified Language.PureScript.Types as T
+import Language.PureScript.CST.Positions
+import Language.PureScript.CST.Print (printToken)
+import Language.PureScript.CST.Types
 
 comment :: Comment a -> Maybe C.Comment
 comment = \case

--- a/lib/purescript-cst/src/Language/PureScript/CST/Errors.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Errors.hs
@@ -9,14 +9,14 @@ module Language.PureScript.CST.Errors
   , prettyPrintWarningMessage
   ) where
 
-import "base" Prelude
+import Prelude
 
-import qualified "text" Data.Text as Text
-import "base" Data.Char (isSpace, toUpper)
-import "this" Language.PureScript.CST.Layout
-import "this" Language.PureScript.CST.Print
-import "this" Language.PureScript.CST.Types
-import "base" Text.Printf (printf)
+import qualified Data.Text as Text
+import Data.Char (isSpace, toUpper)
+import Language.PureScript.CST.Layout
+import Language.PureScript.CST.Print
+import Language.PureScript.CST.Types
+import Text.Printf (printf)
 
 data ParserErrorType
   = ErrWildcardInType

--- a/lib/purescript-cst/src/Language/PureScript/CST/Flatten.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Flatten.hs
@@ -1,9 +1,9 @@
 module Language.PureScript.CST.Flatten where
 
-import "base" Prelude
+import Prelude
 
-import "dlist" Data.DList (DList)
-import "this" Language.PureScript.CST.Types
+import Data.DList (DList)
+import Language.PureScript.CST.Types
 
 flattenWrapped :: (a -> DList SourceToken) -> Wrapped a -> DList SourceToken
 flattenWrapped k (Wrapped a b c) = pure a <> k b <> pure c

--- a/lib/purescript-cst/src/Language/PureScript/CST/Layout.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Layout.hs
@@ -20,13 +20,13 @@
 
 module Language.PureScript.CST.Layout where
 
-import "base" Prelude
+import Prelude
 
-import "dlist" Data.DList (snoc)
-import qualified "dlist" Data.DList as DList
-import "base" Data.Foldable (find)
-import "base" Data.Function ((&))
-import "this" Language.PureScript.CST.Types
+import Data.DList (snoc)
+import qualified Data.DList as DList
+import Data.Foldable (find)
+import Data.Function ((&))
+import Language.PureScript.CST.Types
 
 type LayoutStack = [(SourcePos, LayoutDelim)]
 

--- a/lib/purescript-cst/src/Language/PureScript/CST/Lexer.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Lexer.hs
@@ -6,22 +6,22 @@ module Language.PureScript.CST.Lexer
   , isUnquotedKey
   ) where
 
-import "base" Prelude hiding (lex, exp, exponent, lines)
+import Prelude hiding (lex, exp, exponent, lines)
 
-import "base" Control.Monad (join)
-import qualified "base" Data.Char as Char
-import qualified "dlist" Data.DList as DList
-import "base" Data.Foldable (foldl')
-import "base" Data.Functor (($>))
-import qualified "scientific" Data.Scientific as Sci
-import "base" Data.String (fromString)
-import "text" Data.Text (Text)
-import qualified "text" Data.Text as Text
-import "this" Language.PureScript.CST.Errors
-import "this" Language.PureScript.CST.Monad hiding (token)
-import "this" Language.PureScript.CST.Layout
-import "this" Language.PureScript.CST.Positions
-import "this" Language.PureScript.CST.Types
+import Control.Monad (join)
+import qualified Data.Char as Char
+import qualified Data.DList as DList
+import Data.Foldable (foldl')
+import Data.Functor (($>))
+import qualified Data.Scientific as Sci
+import Data.String (fromString)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Language.PureScript.CST.Errors
+import Language.PureScript.CST.Monad hiding (token)
+import Language.PureScript.CST.Layout
+import Language.PureScript.CST.Positions
+import Language.PureScript.CST.Types
 
 -- | Stops at the first lexing error and replaces it with TokEof. Otherwise,
 -- the parser will fail when it attempts to draw a lookahead token.

--- a/lib/purescript-cst/src/Language/PureScript/CST/Monad.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Monad.hs
@@ -1,15 +1,15 @@
 module Language.PureScript.CST.Monad where
 
-import "base" Prelude
+import Prelude
 
-import "base" Data.List (sortBy)
-import qualified "base" Data.List.NonEmpty as NE
-import "base" Data.Ord (comparing)
-import "text" Data.Text (Text)
-import "this" Language.PureScript.CST.Errors
-import "this" Language.PureScript.CST.Layout
-import "this" Language.PureScript.CST.Positions
-import "this" Language.PureScript.CST.Types
+import Data.List (sortBy)
+import qualified Data.List.NonEmpty as NE
+import Data.Ord (comparing)
+import Data.Text (Text)
+import Language.PureScript.CST.Errors
+import Language.PureScript.CST.Layout
+import Language.PureScript.CST.Positions
+import Language.PureScript.CST.Types
 
 type LexResult = Either (LexState, ParserError) SourceToken
 

--- a/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
@@ -16,23 +16,23 @@ module Language.PureScript.CST.Parser
   , PartialResult(..)
   ) where
 
-import "base" Prelude hiding (lex)
+import Prelude hiding (lex)
 
-import "base" Control.Monad ((<=<), when)
-import "base" Data.Foldable (foldl', for_, toList)
-import qualified "base" Data.List.NonEmpty as NE
-import "text" Data.Text (Text)
-import "base" Data.Traversable (for, sequence)
-import "this" Language.PureScript.CST.Errors
-import "this" Language.PureScript.CST.Flatten (flattenType)
-import "this" Language.PureScript.CST.Lexer
-import "this" Language.PureScript.CST.Monad
-import "this" Language.PureScript.CST.Positions
-import "this" Language.PureScript.CST.Types
-import "this" Language.PureScript.CST.Utils
-import qualified "purescript-ast" Language.PureScript.Names as N
-import qualified "purescript-ast" Language.PureScript.Roles as R
-import "purescript-ast" Language.PureScript.PSString (PSString)
+import Control.Monad ((<=<), when)
+import Data.Foldable (foldl', for_, toList)
+import qualified Data.List.NonEmpty as NE
+import Data.Text (Text)
+import Data.Traversable (for, sequence)
+import Language.PureScript.CST.Errors
+import Language.PureScript.CST.Flatten (flattenType)
+import Language.PureScript.CST.Lexer
+import Language.PureScript.CST.Monad
+import Language.PureScript.CST.Positions
+import Language.PureScript.CST.Types
+import Language.PureScript.CST.Utils
+import qualified Language.PureScript.Names as N
+import qualified Language.PureScript.Roles as R
+import Language.PureScript.PSString (PSString)
 }
 
 %expect 95

--- a/lib/purescript-cst/src/Language/PureScript/CST/Positions.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Positions.hs
@@ -5,14 +5,14 @@
 
 module Language.PureScript.CST.Positions where
 
-import "base" Prelude
+import Prelude
 
-import "base" Data.Foldable (foldl')
-import qualified "base" Data.List.NonEmpty as NE
-import "text" Data.Text (Text)
-import "base" Data.Void (Void)
-import qualified "text" Data.Text as Text
-import "this" Language.PureScript.CST.Types
+import Data.Foldable (foldl')
+import qualified Data.List.NonEmpty as NE
+import Data.Text (Text)
+import Data.Void (Void)
+import qualified Data.Text as Text
+import Language.PureScript.CST.Types
 
 advanceToken :: SourcePos -> Token -> SourcePos
 advanceToken pos = applyDelta pos . tokenDelta

--- a/lib/purescript-cst/src/Language/PureScript/CST/Print.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Print.hs
@@ -9,11 +9,11 @@ module Language.PureScript.CST.Print
   , printTrailingComment
   ) where
 
-import "base" Prelude
+import Prelude
 
-import "text" Data.Text (Text)
-import qualified "text" Data.Text as Text
-import "this" Language.PureScript.CST.Types
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Language.PureScript.CST.Types
 
 printToken :: Token -> Text
 printToken = \case

--- a/lib/purescript-cst/src/Language/PureScript/CST/Traversals.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Traversals.hs
@@ -1,8 +1,8 @@
 module Language.PureScript.CST.Traversals where
 
-import "base" Prelude
+import Prelude
 
-import "this" Language.PureScript.CST.Types
+import Language.PureScript.CST.Types
 
 everythingOnSeparated :: (r -> r -> r) -> (a -> r) -> Separated a -> r
 everythingOnSeparated op k (Separated hd tl) = go hd tl

--- a/lib/purescript-cst/src/Language/PureScript/CST/Traversals/Type.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Traversals/Type.hs
@@ -1,9 +1,9 @@
 module Language.PureScript.CST.Traversals.Type where
 
-import "base" Prelude
+import Prelude
 
-import "this" Language.PureScript.CST.Types
-import "this" Language.PureScript.CST.Traversals
+import Language.PureScript.CST.Types
+import Language.PureScript.CST.Traversals
 
 everythingOnTypes :: (r -> r -> r) -> (Type a -> r) -> Type a -> r
 everythingOnTypes op k = goTy

--- a/lib/purescript-cst/src/Language/PureScript/CST/Types.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Types.hs
@@ -7,15 +7,15 @@
 
 module Language.PureScript.CST.Types where
 
-import "base" Prelude
+import Prelude
 
-import "base" Data.List.NonEmpty (NonEmpty)
-import "text" Data.Text (Text)
-import "base" Data.Void (Void)
-import "base" GHC.Generics (Generic)
-import qualified "purescript-ast" Language.PureScript.Names as N
+import Data.List.NonEmpty (NonEmpty)
+import Data.Text (Text)
+import Data.Void (Void)
+import GHC.Generics (Generic)
+import qualified Language.PureScript.Names as N
 import qualified Language.PureScript.Roles as R
-import "purescript-ast" Language.PureScript.PSString (PSString)
+import Language.PureScript.PSString (PSString)
 
 data SourcePos = SourcePos
   { srcLine :: {-# UNPACK #-} !Int

--- a/lib/purescript-cst/src/Language/PureScript/CST/Utils.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Utils.hs
@@ -1,23 +1,23 @@
 module Language.PureScript.CST.Utils where
 
-import "base" Prelude
+import Prelude
 
-import "base" Control.Monad (when)
-import "base" Data.Coerce (coerce)
-import "base" Data.Foldable (for_)
-import "base" Data.Functor (($>))
-import qualified "base" Data.List.NonEmpty as NE
-import "containers" Data.Set (Set)
-import qualified "containers" Data.Set as Set
-import "text" Data.Text (Text)
-import qualified "text" Data.Text as Text
-import "this" Language.PureScript.CST.Errors
-import "this" Language.PureScript.CST.Monad
-import "this" Language.PureScript.CST.Positions
-import "this" Language.PureScript.CST.Traversals.Type
-import "this" Language.PureScript.CST.Types
-import qualified "purescript-ast" Language.PureScript.Names as N
-import "purescript-ast" Language.PureScript.PSString (PSString, mkString)
+import Control.Monad (when)
+import Data.Coerce (coerce)
+import Data.Foldable (for_)
+import Data.Functor (($>))
+import qualified Data.List.NonEmpty as NE
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Language.PureScript.CST.Errors
+import Language.PureScript.CST.Monad
+import Language.PureScript.CST.Positions
+import Language.PureScript.CST.Traversals.Type
+import Language.PureScript.CST.Types
+import qualified Language.PureScript.Names as N
+import Language.PureScript.PSString (PSString, mkString)
 
 placeholder :: SourceToken
 placeholder = SourceToken

--- a/lib/purescript-cst/tests/Main.hs
+++ b/lib/purescript-cst/tests/Main.hs
@@ -6,13 +6,13 @@
 
 module Main (main) where
 
-import "base-compat" Prelude.Compat
+import Prelude.Compat
 
-import "tasty" Test.Tasty
+import Test.Tasty
 
-import qualified "this" TestCst
+import qualified TestCst
 
-import "base" System.IO (hSetEncoding, stdout, stderr, utf8)
+import System.IO (hSetEncoding, stdout, stderr, utf8)
 
 main :: IO ()
 main = do

--- a/lib/purescript-cst/tests/TestCst.hs
+++ b/lib/purescript-cst/tests/TestCst.hs
@@ -3,24 +3,24 @@
 {-# LANGUAGE PackageImports #-}
 module TestCst where
 
-import "base" Prelude
+import Prelude
 
-import "base" Control.Monad (when)
-import qualified "bytestring" Data.ByteString.Lazy as BS
-import "base" Data.Maybe (fromMaybe)
-import "text" Data.Text (Text)
-import qualified "text" Data.Text as Text
-import qualified "text" Data.Text.Encoding as Text
-import qualified "text" Data.Text.IO as Text
-import "tasty" Test.Tasty (TestTree, testGroup)
-import "tasty-golden" Test.Tasty.Golden (goldenVsString, findByExtension)
-import "tasty-quickcheck" Test.Tasty.QuickCheck
-import "base" Text.Read (readMaybe)
-import "purescript-cst" Language.PureScript.CST.Errors as CST
-import "purescript-cst" Language.PureScript.CST.Lexer as CST
-import "purescript-cst" Language.PureScript.CST.Print as CST
-import "purescript-cst" Language.PureScript.CST.Types
-import "filepath" System.FilePath (takeBaseName, replaceExtension)
+import Control.Monad (when)
+import qualified Data.ByteString.Lazy as BS
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.IO as Text
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Golden (goldenVsString, findByExtension)
+import Test.Tasty.QuickCheck
+import Text.Read (readMaybe)
+import Language.PureScript.CST.Errors as CST
+import Language.PureScript.CST.Lexer as CST
+import Language.PureScript.CST.Print as CST
+import Language.PureScript.CST.Types
+import System.FilePath (takeBaseName, replaceExtension)
 
 main :: IO TestTree
 main = do


### PR DESCRIPTION
As mentioned in #3820, this is necessary to get `ghci` tooling to work in the multi-package setup.