### PR TITLE
[purs ide] Extracts documentation comments for type classes

### DIFF
--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -261,6 +261,7 @@ resolveLocationsForModule (defs, types) decls =
       annotateValue
       annotateDataConstructor
       annotateType
+      annotateType -- type classes live in the type namespace
       annotateModule
       d
       where
@@ -278,9 +279,10 @@ convertDeclaration'
   -> (Text -> IdeDeclaration -> IdeDeclarationAnn)
   -> (Text -> IdeDeclaration -> IdeDeclarationAnn)
   -> (Text -> IdeDeclaration -> IdeDeclarationAnn)
+  -> (Text -> IdeDeclaration -> IdeDeclarationAnn)
   -> IdeDeclaration
   -> IdeDeclarationAnn
-convertDeclaration' annotateFunction annotateValue annotateDataConstructor annotateType annotateModule d =
+convertDeclaration' annotateFunction annotateValue annotateDataConstructor annotateType annotateClass annotateModule d =
   case d of
     IdeDeclValue v ->
       annotateFunction (v ^. ideValueIdent) d
@@ -291,7 +293,7 @@ convertDeclaration' annotateFunction annotateValue annotateDataConstructor annot
     IdeDeclDataConstructor dtor ->
       annotateDataConstructor (dtor ^. ideDtorName . properNameT) d
     IdeDeclTypeClass tc ->
-      annotateType (tc ^. ideTCName . properNameT) d
+      annotateClass (tc ^. ideTCName . properNameT) d
     IdeDeclValueOperator operator ->
       annotateValue (operator ^. ideValueOpName . opNameT) d
     IdeDeclTypeOperator operator ->
@@ -311,14 +313,16 @@ resolveDocumentationForModule
   :: P.Module
     -> [IdeDeclarationAnn]
     -> [IdeDeclarationAnn]
-resolveDocumentationForModule (P.Module _ moduleComments moduleName sdecls _) decls = map convertDecl decls
+resolveDocumentationForModule (P.Module _ moduleComments moduleName sdecls _) decls =
+  map convertDecl decls
   where
   comments :: Map P.Name [P.Comment]
-  comments = Map.insert (P.ModName moduleName) moduleComments $ Map.fromListWith (flip (<>)) $ concatMap (\case
-    P.DataDeclaration (_, cs) _ ctorName _ ctors ->
-      (P.TyName ctorName, cs) : map dtorComments ctors
-    decl ->
-      maybe [] (\name' -> [(name', snd (P.declSourceAnn decl))]) (name decl))
+  comments = Map.insert (P.ModName moduleName) moduleComments $
+    Map.fromListWith (flip (<>)) $ concatMap (\case
+      P.DataDeclaration (_, cs) _ ctorName _ ctors ->
+        (P.TyName ctorName, cs) : map dtorComments ctors
+      decl ->
+        maybe [] (\name' -> [(name', snd (P.declSourceAnn decl))]) (name decl))
     sdecls
 
   dtorComments :: P.DataConstructorDeclaration -> (P.Name, [P.Comment])
@@ -335,6 +339,7 @@ resolveDocumentationForModule (P.Module _ moduleComments moduleName sdecls _) de
       (annotateValue . P.IdentName . P.Ident)
       (annotateValue . P.DctorName . P.ProperName)
       (annotateValue . P.TyName . P.ProperName)
+      (annotateValue . P.TyClassName . P.ProperName)
       (annotateValue . P.ModName . P.moduleNameFromString)
       d
     where

--- a/tests/Language/PureScript/Ide/CompletionSpec.hs
+++ b/tests/Language/PureScript/Ide/CompletionSpec.hs
@@ -72,3 +72,10 @@ spec = describe "Applying completion options" $ do
                   , typ "CompletionSpecDocs"
                   ]
     result `shouldSatisfy` \res -> complDocumentation res == Just "Module Documentation\n"
+
+  it "gets docs on type class declaration" $ do
+    ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
+      Test.runIde [ load ["CompletionSpecDocs"]
+                  , typ "DocClass"
+                  ]
+    result `shouldSatisfy` \res -> complDocumentation res == Just "Doc for class\n"

--- a/tests/Language/PureScript/Ide/CompletionSpec.hs
+++ b/tests/Language/PureScript/Ide/CompletionSpec.hs
@@ -79,3 +79,10 @@ spec = describe "Applying completion options" $ do
                   , typ "DocClass"
                   ]
     result `shouldSatisfy` \res -> complDocumentation res == Just "Doc for class\n"
+
+  it "gets docs on type class members" $ do
+    ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
+      Test.runIde [ load ["CompletionSpecDocs"]
+                  , typ "member"
+                  ]
+    result `shouldSatisfy` \res -> complDocumentation res == Just "doc for member\n"

--- a/tests/support/pscide/src/CompletionSpecDocs.purs
+++ b/tests/support/pscide/src/CompletionSpecDocs.purs
@@ -12,3 +12,8 @@ withType = 42
 -- | a multi-line
 -- | comment
 multiline = "multiline"
+
+-- | Doc for class
+class DocClass where
+  -- | doc for member
+  member :: Int


### PR DESCRIPTION
I had assumed we were already doing this? Maybe something about the Name structure changed, or this was just an oversight in the original PR. I also added a test to make sure it doesn't regress.