### PR TITLE
Update license-related error messages

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,6 +51,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@fehrenbach](https://github.com/fehrenbach) | Stefan Fehrenbach | [MIT license](http://opensource.org/licenses/MIT) |
 | [@felixSchl](https://github.com/felixSchl) | Felix Schlitter | [MIT license](http://opensource.org/licenses/MIT) |
 | [@FrigoEU](https://github.com/FrigoEU) | Simon Van Casteren | [MIT license](http://opensource.org/licenses/MIT) |
+| [@fsoikin](https://github.com/fsoikin) | Fyodor Soikin | [MIT license](http://opensource.org/licenses/MIT) |
 | [@garyb](https://github.com/garyb) | Gary Burgess | [MIT license](http://opensource.org/licenses/MIT) |
 | [@hdgarrood](https://github.com/hdgarrood) | Harry Garrood | [MIT license](http://opensource.org/licenses/MIT) |
 | [@houli](https://github.com/houli) | Eoin Houlihan | [MIT license](http://opensource.org/licenses/MIT) |

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -166,32 +166,32 @@ displayUserError e = case e of
     displayRepositoryError err
   NoLicenseSpecified ->
     vcat $
-      [ para (concat
-          [ "No license is specified in package manifest. Please add one, using the "
-          , "SPDX license expression format. For example, any of the "
-          , "following would be acceptable:"
-          ])
+      [ para
+          "No license is specified in package manifest. Please add a \
+          \\"license\" property with a SPDX license expression. For example, \
+          \any of the following would be acceptable:"
       , spacer
       ] ++ spdxExamples ++
       [ spacer
-      , para (
-          "Note that distributing code without a license means that nobody "
-          ++ "will (legally) be able to use it."
-          )
+      , para
+          "See https://spdx.org/licenses/ for a full list of licenses. For more \
+          \information on SPDX license expressions, see https://spdx.org/ids-how"
       , spacer
-      , para (concat
-          [ "It is also recommended to add a LICENSE file to the repository, "
-          , "including your name and the current year, although this is not "
-          , "necessary."
-          ])
+      , para
+          "Note that distributing code without a license means that nobody will \
+          \(legally) be able to use it."
+      , spacer
+      , para
+          "It is also recommended to add a LICENSE file to the repository, \
+          \including your name and the current year, although this is not necessary."
       ]
   InvalidLicense ->
     vcat $
-      [ para (concat
-          [ "The license specified in package manifest is not a valid SPDX license "
-          , "expression. Please use the SPDX license expression format. For "
-          , "example, any of the following would be acceptable:"
-          ])
+      [ para
+          "The license specified in package manifest is not a valid SPDX \
+          \license expression. Please update the \"license\" property so that \
+          \it is a valid SPDX license expression. For example, any of the \
+          \following would be acceptable:"
       , spacer
       ] ++
       spdxExamples

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -228,8 +228,8 @@ spdxExamples =
     [ "* \"MIT\""
     , "* \"Apache-2.0\""
     , "* \"BSD-2-Clause\""
-    , "* \"GPL-2.0+\""
-    , "* \"(GPL-3.0 OR MIT)\""
+    , "* \"GPL-2.0-or-later\""
+    , "* \"(GPL-3.0-only OR MIT)\""
     ]
 
 displayRepositoryError :: RepositoryFieldError -> Box

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -166,32 +166,37 @@ displayUserError e = case e of
     displayRepositoryError err
   NoLicenseSpecified ->
     vcat $
-      [ para
-          "No license is specified in package manifest. Please add a \
-          \\"license\" property with a SPDX license expression. For example, \
-          \any of the following would be acceptable:"
+      [ para $ concat
+          [ "No license is specified in package manifest. Please add a "
+          , "\"license\" property with a SPDX license expression. For example, "
+          , "any of the following would be acceptable:"
+          ]
       , spacer
       ] ++ spdxExamples ++
       [ spacer
-      , para
-          "See https://spdx.org/licenses/ for a full list of licenses. For more \
-          \information on SPDX license expressions, see https://spdx.org/ids-how"
+      , para $ concat
+          [ "See https://spdx.org/licenses/ for a full list of licenses. For more "
+          , "information on SPDX license expressions, see https://spdx.org/ids-how"
+          ]
       , spacer
-      , para
-          "Note that distributing code without a license means that nobody will \
-          \(legally) be able to use it."
+      , para $ concat
+          [ "Note that distributing code without a license means that nobody will "
+          , "(legally) be able to use it."
+          ]
       , spacer
-      , para
-          "It is also recommended to add a LICENSE file to the repository, \
-          \including your name and the current year, although this is not necessary."
+      , para $ concat
+          [ "It is also recommended to add a LICENSE file to the repository, "
+          , "including your name and the current year, although this is not necessary."
+          ]
       ]
   InvalidLicense ->
     vcat $
-      [ para
-          "The license specified in package manifest is not a valid SPDX \
-          \license expression. Please update the \"license\" property so that \
-          \it is a valid SPDX license expression. For example, any of the \
-          \following would be acceptable:"
+      [ para $ concat
+          [ "The license specified in package manifest is not a valid SPDX "
+          , "license expression. Please update the \"license\" property so that "
+          , "it is a valid SPDX license expression. For example, any of the "
+          , "following would be acceptable:"
+          ]
       , spacer
       ] ++
       spdxExamples


### PR DESCRIPTION
This is a continuation of https://github.com/purescript/purescript/pull/3834
Text of the errors updated according to @hdgarrood's suggestions.
Fixes #3836

### No license field
```
There is a problem with your package, which meant that it could not be
published.
Details:
  No license is specified in package manifest. Please add a "license" property
  with a SPDX license expression. For example, any of the following would be
  acceptable:

    * "MIT"                  
    * "Apache-2.0"           
    * "BSD-2-Clause"         
    * "GPL-2.0-or-later"     
    * "(GPL-3.0-only OR MIT)"
 
  See https://spdx.org/licenses/ for a full list of licenses. For more
  information on SPDX license expressions, see https://spdx.org/ids-how

  Note that distributing code without a license means that nobody will (legally)
  be able to use it.

  It is also recommended to add a LICENSE file to the repository, including your
  name and the current year, although this is not necessary.
```

### Invalid license field
```
There is a problem with your package, which meant that it could not be
published.
Details:
  The license specified in package manifest is not a valid SPDX license
  expression. Please update the "license" property so that it is a valid SPDX
  license expression. For example, any of the following would be acceptable:

    * "MIT"                  
    * "Apache-2.0"           
    * "BSD-2-Clause"         
    * "GPL-2.0-or-later"     
    * "(GPL-3.0-only OR MIT)"
```