### PR TITLE
Improve error message when `negate` isn't imported

### DIFF
--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -725,6 +725,8 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       line $ "The value " <> markCode (showIdent name) <> " has been defined multiple times"
     renderSimpleErrorMessage (UnknownName name@(Qualified Nothing (IdentName (Ident i)))) | i `elem` [ C.bind, C.discard ] =
       line $ "Unknown " <> printName name <> ". You're probably using do-notation, which the compiler replaces with calls to the " <> markCode i <> " function. Please import " <> markCode i <> " from module " <> markCode "Prelude"
+    renderSimpleErrorMessage (UnknownName name@(Qualified Nothing (IdentName (Ident i)))) | i == C.negate =
+      line $ "Unknown " <> printName name <> ". You're probably using numeric negation (the unary " <> markCode "-" <> " operator), which the compiler replaces with calls to the " <> markCode i <> " function. Please import " <> markCode i <> " from module " <> markCode "Prelude"
     renderSimpleErrorMessage (UnknownName name) =
       line $ "Unknown " <> printName name
     renderSimpleErrorMessage (UnknownImport mn name) =

--- a/tests/purs/failing/2109-bind.out
+++ b/tests/purs/failing/2109-bind.out
@@ -1,0 +1,10 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/2109-bind.purs:8:3 - 8:14 (line 8, column 3 - line 8, column 14)
+
+  Unknown value [33mbind[0m. You're probably using do-notation, which the compiler replaces with calls to the [33mbind[0m function. Please import [33mbind[0m from module [33mPrelude[0m
+
+
+See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/2109-bind.purs
+++ b/tests/purs/failing/2109-bind.purs
@@ -1,0 +1,9 @@
+-- @shouldFailWith UnknownName
+module Main where
+
+import Data.Maybe (Maybe(..))
+import Prelude (pure)
+
+x = do
+  x <- Just 1
+  pure x

--- a/tests/purs/failing/2109-discard.out
+++ b/tests/purs/failing/2109-discard.out
@@ -1,0 +1,10 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/2109-discard.purs:7:3 - 7:12 (line 7, column 3 - line 7, column 12)
+
+  Unknown value [33mdiscard[0m. You're probably using do-notation, which the compiler replaces with calls to the [33mdiscard[0m function. Please import [33mdiscard[0m from module [33mPrelude[0m
+
+
+See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/2109-discard.purs
+++ b/tests/purs/failing/2109-discard.purs
@@ -1,0 +1,8 @@
+-- @shouldFailWith UnknownName
+module Main where
+
+import Prelude (unit, pure)
+
+main = do
+  pure unit
+  pure unit

--- a/tests/purs/failing/2109-negate.out
+++ b/tests/purs/failing/2109-negate.out
@@ -1,0 +1,10 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/2109-negate.purs:4:5 - 4:7 (line 4, column 5 - line 4, column 7)
+
+  Unknown value [33mnegate[0m. You're probably using numeric negation (the unary [33m-[0m operator), which the compiler replaces with calls to the [33mnegate[0m function. Please import [33mnegate[0m from module [33mPrelude[0m
+
+
+See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/2109-negate.purs
+++ b/tests/purs/failing/2109-negate.purs
@@ -1,0 +1,4 @@
+-- @shouldFailWith UnknownName
+module Main where
+
+x = -5


### PR DESCRIPTION
Fixes #2109.

Also added tests for `bind` and `discard`. If they are unwanted, I'll remove them.