### PR TITLE
Pin language-javascript to a specific version

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -65,7 +65,7 @@ dependencies:
   - fsnotify >=0.2.1
   - Glob >=0.9 && <0.10
   - haskeline >=0.7.0.0 && <0.8.0.0
-  - language-javascript >=0.7.0.0
+  - language-javascript ==0.7.0.0 # important: keep this pinned to a single specific version, since it's effectively part of the compiler's public API.
   - lifted-async >=0.10.0.3 && <0.10.1
   - lifted-base >=0.2.3 && <0.2.4
   - memory >=0.14 && <0.15


### PR DESCRIPTION
This prevents issues like https://github.com/purescript-web/purescript-web-html/issues/31
where different distributions might end up with different versions of
this library.