### PR TITLE
Instantiate polymorphic kinds when unwrapping newtypes while solving Coercible constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Bugfixes:
 
 * Make close punctuation printable in errors (#3982, @rhendric)
 
+* Instantiate polymorphic kinds when unwrapping newtypes while solving Coercible constraints (#4040, @kl0tl)
+
 Other improvements:
 
 * Add white outline stroke to logo in README (#4003, @ptrfrncsmrph)

--- a/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
@@ -633,9 +633,9 @@ unwrapNewtype env = go (0 :: Int) where
     when (n > 1000) $ throwError CannotUnwrapInfiniteNewtypeChain
     (currentModuleName, currentModuleImports) <- gets $ checkCurrentModule &&& checkCurrentModuleImports
     case unapplyTypes ty of
-      (TypeConstructor _ newtypeName, _, xs)
+      (TypeConstructor _ newtypeName, ks, xs)
         | Just (inScope, fromModuleName, tvs, newtypeCtorName, wrappedTy) <-
-            lookupNewtypeConstructorInScope env currentModuleName currentModuleImports newtypeName
+            lookupNewtypeConstructorInScope env currentModuleName currentModuleImports newtypeName ks
         -- We refuse to unwrap newtypes over polytypes because we don't know how
         -- to canonicalize them yet and we'd rather try to make progress with
         -- another rule.
@@ -658,10 +658,13 @@ unwrapNewtype env = go (0 :: Int) where
 lookupNewtypeConstructor
   :: Environment
   -> Qualified (ProperName 'TypeName)
+  -> [SourceType]
   -> Maybe ([Text], ProperName 'ConstructorName, SourceType)
-lookupNewtypeConstructor env qualifiedNewtypeName = do
-  (_, DataType Newtype tvs [(ctorName, [wrappedTy])]) <- M.lookup qualifiedNewtypeName (types env)
-  pure (map (\(name, _, _) -> name) tvs, ctorName, wrappedTy)
+lookupNewtypeConstructor env qualifiedNewtypeName ks = do
+  (k, DataType Newtype tvs [(ctorName, [wrappedTy])]) <- M.lookup qualifiedNewtypeName (types env)
+  let (kvs, _) = fromMaybe (internalError "lookupNewtypeConstructor: unkinded forall binder") $ completeBinderList k
+      instantiatedKinds = zipWith (\(_, (kv, _)) k -> (kv, k)) kvs ks
+  pure (map (\(name, _, _) -> name) tvs, ctorName, replaceAllTypeVars instantiatedKinds wrappedTy)
 
 -- | Behaves like 'lookupNewtypeConstructor' but also returns whether the
 -- newtype constructor is in scope and the module from which it is imported, or
@@ -677,15 +680,16 @@ lookupNewtypeConstructorInScope
        )
      ]
   -> Qualified (ProperName 'TypeName)
+  -> [SourceType]
   -> Maybe (Bool, Maybe ModuleName, [Text], Qualified (ProperName 'ConstructorName), SourceType)
-lookupNewtypeConstructorInScope env currentModuleName currentModuleImports qualifiedNewtypeName@(Qualified newtypeModuleName newtypeName) = do
+lookupNewtypeConstructorInScope env currentModuleName currentModuleImports qualifiedNewtypeName@(Qualified newtypeModuleName newtypeName) ks = do
   let fromModule = find isNewtypeCtorImported currentModuleImports
       fromModuleName = (\(_, n, _, _, _) -> n) <$> fromModule
       asModuleName = (\(_, _, _, n, _) -> n) =<< fromModule
       isDefinedInCurrentModule = newtypeModuleName == currentModuleName
       isImported = isJust fromModule
       inScope = isDefinedInCurrentModule || isImported
-  (tvs, ctorName, wrappedTy) <- lookupNewtypeConstructor env qualifiedNewtypeName
+  (tvs, ctorName, wrappedTy) <- lookupNewtypeConstructor env qualifiedNewtypeName ks
   pure (inScope, fromModuleName, tvs, Qualified asModuleName ctorName, wrappedTy)
   where
   isNewtypeCtorImported (_, _, importDeclType, _, exportedTypes) =
@@ -780,7 +784,7 @@ canonDecomposition env a b
   | (TypeConstructor _ aTyName, _, axs) <- unapplyTypes a
   , (TypeConstructor _ bTyName, _, bxs) <- unapplyTypes b
   , aTyName == bTyName
-  , Nothing <- lookupNewtypeConstructor env aTyName =
+  , Nothing <- lookupNewtypeConstructor env aTyName [] =
       decompose env aTyName axs bxs
   | otherwise = empty
 
@@ -799,8 +803,8 @@ canonDecompositionFailure env k a b
   | (TypeConstructor _ aTyName, _, _) <- unapplyTypes a
   , (TypeConstructor _ bTyName, _, _) <- unapplyTypes b
   , aTyName /= bTyName
-  , Nothing <- lookupNewtypeConstructor env aTyName
-  , Nothing <- lookupNewtypeConstructor env bTyName =
+  , Nothing <- lookupNewtypeConstructor env aTyName []
+  , Nothing <- lookupNewtypeConstructor env bTyName [] =
       throwError $ insoluble k a b
   | otherwise = empty
 
@@ -849,7 +853,7 @@ canonNewtypeDecomposition env (Just givens) a b
   | (TypeConstructor _ aTyName, _, axs) <- unapplyTypes a
   , (TypeConstructor _ bTyName, _, bxs) <- unapplyTypes b
   , aTyName == bTyName
-  , Just _ <- lookupNewtypeConstructor env aTyName = do
+  , Just _ <- lookupNewtypeConstructor env aTyName [] = do
       let givensCanDischarge = any (\given -> canDischarge given (a, b)) givens
       guard $ not givensCanDischarge
       decompose env aTyName axs bxs

--- a/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
@@ -661,8 +661,8 @@ lookupNewtypeConstructor
   -> [SourceType]
   -> Maybe ([Text], ProperName 'ConstructorName, SourceType)
 lookupNewtypeConstructor env qualifiedNewtypeName ks = do
-  (k, DataType Newtype tvs [(ctorName, [wrappedTy])]) <- M.lookup qualifiedNewtypeName (types env)
-  let (kvs, _) = fromMaybe (internalError "lookupNewtypeConstructor: unkinded forall binder") $ completeBinderList k
+  (newtyk, DataType Newtype tvs [(ctorName, [wrappedTy])]) <- M.lookup qualifiedNewtypeName (types env)
+  let (kvs, _) = fromMaybe (internalError "lookupNewtypeConstructor: unkinded forall binder") $ completeBinderList newtyk
       instantiatedKinds = zipWith (\(_, (kv, _)) k -> (kv, k)) kvs ks
   pure (map (\(name, _, _) -> name) tvs, ctorName, replaceAllTypeVars instantiatedKinds wrappedTy)
 

--- a/tests/purs/passing/Coercible.purs
+++ b/tests/purs/passing/Coercible.purs
@@ -63,6 +63,11 @@ apId1ToApId1 = coerce
 apId1ToApId2 :: forall a. Ap Id1 a -> Ap Id2 a
 apId1ToApId2 = coerce
 
+newtype ApPolykind f = ApPolykind (f ())
+
+apPolykind :: forall f. ApPolykind f -> f ()
+apPolykind = coerce
+
 newtype Phantom1 a b = Phantom1 a
 
 phantom1TypeToPhantom1Symbol :: forall x (y :: Type) (z :: Symbol). Phantom1 x y -> Phantom1 x z


### PR DESCRIPTION
**Description of the change**

@thomashoneyman shared on Slack that the compiler is unable to derive a `Newtype` instance for newtypes applying a variable to a row:

```purescript
newtype X r f = X (r ( field :: f Int ))
derive instance newtypeX :: Newtype (X r f) _
```

```
Error found:
in module Main
at src/Main.purs:6:1 - 6:46 (line 6, column 1 - line 6, column 46)

  No type class instance was found for
                                              
    Prim.Coerce.Coercible (r1                 
                             ( field :: f2 Int
                             )                
                          )                   
                          (r1                 
                             ( field :: f2 Int
                             )                
                          )                   
                                              
  The instance head contains unknown type variables. Consider adding a type annotation.

while solving type class constraint
                                            
  Prim.Coerce.Coercible (X @t3 r1 f2)       
                        (r1                 
                           ( field :: f2 Int
                           )                
                        )                   
                           
```

The issue is easier to understand with an empty row, and compiling with `--verbose-errors`:

```purescript
newtype X r = X (r ())
derive instance newtypeX :: Newtype (X r) _
```

```
Error found:
in module Main
at src/Main.purs:6:1 - 6:44 (line 6, column 1 - line 6, column 44)

  No type class instance was found for
                                       
    Prim.Coerce.Coercible (r1 (() @k)) 
                          (r1 (() @t0))

  The instance head contains unknown type variables. Consider adding a type annotation.

while solving type class constraint
                                     
  Prim.Coerce.Coercible (X @t0 r1)   
                        (r1 (() @t0))
```

Now we see the types differ in how their polymorphic kind is instantiated!

The unknown kind applied to the newtype in the original constraint is replaced by a `k` variable, bound in the (inferred) newtype kind signature. This pull request instantiates those variables when unwrapping newtypes, so that `Coercible (X @t0 r1) (r1 (() @t0))` yields `Coercible (r1 (() @t0)) (r1 (() @t0))` as expected.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
