### PR TITLE
Fix kinded declaration reordering in desugaring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Bugfixes:
 
 * Fix row unification with shared unknown in tails (#4048, @rhendric)
 
+* Fix kinded declaration reordering in desugaring (#4047, @rhendric)
+
 Other improvements:
 
 * Add white outline stroke to logo in README (#4003, @ptrfrncsmrph)

--- a/tests/purs/failing/RowsInKinds.out
+++ b/tests/purs/failing/RowsInKinds.out
@@ -5,7 +5,7 @@ at tests/purs/failing/RowsInKinds.purs:14:16 - 14:17 (line 14, column 16 - line 
   Could not match kind
   [33m             [0m
   [33m  ( z :: Type[0m
-  [33m  | t24      [0m
+  [33m  | t25      [0m
   [33m  )          [0m
   [33m             [0m
   with kind

--- a/tests/purs/passing/4035.purs
+++ b/tests/purs/passing/4035.purs
@@ -1,0 +1,14 @@
+module Main where
+
+import Effect.Console (log)
+import Other (Id)
+
+type Alias = Int
+
+type Wrapped :: forall k. (Type -> k) -> Row k -> Row k
+type Wrapped f r = (key :: f Alias | r)
+
+type Unwrapped :: Row Type -> Row Type
+type Unwrapped r = Wrapped Id r
+
+main = log "Done"

--- a/tests/purs/passing/4035/Other.purs
+++ b/tests/purs/passing/4035/Other.purs
@@ -1,0 +1,4 @@
+module Other where
+
+type Id :: forall k. k -> k
+type Id a = a

--- a/tests/purs/passing/4038.purs
+++ b/tests/purs/passing/4038.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Effect.Console (log)
+
+class A :: Constraint
+class A
+
+class B :: Constraint
+class A <= B
+
+main = log "Done"


### PR DESCRIPTION
The type checker assumes that type class and type synonym definitions
always precede their use (circular references are not allowed between
these declarations). This constraint needs to be enforced by the
`createBindingGroups` phase in desugaring, regardless of whether the
declaration has a kind or is being referenced by a kind declaration.
Failing to do so resulted in one issue where type synonyms were being
expanded out of order with surprising consequences, and another where
a superclass was not known when its subclass was being checked.

**Description of the change**

Fixes #4035, fixes #4038.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
