### PR TITLE
Don't mention unknowns in unification errors when coercing misaligned rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ class Cons label a tail row | label a tail -> row, label row -> a tail
 
 ### Safe zero-cost coercions
 
-Coercible constraints, based on the [Safe Zero-cost Coercions for Haskell](https://www.microsoft.com/en-us/research/uploads/prod/2018/05/coercible-JFP.pdf) paper (#3351, #3810, #3896, #3873, #3860, #3905, #3893, #3909, #3931, #3906, #3881, #3878, #3937, #3930, #3955, #3927, #3999, @lunaris, @rhendric, @kl0tl, @hdgarrood)
+Coercible constraints, based on the [Safe Zero-cost Coercions for Haskell](https://www.microsoft.com/en-us/research/uploads/prod/2018/05/coercible-JFP.pdf) paper (#3351, #3810, #3896, #3873, #3860, #3905, #3893, #3909, #3931, #3906, #3881, #3878, #3937, #3930, #3955, #3927, #3999, #4000, @lunaris, @rhendric, @kl0tl, @hdgarrood)
 
 `Prim.Coerce.Coercible` is a new compiler-solved class, used to relate types with the same runtime representation. One can use `Safe.Coerce.coerce` (from the new [`safe-coerce`](https://github.com/purescript/purescript-safe-coerce) library) instead of `Unsafe.Coerce.unsafeCoerce` to safely turn a `a` into a `b` when `Coercible a b` holds.
 

--- a/tests/purs/failing/CoercibleUnknownRowTail1.out
+++ b/tests/purs/failing/CoercibleUnknownRowTail1.out
@@ -1,0 +1,41 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleUnknownRowTail1.purs:7:9 - 7:24 (line 7, column 9 - line 7, column 24)
+
+  No type class instance was found for
+  [33m                                  [0m
+  [33m  Prim.Coerce.Coercible (() @Type)[0m
+  [33m                        t0        [0m
+  [33m                                  [0m
+  The instance head contains unknown type variables. Consider adding a type annotation.
+
+while solving type class constraint
+[33m                                  [0m
+[33m  Prim.Coerce.Coercible { a :: Int[0m
+[33m                        }         [0m
+[33m                        { a :: Int[0m
+[33m                        | t0      [0m
+[33m                        }         [0m
+[33m                                  [0m
+while applying a function [33mcoerce[0m
+  of type [33mCoercible @Type t1 t2 => t1 -> t2[0m
+  to argument [33m{ a: 0[0m
+              [33m}     [0m
+while checking that expression [33mcoerce { a: 0[0m
+                               [33m       }     [0m
+  has type [33m{ a :: Int[0m
+           [33m| t0      [0m
+           [33m}         [0m
+while checking type of property accessor [33m(coerce { a: ...[0m
+                                         [33m        }       [0m
+                                         [33m)               [0m
+                                         [33m.a              [0m
+in value declaration [33mzero[0m
+
+where [33mt0[0m is an unknown type
+      [33mt1[0m is an unknown type
+      [33mt2[0m is an unknown type
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/CoercibleUnknownRowTail1.out
+++ b/tests/purs/failing/CoercibleUnknownRowTail1.out
@@ -3,10 +3,10 @@ in module [33mMain[0m
 at tests/purs/failing/CoercibleUnknownRowTail1.purs:7:9 - 7:24 (line 7, column 9 - line 7, column 24)
 
   No type class instance was found for
-  [33m                                  [0m
-  [33m  Prim.Coerce.Coercible (() @Type)[0m
-  [33m                        t0        [0m
-  [33m                                  [0m
+  [33m                          [0m
+  [33m  Prim.Coerce.Coercible ()[0m
+  [33m                        t0[0m
+  [33m                          [0m
   The instance head contains unknown type variables. Consider adding a type annotation.
 
 while solving type class constraint

--- a/tests/purs/failing/CoercibleUnknownRowTail1.purs
+++ b/tests/purs/failing/CoercibleUnknownRowTail1.purs
@@ -1,0 +1,7 @@
+-- @shouldFailWith NoInstanceFound
+module Main where
+
+import Safe.Coerce (coerce)
+
+zero :: Int
+zero = (coerce { a: 0 }).a

--- a/tests/purs/failing/CoercibleUnknownRowTail2.out
+++ b/tests/purs/failing/CoercibleUnknownRowTail2.out
@@ -1,0 +1,46 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/CoercibleUnknownRowTail2.purs:7:9 - 7:30 (line 7, column 9 - line 7, column 30)
+
+  No type class instance was found for
+  [33m                                  [0m
+  [33m  Prim.Coerce.Coercible ( b :: Int[0m
+  [33m                        )         [0m
+  [33m                        t0        [0m
+  [33m                                  [0m
+  The instance head contains unknown type variables. Consider adding a type annotation.
+
+while solving type class constraint
+[33m                                  [0m
+[33m  Prim.Coerce.Coercible { a :: Int[0m
+[33m                        , b :: Int[0m
+[33m                        }         [0m
+[33m                        { a :: Int[0m
+[33m                        | t0      [0m
+[33m                        }         [0m
+[33m                                  [0m
+while applying a function [33mcoerce[0m
+  of type [33mCoercible @Type t1 t2 => t1 -> t2[0m
+  to argument [33m{ a: 0[0m
+              [33m, b: 1[0m
+              [33m}     [0m
+while checking that expression [33mcoerce { a: 0[0m
+                               [33m       , b: 1[0m
+                               [33m       }     [0m
+  has type [33m{ a :: Int[0m
+           [33m| t0      [0m
+           [33m}         [0m
+while checking type of property accessor [33m(coerce { a: ...[0m
+                                         [33m        , b: ...[0m
+                                         [33m        }       [0m
+                                         [33m)               [0m
+                                         [33m.a              [0m
+in value declaration [33mzero[0m
+
+where [33mt0[0m is an unknown type
+      [33mt1[0m is an unknown type
+      [33mt2[0m is an unknown type
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/CoercibleUnknownRowTail2.purs
+++ b/tests/purs/failing/CoercibleUnknownRowTail2.purs
@@ -1,0 +1,7 @@
+-- @shouldFailWith NoInstanceFound
+module Main where
+
+import Safe.Coerce (coerce)
+
+zero :: Int
+zero = (coerce { a: 0, b: 1 }).a


### PR DESCRIPTION
This pull request improves error messages when coercing unaligned rows as suggested by @rhendric in https://github.com/purescript/purescript/issues/3983, but does not try to solve unknowns encountered while solving Coercible constraints.

Doing so would be ill-advised should we ever add support for nominal equalities to the interaction solver given my current (lack of) understanding of how functional dependencies affect unification.

I’d be happy to revisit this later though.