### PR TITLE
Reform handling of quote characters in raw strings

### DIFF
--- a/lib/purescript-cst/package.yaml
+++ b/lib/purescript-cst/package.yaml
@@ -35,6 +35,7 @@ library:
   source-dirs: src
   ghc-options: -Wall -O2
   default-extensions: !include "default-extensions.yaml"
+  other-modules: Data.Text.PureScript
 
 tests:
   tests:

--- a/lib/purescript-cst/src/Data/Text/PureScript.hs
+++ b/lib/purescript-cst/src/Data/Text/PureScript.hs
@@ -1,0 +1,23 @@
+-- |
+-- This module contains internal extensions to Data.Text.
+--
+module Data.Text.PureScript (spanUpTo) where
+
+import Prelude
+
+import Data.Text.Internal (Text(..), text)
+import Data.Text.Unsafe (Iter(..), iter)
+
+-- | /O(n)/ 'spanUpTo', applied to a number @n@, predicate @p@, and text @t@,
+-- returns a pair whose first element is the longest prefix (possibly empty) of
+-- @t@ of length less than or equal to @n@ of elements that satisfy @p@, and
+-- whose second is the remainder of the text.
+{-# INLINE spanUpTo #-}
+spanUpTo :: Int -> (Char -> Bool) -> Text -> (Text, Text)
+spanUpTo n p t@(Text arr off len) = (hd, tl)
+  where hd = text arr off k
+        tl = text arr (off + k) (len - k)
+        !k = loop n 0
+        loop !n' !i | n' > 0 && i < len && p c = loop (n' - 1) (i + d)
+                    | otherwise                = i
+            where Iter c d = iter t i

--- a/lib/purescript-cst/src/Language/PureScript/CST/Lexer.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Lexer.hs
@@ -17,6 +17,7 @@ import qualified Data.Scientific as Sci
 import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.PureScript as Text
 import Language.PureScript.CST.Errors
 import Language.PureScript.CST.Monad hiding (token)
 import Language.PureScript.CST.Layout
@@ -119,6 +120,12 @@ next = Parser $ \inp _ ksucc ->
 nextWhile :: (Char -> Bool) -> Lexer Text
 nextWhile p = Parser $ \inp _ ksucc -> do
   let (chs, inp') = Text.span p inp
+  ksucc inp' chs
+
+{-# INLINE nextWhile' #-}
+nextWhile' :: Int -> (Char -> Bool) -> Lexer Text
+nextWhile' n p = Parser $ \inp _ ksucc -> do
+  let (chs, inp') = Text.spanUpTo n p inp
   ksucc inp' chs
 
 {-# INLINE peek #-}
@@ -428,15 +435,15 @@ token = peek >>= maybe (pure TokEof) k0
 
     string
       : '"' stringPart* '"'
-      | '"""' .* '"""'
+      | '"""' '"'{0,2} ([^"]+ '"'{1,2})* [^"]* '"""'
 
-    This assumes maximal munch for quotes. A raw string literal can end with
-    any number of quotes, where the last 3 are considered the closing
-    delimiter.
+    A raw string literal can't contain any sequence of 3 or more quotes,
+    although sequences of 1 or 2 quotes are allowed anywhere, including at the
+    beginning or the end.
   -}
   string :: Lexer Token
   string = do
-    quotes1 <- nextWhile (== '"')
+    quotes1 <- nextWhile' 7 (== '"')
     case Text.length quotes1 of
       0 -> do
         let
@@ -467,19 +474,18 @@ token = peek >>= maybe (pure TokEof) k0
         go "" mempty
       1 ->
         pure $ TokString "" ""
-      n | n >= 5 -> do
-        let str = Text.take 5 quotes1
-        pure $ TokString str (fromString (Text.unpack str))
+      n | n >= 5 ->
+        pure $ TokRawString $ Text.drop 5 quotes1
       _ -> do
         let
           go acc = do
             chs <- nextWhile (/= '"')
-            quotes2 <- nextWhile (== '"')
+            quotes2 <- nextWhile' 5 (== '"')
             case Text.length quotes2 of
               0          -> throw ErrEof
               n | n >= 3 -> pure $ TokRawString $ acc <> chs <> Text.drop 3 quotes2
               _          -> go (acc <> chs <> quotes2)
-        go ""
+        go $ Text.drop 2 quotes1
 
   {-
     escape

--- a/tests/purs/passing/BlockStringEdgeCases.purs
+++ b/tests/purs/passing/BlockStringEdgeCases.purs
@@ -1,0 +1,30 @@
+module Main where
+
+import Prelude
+import Effect.Console (log)
+import Test.Assert (assert')
+
+data Tuple a b = Tuple a b
+derive instance tupleEq :: (Eq a, Eq b) => Eq (Tuple a b)
+
+main = do
+  assert' "empty string" ("""""" == "")
+  assert' "quote" (""""""" == "\"")
+  assert' "starts with quote" (""""x""" == "\"x")
+  assert' "ends with quote" ("""x"""" == "x\"")
+  assert' "two quotes" ("""""""" == "\"\"")
+  assert' "starts with two quotes" ("""""x""" == "\"\"x")
+  assert' "ends with two quotes" ("""x""""" == "x\"\"")
+  assert' "starts and ends with two quotes" ("""""x""""" == "\"\"x\"\"")
+  assert' "mixture 1" ("""""x"y""z"""" == "\"\"x\"y\"\"z\"")
+  assert' "mixture 2" ("""x"y""z""" == "x\"y\"\"z")
+
+  -- These last tests are more about forbidding certain raw string literal
+  -- edge cases than about wanting to support mashing string literals against.
+  -- each other, which is techically legal but generally, if not universally,
+  -- a bad idea.
+  assert' "too many quotes 1" (Tuple """"""""" " == Tuple "\"\"" " ")
+  assert' "too many quotes 2" (Tuple """""""""" == Tuple "\"\"" "")
+  assert' "too many quotes 3" (Tuple """x"""""" " == Tuple "x\"\"" " ")
+  assert' "too many quotes 4" (Tuple """x""""""" == Tuple "x\"\"" "")
+  log "Done"


### PR DESCRIPTION
This corrects a number of regressions introduced in 0.13, and imposes
the uniform restriction that `"""` can't appear anywhere inside a raw
string literal. It's possible (in fact, slightly easier) to lex strings
such that an unlimited number of quotes are allowed at the end (and only
at the end) of a raw string literal, but the simplicity and clarity of a
uniform rule outweighs the implementation cost and the very minor loss
of expressiveness.

Closes #3959.