### PR TITLE
Fix wildly off kind unification positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Bugfixes:
 
 * Fix row unification with shared unknown in tails (#4048, @rhendric)
 
+* Fix wildly off kind unification positions (#4050, @natefaubion)
+
 Other improvements:
 
 * Add white outline stroke to logo in README (#4003, @ptrfrncsmrph)

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -1844,6 +1844,12 @@ withPosition :: SourceSpan -> ErrorMessage -> ErrorMessage
 withPosition NullSourceSpan err = err
 withPosition pos (ErrorMessage hints se) = ErrorMessage (positionedError pos : hints) se
 
+withoutPosition :: ErrorMessage -> ErrorMessage
+withoutPosition (ErrorMessage hints se) = ErrorMessage (filter go hints) se
+  where
+  go (PositionedError _) = False
+  go _ = True
+
 positionedError :: SourceSpan -> ErrorMessageHint
 positionedError = PositionedError . pure
 

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -38,7 +38,7 @@ import Language.PureScript.Environment
 import Language.PureScript.Errors
 import Language.PureScript.Names
 import Language.PureScript.TypeChecker.Entailment.Coercible
-import Language.PureScript.TypeChecker.Kinds (elaborateKind, unifyKinds)
+import Language.PureScript.TypeChecker.Kinds (elaborateKind, unifyKinds')
 import Language.PureScript.TypeChecker.Monad
 import Language.PureScript.TypeChecker.Unify
 import Language.PureScript.TypeClassDictionaries
@@ -320,7 +320,7 @@ entails SolverOptions{..} constraint context hints =
                   for_ (lookup var tcdForAll) $ \instKind -> do
                     tyKind <- elaborateKind ty
                     currentSubst <- gets checkSubstitution
-                    unifyKinds
+                    unifyKinds'
                       (substituteType currentSubst . replaceAllTypeVars (M.toList subst) $ instKind)
                       (substituteType currentSubst tyKind)
 

--- a/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
@@ -279,7 +279,7 @@ unify (a, b) = do
   let kindOf = sequence . (id &&& elaborateKind) <=< replaceAllTypeSynonyms
   (a', kind) <- kindOf a
   (b', kind') <- kindOf b
-  unifyKinds kind kind'
+  unifyKinds' kind kind'
   subst <- gets checkSubstitution
   pure ( substituteType subst kind
        , substituteType subst a'

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -358,9 +358,6 @@ unifyKinds = unifyKindsWithFailure $ \w1 w2 ->
   throwError
     . errorMessage''' (fst . getAnnForType <$> [w1, w2])
     $ KindsDoNotUnify w1 w2
-  -- throwError
-  --   . errorMessage
-  --   $ KindsDoNotUnify w1 w2
 
 -- | Does not attach positions to the error node, instead relies on the
 -- | local position context. This is useful when invoking kind unification

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -10,6 +10,7 @@ module Language.PureScript.TypeChecker.Kinds
   , kindOfClass
   , kindsOfAll
   , unifyKinds
+  , unifyKinds'
   , subsumesKind
   , instantiateKind
   , checkKind
@@ -356,6 +357,22 @@ unifyKinds
 unifyKinds = unifyKindsWithFailure $ \w1 w2 ->
   throwError
     . errorMessage''' (fst . getAnnForType <$> [w1, w2])
+    $ KindsDoNotUnify w1 w2
+  -- throwError
+  --   . errorMessage
+  --   $ KindsDoNotUnify w1 w2
+
+-- | Does not attach positions to the error node, instead relies on the
+-- | local position context. This is useful when invoking kind unification
+-- | outside of kind checker internals.
+unifyKinds'
+  :: (MonadError MultipleErrors m, MonadState CheckState m, HasCallStack)
+  => SourceType
+  -> SourceType
+  -> m ()
+unifyKinds' = unifyKindsWithFailure $ \w1 w2 ->
+  throwError
+    . errorMessage
     $ KindsDoNotUnify w1 w2
 
 -- | Check the kind of a type, failing if it is not of kind *.

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -730,7 +730,7 @@ check' (DeferredDictionary className tys) ty = do
 check' (TypedValue checkType val ty1) ty2 = do
   (elabTy1, kind1) <- kindOf ty1
   (elabTy2, kind2) <- kindOf ty2
-  unifyKinds kind1 kind2
+  unifyKinds' kind1 kind2
   checkTypeKind ty1 kind1
   ty1' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ elabTy1
   ty2' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ elabTy2

--- a/tests/purs/failing/3077.out
+++ b/tests/purs/failing/3077.out
@@ -1,6 +1,6 @@
 Error found:
 in module [33mMain[0m
-at tests/purs/failing/3077.purs:11:24 - 11:30 (line 11, column 24 - line 11, column 30)
+at tests/purs/failing/3077.purs:11:14 - 11:38 (line 11, column 14 - line 11, column 38)
 
   Could not match kind
   [33m      [0m

--- a/tests/purs/failing/4019-1.out
+++ b/tests/purs/failing/4019-1.out
@@ -1,0 +1,27 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/4019-1.purs:26:21 - 26:24 (line 26, column 21 - line 26, column 24)
+
+  Could not match kind
+  [33m    [0m
+  [33m  K1[0m
+  [33m    [0m
+  with kind
+  [33m    [0m
+  [33m  K2[0m
+  [33m    [0m
+
+while trying to match type [33mIndexed @Type @K1 @K2 Array[0m
+  with type [33mt0[0m
+while checking that expression [33mfoo[0m
+  has type [33mt0 t1 t2 t3[0m
+in value declaration [33mbar[0m
+
+where [33mt0[0m is an unknown type
+      [33mt3[0m is an unknown type
+      [33mt1[0m is an unknown type
+      [33mt2[0m is an unknown type
+
+See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/4019-1.purs
+++ b/tests/purs/failing/4019-1.purs
@@ -1,0 +1,26 @@
+-- @shouldFailWith KindsDoNotUnify
+module Main where
+
+import Prelude
+
+newtype Indexed ∷ forall k1 k2 k3. (k1 → Type) → k2 → k3 → k1 → Type
+newtype Indexed m x y a = Indexed (m a)
+
+class IxFunctor ∷ ∀ ix. (ix → ix → Type → Type) → Constraint
+class IxFunctor f where
+  imap ∷ ∀ a b x y. (a → b) → f x y a → f x y b
+
+instance ixFunctorIndexed ∷ Functor m ⇒ IxFunctor (Indexed m) where
+  imap f (Indexed ma) = Indexed (map f ma)
+
+foreign import data K1 :: Type
+foreign import data K2 :: Type
+
+foreign import data D1 :: K1
+foreign import data D2 :: K2
+
+foo :: Indexed Array D1 D2 Int
+foo = Indexed [1]
+
+bar :: Indexed Array D1 D2 Int
+bar = imap identity foo

--- a/tests/purs/failing/4019-2.out
+++ b/tests/purs/failing/4019-2.out
@@ -1,0 +1,28 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/4019-2.purs:26:22 - 26:60 (line 26, column 22 - line 26, column 60)
+
+  Could not match kind
+  [33m    [0m
+  [33m  K1[0m
+  [33m    [0m
+  with kind
+  [33m    [0m
+  [33m  K2[0m
+  [33m    [0m
+
+while trying to match type [33mIndexed @Type @K1 @K2 Array[0m
+  with type [33mt0[0m
+while checking that expression [33mIndexed [ 1[0m
+                               [33m        ]  [0m
+  has type [33mt0 t1 t2 t3[0m
+in value declaration [33mbar[0m
+
+where [33mt0[0m is an unknown type
+      [33mt3[0m is an unknown type
+      [33mt1[0m is an unknown type
+      [33mt2[0m is an unknown type
+
+See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/4019-2.purs
+++ b/tests/purs/failing/4019-2.purs
@@ -1,0 +1,26 @@
+-- @shouldFailWith KindsDoNotUnify
+module Main where
+
+import Prelude
+
+newtype Indexed ∷ forall k1 k2 k3. (k1 → Type) → k2 → k3 → k1 → Type
+newtype Indexed m x y a = Indexed (m a)
+
+class IxFunctor ∷ ∀ ix. (ix → ix → Type → Type) → Constraint
+class IxFunctor f where
+  imap ∷ ∀ a b x y. (a → b) → f x y a → f x y b
+
+instance ixFunctorIndexed ∷ Functor m ⇒ IxFunctor (Indexed m) where
+  imap f (Indexed ma) = Indexed (map f ma)
+
+foreign import data K1 :: Type
+foreign import data K2 :: Type
+
+foreign import data D1 :: K1
+foreign import data D2 :: K2
+
+foo :: Indexed Array D1 D2 Int
+foo = Indexed [1]
+
+bar :: Indexed Array D1 D2 Int
+bar = imap identity (Indexed [1] :: Indexed Array D1 D2 Int)

--- a/tests/purs/failing/CoercibleKindMismatch.out
+++ b/tests/purs/failing/CoercibleKindMismatch.out
@@ -1,6 +1,6 @@
 Error found:
 in module [33mMain[0m
-at tests/purs/failing/CoercibleKindMismatch.purs:14:39 - 14:45 (line 14, column 39 - line 14, column 45)
+at tests/purs/failing/CoercibleKindMismatch.purs:15:17 - 15:23 (line 15, column 17 - line 15, column 23)
 
   Could not match kind
   [33m      [0m

--- a/tests/purs/failing/PolykindInstantiatedInstance.out
+++ b/tests/purs/failing/PolykindInstantiatedInstance.out
@@ -1,6 +1,6 @@
 Error found:
 in module [33mMain[0m
-at tests/purs/failing/PolykindInstantiatedInstance.purs:12:37 - 12:42 (line 12, column 37 - line 12, column 42)
+at tests/purs/failing/PolykindInstantiatedInstance.purs:12:26 - 12:42 (line 12, column 26 - line 12, column 42)
 
   Could not match kind
   [33m        [0m


### PR DESCRIPTION
**Description of the change**

Fixes #4019

This scrubs the kind-checker's error position context when invoking
kind unification from type-checking routines. When the kind-checker
errors, we want to preserve the context of the unification constraint.
Unfortunately, we don't have that position on hand since it's maintained
implicitly as part of the type-checker stack, so this is a somewhat
indirect solution.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
