### PR TITLE
Drop "Proposal:" prefix in proposal template

### DIFF
--- a/.github/ISSUE_TEMPLATE/compiler-proposal.md
+++ b/.github/ISSUE_TEMPLATE/compiler-proposal.md
@@ -1,7 +1,6 @@
 ---
 name: Compiler proposal
 about: A concrete suggestion to change the PureScript compiler
-title: 'Proposal:'
 labels: enhancement
 assignees: ''
 


### PR DESCRIPTION
It's just noise, and the `enhancement` label does a better job at identifying what kind of issue this is.