### PR TITLE
Fix row unification with shared unknown in tails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Bugfixes:
 
 * Make close punctuation printable in errors (#3982, @rhendric)
 
+* Fix row unification with shared unknown in tails (#4048, @rhendric)
+
 Other improvements:
 
 * Add white outline stroke to logo in README (#4003, @ptrfrncsmrph)

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -411,7 +411,7 @@ unifyKindsWithFailure onFailure = go
       solveUnknown a' $ rowFromList (rs, p1)
     (([], w1), ([], w2)) | eqType w1 w2 ->
       pure ()
-    ((rs1, TUnknown _ u1), (rs2, TUnknown _ u2)) -> do
+    ((rs1, TUnknown _ u1), (rs2, TUnknown _ u2)) | u1 /= u2 -> do
       rest <- freshKind nullSourceSpan
       solveUnknown u1 $ rowFromList (rs2, rest)
       solveUnknown u2 $ rowFromList (rs1, rest)

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -166,7 +166,7 @@ unifyRows r1 r2 = sequence_ matches *> uncurry unifyTails rest where
   unifyTails ([], REmptyKinded _ _) ([], REmptyKinded _ _) = return ()
   unifyTails ([], TypeVar _ v1)    ([], TypeVar _ v2)    | v1 == v2 = return ()
   unifyTails ([], Skolem _ _ s1 _ _) ([], Skolem _ _ s2 _ _) | s1 == s2 = return ()
-  unifyTails (sd1, TUnknown a u1)  (sd2, TUnknown _ u2)  = do
+  unifyTails (sd1, TUnknown a u1)  (sd2, TUnknown _ u2)  | u1 /= u2 = do
     forM_ sd1 $ occursCheck u2 . rowListType
     forM_ sd2 $ occursCheck u1 . rowListType
     rest' <- freshTypeWithKind =<< elaborateKind (TUnknown a u1)

--- a/tests/purs/failing/3765-kinds.out
+++ b/tests/purs/failing/3765-kinds.out
@@ -1,0 +1,29 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/3765-kinds.purs:7:28 - 7:29 (line 7, column 28 - line 7, column 29)
+
+  Could not match kind
+  [33m            [0m
+  [33m  ( a :: Int[0m
+  [33m  | t11     [0m
+  [33m  )         [0m
+  [33m            [0m
+  with kind
+  [33m            [0m
+  [33m  ( b :: Int[0m
+  [33m  | t11     [0m
+  [33m  )         [0m
+  [33m            [0m
+
+while checking that type [33mx[0m
+  has kind [33m{ b :: Int[0m
+           [33m| t0      [0m
+           [33m}         [0m
+while inferring the kind of [33mTricky x x[0m
+in type synonym [33mMkTricky[0m
+
+where [33mt0[0m is an unknown type
+
+See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/3765-kinds.purs
+++ b/tests/purs/failing/3765-kinds.purs
@@ -1,0 +1,7 @@
+-- @shouldFailWith KindsDoNotUnify
+module Main where
+
+data Tricky :: forall r. {a :: Int | r} -> {b :: Int | r} -> Type
+data Tricky x y = Tricky
+
+type MkTricky x = Tricky x x

--- a/tests/purs/failing/3765.out
+++ b/tests/purs/failing/3765.out
@@ -1,0 +1,42 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/3765.purs:6:23 - 6:24 (line 6, column 23 - line 6, column 24)
+
+  Could not match type
+  [33m            [0m
+  [33m  ( b :: Int[0m
+  [33m  ...       [0m
+  [33m  | t0      [0m
+  [33m  )         [0m
+  [33m            [0m
+  with type
+  [33m            [0m
+  [33m  ( a :: Int[0m
+  [33m  ...       [0m
+  [33m  | t0      [0m
+  [33m  )         [0m
+  [33m            [0m
+
+while trying to match type [33m            [0m
+                           [33m  ( b :: Int[0m
+                           [33m  ...       [0m
+                           [33m  | t0      [0m
+                           [33m  )         [0m
+                           [33m            [0m
+  with type [33m            [0m
+            [33m  ( a :: Int[0m
+            [33m  ...       [0m
+            [33m  | t0      [0m
+            [33m  )         [0m
+            [33m            [0m
+while checking that expression [33mx[0m
+  has type [33m{ b :: Int[0m
+           [33m| t0      [0m
+           [33m}         [0m
+in value declaration [33mmkTricky[0m
+
+where [33mt0[0m is an unknown type
+
+See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/3765.purs
+++ b/tests/purs/failing/3765.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith TypesDoNotUnify
+module Main where
+
+data Tricky r = Tricky {a :: Int | r} {b :: Int | r}
+
+mkTricky x = Tricky x x


### PR DESCRIPTION
If two row types both have the same unknown type as their tails, they
shouldn't be unified unless their labels all match.

**Description of the change**

Fixes #3765.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
