### PR TITLE
Add source span to PartiallyAppliedSynonym errors

### DIFF
--- a/tests/purs/failing/InvalidDerivedInstance3.out
+++ b/tests/purs/failing/InvalidDerivedInstance3.out
@@ -1,11 +1,9 @@
 Error found:
-in module [33mTypeSynonyms4[0m
-at tests/purs/failing/TypeSynonyms4.purs:8:12 - 8:15 (line 8, column 12 - line 8, column 15)
+at tests/purs/failing/InvalidDerivedInstance3.purs:8:15 - 8:16 (line 8, column 15 - line 8, column 16)
 
-  Type synonym [33mTypeSynonyms4.F[0m is partially applied.
+  Type synonym [33mMain.S[0m is partially applied.
   Type synonyms must be applied to all of their type arguments.
 
-in type synonym [33mG[0m
 
 See https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/InvalidDerivedInstance3.purs
+++ b/tests/purs/failing/InvalidDerivedInstance3.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith PartiallyAppliedSynonym
+module Main where
+
+import Data.Newtype (class Newtype)
+
+data D a
+type S a = D a
+newtype N = N S
+
+derive instance newtypeN :: Newtype N _


### PR DESCRIPTION
An alternative to #3950; fixes #3949.

Advantages: it's a smaller change, and the error message location is more correct.

Disadvantages: ???