### PR TITLE
Support TCO for functions with tail-recursive inner functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Breaking changes:
 
 New features:
 
+* Support TCO for functions with tail-recursive inner functions (#3958, @rhendric)
+
+  Adds support for optimizing functions that contain local functions which call
+  the outer function in tail position, as long as those functions themselves
+  are only called from tail position, either in the outer function or in other
+  such functions.
+
+  This enables hand-written mutually-tail-recursive function groups to be
+  optimized, but more critically, it also means that case guards which desugar
+  to use local functions don't break TCO.
+
 Bugfixes:
 
 Other improvements:

--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -3,7 +3,13 @@ module Language.PureScript.CoreImp.Optimizer.TCO (tco) where
 
 import Prelude.Compat
 
-import Data.Text (Text)
+import Control.Applicative (empty, liftA2)
+import Control.Monad (guard)
+import Control.Monad.State (State, evalState, get, modify)
+import Data.Foldable (foldr)
+import Data.Functor (($>), (<&>))
+import qualified Data.Set as S
+import Data.Text (Text, pack)
 import qualified Language.PureScript.Constants.Prim as C
 import Language.PureScript.CoreImp.AST
 import Language.PureScript.AST.SourcePos (SourceSpan)
@@ -11,15 +17,16 @@ import Safe (headDef, tailSafe)
 
 -- | Eliminate tail calls
 tco :: AST -> AST
-tco = everywhere convert where
+tco = flip evalState 0 . everywhereTopDownM convert where
   tcoVar :: Text -> Text
   tcoVar arg = "$tco_var_" <> arg
 
   copyVar :: Text -> Text
   copyVar arg = "$copy_" <> arg
 
-  tcoDone :: Text
-  tcoDone = "$tco_done"
+  tcoDoneM :: State Int Text
+  tcoDoneM = get <&> \count -> "$tco_done" <>
+    if count == 0 then "" else pack . show $ count
 
   tcoLoop :: Text
   tcoLoop = "$tco_loop"
@@ -27,63 +34,135 @@ tco = everywhere convert where
   tcoResult :: Text
   tcoResult = "$tco_result"
 
-  convert :: AST -> AST
+  convert :: AST -> State Int AST
   convert (VariableIntroduction ss name (Just fn@Function {}))
-      | isTailRecursive name body'
-      = VariableIntroduction ss name (Just (replace (toLoop name outerArgs innerArgs body')))
+      | Just trFns <- findTailRecursiveFns name arity body'
+      = VariableIntroduction ss name . Just . replace <$> toLoop trFns name arity outerArgs innerArgs body'
     where
       innerArgs = headDef [] argss
       outerArgs = concat . reverse $ tailSafe argss
-      (argss, body', replace) = collectAllFunctionArgs [] id fn
-  convert js = js
+      arity = length argss
+      -- ^ this is the number of calls, not the number of arguments, if there's
+      -- ever a practical difference.
+      (argss, body', replace) = topCollectAllFunctionArgs [] id fn
+  convert js = pure js
 
-  collectAllFunctionArgs :: [[Text]] -> (AST -> AST) -> AST -> ([[Text]], AST, AST -> AST)
-  collectAllFunctionArgs allArgs f (Function s1 ident args (Block s2 (body@(Return _ _):_))) =
-    collectAllFunctionArgs (args : allArgs) (\b -> f (Function s1 ident (map copyVar args) (Block s2 [b]))) body
-  collectAllFunctionArgs allArgs f (Function ss ident args body@(Block _ _)) =
-    (args : allArgs, body, f . Function ss ident (map copyVar args))
-  collectAllFunctionArgs allArgs f (Return s1 (Function s2 ident args (Block s3 [body]))) =
-    collectAllFunctionArgs (args : allArgs) (\b -> f (Return s1 (Function s2 ident (map copyVar args) (Block s3 [b])))) body
-  collectAllFunctionArgs allArgs f (Return s1 (Function s2 ident args body@(Block _ _))) =
-    (args : allArgs, body, f . Return s1 . Function s2 ident (map copyVar args))
-  collectAllFunctionArgs allArgs f body = (allArgs, body, f)
+  rewriteFunctionsWith :: ([Text] -> [Text]) -> [[Text]] -> (AST -> AST) -> AST -> ([[Text]], AST, AST -> AST)
+  rewriteFunctionsWith argMapper = collectAllFunctionArgs
+    where
+    collectAllFunctionArgs allArgs f (Function s1 ident args (Block s2 (body@(Return _ _):_))) =
+      collectAllFunctionArgs (args : allArgs) (\b -> f (Function s1 ident (argMapper args) (Block s2 [b]))) body
+    collectAllFunctionArgs allArgs f (Function ss ident args body@(Block _ _)) =
+      (args : allArgs, body, f . Function ss ident (argMapper args))
+    collectAllFunctionArgs allArgs f (Return s1 (Function s2 ident args (Block s3 [body]))) =
+      collectAllFunctionArgs (args : allArgs) (\b -> f (Return s1 (Function s2 ident (argMapper args) (Block s3 [b])))) body
+    collectAllFunctionArgs allArgs f (Return s1 (Function s2 ident args body@(Block _ _))) =
+      (args : allArgs, body, f . Return s1 . Function s2 ident (argMapper args))
+    collectAllFunctionArgs allArgs f body = (allArgs, body, f)
 
-  isTailRecursive :: Text -> AST -> Bool
-  isTailRecursive ident js = countSelfReferences js > 0 && allInTailPosition js where
-    countSelfReferences = everything (+) match where
-      match :: AST -> Int
-      match (Var _ ident') | ident == ident' = 1
-      match _ = 0
+  topCollectAllFunctionArgs :: [[Text]] -> (AST -> AST) -> AST -> ([[Text]], AST, AST -> AST)
+  topCollectAllFunctionArgs = rewriteFunctionsWith (map copyVar)
+
+  innerCollectAllFunctionArgs :: [[Text]] -> (AST -> AST) -> AST -> ([[Text]], AST, AST -> AST)
+  innerCollectAllFunctionArgs = rewriteFunctionsWith id
+
+  countReferences :: Text -> AST -> Int
+  countReferences ident = everything (+) match where
+    match :: AST -> Int
+    match (Var _ ident') | ident == ident' = 1
+    match _ = 0
+
+  -- If `ident` is a tail-recursive function, returns a set of identifiers
+  -- that are locally bound to functions participating in the tail recursion.
+  -- Otherwise, returns Nothing.
+  findTailRecursiveFns :: Text -> Int -> AST -> Maybe (S.Set Text)
+  findTailRecursiveFns ident arity js = guard (countReferences ident js > 0) *> go (S.empty, S.singleton (ident, arity))
+    where
+
+    go :: (S.Set Text, S.Set (Text, Int)) -> Maybe (S.Set Text)
+    go (known, required) =
+      case S.minView required of
+        Just (r, required') -> do
+          required'' <- findTailPositionDeps r js
+          go (S.insert (fst r) known, required' <> (S.filter (not . (`S.member` known) . fst) required''))
+        Nothing ->
+          pure known
+
+  -- Returns set of identifiers (with their arities) that need to be used
+  -- exclusively in tail calls using their full arity in order for this
+  -- identifier to be considered in tail position (or Nothing if this
+  -- identifier is used somewhere not as a tail call with full arity).
+  findTailPositionDeps :: (Text, Int) -> AST -> Maybe (S.Set (Text, Int))
+  findTailPositionDeps (ident, arity) js = allInTailPosition js where
+    countSelfReferences = countReferences ident
 
     allInTailPosition (Return _ expr)
-      | isSelfCall ident expr = countSelfReferences expr == 1
-      | otherwise = countSelfReferences expr == 0
+      | isSelfCall ident arity expr = guard (countSelfReferences expr == 1) $> S.empty
+      | otherwise = guard (countSelfReferences expr == 0) $> S.empty
     allInTailPosition (While _ js1 body)
-      = countSelfReferences js1 == 0 && allInTailPosition body
+      = guard (countSelfReferences js1 == 0) *> allInTailPosition body
     allInTailPosition (For _ _ js1 js2 body)
-      = countSelfReferences js1 == 0 && countSelfReferences js2 == 0 && allInTailPosition body
+      = guard (countSelfReferences js1 == 0 && countSelfReferences js2 == 0) *> allInTailPosition body
     allInTailPosition (ForIn _ _ js1 body)
-      = countSelfReferences js1 == 0 && allInTailPosition body
+      = guard (countSelfReferences js1 == 0) *> allInTailPosition body
     allInTailPosition (IfElse _ js1 body el)
-      = countSelfReferences js1 == 0 && allInTailPosition body && all allInTailPosition el
+      = guard (countSelfReferences js1 == 0) *> liftA2 mappend (allInTailPosition body) (foldMapA allInTailPosition el)
     allInTailPosition (Block _ body)
-      = all allInTailPosition body
+      = foldMapA allInTailPosition body
     allInTailPosition (Throw _ js1)
-      = countSelfReferences js1 == 0
+      = guard (countSelfReferences js1 == 0) $> S.empty
     allInTailPosition (ReturnNoResult _)
-      = True
-    allInTailPosition (VariableIntroduction _ _ js1)
-      = all ((== 0) . countSelfReferences) js1
+      = pure S.empty
+    allInTailPosition (VariableIntroduction _ _ Nothing)
+      = pure S.empty
+    allInTailPosition (VariableIntroduction _ ident' (Just js1))
+      | countSelfReferences js1 == 0 = pure S.empty
+      | Function _ Nothing _ _ <- js1
+      , (argss, body, _) <- innerCollectAllFunctionArgs [] id js1
+        = S.insert (ident', length argss) <$> allInTailPosition body
+      | otherwise = empty
     allInTailPosition (Assignment _ _ js1)
-      = countSelfReferences js1 == 0
+      = guard (countSelfReferences js1 == 0) $> S.empty
     allInTailPosition (Comment _ _ js1)
       = allInTailPosition js1
     allInTailPosition _
-      = False
+      = empty
 
-  toLoop :: Text -> [Text] -> [Text] -> AST -> AST
-  toLoop ident outerArgs innerArgs js =
-      Block rootSS $
+  toLoop :: S.Set Text -> Text -> Int -> [Text] -> [Text] -> AST -> State Int AST
+  toLoop trFns ident arity outerArgs innerArgs js = do
+    tcoDone <- tcoDoneM
+    modify (+ 1)
+
+    let
+      markDone :: Maybe SourceSpan -> AST
+      markDone ss = Assignment ss (Var ss tcoDone) (BooleanLiteral ss True)
+
+      loopify :: AST -> AST
+      loopify (Return ss ret)
+        | isSelfCall ident arity ret =
+          let
+            allArgumentValues = concat $ collectArgs [] ret
+          in
+            Block ss $
+              zipWith (\val arg ->
+                Assignment ss (Var ss (tcoVar arg)) val) allArgumentValues outerArgs
+              ++ zipWith (\val arg ->
+                Assignment ss (Var ss (copyVar arg)) val) (drop (length outerArgs) allArgumentValues) innerArgs
+              ++ [ ReturnNoResult ss ]
+        | isIndirectSelfCall ret = Return ss ret
+        | otherwise = Block ss [ markDone ss, Return ss ret ]
+      loopify (ReturnNoResult ss) = Block ss [ markDone ss, ReturnNoResult ss ]
+      loopify (While ss cond body) = While ss cond (loopify body)
+      loopify (For ss i js1 js2 body) = For ss i js1 js2 (loopify body)
+      loopify (ForIn ss i js1 body) = ForIn ss i js1 (loopify body)
+      loopify (IfElse ss cond body el) = IfElse ss cond (loopify body) (fmap loopify el)
+      loopify (Block ss body) = Block ss (map loopify body)
+      loopify (VariableIntroduction ss f (Just fn@(Function _ Nothing _ _)))
+        | (_, body, replace) <- innerCollectAllFunctionArgs [] id fn
+        , f `S.member` trFns = VariableIntroduction ss f (Just (replace (loopify body)))
+      loopify other = other
+
+    pure $ Block rootSS $
         map (\arg -> VariableIntroduction rootSS (tcoVar arg) (Just (Var rootSS (copyVar arg)))) outerArgs ++
         [ VariableIntroduction rootSS tcoDone (Just (BooleanLiteral rootSS False))
         , VariableIntroduction rootSS tcoResult Nothing
@@ -96,30 +175,6 @@ tco = everywhere convert where
     where
     rootSS = Nothing
 
-    loopify :: AST -> AST
-    loopify (Return ss ret)
-      | isSelfCall ident ret =
-        let
-          allArgumentValues = concat $ collectArgs [] ret
-        in
-          Block ss $
-            zipWith (\val arg ->
-              Assignment ss (Var ss (tcoVar arg)) val) allArgumentValues outerArgs
-            ++ zipWith (\val arg ->
-              Assignment ss (Var ss (copyVar arg)) val) (drop (length outerArgs) allArgumentValues) innerArgs
-            ++ [ ReturnNoResult ss ]
-      | otherwise = Block ss [ markDone ss, Return ss ret ]
-    loopify (ReturnNoResult ss) = Block ss [ markDone ss, ReturnNoResult ss ]
-    loopify (While ss cond body) = While ss cond (loopify body)
-    loopify (For ss i js1 js2 body) = For ss i js1 js2 (loopify body)
-    loopify (ForIn ss i js1 body) = ForIn ss i js1 (loopify body)
-    loopify (IfElse ss cond body el) = IfElse ss cond (loopify body) (fmap loopify el)
-    loopify (Block ss body) = Block ss (map loopify body)
-    loopify other = other
-
-    markDone :: Maybe SourceSpan -> AST
-    markDone ss = Assignment ss (Var ss tcoDone) (BooleanLiteral ss True)
-
     collectArgs :: [[AST]] -> AST -> [[AST]]
     collectArgs acc (App _ fn []) =
       -- count 0-argument applications as single-argument so we get the correct number of args
@@ -127,7 +182,15 @@ tco = everywhere convert where
     collectArgs acc (App _ fn args') = collectArgs (args' : acc) fn
     collectArgs acc _ = acc
 
-  isSelfCall :: Text -> AST -> Bool
-  isSelfCall ident (App _ (Var _ ident') _) = ident == ident'
-  isSelfCall ident (App _ fn _) = isSelfCall ident fn
-  isSelfCall _ _ = False
+    isIndirectSelfCall :: AST -> Bool
+    isIndirectSelfCall (App _ (Var _ ident') _) = ident' `S.member` trFns
+    isIndirectSelfCall (App _ fn _) = isIndirectSelfCall fn
+    isIndirectSelfCall _ = False
+
+  isSelfCall :: Text -> Int -> AST -> Bool
+  isSelfCall ident 1 (App _ (Var _ ident') _) = ident == ident'
+  isSelfCall ident arity (App _ fn _) = isSelfCall ident (arity - 1) fn
+  isSelfCall _ _ _ = False
+
+foldMapA :: (Applicative f, Monoid w, Foldable t) => (a -> f w) -> t a -> f w
+foldMapA f = foldr (liftA2 mappend . f) (pure mempty)

--- a/tests/purs/passing/3957.purs
+++ b/tests/purs/passing/3957.purs
@@ -1,0 +1,39 @@
+module Main where
+
+import Prelude
+import Effect.Console (log)
+import Test.Assert (assertEqual)
+
+data Maybe a = Nothing | Just a
+
+f :: Int -> Int
+f x = case x of
+  0 -> 0
+  n | _ <- n -> f (x - 1)
+  _ -> f (x - 2)
+
+g :: Int -> Int
+g x = case x of
+  0 -> 0
+  n | n == n, true -> g (x - 1)
+  _ -> g (x - 2)
+
+weirdsum :: Int -> (Int -> Maybe Int) -> Int -> Int
+weirdsum accum f n = case n of
+  0 -> accum
+  x | Just y <- f x -> weirdsum (accum + y) f (n - 1)
+  _ -> weirdsum accum f (n - 1)
+
+tricksyinners :: Int -> Int -> Int
+tricksyinners accum x = case x of
+  0 -> accum + f' x * f' x
+  n -> tricksyinners (accum + 2) (n - 1)
+  where
+  f' y = y + 3
+
+main = do
+  assertEqual { expected: 0, actual: f 100000 }
+  assertEqual { expected: 0, actual: g 100000 }
+  assertEqual { expected: 20, actual: weirdsum 0 (\x -> if x < 5 then Just (2 * x) else Nothing) 100000 }
+  assertEqual { expected: 200009, actual: tricksyinners 0 100000 }
+  log "Done"

--- a/tests/purs/passing/TCOMutRec.purs
+++ b/tests/purs/passing/TCOMutRec.purs
@@ -1,0 +1,95 @@
+module Main where
+
+import Prelude
+import Effect (Effect)
+import Effect.Console (log)
+import Test.Assert (assertEqual, assertThrows)
+
+tco1 :: Int -> Int
+tco1 = f 0
+  where
+  f x y = g (x + 2) (y - 1)
+    where
+    g x' y' = if y' <= 0 then x' else f x' y'
+
+tco2 :: Int -> Int
+tco2 = f 0
+  where
+  f x y = g (x + 2) (y - 1)
+    where
+    g x' y' = h (y' <= 0) x' y'
+    h test x' y' = if test then x' else f x' y'
+
+tco3 :: Int -> Int
+tco3 y0 = f 0 y0
+  where
+  f x y = g x (h y)
+    where
+    g x' y' =
+      if y' <= 0 then x'
+      else if y' > y0 / 2 then g (j x') (y' - 1)
+      else f (x' + 2) y'
+    h y = y - 1
+  j x = x + 3
+
+tco4 :: Int -> Int
+tco4 = f 0
+  where
+  f x y = if y <= 0 then x else g (y - 1)
+    where
+    g y' = f (x + 2) y'
+
+-- The following examples are functions which are prevented from being TCO'd
+-- because the arity of the function being looped does not match the function
+-- call. In theory, these could be made to optimize via eta-expansion in the
+-- future, in which case the assertions can change.
+
+ntco1 :: Int -> Int
+ntco1 y0 = f 0 y0
+  where
+  f x = if x > 10 * y0 then (x + _) else g x
+    where
+    g x' y' = f (x' + 10) (y' - 1)
+
+ntco2 :: Int -> Int
+ntco2 = f 0
+  where
+  f x y = if y <= 0 then x else g x (y - 1)
+    where
+    g x' = f (x' + 2)
+
+ntco3 :: Int -> Int
+ntco3 = f 0
+  where
+  f x y = if y <= 0 then x else g (y - 1)
+    where
+    g = f (x + 2)
+
+ntco4 :: Int -> Int
+ntco4 = f 0
+  where
+  f x y = if y <= 0 then x else g (y - 1)
+    where
+    g = h x
+    h x' y' = f (x' + 2) y'
+
+main :: Effect Unit
+main = do
+  assertEqual { expected: 200000, actual: tco1 100000 }
+  assertEqual { expected: 200000, actual: tco2 100000 }
+  assertEqual { expected: 249997, actual: tco3 100000 }
+  assertEqual { expected: 200000, actual: tco4 100000 }
+
+  assertEqual { expected: 1009, actual: ntco1 100 }
+  assertThrows \_ -> ntco1 100000
+
+  assertEqual { expected: 200, actual: ntco2 100 }
+  assertThrows \_ -> ntco2 100000
+
+  assertEqual { expected: 200, actual: ntco3 100 }
+  assertThrows \_ -> ntco3 100000
+
+  assertEqual { expected: 200, actual: ntco4 100 }
+  assertThrows \_ -> ntco4 100000
+
+  log "Done"


### PR DESCRIPTION
This commit adds support for optimizing functions that contain local
functions which call the outer function in tail position, as long as
those functions themselves are only called from tail position, either in
the outer function or in other such local functions.

This enables hand-written mutually-tail-recursive function groups to be
optimized, but more critically, it also means that case guards which
desugar to use local functions don't break TCO.

Closes #3957.