### PR TITLE
Change which channel is used when printing info in specific situations

### DIFF
--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -58,8 +58,8 @@ printWarningsAndErrors verbose True warnings errors = do
 
 compile :: PSCMakeOptions -> IO ()
 compile PSCMakeOptions{..} = do
-  input <- globWarningOnMisses (unless pscmJSONErrors . warnFileTypeNotFound) pscmInput
-  when (null input && not pscmJSONErrors) $ do
+  input <- globWarningOnMisses warnFileTypeNotFound pscmInput
+  when (null input) $ do
     hPutStr stderr $ unlines [ "purs compile: No input files."
                              , "Usage: For basic information, try the `--help' option."
                              ]

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -44,7 +44,7 @@ printWarningsAndErrors verbose False warnings errors = do
   cc <- bool Nothing (Just P.defaultCodeColor) <$> ANSI.hSupportsANSI stdout
   let ppeOpts = P.defaultPPEOptions { P.ppeCodeColor = cc, P.ppeFull = verbose, P.ppeRelativeDirectory = pwd }
   when (P.nonEmpty warnings) $
-    hPutStrLn stderr (P.prettyPrintMultipleWarnings ppeOpts warnings)
+    hPutStrLn stdout (P.prettyPrintMultipleWarnings ppeOpts warnings)
   case errors of
     Left errs -> do
       hPutStrLn stdout (P.prettyPrintMultipleErrors ppeOpts errs)

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -51,7 +51,7 @@ printWarningsAndErrors verbose False warnings errors = do
       exitFailure
     Right _ -> return ()
 printWarningsAndErrors verbose True warnings errors = do
-  hPutStrLn stderr . LBU8.toString . A.encode $
+  hPutStrLn stdout . LBU8.toString . A.encode $
     JSONResult (toJSONErrors verbose P.Warning warnings)
                (either (toJSONErrors verbose P.Error) (const []) errors)
   either (const exitFailure) (const (return ())) errors

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -26,7 +26,7 @@ import qualified System.Console.ANSI as ANSI
 import           System.Exit (exitSuccess, exitFailure)
 import           System.Directory (getCurrentDirectory)
 import           System.FilePath.Glob (glob)
-import           System.IO (hPutStr, hPutStrLn, stderr)
+import           System.IO (hPutStr, hPutStrLn, stderr, stdout)
 import           System.IO.UTF8 (readUTF8FilesT)
 
 data PSCMakeOptions = PSCMakeOptions
@@ -41,13 +41,13 @@ data PSCMakeOptions = PSCMakeOptions
 printWarningsAndErrors :: Bool -> Bool -> P.MultipleErrors -> Either P.MultipleErrors a -> IO ()
 printWarningsAndErrors verbose False warnings errors = do
   pwd <- getCurrentDirectory
-  cc <- bool Nothing (Just P.defaultCodeColor) <$> ANSI.hSupportsANSI stderr
+  cc <- bool Nothing (Just P.defaultCodeColor) <$> ANSI.hSupportsANSI stdout
   let ppeOpts = P.defaultPPEOptions { P.ppeCodeColor = cc, P.ppeFull = verbose, P.ppeRelativeDirectory = pwd }
   when (P.nonEmpty warnings) $
     hPutStrLn stderr (P.prettyPrintMultipleWarnings ppeOpts warnings)
   case errors of
     Left errs -> do
-      hPutStrLn stderr (P.prettyPrintMultipleErrors ppeOpts errs)
+      hPutStrLn stdout (P.prettyPrintMultipleErrors ppeOpts errs)
       exitFailure
     Right _ -> return ()
 printWarningsAndErrors verbose True warnings errors = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -29,6 +29,8 @@ main :: IO ()
 main = do
     IO.hSetEncoding IO.stdout IO.utf8
     IO.hSetEncoding IO.stderr IO.utf8
+    IO.hSetBuffering IO.stdout IO.LineBuffering
+    IO.hSetBuffering IO.stderr IO.LineBuffering
     cmd <- Opts.handleParseResult . execParserPure opts =<< getArgs
     cmd
   where

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -54,6 +54,7 @@ import           SourceMap
 import           SourceMap.Types
 import           System.Directory (getCurrentDirectory)
 import           System.FilePath ((</>), makeRelative, splitPath, normalise)
+import           System.IO (hPutStrLn, stderr)
 
 -- | Determines when to rebuild a module
 data RebuildPolicy

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -269,7 +269,7 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
   requiresForeign = not . null . CF.moduleForeign
 
   progress :: ProgressMessage -> Make ()
-  progress = liftIO . putStrLn . renderProgressMessage
+  progress = liftIO . hPutStrLn stderr . renderProgressMessage
 
   readCacheDb :: Make CacheDb
   readCacheDb = readCacheDb' outputDir

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -26,6 +26,7 @@ import qualified Data.Map as M
 import           Data.Maybe (fromMaybe, maybeToList)
 import qualified Data.Set as S
 import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
 import qualified Data.Text.Encoding as TE
 import           Data.Time.Clock (UTCTime)
 import           Data.Version (showVersion)
@@ -54,7 +55,7 @@ import           SourceMap
 import           SourceMap.Types
 import           System.Directory (getCurrentDirectory)
 import           System.FilePath ((</>), makeRelative, splitPath, normalise)
-import           System.IO (hPutStrLn, stderr)
+import           System.IO (stderr)
 
 -- | Determines when to rebuild a module
 data RebuildPolicy
@@ -71,8 +72,8 @@ data ProgressMessage
   deriving (Show, Eq, Ord)
 
 -- | Render a progress message
-renderProgressMessage :: ProgressMessage -> String
-renderProgressMessage (CompilingModule mn) = "Compiling " ++ T.unpack (runModuleName mn)
+renderProgressMessage :: ProgressMessage -> T.Text
+renderProgressMessage (CompilingModule mn) = T.append "Compiling " (runModuleName mn)
 
 -- | Actions that require implementations when running in "make" mode.
 --
@@ -270,7 +271,7 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
   requiresForeign = not . null . CF.moduleForeign
 
   progress :: ProgressMessage -> Make ()
-  progress = liftIO . hPutStrLn stderr . renderProgressMessage
+  progress = liftIO . TIO.hPutStrLn stderr . renderProgressMessage
 
   readCacheDb :: Make CacheDb
   readCacheDb = readCacheDb' outputDir

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -271,7 +271,7 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
   requiresForeign = not . null . CF.moduleForeign
 
   progress :: ProgressMessage -> Make ()
-  progress = liftIO . TIO.hPutStrLn stderr . renderProgressMessage
+  progress = liftIO . (TIO.hPutStr stderr . (<> "\n")) . renderProgressMessage
 
   readCacheDb :: Make CacheDb
   readCacheDb = readCacheDb' outputDir

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -271,7 +271,7 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
   requiresForeign = not . null . CF.moduleForeign
 
   progress :: ProgressMessage -> Make ()
-  progress = liftIO . (TIO.hPutStr stderr . (<> "\n")) . renderProgressMessage
+  progress = liftIO . TIO.hPutStr stderr . (<> "\n") . renderProgressMessage
 
   readCacheDb :: Make CacheDb
   readCacheDb = readCacheDb' outputDir


### PR DESCRIPTION
Fixes #3672 (when finished)

I'm not sure how to swap the "compiler errors" over to `stdout`, though I know it's going to be in the [printWarningsAndErrors](https://github.com/purescript/purescript/blob/master/app/Command/Compile.hs#L40-L57) function. The below two questions are how I think it's supposed to be done. If correct, I can push those changes to this PR.

1) Due to usage of `ANSI.hSupportsANSI` for `stderr`, does the following need to be duplicated for `stdout`?

Current code...
```haskell
  cc <- bool Nothing (Just P.defaultCodeColor) <$> ANSI.hSupportsANSI stderr
  let ppeOpts = P.defaultPPEOptions { P.ppeCodeColor = cc, P.ppeFull = verbose, P.ppeRelativeDirectory = pwd }
  when (P.nonEmpty warnings) $
    hPutStrLn stderr (P.prettyPrintMultipleWarnings ppeOpts warnings)
  case errors of
    Left errs -> do
      hPutStrLn stderr (P.prettyPrintMultipleErrors ppeOpts errs)
      exitFailure
    Right _ -> return ()
```
New code...?
```haskell
  ccErr <- bool Nothing (Just P.defaultCodeColor) <$> ANSI.hSupportsANSI stderr
  let ppeOptsErr = P.defaultPPEOptions { P.ppeCodeColor = ccErr, P.ppeFull = verbose,   P.ppeRelativeDirectory = pwd }

  ccOut <- bool Nothing (Just P.defaultCodeColor) <$> ANSI.hSupportsANSI stdout
  let ppeOptsOut = P.defaultPPEOptions { P.ppeCodeColor = ccOut, P.ppeFull = verbose, P.ppeRelativeDirectory = pwd }

  when (P.nonEmpty warnings) $
    hPutStrLn stderr (P.prettyPrintMultipleWarnings ppeOptsErr warnings)
  case errors of
    Left errs -> do
      hPutStrLn stdout (P.prettyPrintMultipleErrors ppeOptsOut errs)
      exitFailure
    Right _ -> return ()
```

2) Does this code....
```haskell
printWarningsAndErrors verbose True warnings errors = do
  hPutStrLn stderr . LBU8.toString . A.encode $
    JSONResult (toJSONErrors verbose P.Warning warnings)
               (either (toJSONErrors verbose P.Error) (const []) errors)
  either (const exitFailure) (const (return ())) errors
```
... become this code...?
```haskell
printWarningsAndErrors verbose True warnings errors = do
  hPutStrLn stderr . LBU8.toString . A.encode $ toJSONErrors verbose P.Warning warnings
  hPutStrLn stdout . LBU8.toString . A.encode $ (either (toJSONErrors verbose P.Error) (const []) errors)
  either (const exitFailure) (const (return ())) errors
```