### PR TITLE
Float compiler-synthesized function applications

### DIFF
--- a/CHANGELOG.d/feature_cse-for-typeclass-dicts.md
+++ b/CHANGELOG.d/feature_cse-for-typeclass-dicts.md
@@ -1,0 +1,10 @@
+* Float compiler-synthesized function applications
+
+  This is a limited implementation of common subexpression elimination for
+  expressions created by the compiler in the process of creating and using
+  typeclass dictionaries. Users can expect code that heavily uses typeclasses
+  to produce JavaScript that is shorter, simpler, and faster.
+
+  Common subexpression elimination is not applied to any expressions explicitly
+  written by users. If you want those floated to a higher scope, you have to do
+  so manually.

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -63,6 +63,7 @@ common defaults
     DeriveTraversable
     DeriveGeneric
     DerivingStrategies
+    DerivingVia
     EmptyDataDecls
     FlexibleContexts
     FlexibleInstances
@@ -209,6 +210,7 @@ library
     Language.PureScript.CoreFn
     Language.PureScript.CoreFn.Ann
     Language.PureScript.CoreFn.Binders
+    Language.PureScript.CoreFn.CSE
     Language.PureScript.CoreFn.Desugar
     Language.PureScript.CoreFn.Expr
     Language.PureScript.CoreFn.FromJSON

--- a/src/Control/Monad/Supply.hs
+++ b/src/Control/Monad/Supply.hs
@@ -11,6 +11,8 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Writer
 
+import Data.Functor.Identity
+
 newtype SupplyT m a = SupplyT { unSupplyT :: StateT Integer m a }
   deriving (Functor, Applicative, Monad, MonadTrans, MonadError e, MonadWriter w, MonadReader r, Alternative, MonadPlus)
 
@@ -19,3 +21,8 @@ runSupplyT n = flip runStateT n . unSupplyT
 
 evalSupplyT :: (Functor m) => Integer -> SupplyT m a -> m a
 evalSupplyT n = fmap fst . runSupplyT n
+
+type Supply = SupplyT Identity
+
+runSupply :: Integer -> Supply a -> (a, Integer)
+runSupply n = runIdentity . runSupplyT n

--- a/src/Control/Monad/Supply/Class.hs
+++ b/src/Control/Monad/Supply/Class.hs
@@ -6,8 +6,9 @@ module Control.Monad.Supply.Class where
 
 import Prelude.Compat
 
-import Control.Monad.Supply
+import Control.Monad.RWS
 import Control.Monad.State
+import Control.Monad.Supply
 import Control.Monad.Writer
 import Data.Text (Text, pack)
 
@@ -28,6 +29,7 @@ instance Monad m => MonadSupply (SupplyT m) where
 
 instance MonadSupply m => MonadSupply (StateT s m)
 instance (Monoid w, MonadSupply m) => MonadSupply (WriterT w m)
+instance (Monoid w, MonadSupply m) => MonadSupply (RWST r w s m)
 
 freshName :: MonadSupply m => m Text
 freshName = fmap (("$" <> ) . pack . show) fresh

--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -73,7 +73,7 @@ literals = mkPattern' match'
   match (Var _ ident) = return $ emit ident
   match (VariableIntroduction _ ident value) = mconcat <$> sequence
     [ return $ emit $ "var " <> ident
-    , maybe (return mempty) (fmap (emit " = " <>) . prettyPrintJS') value
+    , maybe (return mempty) (fmap (emit " = " <>) . prettyPrintJS' . snd) value
     ]
   match (Assignment _ target value) = mconcat <$> sequence
     [ prettyPrintJS' target

--- a/src/Language/PureScript/Constants/Prelude.hs
+++ b/src/Language/PureScript/Constants/Prelude.hs
@@ -113,6 +113,9 @@ zshr = "zshr"
 complement :: forall a. (IsString a) => a
 complement = "complement"
 
+identity :: forall a. (IsString a) => a
+identity = "identity"
+
 -- Prelude Values
 
 zero :: forall a. (IsString a) => a
@@ -265,6 +268,9 @@ semigroupString = "semigroupString"
 semigroupoidFn :: forall a. (IsString a) => a
 semigroupoidFn = "semigroupoidFn"
 
+categoryFn :: forall a. (IsString a) => a
+categoryFn = "categoryFn"
+
 -- Data.Symbol
 
 pattern DataSymbol :: ModuleName
@@ -320,6 +326,9 @@ pattern ControlSemigroupoid = ModuleName "Control.Semigroupoid"
 
 pattern ControlBind :: ModuleName
 pattern ControlBind = ModuleName "Control.Bind"
+
+pattern ControlCategory :: ModuleName
+pattern ControlCategory = ModuleName "Control.Category"
 
 pattern ControlMonadEffUncurried :: ModuleName
 pattern ControlMonadEffUncurried = ModuleName "Control.Monad.Eff.Uncurried"

--- a/src/Language/PureScript/CoreFn/Binders.hs
+++ b/src/Language/PureScript/CoreFn/Binders.hs
@@ -31,7 +31,7 @@ data Binder a
   -- |
   -- A binder which binds its input to an identifier
   --
-  | NamedBinder a Ident (Binder a) deriving (Eq, Show, Functor)
+  | NamedBinder a Ident (Binder a) deriving (Eq, Ord, Show, Functor)
 
 
 extractBinderAnn :: Binder a -> a

--- a/src/Language/PureScript/CoreFn/CSE.hs
+++ b/src/Language/PureScript/CoreFn/CSE.hs
@@ -1,0 +1,428 @@
+{-# LANGUAGE TemplateHaskell #-}
+-- | This module performs limited common subexpression elimination
+module Language.PureScript.CoreFn.CSE (optimizeCommonSubexpressions) where
+
+import Protolude hiding (pass)
+
+import Control.Lens
+import Control.Monad.Supply (Supply)
+import Control.Monad.Supply.Class (MonadSupply)
+import Control.Monad.RWS (MonadWriter, RWST, censor, evalRWST, listen, pass, tell)
+import Data.Bitraversable (bitraverse)
+import Data.Functor.Compose (Compose(..))
+import qualified Data.IntMap.Monoidal as IM
+import qualified Data.IntSet as IS
+import qualified Data.Map as M
+import Data.Maybe (fromJust)
+import Data.Semigroup (Min(..))
+import Data.Semigroup.Generic (GenericSemigroupMonoid(..))
+
+import Language.PureScript.AST.Literals
+import Language.PureScript.AST.SourcePos (nullSourceSpan)
+import qualified Language.PureScript.Constants.Prelude as C
+import Language.PureScript.CoreFn.Ann (Ann)
+import Language.PureScript.CoreFn.Binders
+import Language.PureScript.CoreFn.Expr
+import Language.PureScript.CoreFn.Meta (Meta(IsSyntheticApp))
+import Language.PureScript.CoreFn.Traversals
+import Language.PureScript.Environment (dictTypeName)
+import Language.PureScript.Names
+import Language.PureScript.PSString (decodeString)
+
+-- |
+-- `discuss f m` is an action that listens to the output of `m`, passes that
+-- and its value through `f`, and uses (only) the value of the result to set
+-- the new value and output. (Any output produced via the monad in `f` is
+-- ignored, though other monadic effects will hold.)
+--
+discuss :: MonadWriter w m => ((a, w) -> m (b, w)) -> m a -> m b
+discuss f = pass . fmap (second const) . (f <=< listen)
+
+-- |
+-- Modify the target of an optic in the state with a monadic computation that
+-- returns some extra information of type `r` in a tuple.
+--
+-- I would prefer that this be a named function, but I don't know what to name
+-- it. I went with symbols instead because the function that this operator most
+-- resembles is `(%%=)`, which doesn't have a textual name as far as I know.
+-- Compare the following (approximate) types:
+--
+-- @
+-- (%%=)  :: MonadState s m => Lens s s a b -> (a ->   (r, b)) -> m r
+-- (%%<~) :: MonadState s m => Lens s s a b -> (a -> m (r, b)) -> m r
+-- @
+--
+-- Replacing the `=` with `<~` was inspired by analogy with the following pair:
+--
+-- @
+-- (.=) :: MonadState s m => Lens s s a b ->   b -> m ()
+-- (<~) :: MonadState s m => Lens s s a b -> m b -> m ()
+-- @
+--
+-- I regret any confusion that ensues.
+--
+-- Note that there are two interpretations that could reasonably be expected
+-- for this type.
+--
+-- @
+-- (%%<~) :: MonadState s m => Lens s s a b -> (a -> m (r, b)) -> m r
+-- @
+--
+-- One is:
+-- * Get the focused `a` value from the monad
+-- * Run the computation
+-- * Get the new state from the returned monad
+-- * Take the returned `b` value and set it in the new state
+--
+-- The other is:
+-- * Get the focused `a` value from the monad
+-- * Run the computation
+-- * Take the returned `b` value and set it in the *original* state
+-- * Put the result into the returned monad
+--
+-- This operator corresponds to the second interpretation. The purpose of this,
+-- and part of the purpose of having this operator at all instead of composing
+-- simpler operators, is to enable using the lens only once (on the original
+-- state) instead of twice (for a get and a set on different states).
+--
+(%%<~)
+  :: MonadState s m
+  => ((a -> Compose m ((,) r) b) -> s -> Compose m ((,) r) s)
+     -- ^ please read as Lens s s a b
+  -> (a -> m (r, b))
+  -> m r
+l %%<~ f = get >>= getCompose . l (Compose . f) >>= state . const
+infix 4 %%<~
+
+-- |
+-- A PluralityMap is like a weaker multiset: like a multiset, it can hold
+-- several of the same value, but instead of keeping track of their exact
+-- counts, it only records whether there is one (False) or more than one
+-- (True).
+--
+newtype PluralityMap k = PluralityMap { getPluralityMap :: M.Map k Bool }
+
+instance Ord k => Semigroup (PluralityMap k) where
+  PluralityMap l <> PluralityMap r =
+    let
+      l' = M.mapWithKey (\k -> (|| k `M.member` r)) l
+    in PluralityMap $ l' `M.union` r
+
+instance Ord k => Monoid (PluralityMap k) where
+  mempty = PluralityMap M.empty
+
+data BindingType = NonRecursive | Recursive deriving Eq
+
+-- |
+-- Record summary data about an expression.
+--
+data CSESummary = CSESummary
+  { _scopesUsed    :: IS.IntSet
+    -- ^ set of the scope numbers used in this expression
+  , _noFloatWithin :: Maybe (Min Int)
+    -- ^ optionally a scope within which this expression is not to be floated
+    -- (because the expression uses an identifier bound recursively in that
+    -- scope)
+  , _plurality     :: PluralityMap Ident
+    -- ^ which floated identifiers are used more than once in this expression
+    -- (note that a single use inside an Abs will be considered multiple uses,
+    -- as this pass doesn't know when/how many times an Abs will be executed)
+  , _newBindings   :: IM.MonoidalIntMap [(Ident, (PluralityMap Ident, Expr Ann))]
+    -- ^ floated bindings, organized by scope number
+  , _toBeReinlined :: M.Map Ident (Expr Ann)
+    -- ^ a map of floated identifiers that did not end up getting bound and
+    -- will need to be reinlined at the end of the pass
+  }
+  deriving Generic
+  deriving (Semigroup, Monoid) via GenericSemigroupMonoid CSESummary
+
+-- |
+-- Append a value at a given scope depth.
+--
+addToScope :: Semigroup v => Int -> v -> IM.MonoidalIntMap v -> IM.MonoidalIntMap v
+addToScope depth v
+  = IM.alter (Just . maybe v (<> v)) depth
+
+-- |
+-- Remove and return an entire scope from a map of bindings.
+--
+popScope :: Monoid v => Int -> IM.MonoidalIntMap v -> (v, IM.MonoidalIntMap v)
+popScope depth
+  = first fold . IM.updateLookupWithKey (\_ _ -> Nothing) depth
+
+-- |
+-- Describe the context of an expression.
+--
+data CSEEnvironment = CSEEnvironment
+  { _depth :: Int
+    -- ^ number of enclosing binding scopes (this includes not only Abs, but
+    -- Let and CaseAlternative bindings)
+  , _bound :: M.Map Ident (Int, BindingType)
+    -- ^ map from identifiers to depth in which they are bound and whether
+    -- or not the binding is recursive
+  }
+
+makeLenses ''CSESummary
+makeLenses ''CSEEnvironment
+
+-- |
+-- Map from the shape of an expression to an identifier created to represent
+-- that expression, organized by scope depth.
+--
+type CSEState = IM.MonoidalIntMap (M.Map (Expr ()) Ident)
+
+-- |
+-- The monad in which CSE takes place.
+--
+type CSEMonad a = RWST CSEEnvironment CSESummary CSEState Supply a
+
+type HasCSEReader = MonadReader CSEEnvironment
+type HasCSEWriter = MonadWriter CSESummary
+type HasCSEState = MonadState CSEState
+
+-- |
+-- Run a CSEMonad computation; the return value is augmented with a map of
+-- identifiers that should be replaced in the final expression because they
+-- didn't end up needing to be floated.
+--
+runCSEMonad :: CSEMonad a -> Supply (a, M.Map Ident (Expr Ann))
+runCSEMonad x = second (^. toBeReinlined) <$> evalRWST x (CSEEnvironment 0 M.empty) IM.empty
+
+-- |
+-- Mark all expressions floated out of this computation as "plural". This pass
+-- assumes that any given Abs may be invoked multiple times, so any expressions
+-- inside the Abs but floated out of it also count as having multiple uses,
+-- even if they only appear once within the Abs. Consequently, any expressions
+-- that can be floated out of an Abs won't be reinlined at the end.
+--
+enterAbs :: HasCSEWriter m => m a -> m a
+enterAbs = censor $ plurality %~ PluralityMap . fmap (const True) . getPluralityMap
+
+-- |
+-- Run the provided computation in a new scope.
+--
+newScope :: (HasCSEReader m, HasCSEWriter m) => (Int -> m a) -> m a
+newScope body = local (depth %~ succ) $ do
+  d <- view depth
+  censor (filterToDepth d) (body d)
+  where
+  filterToDepth d
+    = (scopesUsed %~ IS.filter (< d))
+    . (noFloatWithin %~ find (< Min d))
+
+-- |
+-- Record a list of identifiers as being bound in the given scope.
+--
+withBoundIdents :: HasCSEReader m => [Ident] -> (Int, BindingType) -> m a -> m a
+withBoundIdents idents t = local (bound %~ flip (foldl' (flip (flip M.insert t))) idents)
+
+-- |
+-- Run the provided computation in a new scope in which the provided
+-- identifiers are bound non-recursively.
+--
+newScopeWithIdents :: (HasCSEReader m, HasCSEWriter m) => [Ident] -> m a -> m a
+newScopeWithIdents idents = newScope . flip (withBoundIdents idents . (, NonRecursive))
+
+-- |
+-- Produce, or retrieve from the state, an identifier for referencing the given
+-- expression, at and below the given depth.
+--
+generateIdentFor :: (HasCSEState m, MonadSupply m) => Int -> Expr () -> m (Bool, Ident)
+generateIdentFor d e = at d . non mempty . at e %%<~ \case
+  Nothing    -> freshIdent (nameHint e) <&> \ident -> ((True, ident), Just ident)
+  Just ident -> pure ((False, ident), Just ident)
+  -- A reminder: as with %%=, the first element of the returned pair is the
+  -- final result of the expression, and the second element is the value to
+  -- stuff back through the lens into the state. (The difference is that %%<~
+  -- enables doing monadic work in the RHS, namely `freshIdent` here.)
+  where
+  nameHint = \case
+    App _ v1 v2
+      | Var _ n <- v1
+      , fmap (ProperName . runIdent) n == fmap dictTypeName C.IsSymbol
+      , Literal _ (ObjectLiteral [(_, Abs _ _ (Literal _ (StringLiteral str)))]) <- v2
+      , Just decodedStr <- decodeString str
+        -> decodedStr <> "IsSymbol"
+      | otherwise
+        -> nameHint v1
+    Var _ (Qualified _ ident)
+      | Ident name             <- ident -> name
+      | GenIdent (Just name) _ <- ident -> name
+    Accessor _ prop _
+      | Just decodedProp <- decodeString prop -> decodedProp
+    _ -> "ref"
+
+nullAnn :: Ann
+nullAnn = (nullSourceSpan, [], Nothing, Nothing)
+
+-- |
+-- Use a map to substitute local Vars in a list of Binds.
+--
+replaceLocals :: M.Map Ident (Expr Ann) -> [Bind Ann] -> [Bind Ann]
+replaceLocals m = if M.null m then identity else map f' where
+  (f', g', _) = everywhereOnValues identity f identity
+  f e@(Var _ (Qualified Nothing ident)) = maybe e g' $ ident `M.lookup` m
+  f e = e
+
+-- |
+-- Store in the monad a new binding for the given expression, returning a Var
+-- referencing it. The provided CSESummary will be transformed to reflect the
+-- replacement.
+--
+floatExpr
+  :: (HasCSEState m, MonadSupply m)
+  => (Expr Ann, CSESummary)
+  -> m (Expr Ann, CSESummary)
+floatExpr = \case
+  (e, w@CSESummary{ _noFloatWithin = Nothing, .. }) -> do
+    let deepestScope = if IS.null _scopesUsed then 0 else IS.findMax _scopesUsed
+    (isNew, ident) <- generateIdentFor deepestScope (void e)
+    let w' = w
+          & (if isNew then newBindings %~ addToScope deepestScope [(ident, (_plurality, e))] else identity)
+          & plurality .~ PluralityMap (M.singleton ident False)
+    pure (Var nullAnn (Qualified Nothing ident), w')
+  (e, w) -> pure (e, w)
+
+-- |
+-- Take possession of the Binds intended to be added to the current scope,
+-- removing them from the state, and return the list of Binds along with
+-- whatever value is returned by the provided computation.
+--
+getNewBinds
+  :: (HasCSEReader m, HasCSEState m, HasCSEWriter m)
+  => m a
+  -> m ([Bind Ann], a)
+getNewBinds =
+  discuss $ \(a, w) -> do
+    d <- view depth
+    at d .= Nothing
+    let (floatedHere, w') = newBindings (popScope d) w
+    pure $ first (, a) $ foldr handleFloat ([], w') floatedHere
+  where
+  handleFloat (ident, (p, e)) (bs, w) =
+    if fromJust . M.lookup ident . getPluralityMap $ w ^. plurality
+    then (NonRec nullAnn ident e : bs, w')
+    else (bs, w' & toBeReinlined %~ M.insert ident e)
+    where w' = w & plurality <>~ p
+
+-- |
+-- Like getNewBinds, but also stores the Binds in a Let wrapping the provided
+-- expression. If said expression is already a Let, adds these Binds to that
+-- Let instead.
+--
+getNewBindsAsLet
+  :: (HasCSEReader m, HasCSEWriter m, HasCSEState m)
+  => m (Expr Ann)
+  -> m (Expr Ann)
+getNewBindsAsLet = fmap (uncurry go) . getNewBinds where
+  go bs = if null bs then identity else \case
+    Let a bs' e' -> Let a (bs ++ bs') e'
+    e'           -> Let nullAnn bs e'
+
+-- |
+-- Feed the Writer part of the monad with the requirements of this name.
+--
+summarizeName
+  :: (HasCSEReader m, HasCSEWriter m)
+  => ModuleName
+  -> Qualified Ident
+  -> m ()
+summarizeName mn (Qualified mn' ident) = do
+  m <- view bound
+  let (s, bt) =
+        fromMaybe (0, NonRecursive) $
+          guard (all (== mn) mn') *> ident `M.lookup` m
+  tell $ mempty
+       & scopesUsed .~ IS.singleton s
+       & noFloatWithin .~ (guard (bt == Recursive) $> Min s)
+
+-- |
+-- Collect all the Idents put in scope by a list of Binders.
+--
+identsFromBinders :: [Binder a] -> [Ident]
+identsFromBinders = foldMap identsFromBinder where
+  identsFromBinder = \case
+    LiteralBinder _ (ArrayLiteral xs)  -> identsFromBinders xs
+    LiteralBinder _ (ObjectLiteral xs) -> identsFromBinders (map snd xs)
+    VarBinder _ ident                  -> [ident]
+    ConstructorBinder _ _ _ xs         -> identsFromBinders xs
+    NamedBinder _ ident x              -> ident : identsFromBinder x
+    LiteralBinder _ BooleanLiteral{}   -> []
+    LiteralBinder _ CharLiteral{}      -> []
+    LiteralBinder _ NumericLiteral{}   -> []
+    LiteralBinder _ StringLiteral{}    -> []
+    NullBinder{}                       -> []
+
+-- |
+-- Float synthetic Apps (right now, the only Apps marked as synthetic are type
+-- class dictionaries being fed to functions with constraints, superclass
+-- accessors, and instances of IsSymbol) to a new or existing Let as close to
+-- the top level as possible.
+--
+optimizeCommonSubexpressions :: ModuleName -> [Bind Ann] -> Supply [Bind Ann]
+optimizeCommonSubexpressions mn
+  = fmap (uncurry (flip replaceLocals))
+  . runCSEMonad
+  . fmap (uncurry (++))
+  . getNewBinds
+  . fmap fst
+  . handleBinds (pure ())
+
+  where
+
+  -- This is the one place (I think?) that keeps this from being a general
+  -- common subexpression elimination pass.
+  shouldFloatExpr :: Expr Ann -> Bool
+  shouldFloatExpr = \case
+    App (_, _, _, Just IsSyntheticApp) e _ -> isSimple e
+    _                                      -> False
+
+  isSimple :: Expr Ann -> Bool
+  isSimple = \case
+    Var{}          -> True
+    Accessor _ _ e -> isSimple e
+    _              -> False
+
+  handleAndWrapExpr :: Expr Ann -> CSEMonad (Expr Ann)
+  handleAndWrapExpr = getNewBindsAsLet . handleExpr
+
+  (handleBind, handleExprDefault, handleBinder, _) = traverseCoreFn handleBind handleExpr handleBinder handleCaseAlternative
+
+  handleExpr :: Expr Ann -> CSEMonad (Expr Ann)
+  handleExpr = discuss (ifM (shouldFloatExpr . fst) floatExpr pure) . \case
+    Abs a ident e   -> enterAbs $ Abs a ident <$> newScopeWithIdents [ident] (handleAndWrapExpr e)
+    v@(Var _ qname) -> summarizeName mn qname $> v
+    Let a bs e      -> uncurry (Let a) <$> handleBinds (handleExpr e) bs
+    x               -> handleExprDefault x
+
+  handleCaseAlternative :: CaseAlternative Ann -> CSEMonad (CaseAlternative Ann)
+  handleCaseAlternative (CaseAlternative bs x) = CaseAlternative bs <$> do
+    newScopeWithIdents (identsFromBinders bs) $
+      bitraverse (traverse $ bitraverse handleAndWrapExpr handleAndWrapExpr) handleAndWrapExpr x
+
+  handleBinds :: forall a. CSEMonad a -> [Bind Ann] -> CSEMonad ([Bind Ann], a)
+  handleBinds = foldr go . fmap pure where
+    go :: Bind Ann -> CSEMonad ([Bind Ann], a) -> CSEMonad ([Bind Ann], a)
+    go b inner = case b of
+      -- For a NonRec Bind, traverse the bound expression in the current scope
+      -- and then create a new scope for any remaining Binds and/or whatever
+      -- inner thing all these Binds are applied to.
+      NonRec a ident e -> do
+        e' <- handleExpr e
+        newScopeWithIdents [ident] $
+          prependToNewBindsFromInner $ NonRec a ident e'
+      Rec es ->
+        -- For a Rec Bind, the bound expressions need a new scope in which all
+        -- these identifiers are bound recursively; then the remaining Binds
+        -- and the inner thing can be traversed in the same scope with the same
+        -- identifiers now bound non-recursively.
+        newScope $ \d -> do
+          let idents = map (snd . fst) es
+          es' <- withBoundIdents idents (d, Recursive) $ traverse (traverse handleExpr) es
+          withBoundIdents idents (d, NonRecursive) $
+            prependToNewBindsFromInner $ Rec es'
+
+      where
+
+      prependToNewBindsFromInner :: Bind Ann -> CSEMonad ([Bind Ann], a)
+      prependToNewBindsFromInner hd = first (hd :) . join <$> getNewBinds inner

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -95,7 +95,19 @@ moduleToCoreFn env (A.Module modSS coms mn decls (Just exps)) =
   exprToCoreFn _ _ _ (A.Abs _ _) =
     internalError "Abs with Binder argument was not desugared before exprToCoreFn mn"
   exprToCoreFn ss com ty (A.App v1 v2) =
-    App (ss, com, ty, Nothing) (exprToCoreFn ss [] Nothing v1) (exprToCoreFn ss [] Nothing v2)
+    App (ss, com, ty, (isDictCtor v1 || isSynthetic v2) `orEmpty` IsSyntheticApp) v1' v2'
+    where
+    v1' = exprToCoreFn ss [] Nothing v1
+    v2' = exprToCoreFn ss [] Nothing v2
+    isDictCtor = \case
+      A.Constructor _ (Qualified _ name) -> isDictTypeName name
+      _ -> False
+    isSynthetic = \case
+      A.App v3 v4            -> isDictCtor v3 || isSynthetic v3 && isSynthetic v4
+      A.Accessor _ v3        -> isSynthetic v3
+      A.Var NullSourceSpan _ -> True
+      A.Unused{}             -> True
+      _                      -> False
   exprToCoreFn ss com ty (A.Unused _) =
     Var (ss, com, ty, Nothing) (Qualified (Just C.Prim) (Ident C.undefined))
   exprToCoreFn _ com ty (A.Var ss ident) =

--- a/src/Language/PureScript/CoreFn/Expr.hs
+++ b/src/Language/PureScript/CoreFn/Expr.hs
@@ -52,7 +52,7 @@ data Expr a
   -- A let binding
   --
   | Let a [Bind a] (Expr a)
-  deriving (Eq, Show, Functor)
+  deriving (Eq, Ord, Show, Functor)
 
 -- |
 -- A let or module binding.
@@ -65,7 +65,7 @@ data Bind a
   -- |
   -- Mutually recursive binding group for several values
   --
-  | Rec [((a, Ident), Expr a)] deriving (Eq, Show, Functor)
+  | Rec [((a, Ident), Expr a)] deriving (Eq, Ord, Show, Functor)
 
 -- |
 -- A guard is just a boolean-valued expression that appears alongside a set of binders
@@ -84,7 +84,7 @@ data CaseAlternative a = CaseAlternative
     -- The result expression or a collect of guarded expressions
     --
   , caseAlternativeResult :: Either [(Guard a, Expr a)] (Expr a)
-  } deriving (Eq, Show)
+  } deriving (Eq, Ord, Show)
 
 instance Functor CaseAlternative where
 

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -53,6 +53,8 @@ metaFromJSON v = withObject "Meta" metaFromObj v
                         -> return $ Just IsTypeClassConstructor
         "IsForeign"     -> return $ Just IsForeign
         "IsWhere"       -> return $ Just IsWhere
+        "IsSyntheticApp"
+                        -> return $ Just IsSyntheticApp
         _               -> fail ("not recognized Meta: " ++ T.unpack type_)
 
     isConstructorFromJSON o = do

--- a/src/Language/PureScript/CoreFn/Meta.hs
+++ b/src/Language/PureScript/CoreFn/Meta.hs
@@ -31,6 +31,10 @@ data Meta
   -- The contained value is a where clause
   --
   | IsWhere
+  -- |
+  -- The contained function application was synthesized by the compiler
+  --
+  | IsSyntheticApp
   deriving (Show, Eq, Ord)
 
 -- |

--- a/src/Language/PureScript/CoreFn/Optimizer.hs
+++ b/src/Language/PureScript/CoreFn/Optimizer.hs
@@ -1,11 +1,13 @@
 module Language.PureScript.CoreFn.Optimizer (optimizeCoreFn) where
 
-import Protolude hiding (Type)
+import Protolude hiding (Type, moduleName)
 
+import Control.Monad.Supply (Supply)
 import Data.List (lookup)
 import Language.PureScript.AST.Literals
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.CoreFn.Ann
+import Language.PureScript.CoreFn.CSE
 import Language.PureScript.CoreFn.Expr
 import Language.PureScript.CoreFn.Module
 import Language.PureScript.CoreFn.Traversals
@@ -18,8 +20,8 @@ import qualified Language.PureScript.Constants.Prim as C
 -- |
 -- CoreFn optimization pass.
 --
-optimizeCoreFn :: Module Ann -> Module Ann
-optimizeCoreFn m = m {moduleDecls = optimizeModuleDecls $ moduleDecls m}
+optimizeCoreFn :: Module Ann -> Supply (Module Ann)
+optimizeCoreFn m = fmap (\md -> m {moduleDecls = md}) . optimizeCommonSubexpressions (moduleName m) . optimizeModuleDecls $ moduleDecls m
 
 optimizeModuleDecls :: [Bind Ann] -> [Bind Ann]
 optimizeModuleDecls = map transformBinds

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -38,6 +38,7 @@ metaToJSON IsNewtype              = object [ T.pack "metaType"  .= "IsNewtype" ]
 metaToJSON IsTypeClassConstructor = object [ T.pack "metaType"  .= "IsTypeClassConstructor" ]
 metaToJSON IsForeign              = object [ T.pack "metaType"  .= "IsForeign" ]
 metaToJSON IsWhere                = object [ T.pack "metaType"  .= "IsWhere" ]
+metaToJSON IsSyntheticApp         = object [ T.pack "metaType"  .= "IsSyntheticApp" ]
 
 sourceSpanToJSON :: SourceSpan -> Value
 sourceSpanToJSON (SourceSpan _ spanStart spanEnd) =

--- a/src/Language/PureScript/CoreImp/AST.hs
+++ b/src/Language/PureScript/CoreImp/AST.hs
@@ -52,6 +52,12 @@ data CIComments
   | PureAnnotation
   deriving (Show, Eq)
 
+-- |
+-- Indicates whether the initializer of a variable is known not to have side
+-- effects, and thus can be inlined if needed or removed if unneeded.
+--
+data InitializerEffects = NoEffects | UnknownEffects deriving (Show, Eq)
+
 -- | Data type for simplified JavaScript expressions
 data AST
   = NumericLiteral (Maybe SourceSpan) (Either Integer Double)
@@ -80,7 +86,7 @@ data AST
   -- ^ Value from another module
   | Block (Maybe SourceSpan) [AST]
   -- ^ A block of expressions in braces
-  | VariableIntroduction (Maybe SourceSpan) Text (Maybe AST)
+  | VariableIntroduction (Maybe SourceSpan) Text (Maybe (InitializerEffects, AST))
   -- ^ A variable introduction and optional initialization
   | Assignment (Maybe SourceSpan) AST AST
   -- ^ A variable assignment
@@ -174,7 +180,7 @@ everywhere f = go where
   go (Function ss name args j) = f (Function ss name args (go j))
   go (App ss j js) = f (App ss (go j) (map go js))
   go (Block ss js) = f (Block ss (map go js))
-  go (VariableIntroduction ss name j) = f (VariableIntroduction ss name (fmap go j))
+  go (VariableIntroduction ss name j) = f (VariableIntroduction ss name (fmap (fmap go) j))
   go (Assignment ss j1 j2) = f (Assignment ss (go j1) (go j2))
   go (While ss j1 j2) = f (While ss (go j1) (go j2))
   go (For ss name j1 j2 j3) = f (For ss name (go j1) (go j2) (go j3))
@@ -200,7 +206,7 @@ everywhereTopDownM f = f >=> go where
   go (Function ss name args j) = Function ss name args <$> f' j
   go (App ss j js) = App ss <$> f' j <*> traverse f' js
   go (Block ss js) = Block ss <$> traverse f' js
-  go (VariableIntroduction ss name j) = VariableIntroduction ss name <$> traverse f' j
+  go (VariableIntroduction ss name j) = VariableIntroduction ss name <$> traverse (traverse f') j
   go (Assignment ss j1 j2) = Assignment ss <$> f' j1 <*> f' j2
   go (While ss j1 j2) = While ss <$> f' j1 <*> f' j2
   go (For ss name j1 j2 j3) = For ss name <$> f' j1 <*> f' j2 <*> f' j3
@@ -222,7 +228,7 @@ everything (<>.) f = go where
   go j@(Function _ _ _ j1) = f j <>. go j1
   go j@(App _ j1 js) = foldl (<>.) (f j <>. go j1) (map go js)
   go j@(Block _ js) = foldl (<>.) (f j) (map go js)
-  go j@(VariableIntroduction _ _ (Just j1)) = f j <>. go j1
+  go j@(VariableIntroduction _ _ (Just (_, j1))) = f j <>. go j1
   go j@(Assignment _ j1 j2) = f j <>. go j1 <>. go j2
   go j@(While _ j1 j2) = f j <>. go j1 <>. go j2
   go j@(For _ _ j1 j2 j3) = f j <>. go j1 <>. go j2 <>. go j3

--- a/src/Language/PureScript/CoreImp/Optimizer.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer.hs
@@ -21,6 +21,8 @@ module Language.PureScript.CoreImp.Optimizer (optimize) where
 
 import Prelude.Compat
 
+import Data.Text (Text)
+
 import Control.Monad.Supply.Class (MonadSupply)
 import Language.PureScript.CoreImp.AST
 import Language.PureScript.CoreImp.Optimizer.Blocks
@@ -31,17 +33,20 @@ import Language.PureScript.CoreImp.Optimizer.TCO
 import Language.PureScript.CoreImp.Optimizer.Unused
 
 -- | Apply a series of optimizer passes to simplified JavaScript code
-optimize :: MonadSupply m => AST -> m AST
-optimize js = do
-    js' <- untilFixedPoint (inlineFnComposition . inlineUnsafeCoerce . inlineUnsafePartial . tidyUp . applyAll
-      [ inlineCommonValues
-      , inlineCommonOperators
-      ]) js
-    untilFixedPoint (return . tidyUp) . tco . inlineST
-      =<< untilFixedPoint (return . magicDoST)
-      =<< untilFixedPoint (return . magicDoEff)
-      =<< untilFixedPoint (return . magicDoEffect) js'
+optimize :: forall m. MonadSupply m => [Text] -> [[AST]] -> m [[AST]]
+optimize exps jsDecls = removeUnusedEffectFreeVars exps <$> traverse (traverse go) jsDecls
   where
+    go :: AST -> m AST
+    go js = do
+      js' <- untilFixedPoint (inlineFnComposition expander . inlineFnIdentity expander . inlineUnsafeCoerce . inlineUnsafePartial . tidyUp . applyAll
+        [ inlineCommonValues expander
+        , inlineCommonOperators expander
+        ]) js
+      untilFixedPoint (return . tidyUp) . tco . inlineST
+        =<< untilFixedPoint (return . magicDoST expander)
+        =<< untilFixedPoint (return . magicDoEff expander)
+        =<< untilFixedPoint (return . magicDoEffect expander) js'
+
     tidyUp :: AST -> AST
     tidyUp = applyAll
       [ collapseNestedBlocks
@@ -54,9 +59,27 @@ optimize js = do
       , inlineVariables
       ]
 
+    expander = buildExpander (concat jsDecls)
+
 untilFixedPoint :: (Monad m, Eq a) => (a -> m a) -> a -> m a
 untilFixedPoint f = go
   where
   go a = do
    a' <- f a
    if a' == a then return a' else go a'
+
+-- |
+-- Take all top-level ASTs and return a function for expanding top-level
+-- variables during the various inlining steps in `optimize`.
+--
+-- Everything that gets inlined as an optimization is of a form that would
+-- have been lifted to a top-level binding during CSE, so for purposes of
+-- inlining we can save some time by only expanding variables bound at that
+-- level and not worrying about any inner scopes.
+--
+buildExpander :: [AST] -> AST -> AST
+buildExpander = replaceIdents . foldr go []
+  where
+  go = \case
+    VariableIntroduction _ name (Just (NoEffects, e)) -> ((name, e) :)
+    _ -> id

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -27,17 +27,17 @@ import qualified Language.PureScript.Constants.Prelude as C
 --    var x = m1();
 --    ...
 --  }
-magicDoEff :: AST -> AST
+magicDoEff :: (AST -> AST) -> AST -> AST
 magicDoEff = magicDo C.Eff C.effDictionaries
 
-magicDoEffect :: AST -> AST
+magicDoEffect :: (AST -> AST) -> AST -> AST
 magicDoEffect = magicDo C.Effect C.effectDictionaries
 
-magicDoST :: AST -> AST
+magicDoST :: (AST -> AST) -> AST -> AST
 magicDoST = magicDo C.ST C.stDictionaries
 
-magicDo :: ModuleName -> C.EffectDictionaries -> AST -> AST
-magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
+magicDo :: ModuleName -> C.EffectDictionaries -> (AST -> AST) -> AST -> AST
+magicDo effectModule C.EffectDictionaries{..} expander = everywhereTopDown convert
   where
   -- The name of the function block which is added to denote a do block
   fnName = "__do"
@@ -54,7 +54,7 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     Function s1 (Just fnName) [] $ Block s2 (App s2 m [] : map applyReturns js )
   -- Desugar bind
   convert (App _ (App _ bind [m]) [Function s1 Nothing [arg] (Block s2 js)]) | isBind bind =
-    Function s1 (Just fnName) [] $ Block s2 (VariableIntroduction s2 arg (Just (App s2 m [])) : map applyReturns js)
+    Function s1 (Just fnName) [] $ Block s2 (VariableIntroduction s2 arg (Just (UnknownEffects, App s2 m [])) : map applyReturns js)
   -- Desugar untilE
   convert (App s1 (App _ f [arg]) []) | isEffFunc edUntil f =
     App s1 (Function s1 Nothing [] (Block s1 [ While s1 (Unary s1 Not (App s1 arg [])) (Block s1 []), Return s1 $ ObjectLiteral s1 []])) []
@@ -68,16 +68,16 @@ magicDo effectModule C.EffectDictionaries{..} = everywhereTopDown convert
     App s1 (Function s2 Nothing [] (Block ss (applyReturns `fmap` body))) []
   convert other = other
   -- Check if an expression represents a monomorphic call to >>= for the Eff monad
-  isBind (App _ fn [dict]) | isDict (effectModule, edBindDict) dict && isBindPoly fn = True
+  isBind (expander -> App _ fn [dict]) | isDict (effectModule, edBindDict) dict && isBindPoly fn = True
   isBind _ = False
   -- Check if an expression represents a call to @discard@
-  isDiscard (App _ (App _ fn [dict1]) [dict2])
+  isDiscard (expander -> App _ (expander -> App _ fn [dict1]) [dict2])
     | isDict (C.ControlBind, C.discardUnitDictionary) dict1 &&
       isDict (effectModule, edBindDict) dict2 &&
       isDiscardPoly fn = True
   isDiscard _ = False
   -- Check if an expression represents a monomorphic call to pure or return for the Eff applicative
-  isPure (App _ fn [dict]) | isDict (effectModule, edApplicativeDict) dict && isPurePoly fn = True
+  isPure (expander -> App _ fn [dict]) | isDict (effectModule, edApplicativeDict) dict && isPurePoly fn = True
   isPure _ = False
   -- Check if an expression represents the polymorphic >>= function
   isBindPoly = isDict (C.ControlBind, C.bind)
@@ -130,7 +130,7 @@ inlineST = everywhere convertBlock
   -- Find all ST Refs initialized in this block
   findSTRefsIn = everything (++) isSTRef
     where
-    isSTRef (VariableIntroduction _ ident (Just (App _ (App _ f [_]) []))) | isSTFunc C.newSTRef f = [ident]
+    isSTRef (VariableIntroduction _ ident (Just (_, App _ (App _ f [_]) []))) | isSTFunc C.newSTRef f = [ident]
     isSTRef _ = []
   -- Find all STRefs used as arguments to readSTRef, writeSTRef, modifySTRef
   findAllSTUsagesIn = everything (++) isSTUsage

--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -33,9 +33,9 @@ tco = flip evalState 0 . everywhereTopDownM convert where
   tcoResult = "$tco_result"
 
   convert :: AST -> State Int AST
-  convert (VariableIntroduction ss name (Just fn@Function {}))
+  convert (VariableIntroduction ss name (Just (p, fn@Function {})))
       | Just trFns <- findTailRecursiveFns name arity body'
-      = VariableIntroduction ss name . Just . replace <$> toLoop trFns name arity outerArgs innerArgs body'
+      = VariableIntroduction ss name . Just . (p,) . replace <$> toLoop trFns name arity outerArgs innerArgs body'
     where
       innerArgs = headDef [] argss
       outerArgs = concat . reverse $ tailSafe argss
@@ -113,7 +113,7 @@ tco = flip evalState 0 . everywhereTopDownM convert where
       = pure S.empty
     allInTailPosition (VariableIntroduction _ _ Nothing)
       = pure S.empty
-    allInTailPosition (VariableIntroduction _ ident' (Just js1))
+    allInTailPosition (VariableIntroduction _ ident' (Just (_, js1)))
       | countSelfReferences js1 == 0 = pure S.empty
       | Function _ Nothing _ _ <- js1
       , (argss, body, _) <- innerCollectAllFunctionArgs [] id js1
@@ -155,14 +155,14 @@ tco = flip evalState 0 . everywhereTopDownM convert where
       loopify (ForIn ss i js1 body) = ForIn ss i js1 (loopify body)
       loopify (IfElse ss cond body el) = IfElse ss cond (loopify body) (fmap loopify el)
       loopify (Block ss body) = Block ss (map loopify body)
-      loopify (VariableIntroduction ss f (Just fn@(Function _ Nothing _ _)))
+      loopify (VariableIntroduction ss f (Just (p, fn@(Function _ Nothing _ _))))
         | (_, body, replace) <- innerCollectAllFunctionArgs [] id fn
-        , f `S.member` trFns = VariableIntroduction ss f (Just (replace (loopify body)))
+        , f `S.member` trFns = VariableIntroduction ss f (Just (p, replace (loopify body)))
       loopify other = other
 
     pure $ Block rootSS $
-        map (\arg -> VariableIntroduction rootSS (tcoVar arg) (Just (Var rootSS (copyVar arg)))) outerArgs ++
-        [ VariableIntroduction rootSS tcoDone (Just (BooleanLiteral rootSS False))
+        map (\arg -> VariableIntroduction rootSS (tcoVar arg) (Just (UnknownEffects, Var rootSS (copyVar arg)))) outerArgs ++
+        [ VariableIntroduction rootSS tcoDone (Just (UnknownEffects, BooleanLiteral rootSS False))
         , VariableIntroduction rootSS tcoResult Nothing
         , Function rootSS (Just tcoLoop) (outerArgs ++ innerArgs) (Block rootSS [loopify js])
         , While rootSS (Unary rootSS Not (Var rootSS tcoDone))

--- a/src/Language/PureScript/CoreImp/Optimizer/Unused.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Unused.hs
@@ -2,9 +2,15 @@
 module Language.PureScript.CoreImp.Optimizer.Unused
   ( removeCodeAfterReturnStatements
   , removeUndefinedApp
+  , removeUnusedEffectFreeVars
   ) where
 
 import Prelude.Compat
+
+import Control.Monad (filterM)
+import Data.Monoid (Any(..))
+import qualified Data.Set as S
+import Data.Text (Text)
 
 import Language.PureScript.CoreImp.AST
 import Language.PureScript.CoreImp.Optimizer.Common
@@ -25,3 +31,22 @@ removeUndefinedApp = everywhere convert
   where
   convert (App ss fn [Var _ arg]) | arg == C.undefined = App ss fn []
   convert js = js
+
+removeUnusedEffectFreeVars :: [Text] -> [[AST]] -> [[AST]]
+removeUnusedEffectFreeVars exps = loop
+  where
+  expsSet = S.fromList exps
+
+  loop :: [[AST]] -> [[AST]]
+  loop asts = if changed then loop (filter (not . null) asts') else asts
+    where
+    used = expsSet <> foldMap (foldMap (everything (<>) (\case Var _ x -> S.singleton x; _ -> S.empty))) asts
+    (Any changed, asts') = traverse (filterM (anyFalses . isInUsedSet used)) asts
+
+  isInUsedSet :: S.Set Text -> AST -> Bool
+  isInUsedSet used = \case
+    VariableIntroduction _ var (Just (NoEffects, _)) -> var `S.member` used
+    _ -> True
+
+  anyFalses :: Bool -> (Any, Bool)
+  anyFalses x = (Any (not x), x)

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -111,7 +111,7 @@ rebuildModuleWithIndex MakeActions{..} exEnv externs m@(Module _ _ moduleName _ 
   regrouped <- createBindingGroups moduleName . collapseBindingGroups $ deguarded
   let mod' = Module ss coms moduleName regrouped exps
       corefn = CF.moduleToCoreFn env' mod'
-      optimized = CF.optimizeCoreFn corefn
+      (optimized, nextVar'') = runSupply nextVar' $ CF.optimizeCoreFn corefn
       (renamedIdents, renamed) = renameInModule optimized
       exts = moduleToExternsFile mod' env' renamedIdents
   ffiCodegen renamed
@@ -129,7 +129,7 @@ rebuildModuleWithIndex MakeActions{..} exEnv externs m@(Module _ _ moduleName _ 
                  ++ "; details:\n" ++ prettyPrintMultipleErrors defaultPPEOptions errs
                Right d -> d
 
-  evalSupplyT nextVar' $ codegen renamed docs exts
+  evalSupplyT nextVar'' $ codegen renamed docs exts
   return exts
 
 -- | Compiles in "make" mode, compiling each module separately to a @.js@ file and an @externs.cbor@ file.

--- a/tests/purs/optimize/4179.out.js
+++ b/tests/purs/optimize/4179.out.js
@@ -52,8 +52,8 @@ var alpha = function (v) {
     };
     if (v === 2) {
         return function (y) {
-            var $7 = y > 0;
-            if ($7) {
+            var $13 = y > 0;
+            if ($13) {
                 return bravo(y);
             };
             return charlie(y);
@@ -81,8 +81,8 @@ var $lazy_delta = /* #__PURE__ */ $runtime_lazy("delta", "Main", function () {
     })({});
     return function (x) {
         return function (y) {
-            var $8 = x === y;
-            if ($8) {
+            var $14 = x === y;
+            if ($14) {
                 return b(0);
             };
             return 1.0;

--- a/tests/purs/optimize/Monad.out.js
+++ b/tests/purs/optimize/Monad.out.js
@@ -1,0 +1,30 @@
+import * as Control_Applicative from "../Control.Applicative/index.js";
+import * as Control_Bind from "../Control.Bind/index.js";
+var liftM1 = function (dictMonad) {
+    var bind = Control_Bind.bind(dictMonad.Bind1());
+    var pure = Control_Applicative.pure(dictMonad.Applicative0());
+    return function (f) {
+        return function (a) {
+            return bind(a)(function (a$prime) {
+                return pure(f(a$prime));
+            });
+        };
+    };
+};
+var ap = function (dictMonad) {
+    var bind = Control_Bind.bind(dictMonad.Bind1());
+    var pure = Control_Applicative.pure(dictMonad.Applicative0());
+    return function (f) {
+        return function (a) {
+            return bind(f)(function (f$prime) {
+                return bind(a)(function (a$prime) {
+                    return pure(f$prime(a$prime));
+                });
+            });
+        };
+    };
+};
+export {
+    liftM1,
+    ap
+};

--- a/tests/purs/optimize/Monad.purs
+++ b/tests/purs/optimize/Monad.purs
@@ -1,0 +1,17 @@
+module Main where
+
+import Control.Applicative (class Applicative, pure)
+import Control.Bind (class Bind, bind)
+
+class (Applicative m, Bind m) <= Monad m
+
+liftM1 :: forall m a b. Monad m => (a -> b) -> m a -> m b
+liftM1 f a = do
+  a' <- a
+  pure (f a')
+
+ap :: forall m a b. Monad m => m (a -> b) -> m a -> m b
+ap f a = do
+  f' <- f
+  a' <- a
+  pure (f' a')

--- a/tests/purs/optimize/Primitives.out.js
+++ b/tests/purs/optimize/Primitives.out.js
@@ -1,0 +1,10 @@
+// This test checks that no unused Semiring abstractions are introduced when
+// the operators are compiled to JS primitives.
+var f = function (x) {
+    return function (y) {
+        return x * (y + 1 | 0) | 0;
+    };
+};
+export {
+    f
+};

--- a/tests/purs/optimize/Primitives.purs
+++ b/tests/purs/optimize/Primitives.purs
@@ -1,0 +1,9 @@
+-- This test checks that no unused Semiring abstractions are introduced when
+-- the operators are compiled to JS primitives.
+
+module Main where
+
+import Prelude
+
+f :: Int -> Int -> Int
+f x y = x * (y + 1)

--- a/tests/purs/optimize/RecursiveInstances.out.js
+++ b/tests/purs/optimize/RecursiveInstances.out.js
@@ -1,0 +1,107 @@
+import * as Data_Semigroup from "../Data.Semigroup/index.js";
+import * as Data_Symbol from "../Data.Symbol/index.js";
+import * as Type_Proxy from "../Type.Proxy/index.js";
+var append = /* #__PURE__ */ Data_Semigroup.append(Data_Semigroup.semigroupArray);
+var findKeysAuxNil = {
+    findKeysAux: function (v) {
+        return [  ];
+    }
+};
+var findKeysAux = function (dict) {
+    return dict.findKeysAux;
+};
+var findKeysAuxCons = function (dictIsSymbol) {
+    var reflectSymbol = Data_Symbol.reflectSymbol(dictIsSymbol);
+    return function (dictFindKeysAux) {
+        var findKeysAux1 = findKeysAux(dictFindKeysAux);
+        return {
+            findKeysAux: function (v) {
+                return append([ reflectSymbol(Type_Proxy["Proxy"].value) ])(findKeysAux1(Type_Proxy["Proxy"].value));
+            }
+        };
+    };
+};
+var findKeysAuxCons1 = /* #__PURE__ */ findKeysAuxCons({
+    reflectSymbol: function () {
+        return "a";
+    }
+});
+var findKeysAuxCons2 = /* #__PURE__ */ findKeysAuxCons({
+    reflectSymbol: function () {
+        return "b";
+    }
+});
+var findKeysAuxCons3 = /* #__PURE__ */ findKeysAuxCons({
+    reflectSymbol: function () {
+        return "c";
+    }
+});
+var findKeysAuxCons4 = /* #__PURE__ */ findKeysAuxCons({
+    reflectSymbol: function () {
+        return "d";
+    }
+});
+var findKeys = function () {
+    return function (dictFindKeysAux) {
+        var findKeysAux1 = findKeysAux(dictFindKeysAux);
+        return function (v) {
+            return findKeysAux1(Type_Proxy["Proxy"].value);
+        };
+    };
+};
+var findKeys11 = /* #__PURE__ */ findKeys();
+var findKeys12 = /* #__PURE__ */ findKeys11(/* #__PURE__ */ findKeysAuxCons1(findKeysAuxNil));
+var findKeys13 = /* #__PURE__ */ findKeys11(/* #__PURE__ */ findKeysAuxCons1(/* #__PURE__ */ findKeysAuxCons2(/* #__PURE__ */ findKeysAuxCons3(/* #__PURE__ */ findKeysAuxCons4(/* #__PURE__ */ findKeysAuxCons({
+    reflectSymbol: function () {
+        return "e";
+    }
+})(findKeysAuxNil))))));
+var findKeys14 = /* #__PURE__ */ findKeys11(/* #__PURE__ */ findKeysAuxCons1(/* #__PURE__ */ findKeysAuxCons2(findKeysAuxNil)));
+var findKeys15 = /* #__PURE__ */ findKeys11(/* #__PURE__ */ findKeysAuxCons1(/* #__PURE__ */ findKeysAuxCons2(/* #__PURE__ */ findKeysAuxCons3(findKeysAuxNil))));
+var findKeys16 = /* #__PURE__ */ findKeys11(/* #__PURE__ */ findKeysAuxCons1(/* #__PURE__ */ findKeysAuxCons2(/* #__PURE__ */ findKeysAuxCons3(/* #__PURE__ */ findKeysAuxCons4(findKeysAuxNil)))));
+var findKeys1 = /* #__PURE__ */ (function () {
+    return findKeys12(Type_Proxy["Proxy"].value);
+})();
+var findKeys10 = /* #__PURE__ */ (function () {
+    return findKeys13(Type_Proxy["Proxy"].value);
+})();
+var findKeys2 = /* #__PURE__ */ (function () {
+    return findKeys14(Type_Proxy["Proxy"].value);
+})();
+var findKeys3 = /* #__PURE__ */ (function () {
+    return findKeys15(Type_Proxy["Proxy"].value);
+})();
+var findKeys4 = /* #__PURE__ */ (function () {
+    return findKeys16(Type_Proxy["Proxy"].value);
+})();
+var findKeys5 = /* #__PURE__ */ (function () {
+    return findKeys13(Type_Proxy["Proxy"].value);
+})();
+var findKeys6 = /* #__PURE__ */ (function () {
+    return findKeys12(Type_Proxy["Proxy"].value);
+})();
+var findKeys7 = /* #__PURE__ */ (function () {
+    return findKeys14(Type_Proxy["Proxy"].value);
+})();
+var findKeys8 = /* #__PURE__ */ (function () {
+    return findKeys15(Type_Proxy["Proxy"].value);
+})();
+var findKeys9 = /* #__PURE__ */ (function () {
+    return findKeys16(Type_Proxy["Proxy"].value);
+})();
+export {
+    findKeysAux,
+    findKeys,
+    findKeys1,
+    findKeys2,
+    findKeys3,
+    findKeys4,
+    findKeys5,
+    findKeys6,
+    findKeys7,
+    findKeys8,
+    findKeys9,
+    findKeys10,
+    findKeysAuxNil,
+    findKeysAuxCons
+};

--- a/tests/purs/optimize/RecursiveInstances.purs
+++ b/tests/purs/optimize/RecursiveInstances.purs
@@ -1,0 +1,31 @@
+module Main where
+
+import Prelude
+
+import Prim.Row as R
+import Prim.RowList as RL
+import Type.Prelude (class IsSymbol, Proxy(..), reflectSymbol)
+
+class FindKeysAux :: forall k. RL.RowList k -> Constraint
+class FindKeysAux a where
+  findKeysAux :: Proxy a -> Array String
+
+instance FindKeysAux RL.Nil where
+  findKeysAux _ = []
+
+else instance (IsSymbol l, FindKeysAux r) => FindKeysAux (RL.Cons l t r) where
+  findKeysAux _ = [ reflectSymbol (Proxy :: Proxy l) ] <> findKeysAux (Proxy :: Proxy r)
+
+findKeys :: forall r rl. RL.RowToList r rl => FindKeysAux rl => Proxy r -> Array String
+findKeys _ = findKeysAux (Proxy :: Proxy rl)
+
+findKeys1 = findKeys (Proxy :: Proxy (a :: Unit))
+findKeys2 = findKeys (Proxy :: Proxy (a :: Unit, b :: Unit))
+findKeys3 = findKeys (Proxy :: Proxy (a :: Unit, b :: Unit, c :: Unit))
+findKeys4 = findKeys (Proxy :: Proxy (a :: Unit, b :: Unit, c :: Unit, d :: Unit))
+findKeys5 = findKeys (Proxy :: Proxy (a :: Unit, b :: Unit, c :: Unit, d :: Unit, e :: Unit))
+findKeys6 = findKeys (Proxy :: Proxy (a :: Unit))
+findKeys7 = findKeys (Proxy :: Proxy (a :: Unit, b :: Unit))
+findKeys8 = findKeys (Proxy :: Proxy (a :: Unit, b :: Unit, c :: Unit))
+findKeys9 = findKeys (Proxy :: Proxy (a :: Unit, b :: Unit, c :: Unit, d :: Unit))
+findKeys10 = findKeys (Proxy :: Proxy (a :: Unit, b :: Unit, c :: Unit, d :: Unit, e :: Unit))

--- a/tests/purs/optimize/Symbols.out.js
+++ b/tests/purs/optimize/Symbols.out.js
@@ -1,0 +1,68 @@
+import * as Data_Symbol from "../Data.Symbol/index.js";
+import * as Record_Unsafe from "../Record.Unsafe/index.js";
+import * as Type_Proxy from "../Type.Proxy/index.js";
+var fooIsSymbol = {
+    reflectSymbol: function () {
+        return "foo";
+    }
+};
+var set = function (dictIsSymbol) {
+    var reflectSymbol = Data_Symbol.reflectSymbol(dictIsSymbol);
+    return function () {
+        return function (l) {
+            return function (a) {
+                return function (r) {
+                    return Record_Unsafe.unsafeSet(reflectSymbol(l))(a)(r);
+                };
+            };
+        };
+    };
+};
+var set1 = /* #__PURE__ */ set(fooIsSymbol)();
+var get = function (dictIsSymbol) {
+    var reflectSymbol = Data_Symbol.reflectSymbol(dictIsSymbol);
+    return function () {
+        return function (l) {
+            return function (r) {
+                return Record_Unsafe.unsafeGet(reflectSymbol(l))(r);
+            };
+        };
+    };
+};
+var get1 = /* #__PURE__ */ get(fooIsSymbol)();
+var get2 = /* #__PURE__ */ get({
+    reflectSymbol: function () {
+        return "bar";
+    }
+})();
+var foo = /* #__PURE__ */ (function () {
+    return Type_Proxy["Proxy"].value;
+})();
+var h = function (n) {
+    return set1(foo)(n)({
+        foo: 0
+    });
+};
+var f = function (n) {
+    return get1(foo)({
+        foo: n
+    });
+};
+var bar = /* #__PURE__ */ (function () {
+    return Type_Proxy["Proxy"].value;
+})();
+var g = function (n) {
+    return get2(bar)({
+        foo: 0,
+        bar: n
+    });
+};
+export {
+    get,
+    set,
+    foo,
+    bar,
+    f,
+    g,
+    h
+};

--- a/tests/purs/optimize/Symbols.purs
+++ b/tests/purs/optimize/Symbols.purs
@@ -1,0 +1,40 @@
+module Main where
+
+import Data.Symbol (class IsSymbol, reflectSymbol)
+import Prim.Row (class Cons)
+import Record.Unsafe (unsafeGet, unsafeSet)
+import Type.Proxy (Proxy(..))
+
+get
+  :: forall r r' l a
+   . IsSymbol l
+  => Cons l a r' r
+  => Proxy l
+  -> Record r
+  -> a
+get l r = unsafeGet (reflectSymbol l) r
+
+set
+  :: forall r r' l a
+   . IsSymbol l
+  => Cons l a r' r
+  => Proxy l
+  -> a
+  -> Record r
+  -> Record r
+set l a r = unsafeSet (reflectSymbol l) a r
+
+foo :: Proxy "foo"
+foo = Proxy
+
+bar :: Proxy "bar"
+bar = Proxy
+
+f :: Int -> Int
+f n = get foo { foo: n }
+
+g :: Int -> Int
+g n = get bar { foo: 0, bar: n }
+
+h :: Int -> { foo :: Int }
+h n = set foo n { foo: 0 }

--- a/tests/purs/passing/CyclicInstances.purs
+++ b/tests/purs/passing/CyclicInstances.purs
@@ -1,0 +1,29 @@
+module Main where
+
+import Prelude
+
+import Data.Generic.Rep (class Generic)
+import Data.Show.Generic (genericShow)
+import Effect.Console (log)
+
+newtype A = A B
+derive newtype instance Show A
+data B = B C
+       | Z
+derive instance Generic B _
+instance Show B where show x = genericShow x
+newtype C = C A
+derive instance Generic C _
+instance Show C where show = genericShow
+
+newtype A2 = A2 { x :: B2 }
+derive newtype instance Show A2
+data B2 = B2 C2
+        | Z2
+derive instance Generic B2 _
+instance Show B2 where show x = genericShow x
+newtype C2 = C2 A2
+derive instance Generic C2 _
+instance Show C2 where show = genericShow
+
+main = log "Done"

--- a/tests/purs/passing/TCOFloated.purs
+++ b/tests/purs/passing/TCOFloated.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Prelude
+import Effect.Console (log)
+
+main = log (looper { foo: 100000 })
+
+-- The Ord instance for { foo :: Int } will be floated to an outer scope. This
+-- test verifies that TCO happens anyway.
+looper :: { foo :: Int } -> String
+looper x = if x <= { foo: 0 } then "Done" else looper { foo: x.foo - 1 }


### PR DESCRIPTION
This commit implements a common subexpression elimination pass during
CoreFn optimization. The optimizer only targets `App`s that the compiler
has created, meaning: applying functions to typeclass dictionaries,
accessing superclasses from a typeclass dictionary, or creating new
instances of `IsSymbol`. Furthermore, the pass only moves subexpressions
if they can be moved to an outer function or if the subexpression
appears more than once inside the scope to which it would be moved.

---

This is a start at what I'm told is the uncontroversial part of #687. Here's some before-and-after:

(before)
```js
var ap = function (dictMonad) {
    return function (f) {
        return function (a) {
            return Control_Bind.bind(dictMonad.Bind1())(f)(function (f$prime) {
                return Control_Bind.bind(dictMonad.Bind1())(a)(function (a$prime) {
                    return Control_Applicative.pure(dictMonad.Applicative0())(f$prime(a$prime));
                });
            });
        };
    };
};
```

(after)
```js
var ap = function (dictMonad) {
    var bind = Control_Bind.bind(dictMonad.Bind1());
    var pure = Control_Applicative.pure(dictMonad.Applicative0());
    return function (f) {
        return function (a) {
            return bind(f)(function (f$prime) {
                return bind(a)(function (a$prime) {
                    return pure(f$prime(a$prime));
                });
            });
        };
    };
};
```

I don't know many public PureScript projects that have sufficiently long-running automated tests to be suitable for benchmarking, but purescript-bytestrings is one. On that project, this patch (backported to the 0.13.x branch) increased total compilation time by about 2% and decreased test execution time by about 20%. I would be happy to run the same benchmarks on any other project you suggest.

In order to verify that the optimization happens, a new (small) suite of tests in `tests/purs/optimize` has been added. In this folder, `*.purs` files are compiled and the result is compared to the contents of the corresponding `.out.js` file. These tests are potentially more expensive than usual in terms of maintenance burden, because they are sensitive to any change in the compiled output, but they can be used to prevent regressions in optimizations that are too subtle to be tested by other means.