### PR TITLE
Update to GHC 8.8.4

### DIFF
--- a/lib/purescript-ast/package.yaml
+++ b/lib/purescript-ast/package.yaml
@@ -19,7 +19,7 @@ extra-source-files:
   - README.md
 dependencies:
   - aeson >=1.0 && <1.5
-  - base >=4.11 && <4.13
+  - base >=4.11 && <4.14
   - base-compat >=0.6.0
   - bytestring
   - containers
@@ -27,7 +27,7 @@ dependencies:
   - filepath
   - microlens >=0.4.10 && <0.5
   - mtl >=2.1.0 && <2.3.0
-  - protolude >=0.1.6 && <0.2.4
+  - protolude >=0.1.6 && <0.2.5
   - scientific >=0.3.4.9 && <0.4
   - serialise
   - text

--- a/lib/purescript-cst/package.yaml
+++ b/lib/purescript-cst/package.yaml
@@ -21,15 +21,15 @@ extra-source-files:
   - README.md
 dependencies:
   - array
-  - base >=4.11 && <4.13
+  - base >=4.11 && <4.14
   - containers
   - dlist
   - purescript-ast
   - scientific >=0.3.4.9 && <0.4
-  - semigroups >=0.16.2 && <0.19
+  - semigroups >=0.16.2 && <0.20
   - text
 build-tools:
-  - happy ==1.19.9
+  - happy ==1.20.0
 
 library:
   source-dirs: src

--- a/lib/purescript-cst/tests/TestCst.hs
+++ b/lib/purescript-cst/tests/TestCst.hs
@@ -73,9 +73,9 @@ readTok' failMsg t = case CST.lex t of
   Right tok : _ ->
     pure tok
   Left (_, err) : _ ->
-    fail $ failMsg <> ": " <> CST.prettyPrintError err
+    error $ failMsg <> ": " <> CST.prettyPrintError err
   [] ->
-    fail "Empty token stream"
+    error "Empty token stream"
 
 readTok :: Text -> Gen SourceToken
 readTok = readTok' "Failed to parse"
@@ -89,7 +89,7 @@ checkTok p f t = do
   SourceToken _ tok <- readTok t
   case f tok of
     Just a  -> p t a
-    Nothing -> fail $ "Failed to lex correctly: " <> show tok
+    Nothing -> error $ "Failed to lex correctly: " <> show tok
 
 roundTripTok :: Text -> Gen Bool
 roundTripTok t = do
@@ -106,7 +106,7 @@ checkReadNum t a = do
       chs' -> chs'
   case (== a) <$> readMaybe chs of
     Just a' -> pure a'
-    Nothing -> fail "Failed to `read`"
+    Nothing -> error "Failed to `read`"
 
 newtype PSSourceInt = PSSourceInt { unInt :: Text }
   deriving (Show, Eq)

--- a/package.yaml
+++ b/package.yaml
@@ -41,15 +41,15 @@ dependencies:
   - aeson >=1.0 && <1.5
   - aeson-better-errors >=0.8
   - aeson-pretty
-  - ansi-terminal >=0.7.1 && <0.9
+  - ansi-terminal >=0.7.1 && <0.11
   - array
-  - base >=4.11 && <4.13
+  - base >=4.11 && <4.14
   - base-compat >=0.6.0
   - blaze-html >=0.8.1 && <0.10
   - bower-json >=1.0.0.1 && <1.1
   - boxes >=0.1.4 && <0.2.0
   - bytestring
-  - Cabal >= 2.2 && <3.0
+  - Cabal >= 2.2 && <3.5
   - cborg
   - serialise
   - cheapskate >=0.1 && <0.2
@@ -63,13 +63,13 @@ dependencies:
   - file-embed
   - filepath
   - fsnotify >=0.2.1
-  - Glob >=0.9 && <0.10
+  - Glob >=0.9 && <0.11
   - haskeline >=0.7.0.0 && <0.8.0.0
   - language-javascript ==0.7.0.0 # important: keep this pinned to a single specific version, since it's effectively part of the compiler's public API.
-  - lifted-async >=0.10.0.3 && <0.10.1
+  - lifted-async >=0.10.0.3 && <0.11
   - lifted-base >=0.2.3 && <0.2.4
-  - memory >=0.14 && <0.15
-  - microlens-platform >=0.3.9.0 && <0.4
+  - memory >=0.14 && <0.16
+  - microlens-platform >=0.3.9.0 && <0.5
   - monad-control >=1.0.0.0 && <1.1
   - monad-logger >=0.3 && <0.4
   - mtl >=2.1.0 && <2.3.0
@@ -77,12 +77,12 @@ dependencies:
   - parsec >=3.1.10
   - pattern-arrows >=0.0.2 && <0.1
   - process >=1.2.0 && <1.7
-  - protolude >=0.1.6 && <0.2.4
+  - protolude >=0.1.6 && <0.2.5
   - purescript-ast
   - purescript-cst
   - regex-tdfa
   - safe >=0.3.9 && <0.4
-  - semigroups >=0.16.2 && <0.19
+  - semigroups >=0.16.2 && <0.20
   - semialign >=1 && <1.1
   - sourcemap >=0.1.6
   - split
@@ -99,7 +99,7 @@ dependencies:
   - utf8-string >=1 && <2
   - vector
 build-tools:
-  - happy ==1.19.9
+  - happy ==1.20.0
 
 library:
   source-dirs: src

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -6,7 +6,7 @@ module Language.PureScript.Docs.Types
   )
   where
 
-import Protolude hiding (to, from)
+import Protolude hiding (to, from, unlines)
 import Prelude (String, unlines, lookup)
 
 import GHC.Generics (Generic)

--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -19,7 +19,7 @@ module Language.PureScript.Publish
   , getModules
   ) where
 
-import Protolude hiding (stdin)
+import Protolude hiding (stdin, lines)
 
 import Control.Arrow ((***))
 import Control.Category ((>>>))
@@ -36,7 +36,7 @@ import Data.Time.Clock (UTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Data.Version
 import qualified Distribution.SPDX as SPDX
-import qualified Distribution.Parsec.Class as CabalParsec
+import qualified Distribution.Parsec as CabalParsec
 
 import System.Directory (doesFileExist)
 import System.FilePath.Glob (globDir1)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.26
+resolver: lts-16.17
 pvp-bounds: upper
 packages:
 - '.'
@@ -7,7 +7,7 @@ packages:
 extra-deps:
 - serialise-0.2.2.0
 - cborg-0.2.2.0
-- happy-1.19.9
+- happy-1.20.0
 - language-javascript-0.7.0.0
 - network-3.0.1.1
 - these-1.0.1


### PR DESCRIPTION
Bumps snapshot, upper bounds and fixes (little amount of) breakage introduced by new versions of libraries. In case of `lib/purescript-cst/tests/TestCst.hs`, I've replaced use of `fail` with `error`, because new version of `Gen` doesn't seem to provide `MonadFail` or some other error reporting functionality (it seems like old `Monad.fail` deferred to default implementation anyway).

- [x] `stack build` works
- [x] `stack run` works
- [x] `stack test` passes


(To add some motivation, I'm trying to build `purescript` with `asterius` which is currently on `8.8.4`)