### PR TITLE
Remove unused Data.Foldable.foldr import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Other improvements:
 
   The previous `logo.png` was not legible against a dark background (#4001).
 
+Internal:
+
+* Remove unused Data.Foldable.foldr import (#4042, @kl0tl)
+
 ## v0.14.0
 
 ### Polykinds

--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -6,7 +6,6 @@ import Prelude.Compat
 import Control.Applicative (empty, liftA2)
 import Control.Monad (guard)
 import Control.Monad.State (State, evalState, get, modify)
-import Data.Foldable (foldr)
 import Data.Functor (($>), (<&>))
 import qualified Data.Set as S
 import Data.Text (Text, pack)


### PR DESCRIPTION
**Description of the change**

We added an import for `Data.Foldable.foldr` to `Language.PureScript.CoreImp.Optimizer.TCO` in #3958. The build passed (https://travis-ci.org/github/purescript/purescript/builds/763606846) but subsequent builds started to fail with “The import of ‘Data.Foldable’ is redundant” since we merged #4013. The latter upgraded `base-compat` and GHC but `base-compat-0.10.5` already exported `Prelude.Compat.foldr`, and according to GHC documentation `-Wunused-imports` was already implied by -Wall in v8.6.5 so I really don’t understand what’s going on 🤷‍♂️ 

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
