### PR TITLE
Fix operator qualifier reversal bug

### DIFF
--- a/lib/purescript-cst/src/Language/PureScript/CST/Lexer.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Lexer.hs
@@ -322,7 +322,7 @@ token = peek >>= maybe (pure TokEof) k0
         peek >>= \case
           Just ')'
             | isReservedSymbol chs -> throw ErrReservedSymbol
-            | otherwise -> next $> TokSymbolName qual chs
+            | otherwise -> next $> TokSymbolName (reverse qual) chs
           Just ch2 -> throw $ ErrLexeme (Just [ch2]) []
           Nothing  -> throw ErrEof
     Just ch -> throw $ ErrLexeme (Just [ch]) []

--- a/tests/purs/failing/QualifiedOperators.out
+++ b/tests/purs/failing/QualifiedOperators.out
@@ -1,0 +1,10 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/QualifiedOperators.purs:4:10 - 4:21 (line 4, column 10 - line 4, column 21)
+
+  Unknown module [33mFoo.Bar[0m
+
+
+See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/QualifiedOperators.purs
+++ b/tests/purs/failing/QualifiedOperators.purs
@@ -1,0 +1,4 @@
+-- @shouldFailWith UnknownName
+module Main where
+
+test = 4 Foo.Bar.-#- 10

--- a/tests/purs/failing/QualifiedOperators2.out
+++ b/tests/purs/failing/QualifiedOperators2.out
@@ -1,0 +1,10 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/QualifiedOperators2.purs:4:8 - 4:21 (line 4, column 8 - line 4, column 21)
+
+  Unknown module [33mFoo.Bar[0m
+
+
+See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/QualifiedOperators2.purs
+++ b/tests/purs/failing/QualifiedOperators2.purs
@@ -1,0 +1,4 @@
+-- @shouldFailWith UnknownName
+module Main where
+
+test = Foo.Bar.(-#-) 4 10

--- a/tests/purs/passing/QualifiedOperators.purs
+++ b/tests/purs/passing/QualifiedOperators.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Prelude
+
+import Effect.Console (log)
+import Test.Assert (assert)
+
+import Foo as Foo.Bar
+
+main = do
+  assert $ 4 Foo.Bar.-#- 10 == 33
+  assert $ Foo.Bar.(-#-) 4 10 == 33
+  log "Done"

--- a/tests/purs/passing/QualifiedOperators/Foo.purs
+++ b/tests/purs/passing/QualifiedOperators/Foo.purs
@@ -1,0 +1,8 @@
+module Foo where
+
+import Prelude
+
+tie :: Int -> Int -> Int
+tie a b = (a - 1) * (b + 1)
+
+infix 5 tie as -#-


### PR DESCRIPTION
The relatively unusual combination of a multi-part qualifier and an
operator used as a symbol—i.e., `Foo.Bar.(!)`—was previously being
wrongly interpreted as `Bar.Foo.(!)`.

Fixes #3892.