### PR TITLE
Allow fixity, kind, role declarations in REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Bugfixes:
 
 * Ensure unnamed instances appear in documentation (#4109 by @JordanMartinez)
 
+* Allow fixity, kind, role declarations in REPL (#4046, @rhendric)
+
 Internal:
 
 * Fix for Haddock (#4072 by @ncaq and @JordanMartinez)

--- a/tests/purs/psci/BasicEval.purs
+++ b/tests/purs/psci/BasicEval.purs
@@ -8,3 +8,12 @@ fac n = foldl mul 1 (1..n)
 
 -- @shouldEvaluateTo 3628800
 fac 10
+
+infix 4 mul as |*|
+
+-- @shouldEvaluateTo 50
+5 |*| 10
+
+data X a = X
+
+type role X representational

--- a/tests/purs/psci/Multiline.purs
+++ b/tests/purs/psci/Multiline.purs
@@ -10,3 +10,8 @@ fac n = foldl mul 1 (1..n)
 
 -- @shouldEvaluateTo 3628800
 fac 10
+
+-- @paste
+data X :: Type -> Type
+data X a = X
+-- @paste


### PR DESCRIPTION
It seems that advances in parsing and/or interpretation have made the
artificial restriction that used to exist on declarations in the REPL no
longer necessary. Fixity, kind, and role declarations are all tested and
working, and the only other types of declarations that exist in the AST
at this time are imports (which are specially handled in an earlier
parser), BoundValueDeclarations (which can't be created at the top
level), and binding groups (which are only created in desugaring).

**Description of the change**

Fixes #3978.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
