### PR TITLE
Represents ModuleNames as a single Text

### DIFF
--- a/lib/purescript-ast/src/Language/PureScript/AST/Declarations.hs
+++ b/lib/purescript-ast/src/Language/PureScript/AST/Declarations.hs
@@ -830,8 +830,8 @@ $(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''ExportSo
 
 isTrueExpr :: Expr -> Bool
 isTrueExpr (Literal _ (BooleanLiteral True)) = True
-isTrueExpr (Var _ (Qualified (Just (ModuleName [ProperName "Prelude"])) (Ident "otherwise"))) = True
-isTrueExpr (Var _ (Qualified (Just (ModuleName [ProperName "Data", ProperName "Boolean"])) (Ident "otherwise"))) = True
+isTrueExpr (Var _ (Qualified (Just (ModuleName "Prelude")) (Ident "otherwise"))) = True
+isTrueExpr (Var _ (Qualified (Just (ModuleName "Data.Boolean")) (Ident "otherwise"))) = True
 isTrueExpr (TypedValue _ e _) = isTrueExpr e
 isTrueExpr (PositionedValue _ _ e) = isTrueExpr e
 isTrueExpr _ = False

--- a/lib/purescript-ast/src/Language/PureScript/Constants/Prim.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Constants/Prim.hs
@@ -17,7 +17,7 @@ partial :: forall a. (IsString a) => a
 partial = "Partial"
 
 pattern Prim :: ModuleName
-pattern Prim = ModuleName [ProperName "Prim"]
+pattern Prim = ModuleName "Prim"
 
 pattern Partial :: Qualified (ProperName 'ClassName)
 pattern Partial = Qualified (Just Prim) (ProperName "Partial")
@@ -43,7 +43,7 @@ pattern Row = Qualified (Just Prim) (ProperName "Row")
 -- Prim.Boolean
 
 pattern PrimBoolean :: ModuleName
-pattern PrimBoolean = ModuleName [ProperName "Prim", ProperName "Boolean"]
+pattern PrimBoolean = ModuleName "Prim.Boolean"
 
 booleanTrue :: Qualified (ProperName 'TypeName)
 booleanTrue = Qualified (Just PrimBoolean) (ProperName "True")
@@ -54,7 +54,7 @@ booleanFalse = Qualified (Just PrimBoolean) (ProperName "False")
 -- Prim.Coerce
 
 pattern PrimCoerce :: ModuleName
-pattern PrimCoerce = ModuleName [ProperName "Prim", ProperName "Coerce"]
+pattern PrimCoerce = ModuleName "Prim.Coerce"
 
 pattern Coercible :: Qualified (ProperName 'ClassName)
 pattern Coercible = Qualified (Just PrimCoerce) (ProperName "Coercible")
@@ -62,7 +62,7 @@ pattern Coercible = Qualified (Just PrimCoerce) (ProperName "Coercible")
 -- Prim.Ordering
 
 pattern PrimOrdering :: ModuleName
-pattern PrimOrdering = ModuleName [ProperName "Prim", ProperName "Ordering"]
+pattern PrimOrdering = ModuleName "Prim.Ordering"
 
 orderingLT :: Qualified (ProperName 'TypeName)
 orderingLT = Qualified (Just PrimOrdering) (ProperName "LT")
@@ -76,7 +76,7 @@ orderingGT = Qualified (Just PrimOrdering) (ProperName "GT")
 -- Prim.Row
 
 pattern PrimRow :: ModuleName
-pattern PrimRow = ModuleName [ProperName "Prim", ProperName "Row"]
+pattern PrimRow = ModuleName "Prim.Row"
 
 pattern RowUnion :: Qualified (ProperName 'ClassName)
 pattern RowUnion = Qualified (Just PrimRow) (ProperName "Union")
@@ -93,7 +93,7 @@ pattern RowLacks = Qualified (Just PrimRow) (ProperName "Lacks")
 -- Prim.RowList
 
 pattern PrimRowList :: ModuleName
-pattern PrimRowList = ModuleName [ProperName "Prim", ProperName "RowList"]
+pattern PrimRowList = ModuleName "Prim.RowList"
 
 pattern RowToList :: Qualified (ProperName 'ClassName)
 pattern RowToList = Qualified (Just PrimRowList) (ProperName "RowToList")
@@ -107,7 +107,7 @@ pattern RowListCons = Qualified (Just PrimRowList) (ProperName "Cons")
 -- Prim.Symbol
 
 pattern PrimSymbol :: ModuleName
-pattern PrimSymbol = ModuleName [ProperName "Prim", ProperName "Symbol"]
+pattern PrimSymbol = ModuleName "Prim.Symbol"
 
 pattern SymbolCompare :: Qualified (ProperName 'ClassName)
 pattern SymbolCompare = Qualified (Just PrimSymbol) (ProperName "Compare")
@@ -121,7 +121,7 @@ pattern SymbolCons = Qualified (Just PrimSymbol) (ProperName "Cons")
 -- Prim.TypeError
 
 pattern PrimTypeError :: ModuleName
-pattern PrimTypeError = ModuleName [ProperName "Prim", ProperName "TypeError"]
+pattern PrimTypeError = ModuleName "Prim.TypeError"
 
 pattern Fail :: Qualified (ProperName 'ClassName)
 pattern Fail = Qualified (Just PrimTypeError) (ProperName "Fail")

--- a/lib/purescript-ast/src/Language/PureScript/Environment.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Environment.hs
@@ -278,12 +278,12 @@ instance A.FromJSON DataDeclType where
 
 -- | Construct a ProperName in the Prim module
 primName :: Text -> Qualified (ProperName a)
-primName = Qualified (Just $ ModuleName [ProperName C.prim]) . ProperName
+primName = Qualified (Just C.Prim) . ProperName
 
 -- | Construct a 'ProperName' in the @Prim.NAME@ module.
 primSubName :: Text -> Text -> Qualified (ProperName a)
 primSubName sub =
-  Qualified (Just $ ModuleName [ProperName C.prim, ProperName sub]) . ProperName
+  Qualified (Just $ ModuleName $ C.prim <> "." <> sub) . ProperName
 
 primKind :: Text -> SourceType
 primKind = primTy

--- a/lib/purescript-ast/src/Language/PureScript/Names.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Names.hs
@@ -11,6 +11,7 @@ import Codec.Serialise (Serialise)
 import Control.Monad.Supply.Class
 import Control.DeepSeq (NFData)
 import Data.Functor.Contravariant (contramap)
+import qualified Data.Vector as V
 
 import GHC.Generics (Generic)
 import Data.Aeson
@@ -157,26 +158,20 @@ coerceProperName = ProperName . runProperName
 -- |
 -- Module names
 --
-newtype ModuleName = ModuleName [ProperName 'Namespace]
+newtype ModuleName = ModuleName Text
   deriving (Show, Eq, Ord, Generic)
+  deriving newtype Serialise
 
 instance NFData ModuleName
-instance Serialise ModuleName
 
 runModuleName :: ModuleName -> Text
-runModuleName (ModuleName pns) = T.intercalate "." (runProperName <$> pns)
+runModuleName (ModuleName name) = name
 
 moduleNameFromString :: Text -> ModuleName
-moduleNameFromString = ModuleName . splitProperNames
-  where
-  splitProperNames s = case T.dropWhile (== '.') s of
-    "" -> []
-    s' -> ProperName w : splitProperNames s''
-      where (w, s'') = T.break (== '.') s'
+moduleNameFromString = ModuleName
 
 isBuiltinModuleName :: ModuleName -> Bool
-isBuiltinModuleName (ModuleName (ProperName "Prim" : _)) = True
-isBuiltinModuleName _ = False
+isBuiltinModuleName (ModuleName mn) = mn == "Prim" || T.isPrefixOf "Prim." mn
 
 -- |
 -- A qualified name, i.e. a name with an optional module name
@@ -241,7 +236,14 @@ isQualifiedWith _ _ = False
 
 $(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''Qualified)
 $(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''Ident)
-$(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''ModuleName)
+
+instance ToJSON ModuleName where
+  toJSON (ModuleName name) = toJSON (T.splitOn "." name)
+
+instance FromJSON ModuleName where
+  parseJSON = withArray "ModuleName" $ \names -> do
+    names' <- traverse parseJSON names
+    pure (ModuleName (T.intercalate "." (V.toList names')))
 
 instance ToJSONKey ModuleName where
   toJSONKey = contramap runModuleName toJSONKey

--- a/lib/purescript-cst/src/Language/PureScript/CST/Convert.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Convert.hs
@@ -85,7 +85,7 @@ moduleName = \case
   _ -> Nothing
   where
   go [] = Nothing
-  go ns = Just $ N.ModuleName $ N.ProperName <$> ns
+  go ns = Just $ N.ModuleName $ Text.intercalate "." ns
 
 qualified :: QualifiedName a -> N.Qualified a
 qualified q = N.Qualified (qualModule q) (qualName q)

--- a/lib/purescript-cst/src/Language/PureScript/CST/Utils.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Utils.hs
@@ -81,14 +81,14 @@ toModuleName :: SourceToken -> [Text] -> Parser (Maybe N.ModuleName)
 toModuleName _ [] = pure Nothing
 toModuleName tok ns = do
   when (not (all isValidModuleNamespace ns)) $ addFailure [tok] ErrModuleName
-  pure . Just . N.ModuleName $ N.ProperName <$> ns
+  pure . Just . N.ModuleName $ Text.intercalate "." ns
 
 upperToModuleName :: SourceToken -> Parser (Name N.ModuleName)
 upperToModuleName tok = case tokValue tok of
   TokUpperName q a -> do
     let ns = q <> [a]
     when (not (all isValidModuleNamespace ns)) $ addFailure [tok] ErrModuleName
-    pure . Name tok . N.ModuleName $ N.ProperName <$> ns
+    pure . Name tok . N.ModuleName $ Text.intercalate "." ns
   _ -> internalError $ "Invalid upper name: " <> show tok
 
 toQualifiedName :: (Text -> a) -> SourceToken -> Parser (QualifiedName a)

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -96,8 +96,8 @@ moduleToJs (Module _ coms mn _ imps exps foreigns decls) foreign_ =
     go acc _ [] = acc
 
     freshModuleName :: Integer -> ModuleName -> [Ident] -> ModuleName
-    freshModuleName i mn'@(ModuleName pns) used =
-      let newName = ModuleName $ init pns ++ [ProperName $ runProperName (last pns) <> "_" <> T.pack (show i)]
+    freshModuleName i mn'@(ModuleName name) used =
+      let newName = ModuleName $ name <> "_" <> T.pack (show i)
       in if Ident (runModuleName newName) `elem` used
          then freshModuleName (i + 1) mn' used
          else newName
@@ -307,7 +307,7 @@ moduleToJs (Module _ coms mn _ imps exps foreigns decls) foreign_ =
   -- | Generate code in the simplified JavaScript intermediate representation for a reference to a
   -- variable that may have a qualified name.
   qualifiedToJS :: (a -> Ident) -> Qualified a -> AST
-  qualifiedToJS f (Qualified (Just (ModuleName [ProperName mn'])) a) | mn' == C.prim = AST.Var Nothing . runIdent $ f a
+  qualifiedToJS f (Qualified (Just C.Prim) a) = AST.Var Nothing . runIdent $ f a
   qualifiedToJS f (Qualified (Just mn') a) | mn /= mn' = accessor (f a) (AST.Var Nothing (moduleNameToJs mn'))
   qualifiedToJS f (Qualified _ a) = AST.Var Nothing $ identToJs (f a)
 

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -11,8 +11,8 @@ import Language.PureScript.Crash
 import Language.PureScript.Names
 
 moduleNameToJs :: ModuleName -> Text
-moduleNameToJs (ModuleName pns) =
-  let name = T.intercalate "_" (runProperName `map` pns)
+moduleNameToJs (ModuleName mn) =
+  let name = T.replace "." "_" mn
   in if nameIsJsBuiltIn name then "$$" <> name else name
 
 -- | Convert an 'Ident' into a valid JavaScript identifier:

--- a/src/Language/PureScript/Constants/Prelude.hs
+++ b/src/Language/PureScript/Constants/Prelude.hs
@@ -371,7 +371,7 @@ main = "main"
 -- Data.Symbol
 
 pattern DataSymbol :: ModuleName
-pattern DataSymbol = ModuleName [ProperName "Data", ProperName "Symbol"]
+pattern DataSymbol = ModuleName "Data.Symbol"
 
 pattern IsSymbol :: Qualified (ProperName 'ClassName)
 pattern IsSymbol = Qualified (Just DataSymbol) (ProperName "IsSymbol")
@@ -398,7 +398,7 @@ controlSemigroupoid :: forall a. (IsString a) => a
 controlSemigroupoid = "Control_Semigroupoid"
 
 pattern ControlBind :: ModuleName
-pattern ControlBind = ModuleName [ProperName "Control", ProperName "Bind"]
+pattern ControlBind = ModuleName "Control.Bind"
 
 controlBind :: forall a. (IsString a) => a
 controlBind = "Control_Bind"

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -89,7 +89,7 @@ moduleToCoreFn env (A.Module modSS coms mn decls (Just exps)) =
   exprToCoreFn ss com ty (A.App v1 v2) =
     App (ss, com, ty, Nothing) (exprToCoreFn ss [] Nothing v1) (exprToCoreFn ss [] Nothing v2)
   exprToCoreFn ss com ty (A.Unused _) =
-    Var (ss, com, ty, Nothing) (Qualified (Just (ModuleName [ProperName C.prim])) (Ident C.undefined))
+    Var (ss, com, ty, Nothing) (Qualified (Just C.Prim) (Ident C.undefined))
   exprToCoreFn _ com ty (A.Var ss ident) =
     Var (ss, com, ty, getValueMeta ident) ident
   exprToCoreFn ss com ty (A.IfThenElse v1 v2 v3) =

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -104,7 +104,7 @@ qualifiedFromJSON f = withObject "Qualified" qualifiedFromObj
     return $ Qualified mn i
 
 moduleNameFromJSON :: Value -> Parser ModuleName
-moduleNameFromJSON v = ModuleName <$> parseJSON v
+moduleNameFromJSON v = ModuleName . T.intercalate "." <$> listParser parseJSON v
 
 moduleFromJSON :: Value -> Parser (Version, Module Ann)
 moduleFromJSON = withObject "Module" moduleFromObj

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -104,7 +104,7 @@ qualifiedFromJSON f = withObject "Qualified" qualifiedFromObj
     return $ Qualified mn i
 
 moduleNameFromJSON :: Value -> Parser ModuleName
-moduleNameFromJSON v = ModuleName <$> listParser properNameFromJSON v
+moduleNameFromJSON v = ModuleName <$> parseJSON v
 
 moduleFromJSON :: Value -> Parser (Version, Module Ann)
 moduleFromJSON = withObject "Module" moduleFromObj

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -100,7 +100,7 @@ qualifiedToJSON f (Qualified mn a) = object
   ]
 
 moduleNameToJSON :: ModuleName -> Value
-moduleNameToJSON (ModuleName pns) = toJSON $ properNameToJSON `map` pns
+moduleNameToJSON (ModuleName name) = toJSON name
 
 moduleToJSON :: Version -> Module Ann -> Value
 moduleToJSON v m = object

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -100,7 +100,7 @@ qualifiedToJSON f (Qualified mn a) = object
   ]
 
 moduleNameToJSON :: ModuleName -> Value
-moduleNameToJSON (ModuleName name) = toJSON name
+moduleNameToJSON (ModuleName name) = toJSON (T.splitOn (T.pack ".") name)
 
 moduleToJSON :: Version -> Module Ann -> Value
 moduleToJSON v m = object

--- a/src/Language/PureScript/Hierarchy.hs
+++ b/src/Language/PureScript/Hierarchy.hs
@@ -54,8 +54,8 @@ prettyPrint (SuperMap (Right (super, sub))) =
   "  " <> P.runProperName super <> " -> " <> P.runProperName sub <> ";"
 
 runModuleName :: P.ModuleName -> GraphName
-runModuleName (P.ModuleName pns) =
-  GraphName $ T.intercalate "_" (P.runProperName <$> pns)
+runModuleName (P.ModuleName name) =
+  GraphName $ T.replace "." "_" name
 
 typeClasses :: Functor f => f P.Module -> f (Maybe Graph)
 typeClasses =

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -272,7 +272,7 @@ handleTypeOf print' val = do
   case e of
     Left errs -> printErrors errs
     Right (_, env') ->
-      case M.lookup (P.mkQualified (P.Ident "it") (P.ModuleName [P.ProperName "$PSCI"])) (P.names env') of
+      case M.lookup (P.mkQualified (P.Ident "it") (P.ModuleName "$PSCI")) (P.names env') of
         Just (ty, _, _) -> print' . P.prettyPrintType maxBound $ ty
         Nothing -> print' "Could not find type"
 
@@ -285,7 +285,7 @@ handleKindOf
 handleKindOf print' typ = do
   st <- get
   let m = createTemporaryModuleForKind st typ
-      mName = P.ModuleName [P.ProperName "$PSCI"]
+      mName = P.ModuleName "$PSCI"
   e <- liftIO . runMake $ rebuild (map snd (psciLoadedExterns st)) m
   case e of
     Left errs -> printErrors errs

--- a/src/Language/PureScript/Interactive/Module.hs
+++ b/src/Language/PureScript/Interactive/Module.hs
@@ -45,18 +45,18 @@ createTemporaryModule exec st val =
   let
     imports       = psciImportedModules st
     lets          = psciLetBindings st
-    moduleName    = P.ModuleName [P.ProperName "$PSCI"]
-    effModuleName = P.moduleNameFromString "Effect"
-    effImport     = (effModuleName, P.Implicit, Just (P.ModuleName [P.ProperName "$Effect"]))
-    supportImport = (fst (psciInteractivePrint st), P.Implicit, Just (P.ModuleName [P.ProperName "$Support"]))
-    eval          = P.Var internalSpan (P.Qualified (Just (P.ModuleName [P.ProperName "$Support"])) (snd (psciInteractivePrint st)))
+    moduleName    = P.ModuleName "$PSCI"
+    effModuleName = P.ModuleName "Effect"
+    effImport     = (effModuleName, P.Implicit, Just (P.ModuleName "$Effect"))
+    supportImport = (fst (psciInteractivePrint st), P.Implicit, Just (P.ModuleName "$Support"))
+    eval          = P.Var internalSpan (P.Qualified (Just (P.ModuleName "$Support")) (snd (psciInteractivePrint st)))
     mainValue     = P.App eval (P.Var internalSpan (P.Qualified Nothing (P.Ident "it")))
     itDecl        = P.ValueDecl (internalSpan, []) (P.Ident "it") P.Public [] [P.MkUnguarded val]
     typeDecl      = P.TypeDeclaration
                       (P.TypeDeclarationData (internalSpan, []) (P.Ident "$main")
                         (P.srcTypeApp
                           (P.srcTypeConstructor
-                            (P.Qualified (Just (P.ModuleName [P.ProperName "$Effect"])) (P.ProperName "Effect")))
+                            (P.Qualified (Just (P.ModuleName "$Effect")) (P.ProperName "Effect")))
                                   P.srcTypeWildcard))
     mainDecl      = P.ValueDecl (internalSpan, []) (P.Ident "$main") P.Public [] [P.MkUnguarded mainValue]
     decls         = if exec then [itDecl, typeDecl, mainDecl] else [itDecl]
@@ -75,7 +75,7 @@ createTemporaryModuleForKind st typ =
   let
     imports    = psciImportedModules st
     lets       = psciLetBindings st
-    moduleName = P.ModuleName [P.ProperName "$PSCI"]
+    moduleName = P.ModuleName "$PSCI"
     itDecl     = P.TypeSynonymDeclaration (internalSpan, []) (P.ProperName "IT") [] typ
   in
     P.Module internalSpan [] moduleName ((importDecl `map` imports) ++ lets ++ [itDecl]) Nothing
@@ -87,7 +87,7 @@ createTemporaryModuleForImports :: PSCiState -> P.Module
 createTemporaryModuleForImports st =
   let
     imports    = psciImportedModules st
-    moduleName = P.ModuleName [P.ProperName "$PSCI"]
+    moduleName = P.ModuleName "$PSCI"
   in
     P.Module internalSpan [] moduleName (importDecl `map` imports) Nothing
 

--- a/src/Language/PureScript/Interactive/Types.hs
+++ b/src/Language/PureScript/Interactive/Types.hs
@@ -134,12 +134,12 @@ updateImportExports st@(PSCiState modules lets externs iprint _ _) =
   createEnv = runExceptT =<< fmap fst . runWriterT . foldM P.externsEnv P.primEnv
 
   temporaryName :: P.ModuleName
-  temporaryName = P.ModuleName [P.ProperName "$PSCI"]
+  temporaryName = P.ModuleName "$PSCI"
 
   temporaryModule :: P.Module
   temporaryModule =
     let
-      prim = (P.ModuleName [P.ProperName "Prim"], P.Implicit, Nothing)
+      prim = (P.ModuleName "Prim", P.Implicit, Nothing)
       decl = (importDecl `map` (prim : modules)) ++ lets
     in
       P.Module internalSpan [] temporaryName decl Nothing

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -142,7 +142,7 @@ lintImports (Module _ _ mn mdecls (Just mexports)) env usedImps = do
   -- Checks whether a module is the Prim module - used to suppress any checks
   -- made, as Prim is always implicitly imported.
   isPrim :: ModuleName -> Bool
-  isPrim = (== ModuleName [ProperName C.prim])
+  isPrim = (== C.Prim)
 
   -- Creates a map of virtual modules mapped to all the declarations that
   -- import to that module, with the corresponding source span, import type,

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -51,7 +51,7 @@ desugarTypeClasses externs = flip evalStateT initialState . traverse desugarModu
   initialState :: MemberMap
   initialState =
     mconcat
-      [ M.mapKeys (qualify (ModuleName [ProperName C.prim])) primClasses
+      [ M.mapKeys (qualify C.Prim) primClasses
       , M.mapKeys (qualify C.PrimCoerce) primCoerceClasses
       , M.mapKeys (qualify C.PrimRow) primRowClasses
       , M.mapKeys (qualify C.PrimRowList) primRowListClasses

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -263,19 +263,19 @@ deriveNewtypeInstance ss mn syns kinds ndis className ds tys tyConNm dargs = do
                 else tell . errorMessage' ss $ UnverifiableSuperclassInstance constraintClass className tys
 
 dataGenericRep :: ModuleName
-dataGenericRep = ModuleName [ ProperName "Data", ProperName "Generic", ProperName "Rep" ]
+dataGenericRep = ModuleName "Data.Generic.Rep"
 
 dataEq :: ModuleName
-dataEq = ModuleName [ ProperName "Data", ProperName "Eq" ]
+dataEq = ModuleName "Data.Eq"
 
 dataOrd :: ModuleName
-dataOrd = ModuleName [ ProperName "Data", ProperName "Ord" ]
+dataOrd = ModuleName "Data.Ord"
 
 dataNewtype :: ModuleName
-dataNewtype = ModuleName [ ProperName "Data", ProperName "Newtype" ]
+dataNewtype = ModuleName "Data.Newtype"
 
 dataFunctor :: ModuleName
-dataFunctor = ModuleName [ ProperName "Data", ProperName "Functor" ]
+dataFunctor = ModuleName "Data.Functor"
 
 unguarded :: Expr -> [GuardedExpr]
 unguarded e = [MkUnguarded e]
@@ -460,7 +460,7 @@ deriveEq ss mn syns kinds ds tyConNm = do
     mkEqFunction _ = internalError "mkEqFunction: expected DataDeclaration"
 
     preludeConj :: Expr -> Expr -> Expr
-    preludeConj = App . App (Var ss (Qualified (Just (ModuleName [ProperName "Data", ProperName "HeytingAlgebra"])) (Ident C.conj)))
+    preludeConj = App . App (Var ss (Qualified (Just (ModuleName "Data.HeytingAlgebra")) (Ident C.conj)))
 
     preludeEq :: Expr -> Expr -> Expr
     preludeEq = App . App (Var ss (Qualified (Just dataEq) (Ident C.eq)))
@@ -541,7 +541,7 @@ deriveOrd ss mn syns kinds ds tyConNm = do
       catchAll = CaseAlternative [NullBinder, NullBinder] (unguarded (orderingCtor "EQ"))
 
     orderingName :: Text -> Qualified (ProperName a)
-    orderingName = Qualified (Just (ModuleName [ProperName "Data", ProperName "Ordering"])) . ProperName
+    orderingName = Qualified (Just (ModuleName "Data.Ordering")) . ProperName
 
     orderingCtor :: Text -> Expr
     orderingCtor = Constructor ss . orderingName

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -198,7 +198,7 @@ entails SolverOptions{..} constraint context hints =
     findDicts ctx cn = fmap (fmap NamedInstance) . foldMap NEL.toList . foldMap M.elems . (>>= M.lookup cn) . flip M.lookup ctx
 
     valUndefined :: Expr
-    valUndefined = Var nullSourceSpan (Qualified (Just (ModuleName [ProperName C.prim])) (Ident C.undefined))
+    valUndefined = Var nullSourceSpan (Qualified (Just C.Prim) (Ident C.undefined))
 
     solve :: SourceConstraint -> WriterT (Any, [(Ident, InstanceContext, SourceConstraint)]) (StateT InstanceContext m) Expr
     solve con = go 0 con

--- a/tests/TestCoreFn.hs
+++ b/tests/TestCoreFn.hs
@@ -42,7 +42,7 @@ isSuccess _           = False
 
 spec :: Spec
 spec = context "CoreFnFromJsonTest" $ do
-  let mn = ModuleName [ProperName "Example", ProperName "Main"]
+  let mn = ModuleName "Example.Main"
       mp = "src/Example/Main.purs"
       ss = SourceSpan mp (SourcePos 0 0) (SourcePos 0 0)
       ann = ssAnn ss
@@ -217,7 +217,7 @@ spec = context "CoreFnFromJsonTest" $ do
                       [ CaseAlternative
                         [ ConstructorBinder
                             ann
-                            (Qualified (Just (ModuleName [ProperName "Data", ProperName "Either"])) (ProperName "Either"))
+                            (Qualified (Just (ModuleName "Data.Either")) (ProperName "Either"))
                             (Qualified Nothing (ProperName "Left"))
                             [VarBinder ann (Ident "z")]
                         ]

--- a/tests/TestHierarchy.hs
+++ b/tests/TestHierarchy.hs
@@ -32,7 +32,7 @@ main = testSpec "hierarchy" $ do
         let mainModule = P.Module
               (P.internalModuleSourceSpan "<hierarchy>")
               []
-              (P.ModuleName [P.ProperName "Main"])
+              (P.ModuleName "Main")
               []
               Nothing
 
@@ -60,7 +60,7 @@ main = testSpec "hierarchy" $ do
         let mainModule = P.Module
               (P.internalModuleSourceSpan "<hierarchy>")
               []
-              (P.ModuleName [P.ProperName "Main"])
+              (P.ModuleName "Main")
               declarations
               Nothing
 


### PR DESCRIPTION
The hierarchy `newtype ModuleName = ModuleName [ProperName]` suggests doesn't actually exist except for the `Prim.` namespace.

The compiler compares module names for equality and ordering all over the place though, so we should pick a representation suitable for that. This improves my extern loading benchmarks by another 10%.

Most of that will be the more compact encoding, that I could get with a handwritten instance as well, but I wanted to suggest this representation for a while now. What do you think?