### PR TITLE
Disallow `Coercible` instance declarations

### DIFF
--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -206,7 +206,10 @@ desugarDecl mn exps = go
     modify (M.insert (mn, name) (makeTypeClassData args (map memberToNameAndType members) implies deps False))
     return (Nothing, d : typeClassDictionaryDeclaration sa name args implies members : map (typeClassMemberToDictionaryAccessor mn name args) members)
   go (TypeInstanceDeclaration _ _ _ _ _ _ _ DerivedInstance) = internalError "Derived instanced should have been desugared"
-  go d@(TypeInstanceDeclaration sa _ _ name deps className tys (ExplicitInstance members)) = do
+  go d@(TypeInstanceDeclaration sa _ _ name deps className tys (ExplicitInstance members))
+    | className == C.Coercible
+    = throwError . errorMessage' (fst sa) $ InvalidCoercibleInstanceDeclaration tys
+    | otherwise = do
     desugared <- desugarCases members
     dictDecl <- typeInstanceDictionaryDeclaration sa name mn deps className tys desugared
     return (expRef name className tys, [d, dictDecl])

--- a/tests/purs/failing/InvalidCoercibleInstanceDeclaration.out
+++ b/tests/purs/failing/InvalidCoercibleInstanceDeclaration.out
@@ -1,0 +1,14 @@
+Error found:
+at tests/purs/failing/InvalidCoercibleInstanceDeclaration.purs:8:1 - 8:36 (line 8, column 1 - line 8, column 36)
+
+  Invalid type class instance declaration for
+  [33m                         [0m
+  [33m  Prim.Coerce.Coercible D[0m
+  [33m                        D[0m
+  [33m                         [0m
+  Instance declarations of this type class are disallowed.
+
+
+See https://github.com/purescript/documentation/blob/master/errors/InvalidCoercibleInstanceDeclaration.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/InvalidCoercibleInstanceDeclaration.purs
+++ b/tests/purs/failing/InvalidCoercibleInstanceDeclaration.purs
@@ -1,0 +1,8 @@
+-- @shouldFailWith InvalidCoercibleInstanceDeclaration
+module Main where
+
+import Prim.Coerce (class Coercible)
+
+data D
+
+instance coercible :: Coercible D D


### PR DESCRIPTION
GHC rejects the following exemple with an explicit error:

```hs
module Example where

import Data.Coerce (Coercible)

data D

instance Coercible D D
```

```
Example.hs:7:10: error:
    • Illegal instance declaration for ‘Coercible D D’
        Manual instances of this class are not permitted.
    • In the instance declaration for ‘Coercible D D’
  |
7 | instance Coercible D D
  |          ^^^^^^^^^^^^^
```

We don‘t accept such declaration either but the error message is less helpful:

```purs
module Example where

import Prim.Coerce (class Coercible)

data D

instance coercible :: Coercible D D
```

```
Error found:
in module Example
at Example.purs:7:1 - 7:36 (line 7, column 1 - line 7, column 36)

  Could not match type
          
    Record
          
  with type
                    
    Coercible$Dict D
                    

while trying to match type Record (() @Type)
  with type Coercible$Dict D D
while checking that expression Coercible {}
  has type Coercible$Dict D D
in value declaration coercible

See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
or to contribute content related to this error.
```