### PR TITLE
Fix #3953

### DIFF
--- a/lib/purescript-cst/src/Language/PureScript/CST/Layout.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Layout.hs
@@ -313,6 +313,9 @@ insertLayout src@(SourceToken tokAnn tok) nextPos stack =
     TokLowerName [] _ ->
       state & insertDefault & popStack (== LytProperty)
 
+    TokNegate ->
+      state & collapse offsideEndP & insertSep & insertToken src
+
     TokOperator _ _ ->
       state & collapse offsideEndP & insertSep & insertToken src
 

--- a/lib/purescript-cst/src/Language/PureScript/CST/Lexer.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Lexer.hs
@@ -12,7 +12,7 @@ import Control.Monad (join)
 import qualified Data.Char as Char
 import qualified Data.DList as DList
 import Data.Foldable (foldl')
-import Data.Functor (($>))
+import Data.Functor (($>), (<&>))
 import qualified Data.Scientific as Sci
 import Data.String (fromString)
 import Data.Text (Text)
@@ -328,7 +328,11 @@ token = peek >>= maybe (pure TokEof) k0
   operator :: [Text] -> [Char] -> Lexer Token
   operator qual pre = do
     rest <- nextWhile isSymbolChar
-    pure . TokOperator (reverse qual) $ Text.pack pre <> rest
+    if null qual && pre == "-" && Text.null rest
+    then peek <&> \case
+      Just ch | isDigitChar ch -> TokNegate
+      _                        -> TokOperator [] "-"
+    else pure . TokOperator (reverse qual) $ Text.pack pre <> rest
 
   {-
     moduleName

--- a/lib/purescript-cst/src/Language/PureScript/CST/Positions.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Positions.hs
@@ -50,6 +50,7 @@ tokenDelta = \case
   TokBackslash             -> (0, 1)
   TokLowerName qual name   -> (0, qualDelta qual + Text.length name)
   TokUpperName qual name   -> (0, qualDelta qual + Text.length name)
+  TokNegate                -> (0, 1)
   TokOperator qual sym     -> (0, qualDelta qual + Text.length sym)
   TokSymbolName qual sym   -> (0, qualDelta qual + Text.length sym + 2)
   TokSymbolArr Unicode     -> (0, 3)

--- a/lib/purescript-cst/src/Language/PureScript/CST/Print.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Print.hs
@@ -50,6 +50,7 @@ printToken' showLayout = \case
   TokBackslash             -> "\\"
   TokLowerName qual name   -> printQual qual <> name
   TokUpperName qual name   -> printQual qual <> name
+  TokNegate                -> "-"
   TokOperator qual sym     -> printQual qual <> sym
   TokSymbolName qual sym   -> printQual qual <> "(" <> sym <> ")"
   TokSymbolArr Unicode     -> "(→)"

--- a/lib/purescript-cst/src/Language/PureScript/CST/Types.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Types.hs
@@ -66,6 +66,7 @@ data Token
   | TokBackslash
   | TokLowerName ![Text] !Text
   | TokUpperName ![Text] !Text
+  | TokNegate -- Only used for '-' when it immediately precedes a digit. TokOperators may end up being negations as well.
   | TokOperator ![Text] !Text
   | TokSymbolName ![Text] !Text
   | TokSymbolArr !SourceStyle

--- a/lib/purescript-cst/src/Language/PureScript/CST/Utils.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Utils.hs
@@ -146,6 +146,7 @@ toQualifiedName k tok = case tokValue tok of
     | otherwise -> addFailure [tok] ErrKeywordVar $> QualifiedName tok Nothing (k "<unexpected>")
   TokUpperName q a  -> flip (QualifiedName tok) (k a) <$> toModuleName tok q
   TokSymbolName q a -> flip (QualifiedName tok) (k a) <$> toModuleName tok q
+  TokNegate         -> pure (QualifiedName tok Nothing (k "-"))
   TokOperator q a   -> flip (QualifiedName tok) (k a) <$> toModuleName tok q
   _                 -> internalError $ "Invalid qualified name: " <> show tok
 
@@ -158,6 +159,7 @@ toName k tok = case tokValue tok of
   TokRawString _ -> parseFail tok ErrQuotedPun
   TokUpperName [] a  -> pure $ Name tok (k a)
   TokSymbolName [] a -> pure $ Name tok (k a)
+  TokNegate          -> pure $ Name tok (k "-")
   TokOperator [] a   -> pure $ Name tok (k a)
   TokHole a          -> pure $ Name tok (k a)
   _                  -> internalError $ "Invalid name: " <> show tok

--- a/tests/purs/passing/MinusConstructor.purs
+++ b/tests/purs/passing/MinusConstructor.purs
@@ -1,0 +1,28 @@
+module Main where
+
+import Prelude
+
+import Effect.Console (log)
+import Test.Assert (assert)
+
+data Tuple a b = Tuple a b
+
+infixl 6 Tuple as -
+
+test1 =
+  let tuple = "" - ""
+      left - right = tuple
+  in left
+
+test2 = case 3 - 4 of
+  left-4 -> left
+  _ -> 0
+
+test3 (Tuple a b - c) = a
+test3 _ = 0
+
+main = do
+  assert $ test1 == ""
+  assert $ test2 == 3
+  assert $ test3 (5-10-15) == 5
+  log "Done"


### PR DESCRIPTION
This commit resolves a grammar conflict between the rule allowing
negative numbers to be atomic binders (so that, e.g., `foo -1 = True` is
a valid partial function declaration) and the rule allowing the minus
sign to be an operator separating binders.

The total number of conflicts in the grammar increases by one with this
commit, but what is actually happening is that a state that previously
had one conflict is now conflict-free, and two states that already had
conflicts involving the token '-' now have one extra conflict each. The
extra conflicts aren't conceptually new, though; those states correspond
to productions where a rule containing '-' was duplicated with OP_NEGATE
replacing '-'. So despite the %expect number increasing, I consider this
a net decrease in the conflicted-ness of the grammar.

Fixes #3953.