### PR TITLE
Extend ImportCompletion with declarationType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Breaking changes:
 
 New features:
 
+* Extend ImportCompletion with declarationType (#3997, @i-am-the-slime)
+
+  By exposing the declaration type (value, type, typeclass, etc.) 
+  downstream tooling can annotate imports with this info so users know what they
+  are about to import. The info can also be mapped to a namespace filter to 
+  allow importing identifiers that appear more than once in a source file which
+  throws an exception without such a filter. 
+
 Bugfixes:
 
 * Only include direct dependencies in the output for `purs graph` (#3993, @colinwahl)

--- a/psc-ide/PROTOCOL.md
+++ b/psc-ide/PROTOCOL.md
@@ -124,7 +124,8 @@ couldn't be extracted from a source file.
     "end": [3, 1]
     },
   "documentation": "A filtering function",
-  "exportedFrom": ["Data.Array"]
+  "exportedFrom": ["Data.Array"],
+  "declarationType": "value",
   }
 ]
 ```

--- a/psc-ide/PROTOCOL.md
+++ b/psc-ide/PROTOCOL.md
@@ -107,14 +107,10 @@ The `complete` command looks up possible completions/corrections.
 
 The following format is returned as the Result:
 
-The `definedAt`, `documentation`, as well as the `declarationType` field might 
-be `null` if they couldn't be extracted from a source file. The 
-`declarationType` represents if a given declaration is a `value`, `type`, 
-`typeSynonym`, `dataConstructor`, `typeClass`, `valueOperator`, `typeOperator`, 
-or a `moduleName`. This information helps users in subsequent import commands.
-It increases their confidence that what they're about to import is actually what
-they meant and allows to produce namespace filters to import identifiers that
-have multiple meanings in their source file.
+The `definedAt`, `documentation`, as well as the `declarationType` field might
+be `null` if they couldn't be extracted from a source file. See the
+[Declaration Type Filter](#declaration-type-filter) further down for all
+possible values of declaration types and how to use this information.
 
 ```json
 [

--- a/psc-ide/PROTOCOL.md
+++ b/psc-ide/PROTOCOL.md
@@ -107,8 +107,14 @@ The `complete` command looks up possible completions/corrections.
 
 The following format is returned as the Result:
 
-Both the `definedAt` as well as the `documentation` field might be `null` if they
-couldn't be extracted from a source file.
+The `definedAt`, `documentation`, as well as the `declarationType` field might 
+be `null` if they couldn't be extracted from a source file. The 
+`declarationType` represents if a given declaration is a `value`, `type`, 
+`typeSynonym`, `dataConstructor`, `typeClass`, `valueOperator`, `typeOperator`, 
+or a `moduleName`. This information helps users in subsequent import commands.
+It increases their confidence that what they're about to import is actually what
+they meant and allows to produce namespace filters to import identifiers that
+have multiple meanings in their source file.
 
 ```json
 [

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -130,7 +130,7 @@ completionFromMatch (Match (m, IdeDeclarationAnn ann decl), mns) =
 
     complDocumentation = _annDocumentation ann
 
-    complDeclarationType = Just (declarationTypeFromIdeDeclaration decl)
+    complDeclarationType = Just (declarationType decl)
 
     showFixity p a r o =
       let asso = case a of

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -130,6 +130,8 @@ completionFromMatch (Match (m, IdeDeclarationAnn ann decl), mns) =
 
     complDocumentation = _annDocumentation ann
 
+    complDeclarationType = Just (declarationTypeFromIdeDeclaration decl)
+
     showFixity p a r o =
       let asso = case a of
             P.Infix -> "infix"

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -66,9 +66,27 @@ encodeRebuildErrors = toJSON . map encodeRebuildError . P.runMultipleErrors
     insertTSCompletions _ _ _ v = v
 
     identCompletion (P.Qualified mn i, ty) =
-      Completion (maybe "" P.runModuleName mn) i (prettyPrintTypeSingleLine ty) (prettyPrintTypeSingleLine ty) Nothing Nothing (maybe [] (\x -> [x]) mn)
+      Completion     
+        { complModule = maybe "" P.runModuleName mn
+        , complIdentifier = i
+        , complType = prettyPrintTypeSingleLine ty
+        , complExpandedType = prettyPrintTypeSingleLine ty
+        , complLocation = Nothing
+        , complDocumentation = Nothing
+        , complExportedFrom = maybe [] (\x -> [x]) mn
+        , complDeclarationType = Nothing
+        }
     fieldCompletion (label, ty) =
-      Completion "" ("_." <> P.prettyPrintLabel label) (prettyPrintTypeSingleLine ty) (prettyPrintTypeSingleLine ty) Nothing Nothing []
+      Completion 
+        { complModule = ""
+        , complIdentifier = ("_." <> P.prettyPrintLabel label)
+        , complType = prettyPrintTypeSingleLine ty
+        , complExpandedType = prettyPrintTypeSingleLine ty
+        , complLocation = Nothing
+        , complDocumentation = Nothing
+        , complExportedFrom = []
+        , complDeclarationType = Nothing
+        }
 
 textError :: IdeError -> Text
 textError (GeneralError msg)          = msg

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -31,7 +31,7 @@ import           Data.Aeson
 import           Data.Text                     (isPrefixOf)
 import qualified Data.Set as Set
 import qualified Data.Map as Map
-import           Language.PureScript.Ide.Filter.Declaration (DeclarationType, declarationType)
+import           Language.PureScript.Ide.Filter.Declaration (DeclarationType)
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
 import qualified Language.PureScript           as P

--- a/src/Language/PureScript/Ide/Filter/Declaration.hs
+++ b/src/Language/PureScript/Ide/Filter/Declaration.hs
@@ -2,13 +2,11 @@
 
 module Language.PureScript.Ide.Filter.Declaration
        ( DeclarationType(..)
-       , declarationType
        ) where
 
 import           Protolude                     hiding (isPrefixOf)
 
 import           Data.Aeson
-import qualified Language.PureScript.Ide.Types as PI
 
 data DeclarationType
   = Value
@@ -33,14 +31,13 @@ instance FromJSON DeclarationType where
       "typeoperator"      -> pure TypeOperator
       "module"            -> pure Module
       _                   -> mzero
-
-declarationType :: PI.IdeDeclaration -> DeclarationType
-declarationType decl = case decl of
-  PI.IdeDeclValue _ -> Value
-  PI.IdeDeclType _ -> Type
-  PI.IdeDeclTypeSynonym _ -> Synonym
-  PI.IdeDeclDataConstructor _ -> DataConstructor
-  PI.IdeDeclTypeClass _ -> TypeClass
-  PI.IdeDeclValueOperator _ -> ValueOperator
-  PI.IdeDeclTypeOperator _ -> TypeOperator
-  PI.IdeDeclModule _ -> Module
+instance ToJSON DeclarationType where
+  toJSON dt = toJSON $ case dt of
+    Value           -> "value" :: Text
+    Type            -> "type"
+    Synonym         -> "synonym"
+    DataConstructor -> "dataconstructor"
+    TypeClass       -> "typeclass"
+    ValueOperator   -> "valueoperator"
+    TypeOperator    -> "typeoperator"
+    Module          -> "module"

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -316,9 +316,6 @@ addImportForIdentifier fp ident qual filters = do
           Right <$> addExplicitImport fp decl m1 qual
         -- Here we need the user to specify whether they wanted a 
         -- dataconstructor or a type
-
-        -- TODO: With the new namespace filter, this can actually be a
-        -- request for the user to specify which of the two was wanted.
         Nothing ->
           throwError (GeneralError "Undecidable between type and dataconstructor")
 

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -314,8 +314,8 @@ addImportForIdentifier fp ident qual filters = do
         -- worst
         Just decl ->
           Right <$> addExplicitImport fp decl m1 qual
-        -- Here we need the user to specify whether he wanted a dataconstructor
-        -- or a type
+        -- Here we need the user to specify whether they wanted a 
+        -- dataconstructor or a type
 
         -- TODO: With the new namespace filter, this can actually be a
         -- request for the user to specify which of the two was wanted.
@@ -323,7 +323,7 @@ addImportForIdentifier fp ident qual filters = do
           throwError (GeneralError "Undecidable between type and dataconstructor")
 
     -- Multiple matches were found so we need to ask the user to clarify which
-    -- module he meant
+    -- module they meant
     xs ->
       pure (Left xs)
     where

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -15,6 +15,7 @@ import           Data.Time.Clock (UTCTime)
 import qualified Data.Map.Lazy as M
 import qualified Language.PureScript as P
 import qualified Language.PureScript.Errors.JSON as P
+import           Language.PureScript.Ide.Filter.Declaration (DeclarationType(..))
 import           Lens.Micro.Platform hiding ((.=))
 
 type ModuleIdent = Text
@@ -222,7 +223,7 @@ data Completion = Completion
   , complLocation :: Maybe P.SourceSpan
   , complDocumentation :: Maybe Text
   , complExportedFrom :: [P.ModuleName]
-  , complDeclarationType :: Maybe Text -- Use a real type instead?
+  , complDeclarationType :: Maybe DeclarationType
   } deriving (Show, Eq, Ord)
 
 instance ToJSON Completion where
@@ -247,17 +248,16 @@ identifierFromDeclarationRef = \case
   P.TypeOpRef _ op -> P.showOp op
   _ -> ""
 
-declarationTypeFromIdeDeclaration :: IdeDeclaration -> Text
-declarationTypeFromIdeDeclaration = \case
-  IdeDeclValue _ -> "value"
-  IdeDeclType _ -> "type"
-  IdeDeclTypeSynonym _ -> "typeSynonym"
-  IdeDeclDataConstructor _ -> "dataConstructor"
-  IdeDeclTypeClass _ -> "typeClass"
-  IdeDeclValueOperator _ -> "valueOperator"
-  IdeDeclTypeOperator _ -> "typeOperator"
-  IdeDeclModule _ -> "moduleName"
-
+declarationType :: IdeDeclaration -> DeclarationType
+declarationType decl = case decl of
+  IdeDeclValue _ -> Value
+  IdeDeclType _ -> Type
+  IdeDeclTypeSynonym _ -> Synonym
+  IdeDeclDataConstructor _ -> DataConstructor
+  IdeDeclTypeClass _ -> TypeClass
+  IdeDeclValueOperator _ -> ValueOperator
+  IdeDeclTypeOperator _ -> TypeOperator
+  IdeDeclModule _ -> Module
 data Success =
   CompletionResult [Completion]
   | TextResult Text

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -222,6 +222,7 @@ data Completion = Completion
   , complLocation :: Maybe P.SourceSpan
   , complDocumentation :: Maybe Text
   , complExportedFrom :: [P.ModuleName]
+  , complDeclarationType :: Maybe Text -- Use a real type instead?
   } deriving (Show, Eq, Ord)
 
 instance ToJSON Completion where
@@ -234,6 +235,7 @@ instance ToJSON Completion where
       , "definedAt" .= complLocation
       , "documentation" .= complDocumentation
       , "exportedFrom" .= map P.runModuleName complExportedFrom
+      , "declarationType" .= complDeclarationType
       ]
 
 identifierFromDeclarationRef :: P.DeclarationRef -> Text
@@ -244,6 +246,17 @@ identifierFromDeclarationRef = \case
   P.ValueOpRef _ op -> P.showOp op
   P.TypeOpRef _ op -> P.showOp op
   _ -> ""
+
+declarationTypeFromIdeDeclaration :: IdeDeclaration -> Text
+declarationTypeFromIdeDeclaration = \case
+  IdeDeclValue _ -> "value"
+  IdeDeclType _ -> "type"
+  IdeDeclTypeSynonym _ -> "typeSynonym"
+  IdeDeclDataConstructor _ -> "dataConstructor"
+  IdeDeclTypeClass _ -> "typeClass"
+  IdeDeclValueOperator _ -> "valueOperator"
+  IdeDeclTypeOperator _ -> "typeOperator"
+  IdeDeclModule _ -> "moduleName"
 
 data Success =
   CompletionResult [Completion]

--- a/tests/Language/PureScript/Ide/CompletionSpec.hs
+++ b/tests/Language/PureScript/Ide/CompletionSpec.hs
@@ -86,3 +86,61 @@ spec = describe "Applying completion options" $ do
                   , typ "member"
                   ]
     result `shouldSatisfy` \res -> complDocumentation res == Just "doc for member\n"
+
+  it "includes declarationType in completions for values" $ do
+    ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
+      Test.runIde [ load ["CompletionSpec"]
+                  , typ "exampleValue"
+                  ]
+    result `shouldSatisfy` \res -> complDeclarationType res == Just "value"
+
+  it "includes declarationType in completions for functions" $ do
+    ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
+      Test.runIde [ load ["CompletionSpec"]
+                  , typ "exampleFunction"
+                  ]
+    result `shouldSatisfy` \res -> complDeclarationType res == Just "value"
+
+  it "includes declarationType in completions for inferred values" $ do
+    ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
+      Test.runIde [ load ["CompletionSpec"]
+                  , typ "exampleInferredString"
+                  ]
+    result `shouldSatisfy` \res -> complDeclarationType res == Just "value"
+
+  it "includes declarationType in completions for operators" $ do
+    ([_, (Right (CompletionResult results))], _) <- Test.inProject $
+      Test.runIde [ load ["CompletionSpec"]
+                  , typ "\\°/"
+                  ]
+    length results `shouldBe` 2
+    results `shouldSatisfy` 
+      any (\res -> complDeclarationType res == Just "valueOperator")
+    results `shouldSatisfy` 
+      any (\res -> complDeclarationType res == Just "typeOperator")
+
+  it "includes declarationType in completions for type constructors with \
+      \conflicting names" $ do
+    ([_, (Right (CompletionResult results))], _) <- Test.inProject $
+      Test.runIde [ load ["CompletionSpec"]
+                  , typ "ExampleTypeConstructor"
+                  ]
+    length results `shouldBe` 2
+    results `shouldSatisfy` 
+      any (\res -> complDeclarationType res == Just "dataConstructor")
+    results `shouldSatisfy` 
+      any (\res -> complDeclarationType res == Just "type")
+
+  it "includes declarationType in completions for type classes" $ do
+    ([_, (Right (CompletionResult [result]))], _) <- Test.inProject $
+      Test.runIde [ load ["CompletionSpec"]
+                  , typ "ExampleClass"
+                  ]
+    result `shouldSatisfy` \res -> complDeclarationType res == Just "typeClass"
+
+  it "includes declarationType in completions for type class members" $ do
+    ([_, (Right (CompletionResult [result]))], _) <- Test.inProject $
+      Test.runIde [ load ["CompletionSpec"]
+                  , typ "exampleMember"
+                  ]
+    result `shouldSatisfy` \res -> complDeclarationType res == Just "value"

--- a/tests/Language/PureScript/Ide/CompletionSpec.hs
+++ b/tests/Language/PureScript/Ide/CompletionSpec.hs
@@ -9,6 +9,7 @@ import qualified Language.PureScript as P
 import Language.PureScript.Ide.Test as Test
 import Language.PureScript.Ide.Command as Command
 import Language.PureScript.Ide.Completion
+import qualified Language.PureScript.Ide.Filter.Declaration as DeclarationType
 import Language.PureScript.Ide.Types
 import Test.Hspec
 import System.FilePath
@@ -92,21 +93,24 @@ spec = describe "Applying completion options" $ do
       Test.runIde [ load ["CompletionSpec"]
                   , typ "exampleValue"
                   ]
-    result `shouldSatisfy` \res -> complDeclarationType res == Just "value"
+    result `shouldSatisfy` \res ->
+      complDeclarationType res == Just DeclarationType.Value
 
   it "includes declarationType in completions for functions" $ do
     ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
       Test.runIde [ load ["CompletionSpec"]
                   , typ "exampleFunction"
                   ]
-    result `shouldSatisfy` \res -> complDeclarationType res == Just "value"
+    result `shouldSatisfy` \res ->
+      complDeclarationType res == Just DeclarationType.Value
 
   it "includes declarationType in completions for inferred values" $ do
     ([_, (Right (CompletionResult [ result ]))], _) <- Test.inProject $
       Test.runIde [ load ["CompletionSpec"]
                   , typ "exampleInferredString"
                   ]
-    result `shouldSatisfy` \res -> complDeclarationType res == Just "value"
+    result `shouldSatisfy` \res ->
+      complDeclarationType res == Just DeclarationType.Value
 
   it "includes declarationType in completions for operators" $ do
     ([_, (Right (CompletionResult results))], _) <- Test.inProject $
@@ -114,10 +118,10 @@ spec = describe "Applying completion options" $ do
                   , typ "\\°/"
                   ]
     length results `shouldBe` 2
-    results `shouldSatisfy` 
-      any (\res -> complDeclarationType res == Just "valueOperator")
-    results `shouldSatisfy` 
-      any (\res -> complDeclarationType res == Just "typeOperator")
+    results `shouldSatisfy` any (\res ->
+      complDeclarationType res == Just DeclarationType.ValueOperator)
+    results `shouldSatisfy` any (\res ->
+      complDeclarationType res == Just DeclarationType.TypeOperator)
 
   it "includes declarationType in completions for type constructors with \
       \conflicting names" $ do
@@ -126,21 +130,23 @@ spec = describe "Applying completion options" $ do
                   , typ "ExampleTypeConstructor"
                   ]
     length results `shouldBe` 2
-    results `shouldSatisfy` 
-      any (\res -> complDeclarationType res == Just "dataConstructor")
-    results `shouldSatisfy` 
-      any (\res -> complDeclarationType res == Just "type")
+    results `shouldSatisfy` any (\res ->
+        complDeclarationType res == Just DeclarationType.DataConstructor)
+    results `shouldSatisfy` any (\res ->
+        complDeclarationType res == Just DeclarationType.Type)
 
   it "includes declarationType in completions for type classes" $ do
     ([_, (Right (CompletionResult [result]))], _) <- Test.inProject $
       Test.runIde [ load ["CompletionSpec"]
                   , typ "ExampleClass"
                   ]
-    result `shouldSatisfy` \res -> complDeclarationType res == Just "typeClass"
+    result `shouldSatisfy` \res ->
+      complDeclarationType res == Just DeclarationType.TypeClass
 
   it "includes declarationType in completions for type class members" $ do
     ([_, (Right (CompletionResult [result]))], _) <- Test.inProject $
       Test.runIde [ load ["CompletionSpec"]
                   , typ "exampleMember"
                   ]
-    result `shouldSatisfy` \res -> complDeclarationType res == Just "value"
+    result `shouldSatisfy` \res ->
+      complDeclarationType res == Just DeclarationType.Value

--- a/tests/support/pscide/src/CompletionSpec.purs
+++ b/tests/support/pscide/src/CompletionSpec.purs
@@ -1,0 +1,18 @@
+module CompletionSpec where
+
+exampleValue :: Int
+exampleValue = 42
+
+exampleFunction :: Int -> Int
+exampleFunction _ = 1
+
+exampleInferredString = ""
+
+infixl 5 exampleFunction as \°/ 
+
+data ExampleTypeConstructor a b = ExampleTypeConstructor a b
+
+infixl 5 type ExampleTypeConstructor as \°/ 
+
+class ExampleClass where
+  exampleMember :: Int


### PR DESCRIPTION
**Description of the change**

This change extends the `Completion` datatype in the IDE. More specifically, it adds `declarationType` as a field to import completions. This type represents what type of declaration (value, type, typeclass, operator, type operator, etc.) the IDE will add to the file if applied. 

This addresses #3083 which currently prevents users from importing identifiers if there is more than one candidate with the same name in a file (for example the type-level `/\` and the value level `/\` from `Data.Tuple.Nested`). Today, attempting to import `/\` causes `psc-ide` to throw an exception. 
It's already possible to refine the import command with a namespace filter to make the import succeed, however users (and clients) currently lack the necessary information to make a decision about the namespace. This PR adds this information.

You can also [read a longer background story](https://gist.github.com/i-am-the-slime/408c4d5e32668e92d9224701f20c6bb9)

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution
