### PR TITLE
Store the inferred role environment in the typechecker monad state

### DIFF
--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -60,6 +60,8 @@ emptySubstitution = Substitution M.empty M.empty
 data CheckState = CheckState
   { checkEnv :: Environment
   -- ^ The current @Environment@
+  , checkRoleEnv :: RoleEnv
+  -- ^ The current role environment used for role inference
   , checkNextType :: Int
   -- ^ The next type unification variable
   , checkNextSkolem :: Int
@@ -79,7 +81,7 @@ data CheckState = CheckState
 
 -- | Create an empty @CheckState@
 emptyCheckState :: Environment -> CheckState
-emptyCheckState env = CheckState env 0 0 0 Nothing emptySubstitution []
+emptyCheckState env = CheckState env (getRoleEnv env) 0 0 0 Nothing emptySubstitution []
 
 -- | Unification variables
 type Unknown = Int
@@ -295,6 +297,10 @@ putEnv env = modify (\s -> s { checkEnv = env })
 -- | Modify the @Environment@
 modifyEnv :: (MonadState CheckState m) => (Environment -> Environment) -> m ()
 modifyEnv f = modify (\s -> s { checkEnv = f (checkEnv s) })
+
+-- | Modify the @RoleEnv@
+modifyRoleEnv :: (MonadState CheckState m) => (RoleEnv -> RoleEnv) -> m ()
+modifyRoleEnv f = modify (\s -> s { checkRoleEnv = f (checkRoleEnv s) })
 
 -- | Run a computation in the typechecking monad, starting with an empty @Environment@
 runCheck :: (Functor m) => StateT CheckState m a -> m (a, Environment)

--- a/src/Language/PureScript/TypeChecker/Roles.hs
+++ b/src/Language/PureScript/TypeChecker/Roles.hs
@@ -7,13 +7,14 @@
 module Language.PureScript.TypeChecker.Roles
   ( lookupRoles
   , checkRoles
-  , checkDataBindingGroupRoles
+  , inferDataBindingGroupRoles
   ) where
 
 import Prelude.Compat
 
+import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.State (MonadState(..), runState, state)
+import Control.Monad.State (MonadState, gets, modify)
 import Data.Coerce (coerce)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
@@ -26,6 +27,7 @@ import Language.PureScript.Errors
 import Language.PureScript.Names
 import Language.PureScript.Roles
 import Language.PureScript.Types
+import Language.PureScript.TypeChecker.Monad
 
 -- |
 -- A map of a type's formal parameter names to their roles. This type's
@@ -43,31 +45,17 @@ instance Monoid RoleMap where
   mempty =
     RoleMap M.empty
 
-type RoleEnv = M.Map (Qualified (ProperName 'TypeName)) [Role]
-
-typeKindRoles :: TypeKind -> Maybe [Role]
-typeKindRoles = \case
-  DataType args _ ->
-    Just $ map (\(_, _, role) -> role) args
-  ExternData roles ->
-    Just roles
-  _ ->
-    Nothing
-
-getRoleEnv :: Environment -> RoleEnv
-getRoleEnv env =
-  M.mapMaybe (typeKindRoles . snd) (types env)
-
 updateRoleEnv
-  :: Qualified (ProperName 'TypeName)
+  :: MonadState CheckState m
+  => Qualified (ProperName 'TypeName)
   -> [Role]
-  -> RoleEnv
-  -> (Any, RoleEnv)
-updateRoleEnv qualTyName roles' roleEnv =
-  let roles = fromMaybe (repeat Phantom) $ M.lookup qualTyName roleEnv
-      mostRestrictiveRoles = zipWith min roles roles'
+  -> m Any
+updateRoleEnv qualTyName roles' = do
+  roles <- gets $ fromMaybe (repeat Phantom) . M.lookup qualTyName . checkRoleEnv
+  let mostRestrictiveRoles = zipWith min roles roles'
       didRolesChange = any (uncurry (<)) $ zip mostRestrictiveRoles roles
-  in (Any didRolesChange, M.insert qualTyName mostRestrictiveRoles roleEnv)
+  modify $ \st -> st { checkRoleEnv = M.insert qualTyName mostRestrictiveRoles $ checkRoleEnv st }
+  pure $ Any didRolesChange
 
 -- |
 -- Lookup the roles for a type in the environment. If the type does not have
@@ -81,28 +69,35 @@ lookupRoles
 lookupRoles env tyName =
   fromMaybe [] $ M.lookup tyName (types env) >>= typeKindRoles . snd
 
--- | This function does the following:
---
--- * Infers roles for the given data type declaration
---
--- * Compares the inferred roles to the explicitly declared roles (if any) and
---   ensures that the explicitly declared roles are not more permissive than
---   the inferred ones
+-- |
+-- Compares the inferred roles to the explicitly declared roles (if any) and
+-- ensures that the explicitly declared roles are not more permissive than
+-- the inferred ones
 --
 checkRoles
-  :: forall m
-   . (MonadError MultipleErrors m)
-  => Environment
-  -> ModuleName
+  :: MonadError MultipleErrors m
+  => MonadState CheckState m
+  => ModuleName
   -> ProperName 'TypeName
     -- ^ The name of the data type whose roles we are checking
   -> [(Text, Maybe SourceType)]
     -- ^ type parameters for the data type whose roles we are checking
-  -> [DataConstructorDeclaration]
-    -- ^ constructors of the data type whose roles we are checking
   -> m [Role]
-checkRoles env moduleName tyName tyArgs ctors =
-  checkDataBindingGroupRoles env moduleName [(tyName, tyArgs, ctors)] tyName tyArgs
+checkRoles moduleName tyName tyArgs = do
+  let qualTyName = Qualified (Just moduleName) tyName
+  inferredRoles <- gets $ M.lookup qualTyName . checkRoleEnv
+  rethrow (addHint (ErrorInRoleDeclaration tyName)) $ do
+    env <- getEnv
+    case M.lookup qualTyName (roleDeclarations env) of
+      Just declaredRoles -> do
+        let
+          k (var, _) inf dec =
+            if inf < dec
+              then throwError . errorMessage $ RoleMismatch var inf dec
+              else pure dec
+        sequence $ zipWith3 k tyArgs (fromMaybe (repeat Phantom) inferredRoles) declaredRoles
+      Nothing ->
+        pure $ fromMaybe (Phantom <$ tyArgs) inferredRoles
 
 type DataDeclaration =
   ( ProperName 'TypeName
@@ -110,73 +105,49 @@ type DataDeclaration =
   , [DataConstructorDeclaration]
   )
 
-checkDataBindingGroupRoles
-  :: forall m
-   . (MonadError MultipleErrors m)
-  => Environment
-  -> ModuleName
-  -> [DataDeclaration]
-  -> ProperName 'TypeName
-  -> [(Text, Maybe SourceType)]
-  -> m [Role]
-checkDataBindingGroupRoles env moduleName group =
-  let initialRoleEnv = M.union (roleDeclarations env) (getRoleEnv env)
-      inferredRoleEnv = inferDataBindingGroupRoles moduleName group initialRoleEnv
-  in \tyName tyArgs -> do
-    let qualTyName = Qualified (Just moduleName) tyName
-        inferredRoles = M.lookup qualTyName inferredRoleEnv
-    rethrow (addHint (ErrorInRoleDeclaration tyName)) $ do
-      case M.lookup qualTyName (roleDeclarations env) of
-        Just declaredRoles -> do
-          let
-            k (var, _) inf dec =
-              if inf < dec
-                then throwError . errorMessage $ RoleMismatch var inf dec
-                else pure dec
-          sequence $ zipWith3 k tyArgs (fromMaybe (repeat Phantom) inferredRoles) declaredRoles
-        Nothing ->
-          pure $ fromMaybe (Phantom <$ tyArgs) inferredRoles
-
+-- |
+-- Infers roles for the given data type declarations.
+--
 inferDataBindingGroupRoles
-  :: ModuleName
+  :: MonadState CheckState m
+  => ModuleName
   -> [DataDeclaration]
-  -> RoleEnv
-  -> RoleEnv
-inferDataBindingGroupRoles moduleName group roleEnv =
-  let (Any didRolesChange, roleEnv') = flip runState roleEnv $
-        mconcat <$> traverse (state . inferDataDeclarationRoles moduleName) group
-  in if didRolesChange
-     then inferDataBindingGroupRoles moduleName group roleEnv'
-     else roleEnv'
+  -> m ()
+inferDataBindingGroupRoles moduleName group = do
+  Any didRolesChange <- mconcat <$> traverse (inferDataDeclarationRoles moduleName) group
+  when didRolesChange $ inferDataBindingGroupRoles moduleName group
 
 -- |
 -- Infers roles for the given data type declaration, along with a flag to tell
 -- if more restrictive roles were added to the environment.
 --
 inferDataDeclarationRoles
-  :: ModuleName
+  :: forall m
+   . MonadState CheckState m
+  => ModuleName
   -> DataDeclaration
-  -> RoleEnv
-  -> (Any, RoleEnv)
-inferDataDeclarationRoles moduleName (tyName, tyArgs, ctors) roleEnv =
-  let qualTyName = Qualified (Just moduleName) tyName
-      ctorRoles = getRoleMap . foldMap (walk mempty . snd) $ ctors >>= dataCtorFields
-      inferredRoles = map (\(arg, _) -> fromMaybe Phantom (M.lookup arg ctorRoles)) tyArgs
-  in updateRoleEnv qualTyName inferredRoles roleEnv
+  -> m Any
+inferDataDeclarationRoles moduleName (tyName, tyArgs, ctors) = do
+  let qualName = Qualified (Just moduleName) tyName
+  roleMaps <- traverse (walk mempty . snd) $ ctors >>= dataCtorFields
+  let
+    ctorRoles = getRoleMap $ mconcat roleMaps
+    inferredRoles = map (\(arg, _) -> fromMaybe Phantom (M.lookup arg ctorRoles)) tyArgs
+  updateRoleEnv qualName inferredRoles
   where
   -- This function is named @walk@ to match the specification given in the
   -- "Role inference" section of the paper "Safe Zero-cost Coercions for
   -- Haskell".
-  walk :: S.Set Text -> SourceType -> RoleMap
+  walk :: S.Set Text -> SourceType -> m RoleMap
   walk btvs (TypeVar _ v)
     -- A type variable standing alone (e.g. @a@ in @data D a b = D a@) is
     -- representational, _unless_ it has been bound by a quantifier, in which
     -- case it is not actually a parameter to the type (e.g. @z@ in
     -- @data T z = T (forall z. z -> z)@).
     | S.member v btvs =
-        mempty
+        pure mempty
     | otherwise =
-        RoleMap $ M.singleton v Representational
+        pure $ RoleMap $ M.singleton v Representational
   walk btvs (ForAll _ tv _ t _) =
     -- We can walk under universal quantifiers as long as we make note of the
     -- variables that they bind. For instance, given a definition
@@ -189,7 +160,9 @@ inferDataDeclarationRoles moduleName (tyName, tyArgs, ctors) roleEnv =
     walk (S.insert tv btvs) t
   walk btvs (RCons _ _ thead ttail) = do
     -- For row types, we just walk along them and collect the results.
-    walk btvs thead <> walk btvs ttail
+    h <- walk btvs thead
+    t <- walk btvs ttail
+    pure (h <> t)
   walk btvs (KindedType _ t _k) =
     -- For kind-annotated types, discard the annotation and recurse on the
     -- type beneath.
@@ -209,24 +182,25 @@ inferDataDeclarationRoles moduleName (tyName, tyArgs, ctors) roleEnv =
           --   its use of our parameters is important.
           -- * If the role is phantom, terminate, since the argument's use of
           --   our parameters is unimportant.
-          TypeConstructor _ t1Name ->
+          TypeConstructor _ t1Name -> do
+            t1Roles <- gets $ fromMaybe (repeat Phantom) . M.lookup t1Name . checkRoleEnv
             let
-              t1Roles = fromMaybe (repeat Phantom) $ M.lookup t1Name roleEnv
               k role ti = case role of
                 Nominal ->
-                  freeNominals ti
+                  pure $ freeNominals ti
                 Representational ->
                   go ti
                 Phantom ->
-                  mempty
-            in mconcat (zipWith k t1Roles t2s)
+                  pure mempty
+            fmap mconcat (zipWithM k t1Roles t2s)
           -- If the type is an application of any other type-level term, walk
           -- that term to collect its roles and mark all free variables in
           -- its argument as nominal.
           _ -> do
-            go t1 <> foldMap freeNominals t2s
+            r <- go t1
+            pure (r <> foldMap freeNominals t2s)
     | otherwise =
-        mempty
+        pure mempty
     where
       go = walk btvs
       -- Given a type, computes the list of free variables in that type


### PR DESCRIPTION
This lifts role inference to the typechecker monad so we can store a role environment in `CheckState` instead of recomputing one each time we infer a binding group roles. This was extracted from https://github.com/purescript/purescript/pull/3860 to not delay the merge and discuss separately. See https://github.com/purescript/purescript/pull/3860#issuecomment-652776016 for context.

I’m happy to be wrong but I’m not sure checked roles, inferred roles and declared roles could all be stored under the types field of the environment because we need to compare declared roles to inferred roles in order to check they’re not more permissive and types are only inserted in the environment once their roles have been checked.