### PR TITLE
Erase elaborated kinds from all errors by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Other improvements:
 
 ### Polykinds
 
-Polymorphic kinds, based on the [Kind Inference for Datatypes](https://richarde.dev/papers/2020/kind-inference/kind-inference.pdf) paper (#3779, #3831, #3929, @natefaubion)
+Polymorphic kinds, based on the [Kind Inference for Datatypes](https://richarde.dev/papers/2020/kind-inference/kind-inference.pdf) paper (#3779, #3831, #3929, #4007, @natefaubion, @kl0tl)
 
 Just as types classify terms, kinds classify types. But while we have polymorphic types, kinds were previously monomorphic.
 

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -846,7 +846,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "Overlapping type class instances found for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
+                , Box.vcat Box.left (map prettyTypeAtom ts)
                 ]
             , line "The following instances were found:"
             , indent $ paras (map (line . showQualified showIdent) ds)
@@ -882,7 +882,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "No type class instance was found for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
+                , Box.vcat Box.left (map prettyTypeAtom ts)
                 ]
             , paras [ line "The instance head contains unknown type variables. Consider adding a type annotation."
                     | any containsUnknowns ts
@@ -909,7 +909,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "Type class instance for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
+                , Box.vcat Box.left (map prettyTypeAtom ts)
                 ]
             , line "is possibly infinite."
             ]
@@ -919,7 +919,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "Cannot derive a type class instance for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
+                , Box.vcat Box.left (map prettyTypeAtom ts)
                 ]
             , line "since instances of this type class are not derivable."
             ]
@@ -927,7 +927,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "Cannot derive newtype instance for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
+                , Box.vcat Box.left (map prettyTypeAtom ts)
                 ]
             , line "Make sure this is a newtype."
             ]
@@ -935,7 +935,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "The derived newtype instance for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName cl)
-                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
+                , Box.vcat Box.left (map prettyTypeAtom ts)
                 ]
             , line $ "does not include a derived superclass instance for " <> markCode (showQualified runProperName su) <> "."
             ]
@@ -943,7 +943,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "The derived newtype instance for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName cl)
-                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
+                , Box.vcat Box.left (map prettyTypeAtom ts)
                 ]
             , line $ "implies an superclass instance for " <> markCode (showQualified runProperName su) <> " which could not be verified."
             ]
@@ -951,7 +951,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "Cannot derive the type class instance"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
+                , Box.vcat Box.left (map prettyTypeAtom ts)
                 ]
             , line $ fold $
                 [ "because the "
@@ -967,7 +967,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line "Cannot derive the type class instance"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
-                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
+                , Box.vcat Box.left (map prettyTypeAtom ts)
                 ]
             , "because the type"
             , markCodeBox $ indent $ prettyType ty
@@ -1022,7 +1022,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ line $ "Orphan instance " <> markCode (showIdent nm) <> " found for "
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName cnm)
-                , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) ts)
+                , Box.vcat Box.left (map prettyTypeAtom ts)
                 ]
             , Box.vcat Box.left $ case modulesToList of
                 [] -> [ line "There is nowhere this instance can be placed without being an orphan."
@@ -1324,7 +1324,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
         [ line "Invalid type class instance declaration for"
         , markCodeBox $ indent $ Box.hsep 1 Box.left
             [ line (showQualified runProperName C.Coercible)
-            , Box.vcat Box.left (map (typeAtomAsBox prettyDepth) tys)
+            , Box.vcat Box.left (map prettyTypeAtom tys)
             ]
         , line "Instance declarations of this type class are disallowed."
         ]
@@ -1589,6 +1589,11 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
   prettyTypeWithDepth depth
     | full = typeAsBox depth
     | otherwise = typeAsBox depth . eraseForAllKindAnnotations . eraseKindApps
+
+  prettyTypeAtom :: Type a -> Box.Box
+  prettyTypeAtom
+    | full = typeAtomAsBox prettyDepth
+    | otherwise = typeAtomAsBox prettyDepth . eraseForAllKindAnnotations . eraseKindApps
 
   levelText :: Text
   levelText = case level of

--- a/tests/purs/failing/CoercibleHigherKindedData.out
+++ b/tests/purs/failing/CoercibleHigherKindedData.out
@@ -3,10 +3,10 @@ in module [33mMain[0m
 at tests/purs/failing/CoercibleHigherKindedData.purs:13:17 - 13:23 (line 13, column 17 - line 13, column 23)
 
   No type class instance was found for
-  [33m                                              [0m
-  [33m  Prim.Coerce.Coercible (Unary @t4 t5)        [0m
-  [33m                        (Binary @t2 @t4 a3 t5)[0m
-  [33m                                              [0m
+  [33m                                      [0m
+  [33m  Prim.Coerce.Coercible (Unary t5)    [0m
+  [33m                        (Binary a3 t5)[0m
+  [33m                                      [0m
   The instance head contains unknown type variables. Consider adding a type annotation.
 
 while solving type class constraint

--- a/tests/purs/failing/CoercibleNonCanonical1.out
+++ b/tests/purs/failing/CoercibleNonCanonical1.out
@@ -3,10 +3,10 @@ in module [33mMain[0m
 at tests/purs/failing/CoercibleNonCanonical1.purs:11:27 - 11:33 (line 11, column 27 - line 11, column 33)
 
   No type class instance was found for
-  [33m                                     [0m
-  [33m  Prim.Coerce.Coercible a0           [0m
-  [33m                        (D (N @k a0))[0m
-  [33m                                     [0m
+  [33m                                  [0m
+  [33m  Prim.Coerce.Coercible a0        [0m
+  [33m                        (D (N a0))[0m
+  [33m                                  [0m
 
 while solving type class constraint
 [33m                                    [0m

--- a/tests/purs/failing/InstanceChainSkolemUnknownMatch.out
+++ b/tests/purs/failing/InstanceChainSkolemUnknownMatch.out
@@ -3,11 +3,11 @@ in module [33mInstanceChainSkolemUnknownMatch[0m
 at tests/purs/failing/InstanceChainSkolemUnknownMatch.purs:14:13 - 14:36 (line 14, column 13 - line 14, column 36)
 
   No type class instance was found for
-  [33m                                                        [0m
-  [33m  InstanceChainSkolemUnknownMatch.Same (Proxy @Type t3) [0m
-  [33m                                       (Proxy @Type Int)[0m
-  [33m                                       t4               [0m
-  [33m                                                        [0m
+  [33m                                                  [0m
+  [33m  InstanceChainSkolemUnknownMatch.Same (Proxy t3) [0m
+  [33m                                       (Proxy Int)[0m
+  [33m                                       t4         [0m
+  [33m                                                  [0m
   The instance head contains unknown type variables. Consider adding a type annotation.
 
 while applying a function [33msame[0m

--- a/tests/purs/failing/PolykindInstanceOverlapping.out
+++ b/tests/purs/failing/PolykindInstanceOverlapping.out
@@ -3,9 +3,9 @@ in module [33mMain[0m
 at tests/purs/failing/PolykindInstanceOverlapping.purs:12:1 - 13:19 (line 12, column 1 - line 13, column 19)
 
   Overlapping type class instances found for
-  [33m                         [0m
-  [33m  Main.ShowP (Proxy @k a)[0m
-  [33m                         [0m
+  [33m                      [0m
+  [33m  Main.ShowP (Proxy a)[0m
+  [33m                      [0m
   The following instances were found:
 
     Main.test1


### PR DESCRIPTION
**Description of the change**

Nate noticed that `NoInstanceFound` errors were showing kind applications, which are supposed to be erased in error messages (not hints) unless with `--verbose-errors`, because they are directly rendered with `typeAtomAsBox` instead of with something similar to `prettyType`.

This pull request replaces all occurrences of `typeAtomAsBox prettyDepth`, except in hints, with a `prettyTypeAtom` function which erase kind applications as `prettyType` does.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
