### PR TITLE
Use type annotation hint only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Bugfixes:
 
 * Make close punctuation printable in errors (#3982, @rhendric)
 
+* Use type annotation hint only when needed (#4025, @rhendric)
+
 Other improvements:
 
 ## v0.14.0

--- a/lib/purescript-ast/src/Language/PureScript/Types.hs
+++ b/lib/purescript-ast/src/Language/PureScript/Types.hs
@@ -549,6 +549,12 @@ unknowns = everythingOnTypes (<>) go where
   go (TUnknown _ u) = IS.singleton u
   go _ = mempty
 
+containsUnknowns :: Type a -> Bool
+containsUnknowns = everythingOnTypes (||) go where
+  go :: Type a -> Bool
+  go TUnknown{} = True
+  go _ = False
+
 eraseKindApps :: Type a -> Type a
 eraseKindApps = everywhereOnTypes $ \case
   KindApp _ ty _ -> ty

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -103,7 +103,7 @@ data SimpleErrorMessage
   | KindsDoNotUnify SourceType SourceType
   | ConstrainedTypeUnified SourceType SourceType
   | OverlappingInstances (Qualified (ProperName 'ClassName)) [SourceType] [Qualified Ident]
-  | NoInstanceFound SourceConstraint
+  | NoInstanceFound SourceConstraint Bool
   | AmbiguousTypeVariables SourceType [Int]
   | UnknownClass (Qualified (ProperName 'ClassName))
   | PossiblyInfiniteInstance (Qualified (ProperName 'ClassName)) [SourceType]
@@ -448,7 +448,7 @@ onTypesInErrorMessageM f (ErrorMessage hints simple) = ErrorMessage <$> traverse
   gSimple (ConstrainedTypeUnified t1 t2) = ConstrainedTypeUnified <$> f t1 <*> f t2
   gSimple (ExprDoesNotHaveType e t) = ExprDoesNotHaveType e <$> f t
   gSimple (InvalidInstanceHead t) = InvalidInstanceHead <$> f t
-  gSimple (NoInstanceFound con) = NoInstanceFound <$> overConstraintArgs (traverse f) con
+  gSimple (NoInstanceFound con unks) = NoInstanceFound <$> overConstraintArgs (traverse f) con <*> pure unks
   gSimple (AmbiguousTypeVariables t us) = AmbiguousTypeVariables <$> f t <*> pure us
   gSimple (OverlappingInstances cl ts insts) = OverlappingInstances cl <$> traverse f ts <*> pure insts
   gSimple (PossiblyInfiniteInstance cl ts) = PossiblyInfiniteInstance cl <$> traverse f ts
@@ -856,14 +856,14 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             , markCodeBox $ indent $ line (showQualified runProperName nm)
             , line "because the class was not in scope. Perhaps it was not exported."
             ]
-    renderSimpleErrorMessage (NoInstanceFound (Constraint _ C.Fail _ [ ty ] _)) | Just box <- toTypelevelString ty =
+    renderSimpleErrorMessage (NoInstanceFound (Constraint _ C.Fail _ [ ty ] _) _) | Just box <- toTypelevelString ty =
       paras [ line "A custom type error occurred while solving type class constraints:"
             , indent box
             ]
     renderSimpleErrorMessage (NoInstanceFound (Constraint _ C.Partial
                                                           _
                                                           _
-                                                          (Just (PartialConstraintData bs b)))) =
+                                                          (Just (PartialConstraintData bs b))) _) =
       paras [ line "A case expression could not be determined to cover all inputs."
             , line "The following additional cases are required to cover all inputs:"
             , indent $ paras $
@@ -872,28 +872,22 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
                   : [line "..." | not b]
             , line "Alternatively, add a Partial constraint to the type of the enclosing value."
             ]
-    renderSimpleErrorMessage (NoInstanceFound (Constraint _ C.Discard _ [ty] _)) =
+    renderSimpleErrorMessage (NoInstanceFound (Constraint _ C.Discard _ [ty] _) _) =
       paras [ line "A result of type"
             , markCodeBox $ indent $ prettyType ty
             , line "was implicitly discarded in a do notation block."
             , line ("You can use " <> markCode "_ <- ..." <> " to explicitly discard the result.")
             ]
-    renderSimpleErrorMessage (NoInstanceFound (Constraint _ nm _ ts _)) =
+    renderSimpleErrorMessage (NoInstanceFound (Constraint _ nm _ ts _) unks) =
       paras [ line "No type class instance was found for"
             , markCodeBox $ indent $ Box.hsep 1 Box.left
                 [ line (showQualified runProperName nm)
                 , Box.vcat Box.left (map prettyTypeAtom ts)
                 ]
             , paras [ line "The instance head contains unknown type variables. Consider adding a type annotation."
-                    | any containsUnknowns ts
+                    | unks
                     ]
             ]
-      where
-      containsUnknowns :: Type a -> Bool
-      containsUnknowns = everythingOnTypes (||) go
-        where
-        go TUnknown{} = True
-        go _ = False
     renderSimpleErrorMessage (AmbiguousTypeVariables t us) =
       paras [ line "The inferred type"
             , markCodeBox $ indent $ prettyType t
@@ -1629,7 +1623,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       where
       isUnifyHint ErrorUnifyingTypes{} = True
       isUnifyHint _ = False
-    stripRedundantHints (NoInstanceFound (Constraint _ C.Coercible _ args _)) = filter (not . isSolverHint)
+    stripRedundantHints (NoInstanceFound (Constraint _ C.Coercible _ args _) _) = filter (not . isSolverHint)
       where
       isSolverHint (ErrorSolvingConstraint (Constraint _ C.Coercible _ args' _)) = args == args'
       isSolverHint _ = False

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -103,7 +103,9 @@ data SimpleErrorMessage
   | KindsDoNotUnify SourceType SourceType
   | ConstrainedTypeUnified SourceType SourceType
   | OverlappingInstances (Qualified (ProperName 'ClassName)) [SourceType] [Qualified Ident]
-  | NoInstanceFound SourceConstraint Bool
+  | NoInstanceFound
+      SourceConstraint -- ^ constraint that could not be solved
+      Bool -- ^ whether eliminating unknowns with annotations might help
   | AmbiguousTypeVariables SourceType [Int]
   | UnknownClass (Qualified (ProperName 'ClassName))
   | PossiblyInfiniteInstance (Qualified (ProperName 'ClassName)) [SourceType]

--- a/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
@@ -527,7 +527,7 @@ insoluble
   -> SourceType
   -> MultipleErrors
 insoluble k a b =
-  errorMessage . NoInstanceFound $ srcConstraint Prim.Coercible [k] [a, b] Nothing
+  errorMessage $ NoInstanceFound (srcConstraint Prim.Coercible [k] [a, b] Nothing) (any containsUnknowns [a, b])
 
 -- | Constraints of the form @Coercible a b@ can be solved if the two arguments
 -- are the same. Since we currently don't support higher-rank arguments in

--- a/tests/purs/failing/2616.out
+++ b/tests/purs/failing/2616.out
@@ -7,7 +7,6 @@ at tests/purs/failing/2616.purs:9:1 - 9:38 (line 9, column 1 - line 9, column 38
   [33m  Prim.RowList.RowToList r1[0m
   [33m                         t2[0m
   [33m                           [0m
-  The instance head contains unknown type variables. Consider adding a type annotation.
 
 while applying a function [33mcompare[0m
   of type [33mOrd t0 => t0 -> t0 -> Ordering[0m

--- a/tests/purs/failing/4024-2.out
+++ b/tests/purs/failing/4024-2.out
@@ -1,0 +1,27 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/4024-2.purs:10:8 - 10:13 (line 10, column 8 - line 10, column 13)
+
+  No type class instance was found for
+  [33m                 [0m
+  [33m  Main.Foo t2    [0m
+  [33m           t3    [0m
+  [33m           String[0m
+  [33m                 [0m
+  The instance head contains unknown type variables. Consider adding a type annotation.
+
+while applying a function [33mbar[0m
+  of type [33mFoo @t0 @t1 @Type t2 t3 String => Int -> String[0m
+  to argument [33m0[0m
+while checking that expression [33mbar 0[0m
+  has type [33mString[0m
+in value declaration [33mtest[0m
+
+where [33mt0[0m is an unknown type
+      [33mt1[0m is an unknown type
+      [33mt2[0m is an unknown type
+      [33mt3[0m is an unknown type
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/4024-2.purs
+++ b/tests/purs/failing/4024-2.purs
@@ -1,0 +1,11 @@
+-- @shouldFailWith NoInstanceFound
+module Main where
+
+class Foo a b c | a -> b c, b -> a c
+
+bar :: forall a b. Foo a b String => Int -> String
+bar _ = ""
+
+test :: String
+test = bar 0
+

--- a/tests/purs/failing/4024.out
+++ b/tests/purs/failing/4024.out
@@ -1,0 +1,26 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/4024.purs:10:8 - 10:13 (line 10, column 8 - line 10, column 13)
+
+  No type class instance was found for
+  [33m                 [0m
+  [33m  Main.Foo String[0m
+  [33m           t2    [0m
+  [33m           t3    [0m
+  [33m                 [0m
+
+while applying a function [33mbar[0m
+  of type [33mFoo @Type @t0 @t1 String t2 t3 => Int -> String[0m
+  to argument [33m0[0m
+while checking that expression [33mbar 0[0m
+  has type [33mString[0m
+in value declaration [33mtest[0m
+
+where [33mt0[0m is an unknown type
+      [33mt1[0m is an unknown type
+      [33mt2[0m is an unknown type
+      [33mt3[0m is an unknown type
+
+See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/4024.purs
+++ b/tests/purs/failing/4024.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith NoInstanceFound
+module Main where
+
+class Foo a b c | a -> b c, b -> a c
+
+bar :: forall a b. Foo String a b => Int -> String
+bar _ = ""
+
+test :: String
+test = bar 0

--- a/tests/purs/failing/InstanceChainBothUnknownAndMatch.out
+++ b/tests/purs/failing/InstanceChainBothUnknownAndMatch.out
@@ -16,7 +16,6 @@ at tests/purs/failing/InstanceChainBothUnknownAndMatch.purs:17:13 - 17:55 (line 
   [33m                                          )            [0m
   [33m                                          t4           [0m
   [33m                                                       [0m
-  The instance head contains unknown type variables. Consider adding a type annotation.
 
 while applying a function [33msame[0m
   of type [33mSame @Type @Type t0 t1 t2 => t0 -> t1 -> SProxy t2[0m

--- a/tests/purs/failing/InstanceChainSkolemUnknownMatch.out
+++ b/tests/purs/failing/InstanceChainSkolemUnknownMatch.out
@@ -8,7 +8,6 @@ at tests/purs/failing/InstanceChainSkolemUnknownMatch.purs:14:13 - 14:36 (line 1
   [33m                                       (Proxy Int)[0m
   [33m                                       t4         [0m
   [33m                                                  [0m
-  The instance head contains unknown type variables. Consider adding a type annotation.
 
 while applying a function [33msame[0m
   of type [33mSame @Type @Type t0 t1 t2 => t0 -> t1 -> SProxy t2[0m


### PR DESCRIPTION
This commit changes the criteria for when the message

    The instance head contains unknown type variables. Consider adding a
    type annotation.

appears in a NoInstanceFound error. Instead of using it whenever an
unknown type variable appears in an instance head, now the compiler
adds this hint only when every covering set of type arguments of the
instance head contains an unknown type variable. (Covering sets are
determined by functional dependencies, if present; otherwise, the entire
set of type arguments is the one and only covering set.)

The rationale is that if any covering set is already completely known,
then the availability of an appropriate instance will not be changed by
adding more type annotations.

**Description of the change**

See above. Fixes #4024.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
