### PR TITLE
Recurse on the right of arrows and under foralls when inferring nominal roles from kinds

### DIFF
--- a/src/Language/PureScript/TypeChecker/Roles.hs
+++ b/src/Language/PureScript/TypeChecker/Roles.hs
@@ -143,7 +143,7 @@ rolesFromForeignTypeKind
   = go []
   where
     go acc = \case
-      TypeApp _ (TypeApp _ fn k1) _k2 | eqType fn tyFunction ->
-        go (Nominal : acc) k1
+      TypeApp _ (TypeApp _ fn _k1) k2 | eqType fn tyFunction ->
+        go (Nominal : acc) k2
       _k ->
-        Nominal : acc
+        acc

--- a/src/Language/PureScript/TypeChecker/Roles.hs
+++ b/src/Language/PureScript/TypeChecker/Roles.hs
@@ -139,13 +139,11 @@ inferRoles env tyName
 -- the absence of a role signature, provides the safest default for a type whose
 -- constructors are opaque to us.
 rolesFromForeignTypeKind :: SourceType -> [Role]
-rolesFromForeignTypeKind
-  = go []
-  where
-    go acc = \case
-      TypeApp _ (TypeApp _ fn _k1) k2 | eqType fn tyFunction ->
-        go (Nominal : acc) k2
-      ForAll _ _ _ k _ ->
-        go acc k
-      _k ->
-        acc
+rolesFromForeignTypeKind k = replicate (kindArity k) Nominal
+
+kindArity :: SourceType -> Int
+kindArity = go 0 where
+  go n (TypeApp _ (TypeApp _ fn _) k)
+    | fn == tyFunction = go (n + 1) k
+  go n (ForAll _ _ _ k _) = go n k
+  go n _ = n

--- a/src/Language/PureScript/TypeChecker/Roles.hs
+++ b/src/Language/PureScript/TypeChecker/Roles.hs
@@ -145,5 +145,7 @@ rolesFromForeignTypeKind
     go acc = \case
       TypeApp _ (TypeApp _ fn _k1) k2 | eqType fn tyFunction ->
         go (Nominal : acc) k2
+      ForAll _ _ _ k _ ->
+        go acc k
       _k ->
         acc

--- a/tests/purs/failing/CoercibleForeign2.out
+++ b/tests/purs/failing/CoercibleForeign2.out
@@ -1,0 +1,28 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleForeign2.purs:9:20 - 9:26 (line 9, column 20 - line 9, column 26)
+
+  No type class instance was found for
+  [33m                                          [0m
+  [33m  Prim.Coerce.Coercible (Foreign a0 b1 c2)[0m
+  [33m                        (Foreign a0 b1 d3)[0m
+  [33m                                          [0m
+
+while checking that type [33mforall (a :: Type) (b :: Type). Coercible a b => a -> b[0m
+  is at least as general as type [33mForeign a0 b1 c2 -> Foreign a0 b1 d3[0m
+while checking that expression [33mcoerce[0m
+  has type [33mForeign a0 b1 c2 -> Foreign a0 b1 d3[0m
+in value declaration [33mforeignToForeign[0m
+
+where [33ma0[0m is a rigid type variable
+        bound at (line 9, column 20 - line 9, column 26)
+      [33mb1[0m is a rigid type variable
+        bound at (line 9, column 20 - line 9, column 26)
+      [33mc2[0m is a rigid type variable
+        bound at (line 9, column 20 - line 9, column 26)
+      [33md3[0m is a rigid type variable
+        bound at (line 9, column 20 - line 9, column 26)
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/CoercibleForeign2.purs
+++ b/tests/purs/failing/CoercibleForeign2.purs
@@ -1,0 +1,9 @@
+-- @shouldFailWith NoInstanceFound
+module Main where
+
+import Safe.Coerce (coerce)
+
+foreign import data Foreign :: Type -> Type -> Type -> Type
+
+foreignToForeign :: forall a b c d. Foreign a b c -> Foreign a b d
+foreignToForeign = coerce

--- a/tests/purs/failing/CoercibleForeign3.out
+++ b/tests/purs/failing/CoercibleForeign3.out
@@ -1,0 +1,28 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleForeign3.purs:9:20 - 9:26 (line 9, column 20 - line 9, column 26)
+
+  No type class instance was found for
+  [33m                                           [0m
+  [33m  Prim.Coerce.Coercible (Foreign @k0 a1 b2)[0m
+  [33m                        (Foreign @k0 a1 c3)[0m
+  [33m                                           [0m
+
+while checking that type [33mforall (a :: Type) (b :: Type). Coercible a b => a -> b[0m
+  is at least as general as type [33mForeign @k0 a1 b2 -> Foreign @k0 a1 c3[0m
+while checking that expression [33mcoerce[0m
+  has type [33mForeign @k0 a1 b2 -> Foreign @k0 a1 c3[0m
+in value declaration [33mforeignToForeign[0m
+
+where [33mk0[0m is a rigid type variable
+        bound at (line 9, column 20 - line 9, column 26)
+      [33ma1[0m is a rigid type variable
+        bound at (line 9, column 20 - line 9, column 26)
+      [33mb2[0m is a rigid type variable
+        bound at (line 9, column 20 - line 9, column 26)
+      [33mc3[0m is a rigid type variable
+        bound at (line 9, column 20 - line 9, column 26)
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/CoercibleForeign3.purs
+++ b/tests/purs/failing/CoercibleForeign3.purs
@@ -1,0 +1,9 @@
+-- @shouldFailWith NoInstanceFound
+module Main where
+
+import Safe.Coerce (coerce)
+
+foreign import data Foreign :: ∀ k. k -> k -> Type
+
+foreignToForeign :: ∀ k (a :: k) (b :: k) (c :: k). Foreign a b -> Foreign a c
+foreignToForeign = coerce


### PR DESCRIPTION
Fix https://github.com/purescript/purescript/issues/3895.