### PR TITLE
Make close punctuation printable in errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ New features:
 
 Bugfixes:
 
+* Make close punctuation printable in errors (#3982, @rhendric)
+
 Other improvements:
 
 ## v0.14.0

--- a/lib/purescript-ast/src/Language/PureScript/PSString.hs
+++ b/lib/purescript-ast/src/Language/PureScript/PSString.hs
@@ -182,6 +182,7 @@ prettyPrintString s = "\"" <> foldMap encodeChar (decodeStringEither s) <> "\""
       , Char.ConnectorPunctuation
       , Char.DashPunctuation
       , Char.OpenPunctuation
+      , Char.ClosePunctuation
       , Char.InitialQuote
       , Char.FinalQuote
       , Char.OtherPunctuation

--- a/tests/purs/failing/3891.out
+++ b/tests/purs/failing/3891.out
@@ -1,0 +1,24 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/3891.purs:4:8 - 4:15 (line 4, column 8 - line 4, column 15)
+
+  Could not match type
+  [33m        [0m
+  [33m  String[0m
+  [33m        [0m
+  with type
+  [33m              [0m
+  [33m  String -> t0[0m
+  [33m              [0m
+
+while applying a function [33m"("[0m
+  of type [33mString[0m
+  to argument [33m")"[0m
+while inferring the type of [33m"(" ")"[0m
+in value declaration [33moops[0m
+
+where [33mt0[0m is an unknown type
+
+See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/3891.purs
+++ b/tests/purs/failing/3891.purs
@@ -1,0 +1,4 @@
+-- @shouldFailWith TypesDoNotUnify
+module Main where
+
+oops = "(" ")"


### PR DESCRIPTION
Fixes #3891.

(For the curious, the [list of affected characters](https://www.fileformat.info/info/unicode/category/Pe/list.htm).)