### PR TITLE
Fix substitution during kind generalization

### DIFF
--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -60,7 +60,7 @@ generalizeUnknowns unks ty =
 
 generalizeUnknownsWithVars :: [(Unknown, (Text, SourceType))] -> SourceType -> SourceType
 generalizeUnknownsWithVars binders ty =
-  mkForAll ((getAnnForType ty,) . fmap Just . snd <$> binders) . replaceUnknownsWithVars binders $ ty
+  mkForAll ((getAnnForType ty,) . fmap (Just . replaceUnknownsWithVars binders) . snd <$> binders) . replaceUnknownsWithVars binders $ ty
 
 replaceUnknownsWithVars :: [(Unknown, (Text, a))] -> SourceType -> SourceType
 replaceUnknownsWithVars binders ty
@@ -855,8 +855,7 @@ checkKindDeclaration _ ty = do
   checkTypeKind kind E.kindType
   ty'' <- replaceAllTypeSynonyms ty'
   unks <- unknownsWithKinds . IS.toList $ unknowns ty''
-  freshUnks <- traverse (traverse (\k -> (,k) <$> freshVar "k")) unks
-  finalTy <- generalizeUnknownsWithVars freshUnks <$> freshenForAlls ty' ty''
+  finalTy <- generalizeUnknowns unks <$> freshenForAlls ty' ty''
   checkQuantification finalTy
   checkValidKind finalTy
   where

--- a/tests/purs/passing/3830.purs
+++ b/tests/purs/passing/3830.purs
@@ -1,0 +1,16 @@
+module Main where
+
+import Effect.Console (log)
+
+data Proxy :: forall k. k -> Type
+data Proxy a = Proxy
+
+data PProxy :: forall k1 (k2 :: k1). (Proxy k2 -> Type) -> Type
+data PProxy p = PProxy
+
+type PProxy' = PProxy
+
+test :: PProxy' Proxy
+test = PProxy
+
+main = log "Done"


### PR DESCRIPTION
We were not applying the substitution for generalized kinds to their own
kinds, which can result in unknowns sticking around in a generalized
kind.

I've also fixed an issue wrt to hygiene in kind declarations, where
the names for generalized kinds were not using the usual name generation
scheme.

Fixes #3830