### PR TITLE
Update the changelog with release notes for the upcoming v0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,9 @@ data RLProxy (row :: RowList) = RLProxy
 
 Now we can have a single proxy type, whose parameter has a polymorphic kind.
 
-#### Type In Type
+#### Type :: Type
 
-The type-checker now supports `TypeInType` (or `Type :: Type`), so the old `Kind` data type and namespace is now gone. Kinds and types are the same and exist in the same namespace.
+The old `Kind` data type and namespace is gone. Kinds and types are the same and exist in the same namespace.
 
 Previously one could do:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,10 +98,11 @@ In GHC, all signatures use the `type` prefix, but we reuse the same keyword as t
 
 It's better to be explicit about polymorphism by writing signatures. Since we don't really quantify over free type variables, it's also necessary in the case that two poly-kinded arguments must have the same kind. The compiler will warn about missing kind signatures when polymorphic kinds are inferred.
 
-Classes can have signatures too, but they must end with the new `Constraint` kind instead of `Type`. For example, `Prim.Row.Cons` now has the signature:
+Classes can have signatures too, but they must end with the new `Constraint` kind instead of `Type`. For example, here's the new definition of `Prim.Row.Cons`:
 
 ```purescript
 class Cons :: forall k. Symbol -> k -> Row k -> Row k -> Constraint
+class Cons label a tail row | label a tail -> row, label row -> a tail
 ```
 
 ### Safe zero-cost coercions
@@ -132,7 +133,7 @@ Here's the annotation we added to `Effect`:
 type role Effect representational
 ```
 
-Conversely, we might want to strengthen the roles of parameters with invariants invisible to the type system. Maps are the canonical example of this: the shape of their underlying tree rely on the `Ord` instance of their keys, but the `Ord` instance of a newtype may behave differently than the one of the wrapped type so it would be unsafe to allow coercions between `Map k1 a` and `Map k2 a` when `Coercible k1 k2` holds.
+Conversely, we might want to strengthen the roles of parameters with invariants invisible to the type system. Maps are the canonical example of this: the shape of their underlying tree rely on the `Ord` instance of their keys, but the `Ord` instance of a newtype may behave differently than the one of the wrapped type so it would be unsafe to allow coercions between `Map k1 a` and `Map k2 a`, even when `Coercible k1 k2` holds.
 
 In order to forbid such unsafe coercion we added a _nominal_ annotation to the first parameter of `Map`:
 
@@ -173,11 +174,11 @@ Meaning that raw strings can contain up to two successive quotes, any number of 
 
 * Unsupport bare negative literals as equational binders (#3956, @rhendric)
 
-It used to be possible to match on negative litterals, such as `-1`, but this prevented parsing matches on constructors aliased to `-`. The compiler will reject matches on _bare_ negative litterals, but they can still be matched by wrapping them in parentheses.
+It used to be possible to match on negative literals, such as `-1`, but this prevented parsing matches on constructors aliased to `-`. The compiler will reject matches on _bare_ negative literals, but they can still be matched by wrapping them in parentheses.
 
 * Forbid partial data constructors exports (#3872, @kl0tl)
 
-Exporting only some of the constructors of a type meant that changes internal to a module, such that adding or removing an unexported constructor, could cause unexhaustive pattern matches errors in downstream code. Partial explicit export lists will have to be completed with the missing constructors or replaced by implicit export lists.
+Exporting only some of the constructors of a type meant that changes internal to a module, such as adding or removing an unexported constructor, could cause unexhaustive pattern match errors in downstream code. Partial explicit export lists will have to be completed with the missing constructors or replaced by implicit export lists.
 
 * Print compile errors to stdout, progress messages to stderr (#3839, @JordanMartinez)
 
@@ -205,9 +206,17 @@ Allowing the compiler to be built against various versions of `language-javascri
 
 #### Improvements
 
+* Improves protocol errors from the IDE server (#3998, @kritzcreek)
+
+The IDE server now respond with more descriptive error messages when failing to parse a command. This should make it easier to contribute fixes to the various clients.
+
+* Extend ImportCompletion with declarationType (#3997, @i-am-the-slime)
+
+By exposing the declaration type (value, type, typeclass, etc.) downstream tooling can annotate imports with this info so users know what they are about to import. The info can also be mapped to a namespace filter to allow importing identifiers that appear more than once in a source file which throws an exception without such a filter.
+
 * Improve error message when `negate` isn't imported (#3952, @mhmdanas)
 
-This shows a specific message when using negative litterals but `Data.Ring.negate` is out of scope, similar to the messages shown when using do notation if `Control.Bind.bind` and `Control.Bind.discard` are out of scope.
+This shows a specific message when using negative literals but `Data.Ring.negate` is out of scope, similar to the messages shown when using do notation if `Control.Bind.bind` and `Control.Bind.discard` are out of scope.
 
 * Add source spans to `PartiallyAppliedSynonym` errors (#3951, @rhendric)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Other improvements:
 
 Polymorphic kinds, based on the [Kind Inference for Datatypes](https://richarde.dev/papers/2020/kind-inference/kind-inference.pdf) paper (#3779, #3831, #3929, @natefaubion)
 
-Kinds are to types what types are to terms (although kinds are themselves types now), but whereas we have polymorphic types, kinds were monomorphic.
+Just as types classify terms, kinds classify types. But while we have polymorphic types, kinds were previously monomorphic.
 
 This meant that we were not able to abstract over kinds, leading for instance to a proliferation of proxy types:
 
@@ -113,17 +113,17 @@ Coercible constraints, based on the [Safe Zero-cost Coercions for Haskell](https
 
 #### Roles
 
-Types parameters now have _roles_, which depend on how they affect the runtime representation of their type. There's three roles, from most to least restrictive:
+Types parameters now have _roles_, which depend on how they affect the runtime representation of their type. There are three roles, from most to least restrictive:
 
-* _nominal_ parameters are only coercible to themselves.
+* _nominal_ parameters can only be coerced to themselves.
 
-* _representational_ parameters are coercible when a Coercible constraint holds.
+* _representational_ parameters can only be coerced to each other when a Coercible constraint holds.
 
-* _phantom_ parameters are coercible to anything.
+* _phantom_ parameters can be coerced to anything.
 
 #### Role annotations
 
-The compiler infers _nominal_ roles for foreign data types, which is safe but can be too constraining sometimes. For example this prevents to coerce `Effect Age` to `Effect Int`, even though they actually have the same runtime representation.
+The compiler infers _nominal_ roles for foreign data types, which is safe but can be too constraining sometimes. For example this prevents the coercion of `Effect Age` to `Effect Int`, even though they have the same runtime representation.
 
 The roles of foreign data types can thus be loosened with explicit role annotations, similar to the [RoleAnnotations](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#role-annotations) GHC extension.
 
@@ -182,7 +182,7 @@ Exporting only some of the constructors of a type meant that changes internal to
 
 * Print compile errors to stdout, progress messages to stderr (#3839, @JordanMartinez)
 
-The compiler used to print errors to stderr, which is especially annoying when piping its output to another program with the `--json-errors` flag. Stderr is really for diagnostics about the execution of a program, whereas its expected output ought to be printed to stdout.
+Compiler errors and warnings arising from your code are now printed to stdout rather than stderr, and progress messages such as "Compiling Data.Array" are now printed to stderr rather than stdout. Warnings and errors arising from incorrect use of the CLI, such as specifying input files which don't exist or specifying globs which don't match any files, are still printed to stderr (as they were before). This change is useful when using the `--json-errors` flag, since you can now pipe JSON errors into other programs without having to perform awkward gymnastics such as `2>&1`.
 
 #### Fixes
 
@@ -210,7 +210,7 @@ Allowing the compiler to be built against various versions of `language-javascri
 
 The IDE server now respond with more descriptive error messages when failing to parse a command. This should make it easier to contribute fixes to the various clients.
 
-* Extend ImportCompletion with declarationType (#3997, @i-am-the-slime)
+* Extend IDE ImportCompletion with declarationType (#3997, @i-am-the-slime)
 
 By exposing the declaration type (value, type, typeclass, etc.) downstream tooling can annotate imports with this info so users know what they are about to import. The info can also be mapped to a namespace filter to allow importing identifiers that appear more than once in a source file which throws an exception without such a filter.
 
@@ -238,7 +238,7 @@ or
 class (Monad m, MonadAsk Env m) <= MonadAskEnv m
 ```
 
-* Improve incremental rebuilds time for modules with large dependencies (#3899, @milesfrain)
+* Improve incremental rebuild times for modules with large dependencies (#3899, @milesfrain)
 
 #### Other
 
@@ -254,7 +254,7 @@ This is the first step towards smarter incremental rebuilds, which could skip re
 
 * Deprecate constraints in foreign imports (#3829, @kl0tl)
 
-Constrained foreign imports leak instances dictionaries, hindering the compiler ability to optimize their representation. Manipulating dictionaries in foreign code should be avoided and foreign imports should accept the class members they need as additional arguments instead of being constrained.
+Constrained foreign imports leak instance dictionaries, hindering the compiler ability to optimize their representation. Manipulating dictionaries in foreign code should be avoided and foreign imports should accept the class members they need as additional arguments instead of being constrained.
 
 * Deprecate primes (the `'` character) in identifiers exported from foreign modules (#3792, @kl0tl)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ Coercible constraints, based on the [Safe Zero-cost Coercions for Haskell](https
 
 #### Roles
 
-Types parameters now have _roles_, which depend on how they affect the runtime representation of their type. There's three roles, from most to least restrictive: _nominal_, _representational_ and _phantom_.
+Types parameters now have _roles_, which depend on how they affect the runtime representation of their type. There's three roles, from most to least restrictive:
 
 * _nominal_ parameters are only coercible to themselves.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This meant that we were not able to abstract over kinds, leading for instance to
 data Proxy (a :: Type) = Proxy
 data SProxy (a :: Symbol) = SProxy
 data RProxy (row :: # Type) = RProxy
+data RLProxy (row :: RowList) = RLProxy
 ```
 
 Now we can have a single proxy type, whose parameter has a polymorphic kind.
@@ -65,6 +66,8 @@ It is treated internally as:
 ```purescript
 data Foo
 ```
+
+Note that `foreign import data` declarations are not deprecated. They are still necessary to define types with kinds other than `Type` since constructors are not lifted as in GHC with [DataKinds](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#extension-DataKinds).
 
 Likewise, `kind` imports and exports are deprecated and treated the same as a type import or export.
 
@@ -129,7 +132,7 @@ Here's the annotation we added to `Effect`:
 type role Effect representational
 ```
 
-Conversely, we might want to strengthen the roles of parameters with invariants invisible to the type system. Maps are the canonical example of this: the shape of their underlying tree rely on the `Ord` instance of their keys, but the `Ord` instance of a newtype may behave differently than the one of the wrapped type so it would be unsafe to allow coercions between `Map k1 a` and `Map k2 a`, even when `Coercible k1 k2` holds.
+Conversely, we might want to strengthen the roles of parameters with invariants invisible to the type system. Maps are the canonical example of this: the shape of their underlying tree rely on the `Ord` instance of their keys, but the `Ord` instance of a newtype may behave differently than the one of the wrapped type so it would be unsafe to allow coercions between `Map k1 a` and `Map k2 a` when `Coercible k1 k2` holds.
 
 In order to forbid such unsafe coercion we added a _nominal_ annotation to the first parameter of `Map`:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ It is treated internally as:
 data Foo
 ```
 
-Note that `foreign import data` declarations are not deprecated. They are still necessary to define types with kinds other than `Type` since constructors are not lifted as in GHC with [DataKinds](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#extension-DataKinds).
+Note that `foreign import data` declarations are not deprecated. They are still necessary to define types with kinds other than `Type` since constructors are not lifted as in GHC with [DataKinds](https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/data_kinds.html#extension-DataKinds).
 
 Likewise, `kind` imports and exports are deprecated and treated the same as a type import or export.
 
@@ -125,7 +125,7 @@ Types parameters now have _roles_, which depend on how they affect the runtime r
 
 The compiler infers _nominal_ roles for foreign data types, which is safe but can be too constraining sometimes. For example this prevents the coercion of `Effect Age` to `Effect Int`, even though they have the same runtime representation.
 
-The roles of foreign data types can thus be loosened with explicit role annotations, similar to the [RoleAnnotations](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#role-annotations) GHC extension.
+The roles of foreign data types can thus be loosened with explicit role annotations, similar to the [RoleAnnotations](https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/roles.html#extension-RoleAnnotations) GHC extension.
 
 Here's the annotation we added to `Effect`:
 


### PR DESCRIPTION
This pull request lists every pull request we merged since v0.13.6 minus those that were already released in v0.13.8 and the following that I took the liberty to omit: https://github.com/purescript/purescript/pull/3894, https://github.com/purescript/purescript/pull/3934, https://github.com/purescript/purescript/pull/3945, https://github.com/purescript/purescript/pull/3969, https://github.com/purescript/purescript/pull/3976.

I tried to motivate and detail most of the changes, except under the **Docs** and **Internal** sections where I only rewrote commit messages when necessary.