### PR TITLE
Fix build with new Happy versions.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@andyarvanitis](https://github.com/andyarvanitis) | Andy Arvanitis | [MIT license](http://opensource.org/licenses/MIT) |
 | [@anthok88](https://github.com/anthok88) | anthoq88 | MIT license |
 | [@ardumont](https://github.com/ardumont) | Antoine R. Dumont | [MIT license](http://opensource.org/licenses/MIT) |
+| [@arrowd](https://github.com/arrowd) | Gleb Popov | [MIT license](http://opensource.org/licenses/MIT) |
 | [@aspidites](https://github.com/aspidites) | Edwin Marshall | [MIT license](http://opensource.org/licenses/MIT) |
 | [@bagl](https://github.com/bagl) | Petr Vapenka | [MIT license](http://opensource.org/licenses/MIT) |
 | [@balajirrao](https://github.com/balajirrao) | Balaji Rao | MIT license |

--- a/lib/purescript-ast/src/Language/PureScript/Names.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Names.hs
@@ -118,6 +118,9 @@ data OpNameType = ValueOpName | TypeOpName | AnyOpName
 eraseOpName :: OpName a -> OpName 'AnyOpName
 eraseOpName = OpName . runOpName
 
+coerceOpName :: OpName a -> OpName b
+coerceOpName = OpName . runOpName
+
 -- |
 -- Proper names, i.e. capitalized names for e.g. module names, type//data constructors.
 --

--- a/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
@@ -180,12 +180,12 @@ moduleName :: { Name N.ModuleName }
   : UPPER {% upperToModuleName $1 }
   | QUAL_UPPER {% upperToModuleName $1 }
 
-qualProperName :: { QualifiedName (N.ProperName a) }
-  : UPPER {% toQualifiedName N.ProperName $1 }
-  | QUAL_UPPER {% toQualifiedName N.ProperName $1 }
+qualProperName :: { QualifiedProperName }
+  : UPPER {% qualifiedProperName <\$> toQualifiedName N.ProperName $1 }
+  | QUAL_UPPER {% qualifiedProperName <\$> toQualifiedName N.ProperName $1 }
 
-properName :: { Name (N.ProperName a) }
-  : UPPER {% toName N.ProperName $1 }
+properName :: { ProperName }
+  : UPPER {% properName <\$> toName N.ProperName $1 }
 
 qualIdent :: { QualifiedName Ident }
   : LOWER {% toQualifiedName Ident $1 }
@@ -208,29 +208,29 @@ ident :: { Name Ident }
   | 'representational' {% toName Ident $1 }
   | 'phantom' {% toName Ident $1 }
 
-qualOp :: { QualifiedName (N.OpName a) }
-  : OPERATOR {% toQualifiedName N.OpName $1 }
-  | QUAL_OPERATOR {% toQualifiedName N.OpName $1 }
-  | '<=' {% toQualifiedName N.OpName $1 }
-  | '-' {% toQualifiedName N.OpName $1 }
-  | '#' {% toQualifiedName N.OpName $1 }
-  | ':' {% toQualifiedName N.OpName $1 }
+qualOp :: { QualifiedOpName }
+  : OPERATOR {% qualifiedOpName <\$> toQualifiedName N.OpName $1 }
+  | QUAL_OPERATOR {% qualifiedOpName <\$> toQualifiedName N.OpName $1 }
+  | '<=' {% qualifiedOpName <\$> toQualifiedName N.OpName $1 }
+  | '-' {% qualifiedOpName <\$> toQualifiedName N.OpName $1 }
+  | '#' {% qualifiedOpName <\$> toQualifiedName N.OpName $1 }
+  | ':' {% qualifiedOpName <\$> toQualifiedName N.OpName $1 }
 
-op :: { Name (N.OpName a) }
-  : OPERATOR {% toName N.OpName $1 }
-  | '<=' {% toName N.OpName $1 }
-  | '-' {% toName N.OpName $1 }
-  | '#' {% toName N.OpName $1 }
-  | ':' {% toName N.OpName $1 }
+op :: { OpName }
+  : OPERATOR {% opName <\$> toName N.OpName $1 }
+  | '<=' {% opName <\$> toName N.OpName $1 }
+  | '-' {% opName <\$> toName N.OpName $1 }
+  | '#' {% opName <\$> toName N.OpName $1 }
+  | ':' {% opName <\$> toName N.OpName $1 }
 
-qualSymbol :: { QualifiedName (N.OpName a) }
-  : SYMBOL {% toQualifiedName N.OpName $1 }
-  | QUAL_SYMBOL {% toQualifiedName N.OpName $1 }
-  | '(..)' {% toQualifiedName N.OpName $1 }
+qualSymbol :: { QualifiedOpName }
+  : SYMBOL {% qualifiedOpName <\$> toQualifiedName N.OpName $1 }
+  | QUAL_SYMBOL {% qualifiedOpName <\$> toQualifiedName N.OpName $1 }
+  | '(..)' {% qualifiedOpName <\$> toQualifiedName N.OpName $1 }
 
-symbol :: { Name (N.OpName a) }
-  : SYMBOL {% toName N.OpName $1 }
-  | '(..)' {% toName N.OpName $1 }
+symbol :: { OpName }
+  : SYMBOL {% opName <\$> toName N.OpName $1 }
+  | '(..)' {% opName <\$> toName N.OpName $1 }
 
 label :: { Label }
   : LOWER { toLabel $1 }
@@ -305,7 +305,7 @@ type2 :: { Type () }
 
 type3 :: { Type () }
   : type4 { $1 }
-  | type3 qualOp type4 { TypeOp () $1 $2 $3 }
+  | type3 qualOp type4 { TypeOp () $1 (getQualifiedOpName $2) $3 }
 
 type4 :: { Type () }
   : type5 { $1 }
@@ -318,8 +318,8 @@ type5 :: { Type () }
 typeAtom :: { Type ()}
   : '_' { TypeWildcard () $1 }
   | ident { TypeVar () $1 }
-  | qualProperName { TypeConstructor () $1 }
-  | qualSymbol { TypeOpName () $1 }
+  | qualProperName { TypeConstructor () (getQualifiedProperName $1) }
+  | qualSymbol { TypeOpName () (getQualifiedOpName $1) }
   | string { uncurry (TypeString ()) $1 }
   | hole { TypeHole () $1 }
   | '(->)' { TypeArrName () $1 }
@@ -333,8 +333,8 @@ typeAtom :: { Type ()}
 -- row, and to annotate `a` with kind `Foo`, one must use `((a) :: Foo)`.
 typeKindedAtom :: { Type () }
   : '_' { TypeWildcard () $1 }
-  | qualProperName { TypeConstructor () $1 }
-  | qualSymbol { TypeOpName () $1 }
+  | qualProperName { TypeConstructor () (getQualifiedProperName $1) }
+  | qualSymbol { TypeOpName () (getQualifiedOpName $1) }
   | hole { TypeHole () $1 }
   | '{' row '}' { TypeRecord () (Wrapped $1 $2 $3) }
   | '(' row ')' { TypeRow () (Wrapped $1 $2 $3) }
@@ -368,7 +368,7 @@ expr :: { Expr () }
 
 expr1 :: { Expr () }
   : expr2 { $1 }
-  | expr1 qualOp expr2 { ExprOp () $1 $2 $3 }
+  | expr1 qualOp expr2 { ExprOp () $1 (getQualifiedOpName $2) $3 }
 
 expr2 :: { Expr () }
   : expr3 { $1 }
@@ -376,7 +376,7 @@ expr2 :: { Expr () }
 
 exprBacktick :: { Expr () }
   : expr3 { $1 }
-  | exprBacktick qualOp expr3 { ExprOp () $1 $2 $3 }
+  | exprBacktick qualOp expr3 { ExprOp () $1 (getQualifiedOpName $2) $3 }
 
 expr3 :: { Expr () }
   : expr4 { $1 }
@@ -427,8 +427,8 @@ exprAtom :: { Expr () }
   : '_' { ExprSection () $1 }
   | hole { ExprHole () $1 }
   | qualIdent { ExprIdent () $1 }
-  | qualProperName { ExprConstructor () $1 }
-  | qualSymbol { ExprOpName () $1 }
+  | qualProperName { ExprConstructor () (getQualifiedProperName $1) }
+  | qualSymbol { ExprOpName () (getQualifiedOpName $1) }
   | boolean { uncurry (ExprBoolean ()) $1 }
   | char { uncurry (ExprChar ()) $1 }
   | string { uncurry (ExprString ()) $1 }
@@ -566,7 +566,7 @@ binder :: { Binder () }
 
 binder1 :: { Binder () }
   : binder2 { $1 }
-  | binder1 qualOp binder2 { BinderOp () $1 $2 $3 }
+  | binder1 qualOp binder2 { BinderOp () $1 (getQualifiedOpName $2) $3 }
 
 binder2 :: { Binder () }
   : many(binderAtom) {% toBinderConstructor $1 }
@@ -575,7 +575,7 @@ binderAtom :: { Binder () }
   : '_' { BinderWildcard () $1 }
   | ident { BinderVar () $1 }
   | ident '@' binderAtom { BinderNamed () $1 $2 $3 }
-  | qualProperName { BinderConstructor () $1 [] }
+  | qualProperName { BinderConstructor () (getQualifiedProperName $1) [] }
   | boolean { uncurry (BinderBoolean ()) $1 }
   | char { uncurry (BinderChar ()) $1 }
   | string { uncurry (BinderString ()) $1 }
@@ -614,7 +614,7 @@ moduleDecls :: { ([ImportDecl ()], [Declaration ()]) }
   : manySep(moduleDecl, '\;') {% toModuleDecls $ NE.toList $1 }
   | {- empty -} { ([], []) }
 
-moduleDecl :: { TmpModuleDecl a }
+moduleDecl :: { TmpModuleDecl () }
   : importDecl { TmpImport $1 }
   | sep(decl, declElse) { TmpChain $1 }
 
@@ -628,18 +628,18 @@ exports :: { Maybe (DelimitedNonEmpty (Export ())) }
 
 export :: { Export () }
   : ident { ExportValue () $1 }
-  | symbol { ExportOp () $1 }
-  | properName { ExportType () $1 Nothing }
-  | properName dataMembers { ExportType () $1 (Just $2) }
-  | 'type' symbol { ExportTypeOp () $1 $2 }
-  | 'class' properName { ExportClass () $1 $2 }
-  | 'kind' properName {% addWarning [$1, nameTok $2] WarnDeprecatedKindExportSyntax *> pure (ExportKind () $1 $2) }
+  | symbol { ExportOp () (getOpName $1) }
+  | properName { ExportType () (getProperName $1) Nothing }
+  | properName dataMembers { ExportType () (getProperName $1) (Just $2) }
+  | 'type' symbol { ExportTypeOp () $1 (getOpName $2) }
+  | 'class' properName { ExportClass () $1 (getProperName $2) }
+  | 'kind' properName {% addWarning [$1, nameTok (getProperName $2)] WarnDeprecatedKindExportSyntax *> pure (ExportKind () $1 (getProperName $2)) }
   | 'module' moduleName { ExportModule () $1 $2 }
 
 dataMembers :: { (DataMembers ()) }
  : '(..)' { DataAll () $1 }
  | '(' ')' { DataEnumerated () (Wrapped $1 Nothing $2) }
- | '(' sep(properName, ',') ')' { DataEnumerated () (Wrapped $1 (Just $2) $3) }
+ | '(' sep(properName, ',') ')' { DataEnumerated () (Wrapped $1 (Just \$ getProperName <\$> $2) $3) }
 
 importDecl :: { ImportDecl () }
   : 'import' moduleName imports { ImportDecl () $1 $2 $3 Nothing }
@@ -652,47 +652,47 @@ imports :: { Maybe (Maybe SourceToken, DelimitedNonEmpty (Import ())) }
 
 import :: { Import () }
   : ident { ImportValue () $1 }
-  | symbol { ImportOp () $1 }
-  | properName { ImportType () $1 Nothing }
-  | properName dataMembers { ImportType () $1 (Just $2) }
-  | 'type' symbol { ImportTypeOp () $1 $2 }
-  | 'class' properName { ImportClass () $1 $2 }
-  | 'kind' properName {% addWarning [$1, nameTok $2] WarnDeprecatedKindImportSyntax *> pure (ImportKind () $1 $2) }
+  | symbol { ImportOp () (getOpName $1) }
+  | properName { ImportType () (getProperName $1) Nothing }
+  | properName dataMembers { ImportType () (getProperName $1) (Just $2) }
+  | 'type' symbol { ImportTypeOp () $1 (getOpName $2) }
+  | 'class' properName { ImportClass () $1 (getProperName $2) }
+  | 'kind' properName {% addWarning [$1, nameTok (getProperName $2)] WarnDeprecatedKindImportSyntax *> pure (ImportKind () $1 (getProperName $2)) }
 
 decl :: { Declaration () }
   : dataHead { DeclData () $1 Nothing }
   | dataHead '=' sep(dataCtor, '|') { DeclData () $1 (Just ($2, $3)) }
   | typeHead '=' type {% checkNoWildcards $3 *> pure (DeclType () $1 $2 $3) }
-  | newtypeHead '=' properName typeAtom {% checkNoWildcards $4 *> pure (DeclNewtype () $1 $2 $3 $4) }
+  | newtypeHead '=' properName typeAtom {% checkNoWildcards $4 *> pure (DeclNewtype () $1 $2 (getProperName $3) $4) }
   | classHead { either id (\h -> DeclClass () h Nothing) $1 }
   | classHead 'where' '\{' manySep(classMember, '\;') '\}' {% either (const (parseError $2)) (\h -> pure $ DeclClass () h (Just ($2, $4))) $1 }
   | instHead { DeclInstanceChain () (Separated (Instance $1 Nothing) []) }
   | instHead 'where' '\{' manySep(instBinding, '\;') '\}' { DeclInstanceChain () (Separated (Instance $1 (Just ($2, $4))) []) }
-  | 'data' properName '::' type {% checkNoWildcards $4 *> pure (DeclKindSignature () $1 (Labeled $2 $3 $4)) }
-  | 'newtype' properName '::' type {% checkNoWildcards $4 *> pure (DeclKindSignature () $1 (Labeled $2 $3 $4)) }
-  | 'type' properName '::' type {% checkNoWildcards $4 *> pure (DeclKindSignature () $1 (Labeled $2 $3 $4)) }
+  | 'data' properName '::' type {% checkNoWildcards $4 *> pure (DeclKindSignature () $1 (Labeled (getProperName $2) $3 $4)) }
+  | 'newtype' properName '::' type {% checkNoWildcards $4 *> pure (DeclKindSignature () $1 (Labeled (getProperName $2) $3 $4)) }
+  | 'type' properName '::' type {% checkNoWildcards $4 *> pure (DeclKindSignature () $1 (Labeled (getProperName $2) $3 $4)) }
   | 'derive' instHead { DeclDerive () $1 Nothing $2 }
   | 'derive' 'newtype' instHead { DeclDerive () $1 (Just $2) $3 }
   | ident '::' type { DeclSignature () (Labeled $1 $2 $3) }
   | ident manyOrEmpty(binderAtom) guardedDecl { DeclValue () (ValueBindingFields $1 $2 $3) }
   | fixity { DeclFixity () $1 }
   | 'foreign' 'import' ident '::' type { DeclForeign () $1 $2 (ForeignValue (Labeled $3 $4 $5)) }
-  | 'foreign' 'import' 'data' properName '::' type { DeclForeign () $1 $2 (ForeignData $3 (Labeled $4 $5 $6)) }
-  | 'foreign' 'import' 'kind' properName {% addWarning [$1, $2, $3, nameTok $4] WarnDeprecatedForeignKindSyntax *> pure (DeclForeign () $1 $2 (ForeignKind $3 $4)) }
-  | 'type' 'role' properName many(role) { DeclRole () $1 $2 $3 $4 }
+  | 'foreign' 'import' 'data' properName '::' type { DeclForeign () $1 $2 (ForeignData $3 (Labeled (getProperName $4) $5 $6)) }
+  | 'foreign' 'import' 'kind' properName {% addWarning [$1, $2, $3, nameTok (getProperName $4)] WarnDeprecatedForeignKindSyntax *> pure (DeclForeign () $1 $2 (ForeignKind $3 (getProperName $4))) }
+  | 'type' 'role' properName many(role) { DeclRole () $1 $2 (getProperName $3) $4 }
 
 dataHead :: { DataHead () }
-  : 'data' properName manyOrEmpty(typeVarBinding) { DataHead $1 $2 $3 }
+  : 'data' properName manyOrEmpty(typeVarBinding) { DataHead $1 (getProperName $2) $3 }
 
 typeHead :: { DataHead () }
-  : 'type' properName manyOrEmpty(typeVarBinding) { DataHead $1 $2 $3 }
+  : 'type' properName manyOrEmpty(typeVarBinding) { DataHead $1 (getProperName $2) $3 }
 
 newtypeHead :: { DataHead () }
-  : 'newtype' properName manyOrEmpty(typeVarBinding) { DataHead $1 $2 $3 }
+  : 'newtype' properName manyOrEmpty(typeVarBinding) { DataHead $1 (getProperName $2) $3 }
 
 dataCtor :: { DataCtor () }
   : properName manyOrEmpty(typeAtom)
-      {% for_ $2 checkNoWildcards *> pure (DataCtor () $1 $2) }
+      {% for_ $2 checkNoWildcards *> pure (DataCtor () (getProperName $1) $2) }
 
 -- Class head syntax requires unbounded lookahead due to a conflict between
 -- row syntax and `typeVarBinding`. `(a :: B)` is either a row in `constraint`
@@ -716,13 +716,13 @@ classHead :: { Either (Declaration ()) (ClassHead ()) }
       }
 
 classSignature :: { Labeled (Name (N.ProperName 'N.TypeName)) (Type ()) }
-  : properName '::' type {%^ revert $ checkNoWildcards $3 *> pure (Labeled $1 $2 $3) }
+  : properName '::' type {%^ revert $ checkNoWildcards $3 *> pure (Labeled (getProperName $1) $2 $3) }
 
 classSuper :: { (OneOrDelimited (Constraint ()), SourceToken) }
   : constraints '<=' {%^ revert $ pure ($1, $2) }
 
 classNameAndFundeps :: { (Name (N.ProperName 'N.ClassName), [TypeVarBinding ()], Maybe (SourceToken, Separated ClassFundep)) }
-  : properName manyOrEmpty(typeVarBinding) fundeps {%^ revert $ pure ($1, $2, $3) }
+  : properName manyOrEmpty(typeVarBinding) fundeps {%^ revert $ pure (getProperName $1, $2, $3) }
 
 fundeps :: { Maybe (SourceToken, Separated ClassFundep) }
   : {- empty -} { Nothing }
@@ -737,16 +737,16 @@ classMember :: { Labeled (Name Ident) (Type ()) }
 
 instHead :: { InstanceHead () }
   : 'instance' ident '::' constraints '=>' qualProperName manyOrEmpty(typeAtom)
-      { InstanceHead $1 $2 $3 (Just ($4, $5)) $6 $7 }
+      { InstanceHead $1 $2 $3 (Just ($4, $5)) (getQualifiedProperName $6) $7 }
   | 'instance' ident '::' qualProperName manyOrEmpty(typeAtom)
-      { InstanceHead $1 $2 $3 Nothing $4 $5 }
+      { InstanceHead $1 $2 $3 Nothing (getQualifiedProperName $4) $5 }
 
 constraints :: { OneOrDelimited (Constraint ()) }
   : constraint { One $1 }
   | '(' sep(constraint, ',') ')' { Many (Wrapped $1 $2 $3) }
 
 constraint :: { Constraint () }
-  : qualProperName manyOrEmpty(typeAtom) {% for_ $2 checkNoWildcards *> for_ $2 checkNoForalls *> pure (Constraint () $1 $2) }
+  : qualProperName manyOrEmpty(typeAtom) {% for_ $2 checkNoWildcards *> for_ $2 checkNoForalls *> pure (Constraint () (getQualifiedProperName $1) $2) }
   | '(' constraint ')' { ConstraintParens () (Wrapped $1 $2 $3) }
 
 instBinding :: { InstanceBinding () }
@@ -754,9 +754,9 @@ instBinding :: { InstanceBinding () }
   | ident manyOrEmpty(binderAtom) guardedDecl { InstanceBindingName () (ValueBindingFields $1 $2 $3) }
 
 fixity :: { FixityFields }
-  : infix int qualIdent 'as' op { FixityFields $1 $2 (FixityValue (fmap Left $3) $4 $5) }
-  | infix int qualProperName 'as' op { FixityFields $1 $2 (FixityValue (fmap Right $3) $4 $5) }
-  | infix int 'type' qualProperName 'as' op { FixityFields $1 $2 (FixityType $3 $4 $5 $6) }
+  : infix int qualIdent 'as' op { FixityFields $1 $2 (FixityValue (fmap Left $3) $4 (getOpName $5)) }
+  | infix int qualProperName 'as' op { FixityFields $1 $2 (FixityValue (fmap Right (getQualifiedProperName $3)) $4 (getOpName $5)) }
+  | infix int 'type' qualProperName 'as' op { FixityFields $1 $2 (FixityType $3 (getQualifiedProperName $4) $5 (getOpName $6)) }
 
 infix :: { (SourceToken, Fixity) }
   : 'infix' { ($1, Infix) }

--- a/lib/purescript-cst/src/Language/PureScript/CST/Utils.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Utils.hs
@@ -19,6 +19,54 @@ import Language.PureScript.CST.Types
 import qualified Language.PureScript.Names as N
 import Language.PureScript.PSString (PSString, mkString)
 
+-- |
+-- A newtype for a qualified proper name whose ProperNameType has not yet been determined.
+-- This is a workaround for Happy's limited support for polymorphism; it is used
+-- inside the parser to allow us to write just one parser for qualified proper names
+-- which can be used for all of the different ProperNameTypes
+-- (via a call to getQualifiedProperName).
+newtype QualifiedProperName =
+  QualifiedProperName { getQualifiedProperName :: forall a. QualifiedName (N.ProperName a) }
+
+qualifiedProperName :: QualifiedName (N.ProperName a) -> QualifiedProperName
+qualifiedProperName n = QualifiedProperName (N.coerceProperName <$> n)
+
+-- |
+-- A newtype for a proper name whose ProperNameType has not yet been determined.
+-- This is a workaround for Happy's limited support for polymorphism; it is used
+-- inside the parser to allow us to write just one parser for proper names
+-- which can be used for all of the different ProperNameTypes
+-- (via a call to getProperName).
+newtype ProperName =
+  ProperName { getProperName :: forall a. Name (N.ProperName a) }
+
+properName :: Name (N.ProperName a) -> ProperName
+properName n = ProperName (N.coerceProperName <$> n)
+
+-- |
+-- A newtype for a qualified operator name whose OpNameType has not yet been determined.
+-- This is a workaround for Happy's limited support for polymorphism; it is used
+-- inside the parser to allow us to write just one parser for qualified operator names
+-- which can be used for all of the different OpNameTypes
+-- (via a call to getQualifiedOpName).
+newtype QualifiedOpName =
+  QualifiedOpName { getQualifiedOpName :: forall a. QualifiedName (N.OpName a) }
+
+qualifiedOpName :: QualifiedName (N.OpName a) -> QualifiedOpName
+qualifiedOpName n = QualifiedOpName (N.coerceOpName <$> n)
+
+-- |
+-- A newtype for a operator name whose OpNameType has not yet been determined.
+-- This is a workaround for Happy's limited support for polymorphism; it is used
+-- inside the parser to allow us to write just one parser for operator names
+-- which can be used for all of the different OpNameTypes
+-- (via a call to getOpName).
+newtype OpName =
+  OpName { getOpName :: forall a. Name (N.OpName a) }
+
+opName :: Name (N.OpName a) -> OpName
+opName n = OpName (N.coerceOpName <$> n)
+
 placeholder :: SourceToken
 placeholder = SourceToken
   { tokAnn = TokenAnn (SourceRange (SourcePos 0 0) (SourcePos 0 0)) [] []


### PR DESCRIPTION
This fixes https://github.com/purescript/purescript/issues/3664 by adding non-polymorphic versions of `qualProperName`, `properName`, `qualOp`, `op` and `symbol` productions.

Not an elegant solution, but I'm not a type-level magician, so maybe a better solution exists.