### PR TITLE
Only include direct dependencies in output for purs graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ New features:
 
 Bugfixes:
 
+* Only include direct dependencies in the output for `purs graph` (#3993, @colinwahl)
+
+Fixes a bug where the transitive closure of a module's dependencies
+where included in the `depends` field in the output for `purs graph`.
+
 Other improvements:
 
 ## [v0.13.8](https://github.com/purescript/purescript/releases/tag/v0.13.8) - 2020-05-23

--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -68,7 +68,7 @@ updateReExports externs withPackage = execState action
 
   traversalOrder :: [P.ModuleName]
   traversalOrder =
-    case P.sortModules externsSignature externs of
+    case P.sortModules P.Transitive externsSignature externs of
       Right (es, _) -> map P.efModuleName es
       Left errs -> internalError $
         "failed to sortModules: " ++

--- a/src/Language/PureScript/Graph.hs
+++ b/src/Language/PureScript/Graph.hs
@@ -32,7 +32,7 @@ graph input = do
   Make.runMake Options.defaultOptions $ do
     ms <- CST.parseModulesFromFiles id moduleFiles
     let parsedModuleSig = Dependencies.moduleSignature . CST.resPartial
-    (_sorted, moduleGraph) <- Dependencies.sortModules (parsedModuleSig . snd) ms
+    (_sorted, moduleGraph) <- Dependencies.sortModules Dependencies.Direct (parsedModuleSig . snd) ms
     let pathMap = Map.fromList $
           map (\(p, m) -> (Dependencies.sigModuleName (parsedModuleSig m), p)) ms
     pure (moduleGraphToJSON pathMap moduleGraph)

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -186,7 +186,7 @@ sortExterns
   -> m [P.ExternsFile]
 sortExterns m ex = do
   sorted' <- runExceptT
-           . P.sortModules P.moduleSignature
+           . P.sortModules P.Transitive P.moduleSignature
            . (:) m
            . map mkShallowModule
            . M.elems

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -131,7 +131,7 @@ make ma@MakeActions{..} ms = do
   checkModuleNames
   cacheDb <- readCacheDb
 
-  (sorted, graph) <- sortModules (moduleSignature . CST.resPartial) ms
+  (sorted, graph) <- sortModules Transitive (moduleSignature . CST.resPartial) ms
 
   (buildPlan, newCacheDb) <- BuildPlan.construct ma cacheDb (sorted, graph)
 

--- a/tests/TestGraph.hs
+++ b/tests/TestGraph.hs
@@ -22,7 +22,7 @@ spec = do
   let baseDir = "tests/purs/graph/"
   let sourcesDir = baseDir <> "src/"
   it "should match the graph fixture" $ do
-    let modulePaths = (sourcesDir <>) <$> ["Module.purs", "Module2.purs"]
+    let modulePaths = (sourcesDir <>) <$> ["Module.purs", "Module2.purs", "Module3.purs"]
     let graphFixtureName = "graph.json"
 
     graphFixture <- readUTF8FileT (baseDir <> graphFixtureName)

--- a/tests/purs/graph/graph.json
+++ b/tests/purs/graph/graph.json
@@ -1,1 +1,1 @@
-{"Module2":{"path":"tests/purs/graph/src/Module2.purs","depends":[]},"Module":{"path":"tests/purs/graph/src/Module.purs","depends":["Module2"]}}
+{"Module2":{"path":"tests/purs/graph/src/Module2.purs","depends":["Module3"]},"Module3":{"path":"tests/purs/graph/src/Module3.purs","depends":[]},"Module":{"path":"tests/purs/graph/src/Module.purs","depends":["Module2"]}}

--- a/tests/purs/graph/graph.json
+++ b/tests/purs/graph/graph.json
@@ -1,1 +1,2 @@
 {"Module2":{"path":"tests/purs/graph/src/Module2.purs","depends":["Module3"]},"Module3":{"path":"tests/purs/graph/src/Module3.purs","depends":[]},"Module":{"path":"tests/purs/graph/src/Module.purs","depends":["Module2"]}}
+

--- a/tests/purs/graph/graph.json
+++ b/tests/purs/graph/graph.json
@@ -1,2 +1,1 @@
 {"Module2":{"path":"tests/purs/graph/src/Module2.purs","depends":["Module3"]},"Module3":{"path":"tests/purs/graph/src/Module3.purs","depends":[]},"Module":{"path":"tests/purs/graph/src/Module.purs","depends":["Module2"]}}
-

--- a/tests/purs/graph/src/Module2.purs
+++ b/tests/purs/graph/src/Module2.purs
@@ -1,4 +1,6 @@
 module Module2 (bar) where
 
+import Module3 (baz)
+
 bar :: Int
 bar = 1

--- a/tests/purs/graph/src/Module3.purs
+++ b/tests/purs/graph/src/Module3.purs
@@ -1,0 +1,4 @@
+module Module3 (baz) where
+
+baz :: Int
+baz = 3


### PR DESCRIPTION
This intends to close #3991

**Description of the change**

Modifies `sortModules` to take an additional `DependencyDepth` argument, and modifies the `purs graph` workflow to only include direct dependencies in the module graph.

* `purs graph` now uses the `Direct` option
* all other workflows use `Transitive` and have the same behavior as they did previously

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
