### PR TITLE
Check all recursive paths in data binding groups

### DIFF
--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -17,7 +17,8 @@ import Control.Monad.Error.Class (MonadError(..))
 
 import Data.Graph
 import Data.List (intersect)
-import Data.Maybe (isJust, mapMaybe)
+import Data.Foldable (find)
+import Data.Maybe (isJust, isNothing, mapMaybe)
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Set as S
 
@@ -94,7 +95,7 @@ createBindingGroups moduleName = mapM f <=< handleDecls
                 | otherwise = []
           in (d, (name, vty), self ++ deps)
         dataVerts = fmap mkVert allDecls
-    dataBindingGroupDecls <- parU (stronglyConnComp dataVerts) toDataBindingGroup
+    dataBindingGroupDecls <- parU (stronglyConnCompR dataVerts) toDataBindingGroup
     let allIdents = fmap valdeclIdent values
         valueVerts = fmap (\d -> (d, valdeclIdent d, usedIdents moduleName d `intersect` allIdents)) values
     bindingGroupDecls <- parU (stronglyConnComp valueVerts) (toBindingGroup moduleName)
@@ -224,20 +225,35 @@ toBindingGroup moduleName (CyclicSCC ds') = do
 
 toDataBindingGroup
   :: MonadError MultipleErrors m
-  => SCC Declaration
+  => SCC (Declaration, (ProperName 'TypeName, VertexType), [(ProperName 'TypeName, VertexType)])
   -> m Declaration
-toDataBindingGroup (AcyclicSCC d) = return d
-toDataBindingGroup (CyclicSCC [d]) = case isTypeSynonym d of
+toDataBindingGroup (AcyclicSCC (d, _, _)) = return d
+toDataBindingGroup (CyclicSCC [(d, _, _)]) = case isTypeSynonym d of
   Just pn -> throwError . errorMessage' (declSourceSpan d) $ CycleInTypeSynonym (Just pn)
   _ -> return d
 toDataBindingGroup (CyclicSCC ds')
-  | all (isJust . isTypeSynonym) ds' = throwError . errorMessage' (declSourceSpan (head ds')) $ CycleInTypeSynonym Nothing
-  | kds@((ss, _):_) <- concatMap kindDecl ds' = throwError . errorMessage' ss . CycleInKindDeclaration $ fmap snd kds
-  | otherwise = return . DataBindingGroupDeclaration $ NEL.fromList ds'
+  | kds@((ss, _):_) <- concatMap (kindDecl . getDecl) ds' = throwError . errorMessage' ss . CycleInKindDeclaration $ fmap snd kds
+  | isNothing . depsTerminate [] [] $ getName <$> ds' = throwError . errorMessage' (declSourceSpan (getDecl (head ds'))) $ CycleInTypeSynonym Nothing
+  | otherwise = return . DataBindingGroupDeclaration . NEL.fromList $ getDecl <$> ds'
   where
   kindDecl (KindDeclaration sa _ pn _) = [(fst sa, Qualified Nothing pn)]
   kindDecl (ExternDataDeclaration sa pn _) = [(fst sa, Qualified Nothing pn)]
   kindDecl _ = []
+
+  getDecl (decl, _, _) = decl
+  getName (_, name, _) = name
+  lookupVert name = find ((==) name . getName) ds'
+
+  depsTerminate seen _ [] = Just seen
+  depsTerminate seen stop (n : ns)
+    | n `elem` seen = depsTerminate seen stop ns
+    | n `elem` stop = Nothing
+    | Just (decl, _, deps) <- lookupVert n
+    , isJust $ isTypeSynonym decl = do
+        seen' <- depsTerminate seen (n : stop) deps
+        depsTerminate (n : seen') stop ns
+    | otherwise =
+        depsTerminate (n : seen) stop ns
 
 isTypeSynonym :: Declaration -> Maybe (ProperName 'TypeName)
 isTypeSynonym (TypeSynonymDeclaration _ pn _ _) = Just pn

--- a/tests/purs/failing/InfiniteKind2.out
+++ b/tests/purs/failing/InfiniteKind2.out
@@ -10,7 +10,7 @@ at tests/purs/failing/InfiniteKind2.purs:5:23 - 5:27 (line 5, column 23 - line 5
 while checking that type [33mTree[0m
   has kind [33mt0[0m
 while inferring the kind of [33mm Tree[0m
-in type constructor [33mTree[0m
+in data binding group Tree
 
 where [33mt0[0m is an unknown type
 

--- a/tests/purs/failing/TypeSynonyms.out
+++ b/tests/purs/failing/TypeSynonyms.out
@@ -1,7 +1,10 @@
 Error found:
 at tests/purs/failing/TypeSynonyms.purs:6:1 - 6:19 (line 6, column 1 - line 6, column 19)
 
-  A cycle appears in a set of type synonym definitions.
+   A cycle appears in a set of type synonym definitions:
+
+    {[33mT1[0m, [33mT2[0m}
+
   Cycles are disallowed because they can lead to loops in the type checker.
   Consider using a 'newtype' instead.
 

--- a/tests/purs/failing/TypeSynonyms6.out
+++ b/tests/purs/failing/TypeSynonyms6.out
@@ -1,0 +1,11 @@
+Error found:
+at tests/purs/failing/TypeSynonyms6.purs:4:1 - 4:11 (line 4, column 1 - line 4, column 11)
+
+  A cycle appears in a set of type synonym definitions.
+  Cycles are disallowed because they can lead to loops in the type checker.
+  Consider using a 'newtype' instead.
+
+
+See https://github.com/purescript/documentation/blob/master/errors/CycleInTypeSynonym.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/TypeSynonyms6.out
+++ b/tests/purs/failing/TypeSynonyms6.out
@@ -1,7 +1,10 @@
 Error found:
 at tests/purs/failing/TypeSynonyms6.purs:4:1 - 4:11 (line 4, column 1 - line 4, column 11)
 
-  A cycle appears in a set of type synonym definitions.
+   A cycle appears in a set of type synonym definitions:
+
+    {[33mA[0m, [33mB[0m}
+
   Cycles are disallowed because they can lead to loops in the type checker.
   Consider using a 'newtype' instead.
 

--- a/tests/purs/failing/TypeSynonyms6.purs
+++ b/tests/purs/failing/TypeSynonyms6.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith CycleInTypeSynonym
+module Main where
+
+type A = B
+type B = { a :: A, b :: Loop }
+data Loop = Loop B


### PR DESCRIPTION
This changes the data binding group check to follow all dependency paths, looking for loops in synonyms.

Fixes #3918