### PR TITLE
Warn against exported types with hidden constructors but `Generic` or `Newtype` instances

### DIFF
--- a/src/Language/PureScript/Constants/Data/Generic/Rep.hs
+++ b/src/Language/PureScript/Constants/Data/Generic/Rep.hs
@@ -1,0 +1,40 @@
+module Language.PureScript.Constants.Data.Generic.Rep where
+
+import Prelude.Compat
+import Language.PureScript.Names
+
+pattern DataGenericRep :: ModuleName
+pattern DataGenericRep = ModuleName "Data.Generic.Rep"
+
+pattern Generic :: Qualified (ProperName 'ClassName)
+pattern Generic = Qualified (Just DataGenericRep) (ProperName "Generic")
+
+to :: Qualified Ident
+to = Qualified (Just DataGenericRep) (Ident "to")
+
+from :: Qualified Ident
+from = Qualified (Just DataGenericRep) (Ident "from")
+
+pattern NoConstructors :: Qualified (ProperName a)
+pattern NoConstructors = Qualified (Just DataGenericRep) (ProperName "NoConstructors")
+
+pattern NoArguments :: Qualified (ProperName a)
+pattern NoArguments = Qualified (Just DataGenericRep) (ProperName "NoArguments")
+
+pattern Sum :: Qualified (ProperName a)
+pattern Sum = Qualified (Just DataGenericRep) (ProperName "Sum")
+
+pattern Inl :: Qualified (ProperName a)
+pattern Inl = Qualified (Just DataGenericRep) (ProperName "Inl")
+
+pattern Inr :: Qualified (ProperName a)
+pattern Inr = Qualified (Just DataGenericRep) (ProperName "Inr")
+
+pattern Product :: Qualified (ProperName a)
+pattern Product = Qualified (Just DataGenericRep) (ProperName "Product")
+
+pattern Constructor :: Qualified (ProperName a)
+pattern Constructor = Qualified (Just DataGenericRep) (ProperName "Constructor")
+
+pattern Argument :: Qualified (ProperName a)
+pattern Argument = Qualified (Just DataGenericRep) (ProperName "Argument")

--- a/src/Language/PureScript/Constants/Data/Newtype.hs
+++ b/src/Language/PureScript/Constants/Data/Newtype.hs
@@ -1,0 +1,7 @@
+module Language.PureScript.Constants.Data.Newtype where
+
+import Prelude.Compat
+import Language.PureScript.Names
+
+pattern Newtype :: Qualified (ProperName 'ClassName)
+pattern Newtype = Qualified (Just (ModuleName "Data.Newtype")) (ProperName "Newtype")

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -131,6 +131,7 @@ data SimpleErrorMessage
   | InvalidInstanceHead SourceType
   | TransitiveExportError DeclarationRef [DeclarationRef]
   | TransitiveDctorExportError DeclarationRef [ProperName 'ConstructorName]
+  | HiddenConstructors DeclarationRef (Qualified (ProperName 'ClassName))
   | ShadowedName Ident
   | ShadowedTypeVar Text
   | UnusedTypeVar Text
@@ -295,6 +296,7 @@ errorCode em = case unwrapErrorMessage em of
   InvalidInstanceHead{} -> "InvalidInstanceHead"
   TransitiveExportError{} -> "TransitiveExportError"
   TransitiveDctorExportError{} -> "TransitiveDctorExportError"
+  HiddenConstructors{} -> "HiddenConstructors"
   ShadowedName{} -> "ShadowedName"
   ShadowedTypeVar{} -> "ShadowedTypeVar"
   UnusedTypeVar{} -> "UnusedTypeVar"
@@ -1033,6 +1035,10 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderSimpleErrorMessage (TransitiveDctorExportError x ctors) =
       paras [ line $ "An export for " <> markCode (prettyPrintExport x) <> " requires the following data constructor" <> (if length ctors == 1 then "" else "s") <> " to also be exported: "
             , indent $ paras $ map (line . markCode . runProperName) ctors
+            ]
+    renderSimpleErrorMessage (HiddenConstructors x className) =
+      paras [ line $ "An export for " <> markCode (prettyPrintExport x) <> " hides data constructors but the type declares an instance of " <> markCode (showQualified runProperName className) <> "."
+            , line "Such instance allows to match and construct values of this type, effectively making the constructors public."
             ]
     renderSimpleErrorMessage (ShadowedName nm) =
       line $ "Name " <> markCode (showIdent nm) <> " was shadowed."

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -734,10 +734,20 @@ typeCheckModule (Module ss coms mn decls (Just exps)) =
     extractMemberName _ = internalError "Unexpected declaration in typeclass member list"
   checkClassMembersAreExported _ = return ()
 
-  -- | If any data constructors of a type are exported, we require all its data constructors to be exported.
+  -- If a type is exported without data constructors, we warn on `Generic` or `Newtype` instances.
+  -- On the other hand if any data constructors are exported, we require all of them to be exported.
   checkDataConstructorsAreExported :: DeclarationRef -> m ()
-  checkDataConstructorsAreExported dr@(TypeRef ss' name (Just exportedDataConstructorsNames))
-    | not (null exportedDataConstructorsNames) = do
+  checkDataConstructorsAreExported dr@(TypeRef ss' name (fromMaybe [] -> exportedDataConstructorsNames))
+    | null exportedDataConstructorsNames = for_
+      [ Qualified (Just (ModuleName "Data.Generic.Rep")) (ProperName "Generic")
+      , Qualified (Just (ModuleName "Data.Newtype")) (ProperName "Newtype")
+      ] $ \className -> do
+        env <- getEnv
+        let dicts = foldMap (foldMap NEL.toList) $
+              M.lookup (Just mn) (typeClassDictionaries env) >>= M.lookup className
+        when (any isDictOfTypeRef dicts) $
+          tell . errorMessage' ss' $ HiddenConstructors dr className
+    | otherwise = do
       env <- getEnv
       let dataConstructorNames = fromMaybe [] $
             M.lookup (mkQualified name mn) (types env) >>= getDataConstructorNames . snd
@@ -745,6 +755,12 @@ typeCheckModule (Module ss coms mn decls (Just exps)) =
       unless (null missingDataConstructorsNames) $
         throwError . errorMessage' ss' $ TransitiveDctorExportError dr missingDataConstructorsNames
       where
+      isDictOfTypeRef :: TypeClassDictionaryInScope a -> Bool
+      isDictOfTypeRef dict
+        | (TypeConstructor _ qualTyName, _, _) : _ <- unapplyTypes <$> tcdInstanceTypes dict
+        , qualTyName == Qualified (Just mn) name
+        = True
+      isDictOfTypeRef _ = False
       getDataConstructorNames :: TypeKind -> Maybe [ProperName 'ConstructorName]
       getDataConstructorNames (DataType _ constructors) = Just $ fst <$> constructors
       getDataConstructorNames _ = Nothing

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -28,6 +28,8 @@ import qualified Data.Set as S
 import qualified Data.Text as T
 
 import Language.PureScript.AST
+import qualified Language.PureScript.Constants.Data.Generic.Rep as DataGenericRep
+import qualified Language.PureScript.Constants.Data.Newtype as DataNewtype
 import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Errors
@@ -739,8 +741,8 @@ typeCheckModule (Module ss coms mn decls (Just exps)) =
   checkDataConstructorsAreExported :: DeclarationRef -> m ()
   checkDataConstructorsAreExported dr@(TypeRef ss' name (fromMaybe [] -> exportedDataConstructorsNames))
     | null exportedDataConstructorsNames = for_
-      [ Qualified (Just (ModuleName "Data.Generic.Rep")) (ProperName "Generic")
-      , Qualified (Just (ModuleName "Data.Newtype")) (ProperName "Newtype")
+      [ DataGenericRep.Generic
+      , DataNewtype.Newtype
       ] $ \className -> do
         env <- getEnv
         let dicts = foldMap (foldMap NEL.toList) $

--- a/tests/purs/warning/HiddenConstructorsGeneric.out
+++ b/tests/purs/warning/HiddenConstructorsGeneric.out
@@ -1,0 +1,11 @@
+Warning found:
+in module [33mMain[0m
+at tests/purs/warning/HiddenConstructorsGeneric.purs:2:1 - 8:40 (line 2, column 1 - line 8, column 40)
+
+  An export for [33mD[0m hides data constructors but the type declares an instance of [33mData.Generic.Rep.Generic[0m.
+  Such instance allows to match and construct values of this type, effectively making the constructors public.
+
+
+See https://github.com/purescript/documentation/blob/master/errors/HiddenConstructors.md for more information,
+or to contribute content related to this warning.
+

--- a/tests/purs/warning/HiddenConstructorsGeneric.purs
+++ b/tests/purs/warning/HiddenConstructorsGeneric.purs
@@ -1,0 +1,8 @@
+-- @shouldWarnWith HiddenConstructors
+module Main (D) where
+
+import Data.Generic.Rep (class Generic)
+
+data D = D
+
+derive instance genericD :: Generic D _

--- a/tests/purs/warning/HiddenConstructorsNewtype.out
+++ b/tests/purs/warning/HiddenConstructorsNewtype.out
@@ -1,0 +1,11 @@
+Warning found:
+in module [33mMain[0m
+at tests/purs/warning/HiddenConstructorsNewtype.purs:2:1 - 8:44 (line 2, column 1 - line 8, column 44)
+
+  An export for [33mN[0m hides data constructors but the type declares an instance of [33mData.Newtype.Newtype[0m.
+  Such instance allows to match and construct values of this type, effectively making the constructors public.
+
+
+See https://github.com/purescript/documentation/blob/master/errors/HiddenConstructors.md for more information,
+or to contribute content related to this warning.
+

--- a/tests/purs/warning/HiddenConstructorsNewtype.purs
+++ b/tests/purs/warning/HiddenConstructorsNewtype.purs
@@ -1,0 +1,8 @@
+-- @shouldWarnWith HiddenConstructors
+module Main (N) where
+
+import Data.Newtype (class Newtype)
+
+newtype N a = N a
+
+derive instance newtypeN :: Newtype (N a) _


### PR DESCRIPTION
Close https://github.com/purescript/purescript/issues/3707.