### PR TITLE
Walk under constrained types during role inference

### DIFF
--- a/tests/purs/failing/CoercibleConstrained1.out
+++ b/tests/purs/failing/CoercibleConstrained1.out
@@ -1,0 +1,24 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleConstrained1.purs:11:28 - 11:34 (line 11, column 28 - line 11, column 34)
+
+  No type class instance was found for
+  [33m                          [0m
+  [33m  Prim.Coerce.Coercible a0[0m
+  [33m                        b1[0m
+  [33m                          [0m
+
+while checking that type [33mforall (a :: Type) (b :: Type). Coercible @Type a b => a -> b[0m
+  is at least as general as type [33mConstrained a0 -> Constrained b1[0m
+while checking that expression [33mcoerce[0m
+  has type [33mConstrained a0 -> Constrained b1[0m
+in value declaration [33mconstrainedToConstrained[0m
+
+where [33ma0[0m is a rigid type variable
+        bound at (line 11, column 28 - line 11, column 34)
+      [33mb1[0m is a rigid type variable
+        bound at (line 11, column 28 - line 11, column 34)
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/CoercibleConstrained1.purs
+++ b/tests/purs/failing/CoercibleConstrained1.purs
@@ -1,0 +1,11 @@
+-- @shouldFailWith NoInstanceFound
+module Main where
+
+import Safe.Coerce (coerce)
+
+class Nullary
+
+data Constrained a = Constrained (Nullary => a)
+
+constrainedToConstrained :: forall a b. Constrained a -> Constrained b
+constrainedToConstrained = coerce

--- a/tests/purs/failing/CoercibleConstrained2.out
+++ b/tests/purs/failing/CoercibleConstrained2.out
@@ -1,0 +1,24 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleConstrained2.purs:11:28 - 11:34 (line 11, column 28 - line 11, column 34)
+
+  No type class instance was found for
+  [33m                                        [0m
+  [33m  Prim.Coerce.Coercible (Constrained a0)[0m
+  [33m                        (Constrained b1)[0m
+  [33m                                        [0m
+
+while checking that type [33mforall (a :: Type) (b :: Type). Coercible @Type a b => a -> b[0m
+  is at least as general as type [33mConstrained a0 -> Constrained b1[0m
+while checking that expression [33mcoerce[0m
+  has type [33mConstrained a0 -> Constrained b1[0m
+in value declaration [33mconstrainedToConstrained[0m
+
+where [33ma0[0m is a rigid type variable
+        bound at (line 11, column 28 - line 11, column 34)
+      [33mb1[0m is a rigid type variable
+        bound at (line 11, column 28 - line 11, column 34)
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/CoercibleConstrained2.purs
+++ b/tests/purs/failing/CoercibleConstrained2.purs
@@ -1,0 +1,11 @@
+-- @shouldFailWith NoInstanceFound
+module Main where
+
+import Safe.Coerce (coerce)
+
+class Unary a
+
+data Constrained a = Constrained (Unary a => a)
+
+constrainedToConstrained :: forall a b. Constrained a -> Constrained b
+constrainedToConstrained = coerce

--- a/tests/purs/failing/CoercibleConstrained3.out
+++ b/tests/purs/failing/CoercibleConstrained3.out
@@ -1,0 +1,22 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleConstrained3.purs:13:28 - 13:34 (line 13, column 28 - line 13, column 34)
+
+  No type class instance was found for
+  [33m                                            [0m
+  [33m  Prim.Coerce.Coercible (Constrained a0)    [0m
+  [33m                        (Constrained (N a0))[0m
+  [33m                                            [0m
+
+while checking that type [33mforall (a :: Type) (b :: Type). Coercible @Type a b => a -> b[0m
+  is at least as general as type [33mConstrained a0 -> Constrained (N a0)[0m
+while checking that expression [33mcoerce[0m
+  has type [33mConstrained a0 -> Constrained (N a0)[0m
+in value declaration [33mconstrainedToConstrained[0m
+
+where [33ma0[0m is a rigid type variable
+        bound at (line 13, column 28 - line 13, column 34)
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/CoercibleConstrained3.purs
+++ b/tests/purs/failing/CoercibleConstrained3.purs
@@ -1,0 +1,13 @@
+-- @shouldFailWith NoInstanceFound
+module Main where
+
+import Safe.Coerce (coerce)
+
+class Unary a
+
+data Constrained a = Constrained (Unary a => a)
+
+newtype N a = N a
+
+constrainedToConstrained :: forall a. Constrained a -> Constrained (N a)
+constrainedToConstrained = coerce

--- a/tests/purs/passing/Coercible.purs
+++ b/tests/purs/passing/Coercible.purs
@@ -159,6 +159,17 @@ type role MyMap nominal representational
 mapToMap :: MyMap String String -> MyMap String NTString1
 mapToMap = coerce
 
+class Unary a
+
+data Constrained1 a b = Constrained1 (Unary a => b)
+
+constrained1ToConstrained1 :: forall a b. Constrained1 a b -> Constrained1 a (Id1 b)
+constrained1ToConstrained1 = coerce
+
+data Constrained2 a = Constrained2 a (forall a. Unary a => a)
+
+type role Constrained2 representational
+
 -- "role" should only be a reserved word after "type"
 testRoleNotReserved :: String -> String
 testRoleNotReserved role = role


### PR DESCRIPTION
The Safe Zero-cost Coercions for Haskell paper argues that type instances arguments should get nominal roles in section **3.2 Preserving class coherence** with the following exemple:

```
data HowToShow a where
  MkHTS :: Show a ⇒ HowToShow a

showH :: HowToShow a → a → String
showH MkHTS x = show x

instance Show HTML where
  show (MkHTML s) = "HTML:" ++ show s

stringShow :: HowToShow String
stringShow = MkHTS
htmlShow :: HowToShow HTML
htmlShow = MkHTS
badShow :: HowToShow HTML
badShow = coerce stringShow

λ> showH stringShow "Hello"
"Hello"
λ> showH htmlShow (MkHTML "Hello")
"HTML:Hello"
λ> showH badShow (MkHTML "Hello")
"Hello"
```

I can‘t think of a way to store an instance dictionary under a constructor in PureScript so we should be able to disregard the constraint arguments of constrained types entirely.

Fix https://github.com/purescript/purescript/issues/3868.