### PR TITLE
Printer for CST Modules

### DIFF
--- a/lib/purescript-cst/src/Language/PureScript/CST/Flatten.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Flatten.hs
@@ -18,11 +18,216 @@ flattenModule (Module _ a b c d e f g) =
     dummyPos = SourcePos 0 0
     dummyRange = SourceRange dummyPos dummyPos
 
+flattenDataHead :: DataHead a -> DList SourceToken
+flattenDataHead (DataHead a b c) = pure a <> flattenName b <> foldMap flattenTypeVarBinding c
+
+flattenDataCtor :: DataCtor a -> DList SourceToken
+flattenDataCtor (DataCtor _ a b) = flattenName a <> foldMap flattenType b
+
+flattenClassHead :: ClassHead a -> DList SourceToken
+flattenClassHead (ClassHead a b c d e) =
+  pure a <>
+  foldMap (\(f, g) -> flattenOneOrDelimited flattenConstraint f <> pure g) b <>
+  flattenName c <>
+  foldMap flattenTypeVarBinding d <>
+  foldMap (\(f, g) -> pure f <> flattenSeparated flattenClassFundep g) e
+
+flattenClassFundep :: ClassFundep -> DList SourceToken
+flattenClassFundep = \case
+  FundepDetermined a b ->
+    pure a <> foldMap flattenName b
+  FundepDetermines a b c ->
+    foldMap flattenName a <> pure b <> foldMap flattenName c
+
+flattenInstance :: Instance a -> DList SourceToken
+flattenInstance (Instance a b) =
+  flattenInstanceHead a <> foldMap (\(c, d) -> pure c <> foldMap flattenInstanceBinding d) b
+
+flattenInstanceHead :: InstanceHead a -> DList SourceToken
+flattenInstanceHead (InstanceHead a b c d e f) =
+  pure a <>
+  flattenName b <>
+  pure c <>
+  foldMap (\(g, h) -> flattenOneOrDelimited flattenConstraint g <> pure h) d <>
+  flattenQualifiedName e <>
+  foldMap flattenType f
+
+flattenInstanceBinding :: InstanceBinding a -> DList SourceToken
+flattenInstanceBinding = \case
+  InstanceBindingSignature _ a -> flattenLabeled flattenName flattenType a
+  InstanceBindingName _ a -> flattenValueBindingFields a
+
+flattenValueBindingFields :: ValueBindingFields a -> DList SourceToken
+flattenValueBindingFields (ValueBindingFields a b c) =
+  flattenName a <>
+  foldMap flattenBinder b <>
+  flattenGuarded c
+
+flattenBinder :: Binder a -> DList SourceToken
+flattenBinder = \case
+  BinderWildcard _ a -> pure a
+  BinderVar _ a -> flattenName a
+  BinderNamed _ a b c -> flattenName a <> pure b <> flattenBinder c
+  BinderConstructor _ a b -> flattenQualifiedName a <> foldMap flattenBinder b
+  BinderBoolean _ a _ -> pure a
+  BinderChar _ a _ -> pure a
+  BinderString _ a _ -> pure a
+  BinderNumber _ a b _ -> foldMap pure a <> pure b
+  BinderArray _ a -> flattenWrapped (foldMap (flattenSeparated flattenBinder)) a
+  BinderRecord _ a ->
+    flattenWrapped (foldMap (flattenSeparated (flattenRecordLabeled flattenBinder))) a
+  BinderParens _ a -> flattenWrapped flattenBinder a
+  BinderTyped _ a b c -> flattenBinder a <> pure b <> flattenType c
+  BinderOp _ a b c -> flattenBinder a <> flattenQualifiedName b <> flattenBinder c
+
+flattenRecordLabeled :: (a -> DList SourceToken) -> RecordLabeled a -> DList SourceToken
+flattenRecordLabeled f = \case
+  RecordPun a -> flattenName a
+  RecordField a b c -> flattenLabel a <> pure b <> f c
+
+flattenRecordAccessor :: RecordAccessor a -> DList SourceToken
+flattenRecordAccessor (RecordAccessor a b c) =
+  flattenExpr a <> pure b <> flattenSeparated flattenLabel c
+
+flattenRecordUpdate :: RecordUpdate a -> DList SourceToken
+flattenRecordUpdate = \case
+  RecordUpdateLeaf a b c -> flattenLabel a <> pure b <> flattenExpr c
+  RecordUpdateBranch a b ->
+    flattenLabel a <> flattenWrapped (flattenSeparated flattenRecordUpdate) b
+
+flattenLambda :: Lambda a -> DList SourceToken
+flattenLambda (Lambda a b c d) =
+  pure a <> foldMap flattenBinder b <> pure c <> flattenExpr d
+
+flattenIfThenElse :: IfThenElse a -> DList SourceToken
+flattenIfThenElse (IfThenElse a b c d e f) =
+  pure a <> flattenExpr b <> pure c <> flattenExpr d <> pure e <> flattenExpr f
+
+flattenCaseOf :: CaseOf a -> DList SourceToken
+flattenCaseOf (CaseOf a b c d) =
+  pure a <>
+  flattenSeparated flattenExpr b <>
+  pure c <>
+  foldMap (\(e, f) -> flattenSeparated flattenBinder e <> flattenGuarded f) d
+
+flattenLetIn :: LetIn a -> DList SourceToken
+flattenLetIn (LetIn a b c d) =
+  pure a <> foldMap flattenLetBinding b <> pure c <> flattenExpr d
+
+flattenDoBlock :: DoBlock a -> DList SourceToken
+flattenDoBlock (DoBlock a b) =
+  pure a <> foldMap flattenDoStatement b
+
+flattenAdoBlock :: AdoBlock a -> DList SourceToken
+flattenAdoBlock (AdoBlock a b c d) =
+  pure a <> foldMap flattenDoStatement b <> pure c <> flattenExpr d
+
+flattenDoStatement :: DoStatement a -> DList SourceToken
+flattenDoStatement = \case
+  DoLet a b -> pure a <> foldMap flattenLetBinding b
+  DoDiscard a -> flattenExpr a
+  DoBind a b c -> flattenBinder a <> pure b <> flattenExpr c
+
+flattenExpr :: Expr a -> DList SourceToken
+flattenExpr = \case
+  ExprHole _ a -> flattenName a
+  ExprSection _ a -> pure a
+  ExprIdent _ a -> flattenQualifiedName a
+  ExprConstructor _ a -> flattenQualifiedName a
+  ExprBoolean _ a _ -> pure a
+  ExprChar _ a _ -> pure a
+  ExprString _ a _ -> pure a
+  ExprNumber _ a _ -> pure a
+  ExprArray _ a -> flattenWrapped (foldMap (flattenSeparated flattenExpr)) a
+  ExprRecord _ a ->
+    flattenWrapped (foldMap (flattenSeparated (flattenRecordLabeled flattenExpr))) a
+  ExprParens _ a -> flattenWrapped flattenExpr a
+  ExprTyped _ a b c -> flattenExpr a <> pure b <> flattenType c
+  ExprInfix _ a b c -> flattenExpr a <> flattenWrapped flattenExpr b <> flattenExpr c
+  ExprOp _ a b c -> flattenExpr a <> flattenQualifiedName b <> flattenExpr c
+  ExprOpName _ a -> flattenQualifiedName a
+  ExprNegate _ a b -> pure a <> flattenExpr b
+  ExprRecordAccessor _ a -> flattenRecordAccessor a
+  ExprRecordUpdate _ a b -> flattenExpr a <> flattenWrapped (flattenSeparated flattenRecordUpdate) b
+  ExprApp _ a b -> flattenExpr a <> flattenExpr b
+  ExprLambda _ a -> flattenLambda a
+  ExprIf _ a -> flattenIfThenElse a
+  ExprCase _ a -> flattenCaseOf a
+  ExprLet _ a -> flattenLetIn a
+  ExprDo _ a -> flattenDoBlock a
+  ExprAdo _ a -> flattenAdoBlock a
+
+flattenLetBinding :: LetBinding a -> DList SourceToken
+flattenLetBinding = \case
+  LetBindingSignature _ a -> flattenLabeled flattenName flattenType a
+  LetBindingName _ a -> flattenValueBindingFields a
+  LetBindingPattern _ a b c -> flattenBinder a <> pure b <> flattenWhere c
+
+flattenWhere :: Where a -> DList SourceToken
+flattenWhere (Where a b) =
+  flattenExpr a <> foldMap (\(c, d) -> pure c <> foldMap flattenLetBinding d) b
+
+flattenPatternGuard :: PatternGuard a -> DList SourceToken
+flattenPatternGuard (PatternGuard a b) =
+  foldMap (\(c, d) -> flattenBinder c <> pure d) a <> flattenExpr b
+
+flattenGuardedExpr :: GuardedExpr a -> DList SourceToken
+flattenGuardedExpr (GuardedExpr a b c d) =
+  pure a <>
+  flattenSeparated flattenPatternGuard b <>
+  pure c <>
+  flattenWhere d
+
+flattenGuarded :: Guarded a -> DList SourceToken
+flattenGuarded = \case
+  Unconditional a b -> pure a <> flattenWhere b
+  Guarded a -> foldMap flattenGuardedExpr a
+
+flattenFixityFields :: FixityFields -> DList SourceToken
+flattenFixityFields (FixityFields (a, _) (b, _) c) =
+  pure a <> pure b <> flattenFixityOp c
+
+flattenFixityOp :: FixityOp -> DList SourceToken
+flattenFixityOp = \case
+  FixityValue a b c -> flattenQualifiedName a <> pure b <> flattenName c
+  FixityType a b c d -> pure a <> flattenQualifiedName b <> pure c <> flattenName d
+
+flattenForeign :: Foreign a -> DList SourceToken
+flattenForeign = \case
+  ForeignValue a -> flattenLabeled flattenName flattenType a
+  ForeignData a b -> pure a <> flattenLabeled flattenName flattenType b
+  ForeignKind a b -> pure a <> flattenName b
+
+flattenRole :: Role -> DList SourceToken
+flattenRole = pure . roleTok
+
 flattenDeclaration :: Declaration a -> DList SourceToken
-flattenDeclaration _ = mempty
+flattenDeclaration = \case
+  DeclData _ a b ->
+    flattenDataHead a <>
+    foldMap (\(t, cs) -> pure t <> flattenSeparated flattenDataCtor cs) b
+  DeclType _ a b c ->flattenDataHead a <> pure b <> flattenType c
+  DeclNewtype _ a b c d -> flattenDataHead a <> pure b <> flattenName c <> flattenType d
+  DeclClass _ a b ->
+    flattenClassHead a <>
+    foldMap (\(c, d) -> pure c <> foldMap (flattenLabeled flattenName flattenType) d) b
+  DeclInstanceChain _ a -> flattenSeparated flattenInstance a
+  DeclDerive _ a b c -> pure a <> foldMap pure b <> flattenInstanceHead c
+  DeclKindSignature _ a b -> pure a <> flattenLabeled flattenName flattenType b
+  DeclSignature _ a -> flattenLabeled flattenName flattenType a
+  DeclFixity _ a -> flattenFixityFields a
+  DeclForeign _ a b c -> pure a <> pure b <> flattenForeign c
+  DeclRole _ a b c d -> pure a <> pure b <> flattenName c <> foldMap flattenRole d
+  DeclValue _ a -> flattenValueBindingFields a
+
+flattenQualifiedName :: QualifiedName a -> DList SourceToken
+flattenQualifiedName = pure . qualTok
 
 flattenName :: Name a -> DList SourceToken
 flattenName = pure . nameTok
+
+flattenLabel :: Label -> DList SourceToken
+flattenLabel = pure . lblTok
 
 flattenExport :: Export a -> DList SourceToken
 flattenExport = \case
@@ -61,6 +266,12 @@ flattenWrapped k (Wrapped a b c) = pure a <> k b <> pure c
 
 flattenSeparated :: (a -> DList SourceToken) -> Separated a -> DList SourceToken
 flattenSeparated k (Separated a b) = k a <> foldMap (\(c, d) -> pure c <> k d) b
+
+flattenOneOrDelimited
+  :: (a -> DList SourceToken) -> OneOrDelimited a -> DList SourceToken
+flattenOneOrDelimited f = \case
+  One a -> f a
+  Many a -> flattenWrapped (flattenSeparated f) a
 
 flattenLabeled :: (a -> DList SourceToken) -> (b -> DList SourceToken) -> Labeled a b -> DList SourceToken
 flattenLabeled ka kc (Labeled a b c) = ka a <> pure b <> kc c

--- a/lib/purescript-cst/src/Language/PureScript/CST/Flatten.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Flatten.hs
@@ -17,8 +17,8 @@ flattenModule m@(Module _ a b c d e f g) =
   pure (SourceToken (TokenAnn eofRange g []) TokEof)
   where
     (_, endTkn) = moduleRange m
-    endPos = srcEnd (srcRange endTkn)
-    eofRange = SourceRange endPos endPos
+    eofPos = advanceLeading (srcEnd (srcRange endTkn)) g
+    eofRange = SourceRange eofPos eofPos
 
 flattenDataHead :: DataHead a -> DList SourceToken
 flattenDataHead (DataHead a b c) = pure a <> flattenName b <> foldMap flattenTypeVarBinding c

--- a/lib/purescript-cst/src/Language/PureScript/CST/Flatten.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Flatten.hs
@@ -4,19 +4,21 @@ import Prelude
 
 import Data.DList (DList)
 import Language.PureScript.CST.Types
+import Language.PureScript.CST.Positions
 
 flattenModule :: Module a -> DList SourceToken
-flattenModule (Module _ a b c d e f g) =
+flattenModule m@(Module _ a b c d e f g) =
   pure a <>
   flattenName b <>
   foldMap (flattenWrapped (flattenSeparated flattenExport)) c <>
   pure d <>
   foldMap flattenImportDecl e <>
   foldMap flattenDeclaration f <>
-  pure (SourceToken (TokenAnn dummyRange g []) TokEof)
+  pure (SourceToken (TokenAnn eofRange g []) TokEof)
   where
-    dummyPos = SourcePos 0 0
-    dummyRange = SourceRange dummyPos dummyPos
+    (_, endTkn) = moduleRange m
+    endPos = srcEnd (srcRange endTkn)
+    eofRange = SourceRange endPos endPos
 
 flattenDataHead :: DataHead a -> DList SourceToken
 flattenDataHead (DataHead a b c) = pure a <> flattenName b <> foldMap flattenTypeVarBinding c

--- a/lib/purescript-cst/src/Language/PureScript/CST/Print.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Print.hs
@@ -19,7 +19,12 @@ import Language.PureScript.CST.Types
 import Language.PureScript.CST.Flatten (flattenModule)
 
 printToken :: Token -> Text
-printToken = \case
+printToken = printToken' True
+
+-- | Prints a given Token. The bool controls whether or not layout
+-- tokens should be printed.
+printToken' :: Bool -> Token -> Text
+printToken' showLayout = \case
   TokLeftParen             -> "("
   TokRightParen            -> ")"
   TokLeftBrace             -> "{"
@@ -55,24 +60,27 @@ printToken = \case
   TokRawString raw         -> "\"\"\"" <> raw <> "\"\"\""
   TokInt raw _             -> raw
   TokNumber raw _          -> raw
-  TokLayoutStart           -> "{"
-  TokLayoutSep             -> ";"
-  TokLayoutEnd             -> "}"
-  TokEof                   -> "<eof>"
+  TokLayoutStart           -> if showLayout then "{" else ""
+  TokLayoutSep             -> if showLayout then ";" else ""
+  TokLayoutEnd             -> if showLayout then "}" else ""
+  TokEof                   -> if showLayout then "<eof>" else ""
 
 printQual :: [Text] -> Text
 printQual = Text.concat . map (<> ".")
 
 printTokens :: [SourceToken] -> Text
-printTokens toks = Text.concat (map pp toks)
+printTokens = printTokens' True
+
+printTokens' :: Bool -> [SourceToken] -> Text
+printTokens' showLayout toks = Text.concat (map pp toks)
   where
   pp (SourceToken (TokenAnn _ leading trailing) tok) =
     Text.concat (map printLeadingComment leading)
-      <> printToken tok
+      <> printToken' showLayout tok
       <> Text.concat (map printTrailingComment trailing)
 
 printModule :: Module a -> Text
-printModule = printTokens . DList.toList . flattenModule
+printModule = printTokens' False . DList.toList . flattenModule
 
 printLeadingComment :: Comment LineFeed -> Text
 printLeadingComment = \case

--- a/lib/purescript-cst/src/Language/PureScript/CST/Print.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Print.hs
@@ -5,15 +5,18 @@
 module Language.PureScript.CST.Print
   ( printToken
   , printTokens
+  , printModule
   , printLeadingComment
   , printTrailingComment
   ) where
 
 import Prelude
 
+import qualified Data.DList as DList
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Language.PureScript.CST.Types
+import Language.PureScript.CST.Flatten (flattenModule)
 
 printToken :: Token -> Text
 printToken = \case
@@ -67,6 +70,9 @@ printTokens toks = Text.concat (map pp toks)
     Text.concat (map printLeadingComment leading)
       <> printToken tok
       <> Text.concat (map printTrailingComment trailing)
+
+printModule :: Module a -> Text
+printModule = printTokens . DList.toList . flattenModule
 
 printLeadingComment :: Comment LineFeed -> Text
 printLeadingComment = \case


### PR DESCRIPTION
Adds flatten functions for all constructions in the CST, that turn a module back into its individual tokens.

Still need to make sure this is proper bidirectional by running it over all our test files