### PR TITLE
Fix CoreFn FromJSON version parsing and add test

### DIFF
--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -4,6 +4,7 @@
 
 module Language.PureScript.CoreFn.FromJSON
   ( moduleFromJSON
+  , parseVersion'
   ) where
 
 import Prelude.Compat
@@ -13,15 +14,22 @@ import           Data.Aeson.Types (Parser, Value, listParser)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Vector as V
-import           Data.Version (Version)
+import           Data.Version (Version, parseVersion)
 
 import           Language.PureScript.AST.SourcePos (SourceSpan(SourceSpan))
 import           Language.PureScript.AST.Literals
 import           Language.PureScript.CoreFn.Ann
 import           Language.PureScript.CoreFn
-import           Language.PureScript.Docs.Types (parseVersion')
 import           Language.PureScript.Names
 import           Language.PureScript.PSString (PSString)
+
+import           Text.ParserCombinators.ReadP (readP_to_S)
+
+parseVersion' :: String -> Maybe Version
+parseVersion' str =
+  case filter (null . snd) $ readP_to_S parseVersion str of
+    [(vers, "")] -> Just vers
+    _            -> Nothing
 
 constructorTypeFromJSON :: Value -> Parser ConstructorType
 constructorTypeFromJSON v = do

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -12,14 +12,14 @@ import           Data.Aeson
 import           Data.Aeson.Types (Parser, Value, listParser)
 import           Data.Text (Text)
 import qualified Data.Text as T
-import           Text.ParserCombinators.ReadP (readP_to_S)
 import qualified Data.Vector as V
-import           Data.Version (Version, parseVersion)
+import           Data.Version (Version)
 
 import           Language.PureScript.AST.SourcePos (SourceSpan(SourceSpan))
 import           Language.PureScript.AST.Literals
 import           Language.PureScript.CoreFn.Ann
 import           Language.PureScript.CoreFn
+import           Language.PureScript.Docs.Types (parseVersion')
 import           Language.PureScript.Names
 import           Language.PureScript.PSString (PSString)
 
@@ -123,9 +123,9 @@ moduleFromJSON = withObject "Module" moduleFromObj
 
   versionFromJSON :: String -> Parser Version
   versionFromJSON v =
-    case readP_to_S parseVersion v of
-      (r, _) : _ -> return r
-      _ -> fail "failed parsing purs version"
+    case parseVersion' v of
+      Just r -> return r
+      Nothing -> fail "failed parsing purs version"
 
   importFromJSON :: FilePath -> Value -> Parser (Ann, ModuleName)
   importFromJSON modulePath = withObject "Import"

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -28,13 +28,12 @@ import qualified Data.Text as T
 import qualified Data.Vector as V
 
 import qualified Language.PureScript.AST as P
+import qualified Language.PureScript.CoreFn.FromJSON as P
 import qualified Language.PureScript.Crash as P
 import qualified Language.PureScript.Environment as P
 import qualified Language.PureScript.Names as P
 import qualified Language.PureScript.Types as P
 import qualified Paths_purescript as Paths
-
-import Text.ParserCombinators.ReadP (readP_to_S)
 
 import Web.Bower.PackageMeta hiding (Version, displayError)
 
@@ -549,13 +548,7 @@ instance A.FromJSON GithubUser where
   parseJSON = toAesonParser' asGithubUser
 
 asVersion :: Parse PackageError Version
-asVersion = withString (maybe (Left InvalidVersion) Right . parseVersion')
-
-parseVersion' :: String -> Maybe Version
-parseVersion' str =
-  case filter (null . snd) $ readP_to_S parseVersion str of
-    [(vers, "")] -> Just vers
-    _            -> Nothing
+asVersion = withString (maybe (Left InvalidVersion) Right . P.parseVersion')
 
 asModule :: Parse PackageError Module
 asModule =

--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -48,6 +48,7 @@ import qualified Web.Bower.PackageMeta as Bower
 import Language.PureScript.Publish.ErrorsWarnings
 import Language.PureScript.Publish.Utils
 import qualified Language.PureScript as P (version, ModuleName)
+import qualified Language.PureScript.CoreFn.FromJSON as P
 import qualified Language.PureScript.Docs as D
 
 data PublishOptions = PublishOptions
@@ -199,7 +200,7 @@ getVersionFromGitTag = do
     dropWhile isSpace >>> reverse >>> dropWhile isSpace >>> reverse
   parseMay str = do
     digits <- stripPrefix "v" str
-    (str,) <$> D.parseVersion' digits
+    (str,) <$> P.parseVersion' digits
 
 -- | Given a git tag, get the time it was created.
 getTagTime :: Text -> PrepareM UTCTime
@@ -330,7 +331,7 @@ asResolutions =
 
 asVersion :: Parse D.PackageError Version
 asVersion =
-  withString (note D.InvalidVersion . D.parseVersion')
+  withString (note D.InvalidVersion . P.parseVersion')
 
 parsePackageName :: Text -> Either D.PackageError PackageName
 parsePackageName = first D.ErrorInPackageMeta . Bower.parsePackageName

--- a/tests/TestCoreFn.hs
+++ b/tests/TestCoreFn.hs
@@ -47,6 +47,15 @@ spec = context "CoreFnFromJsonTest" $ do
       ss = SourceSpan mp (SourcePos 0 0) (SourcePos 0 0)
       ann = ssAnn ss
 
+  specify "should parse version" $ do
+    let v = Version [0, 13, 6] []
+        m = Module ss [] mn mp [] [] [] []
+        r = fst <$> parseModule (moduleToJSON v m)
+    r `shouldSatisfy` isSuccess
+    case r of
+      Error _   -> return ()
+      Aeson.Success v' -> v' `shouldBe` v
+
   specify "should parse an empty module" $ do
     let r = parseMod $ Module ss [] mn mp [] [] [] []
     r `shouldSatisfy` isSuccess


### PR DESCRIPTION
I noticed that a value of `0.13.6` in `corefn.json` was being parsed as `0`. This fixes that, and adds a test.

This bug appears to have been around since https://github.com/purescript/purescript/pull/3049, so about 3 years 😎 