### PR TITLE
Unsupport bare negative literals as equational binders

### DIFF
--- a/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
@@ -35,7 +35,7 @@ import qualified Language.PureScript.Roles as R
 import Language.PureScript.PSString (PSString)
 }
 
-%expect 95
+%expect 93
 
 %name parseType type
 %name parseExpr expr
@@ -570,6 +570,7 @@ binder1 :: { Binder () }
 
 binder2 :: { Binder () }
   : many(binderAtom) {% toBinderConstructor $1 }
+  | '-' number { uncurry (BinderNumber () (Just $1)) $2 }
 
 binderAtom :: { Binder () }
   : '_' { BinderWildcard () $1 }
@@ -580,7 +581,6 @@ binderAtom :: { Binder () }
   | char { uncurry (BinderChar ()) $1 }
   | string { uncurry (BinderString ()) $1 }
   | number { uncurry (BinderNumber () Nothing) $1 }
-  | '-' number { uncurry (BinderNumber () (Just $1)) $2 }
   | delim('[', binder, ',', ']') { BinderArray () $1 }
   | delim('{', recordBinder, ',', '}') { BinderRecord () $1 }
   | '(' binder ')' { BinderParens () (Wrapped $1 $2 $3) }

--- a/tests/purs/passing/MinusConstructor.purs
+++ b/tests/purs/passing/MinusConstructor.purs
@@ -1,0 +1,38 @@
+module Main where
+
+import Prelude
+
+import Effect.Console (log)
+import Test.Assert (assert)
+
+data Tuple a b = Tuple a b
+
+infixl 6 Tuple as -
+
+test1 =
+  let tuple = "" - ""
+      left - right = tuple
+  in left
+
+test2 = case 3 - 4 of
+  left-4 -> left
+  _ -> 0
+
+test3 (Tuple a b - c) = a
+test3 _ = 0
+
+test4 = case 7 - -3 of
+  left - -3 -> left
+  _ -> 0
+
+test5 = case -7 - 8 of
+  -7-right -> right
+  _ -> 0
+
+main = do
+  assert $ test1 == ""
+  assert $ test2 == 3
+  assert $ test3 (5-10-15) == 5
+  assert $ test4 == 7
+  assert $ test5 == 8
+  log "Done"

--- a/tests/purs/passing/NegativeBinder.purs
+++ b/tests/purs/passing/NegativeBinder.purs
@@ -4,7 +4,12 @@ import Prelude
 import Effect.Console (log)
 
 test :: Number -> Boolean
-test -1.0 = false
+test (-1.0) = false
 test _  = true
+
+test2 :: Number -> Number -> Boolean
+test2 x y = case x, y of
+  -1.0, -1.0 -> false
+  _, _ -> true
 
 main = log "Done"


### PR DESCRIPTION
This is a breaking change. The syntax

    foo -1 = ...

as part of an equational definition, either at top-level or in a
let-binding, is no longer supported. The fix is to wrap the negation in
parentheses, as one would for an expression:

    foo (-1) = ...

This enables using `-` as a constructor operator in binders.

Fixes #3953.