### PR TITLE
Don't implement Newtype methods when deriving

### DIFF
--- a/src/Language/PureScript/Make/BuildPlan.hs
+++ b/src/Language/PureScript/Make/BuildPlan.hs
@@ -1,5 +1,5 @@
 module Language.PureScript.Make.BuildPlan
-  ( BuildPlan(bpEnv, bpPrebuilt), Prebuilt(..)
+  ( BuildPlan(bpEnv)
   , BuildJobResult(..)
   , buildJobSuccess
   , buildJobFailure

--- a/src/Language/PureScript/Make/BuildPlan.hs
+++ b/src/Language/PureScript/Make/BuildPlan.hs
@@ -1,5 +1,5 @@
 module Language.PureScript.Make.BuildPlan
-  ( BuildPlan(bpEnv)
+  ( BuildPlan(bpEnv, bpPrebuilt), Prebuilt(..)
   , BuildJobResult(..)
   , buildJobSuccess
   , buildJobFailure

--- a/tests/purs/docs/bower_components/purescript-newtype/src/Data/Newtype.purs
+++ b/tests/purs/docs/bower_components/purescript-newtype/src/Data/Newtype.purs
@@ -1,5 +1,6 @@
 module Data.Newtype where
 
-class Newtype t a | t -> a where
-  wrap :: a -> t
-  unwrap :: t -> a
+import Prim.Coerce (class Coercible)
+
+class Newtype :: Type -> Type -> Constraint
+class Coercible t a <= Newtype t a | t -> a

--- a/tests/purs/passing/GenericsRep.purs
+++ b/tests/purs/passing/GenericsRep.purs
@@ -4,7 +4,7 @@ import Prelude
 import Effect (Effect)
 import Effect.Console (log, logShow)
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Eq (genericEq)
+import Data.Eq.Generic (genericEq)
 
 data X a = X a
 

--- a/tests/purs/passing/NewtypeClass.purs
+++ b/tests/purs/passing/NewtypeClass.purs
@@ -3,16 +3,20 @@ module Main where
 import Prelude
 import Effect
 import Effect.Console
+import Safe.Coerce (class Coercible, coerce)
 
-class Newtype t a | t -> a where
-  wrap :: a -> t
-  unwrap :: t -> a
+class Newtype :: Type -> Type -> Constraint
+class Coercible t a <= Newtype t a | t -> a
 
-instance newtypeMultiplicative :: Newtype (Multiplicative a) a where
-  wrap = Multiplicative
-  unwrap (Multiplicative a) = a
+wrap :: forall t a. Newtype t a => a -> t
+wrap = coerce
 
-data Multiplicative a = Multiplicative a
+unwrap :: forall t a. Newtype t a => t -> a
+unwrap = coerce
+
+instance newtypeMultiplicative :: Newtype (Multiplicative a) a
+
+newtype Multiplicative a = Multiplicative a
 
 instance semiringMultiplicative :: Semiring a => Semigroup (Multiplicative a) where
   append (Multiplicative a) (Multiplicative b) = Multiplicative (a * b)

--- a/tests/purs/passing/RowsInInstanceContext.purs
+++ b/tests/purs/passing/RowsInInstanceContext.purs
@@ -3,7 +3,6 @@ module Main where
 import Prelude
 import Effect (Effect)
 import Effect.Console (log)
-import Data.Newtype (class Newtype, unwrap)
 
 class TypeEquals a b | a -> b, b -> a where
   coerce :: a -> b
@@ -15,9 +14,13 @@ instance refl :: TypeEquals a a where
 
 newtype RecordNewtype = RecordNewtype { x :: String }
 
+class OldStyleNewtype t a where
+  wrap :: a -> t
+  unwrap :: t -> a
+
 instance newtypeRecordNewtype ::
   TypeEquals inner { x :: String }
-    => Newtype RecordNewtype inner where
+    => OldStyleNewtype RecordNewtype inner where
   wrap = RecordNewtype <<< coerce
   unwrap (RecordNewtype rec) = coerceBack rec
 

--- a/tests/purs/passing/SolvingAppendSymbol.purs
+++ b/tests/purs/passing/SolvingAppendSymbol.purs
@@ -3,31 +3,31 @@ module Main where
 import Prelude
 import Effect.Console (log)
 import Prim.Symbol (class Append)
-import Type.Data.Symbol (SProxy(..), reflectSymbol)
-import Type.Data.Symbol (append) as Symbol
+import Type.Proxy (Proxy(..))
+import Type.Data.Symbol (append, reflectSymbol) as Symbol
 
-sym :: SProxy ""
-sym = SProxy
+sym :: Proxy ""
+sym = Proxy
 
-symA :: SProxy "A"
-symA = SProxy
+symA :: Proxy "A"
+symA = Proxy
 
-symB :: SProxy "B"
-symB = SProxy
+symB :: Proxy "B"
+symB = Proxy
 
-egAB :: SProxy "AB"
+egAB :: Proxy "AB"
 egAB = Symbol.append symA symB
 
-egBA :: SProxy "BA"
+egBA :: Proxy "BA"
 egBA = Symbol.append symB symA
 
-egA' :: SProxy "A"
+egA' :: Proxy "A"
 egA' = Symbol.append sym (Symbol.append symA sym)
 
 main = do
-  let gotAB = reflectSymbol egAB == "AB"
-      gotBA = reflectSymbol egBA == "BA"
-      gotA' = reflectSymbol egA' == "A"
+  let gotAB = Symbol.reflectSymbol egAB == "AB"
+      gotBA = Symbol.reflectSymbol egBA == "BA"
+      gotA' = Symbol.reflectSymbol egA' == "A"
   when (not gotAB) $ log "Did not get AB"
   when (not gotBA) $ log "Did not get BA"
   when (not gotA') $ log "Did not get A"

--- a/tests/purs/passing/SolvingCompareSymbol.purs
+++ b/tests/purs/passing/SolvingCompareSymbol.purs
@@ -4,23 +4,23 @@ import Prelude
 import Effect.Console (log)
 import Prim.Symbol (class Compare)
 import Prim.Ordering (kind Ordering, LT, EQ, GT)
-import Type.Data.Symbol (SProxy(..))
+import Type.Proxy (Proxy(..))
 import Type.Data.Symbol (compare) as Symbol
-import Type.Data.Ordering (OProxy(..), reflectOrdering)
+import Type.Data.Ordering (reflectOrdering)
 
-symA :: SProxy "A"
-symA = SProxy
+symA :: Proxy "A"
+symA = Proxy
 
-symB :: SProxy "B"
-symB = SProxy
+symB :: Proxy "B"
+symB = Proxy
 
-egLT :: OProxy LT
+egLT :: Proxy LT
 egLT = Symbol.compare symA symB
 
-egEQ :: OProxy EQ
+egEQ :: Proxy EQ
 egEQ = Symbol.compare symA symA
 
-egGT :: OProxy GT
+egGT :: Proxy GT
 egGT = Symbol.compare symB symA
 
 main = do

--- a/tests/purs/publish/basic-example/resolutions.json
+++ b/tests/purs/publish/basic-example/resolutions.json
@@ -13,5 +13,11 @@
   },
   "purescript-newtype": {
     "path": "../../../support/bower_components/purescript-newtype"
+  },
+  "purescript-safe-coerce": {
+    "path": "../../../support/bower_components/purescript-safe-coerce"
+  },
+  "purescript-unsafe-coerce": {
+    "path": "../../../support/bower_components/purescript-unsafe-coerce"
   }
 }

--- a/tests/support/bower.json
+++ b/tests/support/bower.json
@@ -34,7 +34,7 @@
     "purescript-type-equality": "#8be8f46e70074dd3ace313bd15227f26166e9675",
     "purescript-typelevel-prelude": "#e1b1c9a73f5407c2b1b197d4776d8939129a2444",
     "purescript-unfoldable": "4.0.0",
-    "purescript-unsafe-coerce": "master"
+    "purescript-unsafe-coerce": "#76f1d3494a571b97a07f893a1e766f01f86f46f1"
   },
   "resolutions": {
     "purescript-newtype": "debb7bdf5d712fb568eee16fae896fd2bc6087d0",
@@ -42,6 +42,6 @@
     "purescript-safe-coerce": "46b3171f71ca5052de6411e383bef6abe80b3f86",
     "purescript-type-equality": "8be8f46e70074dd3ace313bd15227f26166e9675",
     "purescript-typelevel-prelude": "e1b1c9a73f5407c2b1b197d4776d8939129a2444",
-    "purescript-unsafe-coerce": "master"
+    "purescript-unsafe-coerce": "76f1d3494a571b97a07f893a1e766f01f86f46f1"
   }
 }

--- a/tests/support/bower.json
+++ b/tests/support/bower.json
@@ -12,7 +12,6 @@
     "purescript-foldable-traversable": "4.0.0",
     "purescript-functions": "4.0.0",
     "purescript-gen": "2.0.0",
-    "purescript-generics-rep": "6.0.0",
     "purescript-globals": "4.0.0",
     "purescript-identity": "4.0.0",
     "purescript-integers": "4.0.0",
@@ -21,25 +20,28 @@
     "purescript-lists": "5.0.0",
     "purescript-math": "2.1.1",
     "purescript-maybe": "4.0.0",
-    "purescript-newtype": "3.0.0",
+    "purescript-newtype": "#debb7bdf5d712fb568eee16fae896fd2bc6087d0",
     "purescript-nonempty": "5.0.0",
     "purescript-partial": "2.0.0",
-    "purescript-prelude": "#c932361d008379958f14ca8cc2fe32e06cc2647d",
-    "purescript-proxy": "3.0.0",
+    "purescript-prelude": "#d3cdad16a1479403a3f14f94190868ba5e25c657",
     "purescript-psci-support": "4.0.0",
     "purescript-refs": "4.1.0",
-    "purescript-safe-coerce": "0.0.2",
+    "purescript-safe-coerce": "#46b3171f71ca5052de6411e383bef6abe80b3f86",
     "purescript-st": "4.0.0",
     "purescript-strings": "4.0.0",
     "purescript-tailrec": "4.0.0",
     "purescript-tuples": "5.0.0",
-    "purescript-type-equality": "3.0.0",
-    "purescript-typelevel-prelude": "#52ac4bcf9a38941606b3d928127089bd363ee946",
+    "purescript-type-equality": "#8be8f46e70074dd3ace313bd15227f26166e9675",
+    "purescript-typelevel-prelude": "#e1b1c9a73f5407c2b1b197d4776d8939129a2444",
     "purescript-unfoldable": "4.0.0",
-    "purescript-unsafe-coerce": "4.0.0"
+    "purescript-unsafe-coerce": "master"
   },
   "resolutions": {
-    "purescript-prelude": "c932361d008379958f14ca8cc2fe32e06cc2647d",
-    "purescript-typelevel-prelude": "52ac4bcf9a38941606b3d928127089bd363ee946"
+    "purescript-newtype": "debb7bdf5d712fb568eee16fae896fd2bc6087d0",
+    "purescript-prelude": "d3cdad16a1479403a3f14f94190868ba5e25c657",
+    "purescript-safe-coerce": "46b3171f71ca5052de6411e383bef6abe80b3f86",
+    "purescript-type-equality": "8be8f46e70074dd3ace313bd15227f26166e9675",
+    "purescript-typelevel-prelude": "e1b1c9a73f5407c2b1b197d4776d8939129a2444",
+    "purescript-unsafe-coerce": "master"
   }
 }


### PR DESCRIPTION
This PR removes implementation of `wrap` and `unwrap` methods when deriving the `Newtype` class in the old-style syntax, like `derive instance foo :: Newtype Bar _`. 

These methods have been removed from the class in https://github.com/purescript/purescript-newtype/pull/22, so now the old way of deriving them causes an error "_wrap is not a method of Newtype_".

To make tests pass after this change, `tests/support/bower.json` was updated with latest versions of `newtype`, `safe-coerce`, `type-equality`, `typelevel-relude`, and `prelude` packages.

And updating `prelude` required updates to the `Proxy`-related tests.

Sorry if I'm missing the mark again, just trying to help. Feel free to close if so.