### PR TITLE
Bump version for 0.14.0-rc2

### DIFF
--- a/app/Version.hs
+++ b/app/Version.hs
@@ -12,8 +12,15 @@ import Paths_purescript as Paths
 import qualified Development.GitRev as GitRev
 #endif
 
+-- Unfortunately, Cabal doesn't support prerelease identifiers on versions. To
+-- avoid misleading users who run `purs --version`, we manually add the
+-- prerelease identifier here (if any). When releasing a proper version, simply
+-- set this to an empty string.
+prerelease :: String
+prerelease = "-rc2"
+
 versionString :: String
-versionString = showVersion Paths.version ++ extra
+versionString = showVersion Paths.version ++ prerelease ++ extra
   where
 #ifdef RELEASE
   extra = ""

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: purescript
-version: '0.13.8'
+version: '0.14.0-rc2' # note: when updating this, update the prerelease identifier in app/Version.hs too!
 synopsis: PureScript Programming Language Compiler
 description: A small strongly, statically typed programming language with expressive
   types, inspired by Haskell and compiling to JavaScript.


### PR DESCRIPTION
The rc1 I already tagged is no good, because I forgot to update the
version. That is particularly important for this release, because tools
like psa need to be able to know what version of the CLI they have
encountered in order to know whether to read from stdout or stderr if
they want to maintain compatibility with both 0.13.x and 0.14.x.