### PR TITLE
[purs ide] Improves protocol errors from the ide server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ where included in the `depends` field in the output for `purs graph`.
 
 Other improvements:
 
+* More descriptive protocol errors from the ide server (@kritzcreek)
+
 ## [v0.13.8](https://github.com/purescript/purescript/releases/tag/v0.13.8) - 2020-05-23
 
 **Bug Fixes**

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -26,9 +26,10 @@ module Language.PureScript.Ide.Filter
 
 import           Protolude                     hiding (isPrefixOf, Prefix)
 
+import           Control.Monad.Fail (fail)
 import           Data.Bifunctor (first)
 import           Data.Aeson
-import           Data.Text                     (isPrefixOf)
+import           Data.Text (isPrefixOf)
 import qualified Data.Set as Set
 import qualified Data.Map as Map
 import           Language.PureScript.Ide.Filter.Declaration (DeclarationType, declarationType)
@@ -141,4 +142,4 @@ instance FromJSON Filter where
       "declarations" -> do
         declarations <- o.: "params"
         pure (declarationTypeFilter (Set.fromList declarations))
-      _ -> mzero
+      s -> fail ("Unknown filter: " <> show s)

--- a/src/Language/PureScript/Ide/Filter/Declaration.hs
+++ b/src/Language/PureScript/Ide/Filter/Declaration.hs
@@ -7,6 +7,7 @@ module Language.PureScript.Ide.Filter.Declaration
 
 import           Protolude                     hiding (isPrefixOf)
 
+import           Control.Monad.Fail (fail)
 import           Data.Aeson
 import qualified Language.PureScript.Ide.Types as PI
 
@@ -32,7 +33,7 @@ instance FromJSON DeclarationType where
       "valueoperator"     -> pure ValueOperator
       "typeoperator"      -> pure TypeOperator
       "module"            -> pure Module
-      _                   -> mzero
+      s                   -> fail ("Unknown declaration type: " <> show s)
 
 declarationType :: PI.IdeDeclaration -> DeclarationType
 declarationType decl = case decl of

--- a/src/Language/PureScript/Ide/Matcher.hs
+++ b/src/Language/PureScript/Ide/Matcher.hs
@@ -24,6 +24,7 @@ module Language.PureScript.Ide.Matcher
 
 import           Protolude
 
+import           Control.Monad.Fail (fail)
 import           Data.Aeson
 import qualified Data.Text                     as T
 import qualified Data.Text.Encoding            as TE
@@ -49,7 +50,7 @@ instance FromJSON (Matcher IdeDeclarationAnn) where
         distanceMatcher
           <$> params .: "search"
           <*> params .: "maximumDistance"
-      Just _ -> mzero
+      Just s -> fail ("Unknown matcher: " <> show s)
       Nothing -> return mempty
 
 -- | Matches any occurrence of the search string with intersections

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -8,6 +8,7 @@ module Language.PureScript.Ide.Types where
 import           Protolude hiding (moduleName)
 
 import           Control.Concurrent.STM (TVar)
+import           Control.Monad.Fail (fail)
 import           Data.Aeson (ToJSON, FromJSON, (.=))
 import qualified Data.Aeson as Aeson
 import           Data.IORef (IORef)
@@ -301,12 +302,11 @@ data IdeNamespace = IdeNSValue | IdeNSType | IdeNSModule
   deriving (Show, Eq, Ord, Generic, NFData)
 
 instance FromJSON IdeNamespace where
-  parseJSON (Aeson.String s) = case s of
+  parseJSON = Aeson.withText "Namespace" $ \case
     "value" -> pure IdeNSValue
     "type" -> pure IdeNSType
     "module" -> pure IdeNSModule
-    _       -> mzero
-  parseJSON _ = mzero
+    s -> fail ("Unknown namespace: " <> show s)
 
 -- | A name tagged with a namespace
 data IdeNamespaced = IdeNamespaced IdeNamespace Text

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -33,6 +33,7 @@ import           Protolude                           hiding (decodeUtf8,
                                                       encodeUtf8, to)
 
 import           Data.Aeson
+import qualified Data.Text                           as T
 import qualified Data.Text.Lazy                      as TL
 import           Data.Text.Lazy.Encoding             as TLE
 import qualified Language.PureScript                 as P
@@ -87,8 +88,8 @@ typeOperatorAliasT i =
 encodeT :: (ToJSON a) => a -> Text
 encodeT = TL.toStrict . TLE.decodeUtf8 . encode
 
-decodeT :: (FromJSON a) => Text -> Maybe a
-decodeT = decode . TLE.encodeUtf8 . TL.fromStrict
+decodeT :: (FromJSON a) => Text -> Either Text a
+decodeT = first T.pack . eitherDecode . TLE.encodeUtf8 . TL.fromStrict
 
 properNameT :: Getting r (P.ProperName a) Text
 properNameT = to P.runProperName


### PR DESCRIPTION
**Description of the change**

When failing to parse the Command Json we're now returning more descriptive error messages from the IDE server. This should make it easier to contribute fixes to the various clients. See https://gist.github.com/i-am-the-slime/408c4d5e32668e92d9224701f20c6bb9#coda-purescript-014-caveats for an example of someone stumbling over this.

/cc @i-am-the-slime 