### PR TITLE
Update the desugaring pipeline to work on individual modules

### DIFF
--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -39,10 +39,8 @@ convertModule ::
   P.Environment ->
   P.Module ->
   m Module
-convertModule externs env checkEnv m =
-  partiallyDesugar externs env [m] >>= \case
-    [m'] -> pure (insertValueTypes checkEnv (convertSingleModule m'))
-    _ -> P.internalError "partiallyDesugar did not return a singleton"
+convertModule externs env checkEnv =
+  fmap (insertValueTypes checkEnv . convertSingleModule) . partiallyDesugar externs env
 
 -- |
 -- Updates all the types of the ValueDeclarations inside the module based on
@@ -90,16 +88,16 @@ partiallyDesugar ::
   (MonadError P.MultipleErrors m) =>
   [P.ExternsFile] ->
   P.Env ->
-  [P.Module] ->
-  m [P.Module]
+  P.Module ->
+  m P.Module
 partiallyDesugar externs env = evalSupplyT 0 . desugar'
   where
   desugar' =
-    traverse P.desugarDoModule
-      >=> traverse P.desugarAdoModule
-      >=> map P.desugarLetPatternModule
-      >>> traverse P.desugarCasesModule
-      >=> traverse P.desugarTypeDeclarationsModule
+    P.desugarDoModule
+      >=> P.desugarAdoModule
+      >=> P.desugarLetPatternModule
+      >>> P.desugarCasesModule
+      >=> P.desugarTypeDeclarationsModule
       >=> fmap fst . runWriterT . flip evalStateT (env, mempty) . P.desugarImports
       >=> P.rebracketFiltered isInstanceDecl externs
 

--- a/src/Language/PureScript/Interactive/Types.hs
+++ b/src/Language/PureScript/Interactive/Types.hs
@@ -120,7 +120,7 @@ psciImportedModuleNames st =
 -- ensure that completions remain accurate.
 updateImportExports :: PSCiState -> PSCiState
 updateImportExports st@(PSCiState modules lets externs iprint _ _) =
-  case createEnv (map snd externs) >>= flip desugarModule [temporaryModule] of
+  case createEnv (map snd externs) >>= flip desugarModule temporaryModule of
     Left _          -> st -- TODO: can this fail and what should we do?
     Right env  ->
       case M.lookup temporaryName env of
@@ -128,7 +128,7 @@ updateImportExports st@(PSCiState modules lets externs iprint _ _) =
         _                 -> st -- impossible
   where
 
-  desugarModule :: P.Env -> [P.Module] -> Either P.MultipleErrors P.Env
+  desugarModule :: P.Env -> P.Module -> Either P.MultipleErrors P.Env
   desugarModule e = runExceptT =<< fmap (fst . fst) . runWriterT . flip execStateT (e, mempty) . P.desugarImports
 
   createEnv :: [P.ExternsFile] -> Either P.MultipleErrors P.Env

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -10,15 +10,10 @@ import Control.Monad.Supply.Class (MonadSupply)
 import Control.Monad.State.Class (MonadState)
 import Control.Monad.Writer.Class (MonadWriter)
 
-import Data.List (map)
-import Data.Traversable (traverse)
-import Data.Map (Map)
-
 import Language.PureScript.AST
 import Language.PureScript.Errors
 import Language.PureScript.Externs
 import Language.PureScript.Linter.Imports
-import Language.PureScript.Names
 import Language.PureScript.Sugar.BindingGroups as S
 import Language.PureScript.Sugar.CaseDeclarations as S
 import Language.PureScript.Sugar.DoNotation as S
@@ -60,21 +55,21 @@ desugar
   :: MonadSupply m
   => MonadError MultipleErrors m
   => MonadWriter MultipleErrors m
-  => MonadState (Env, Map ModuleName UsedImports) m
+  => MonadState (Env, UsedImports) m
   => [ExternsFile]
-  -> [Module]
-  -> m [Module]
+  -> Module
+  -> m Module
 desugar externs =
-  map desugarSignedLiterals
-    >>> traverse desugarObjectConstructors
-    >=> traverse desugarDoModule
-    >=> traverse desugarAdoModule
-    >=> map desugarLetPatternModule
-    >>> traverse desugarCasesModule
-    >=> traverse desugarTypeDeclarationsModule
+  desugarSignedLiterals
+    >>> desugarObjectConstructors
+    >=> desugarDoModule
+    >=> desugarAdoModule
+    >=> desugarLetPatternModule
+    >>> desugarCasesModule
+    >=> desugarTypeDeclarationsModule
     >=> desugarImports
     >=> rebracket externs
-    >=> traverse checkFixityExports
-    >=> traverse (deriveInstances externs)
+    >=> checkFixityExports
+    >=> deriveInstances externs
     >=> desugarTypeClasses externs
-    >=> traverse createBindingGroupsModule
+    >=> createBindingGroupsModule

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -44,9 +44,9 @@ type Desugar = StateT MemberMap
 desugarTypeClasses
   :: (MonadSupply m, MonadError MultipleErrors m)
   => [ExternsFile]
-  -> [Module]
-  -> m [Module]
-desugarTypeClasses externs = flip evalStateT initialState . traverse desugarModule
+  -> Module
+  -> m Module
+desugarTypeClasses externs = flip evalStateT initialState . desugarModule
   where
   initialState :: MemberMap
   initialState =


### PR DESCRIPTION
Since 6d1b5ec3af12812810701b766a12f7c9aceabe75, `Language.PureScript.Sugar.desugar` is always applied to singleton arrays so this simplifies a few things.