### PR TITLE
Fix 1120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Other improvements:
   The previous `logo.png` was not legible against a dark background (#4001).
 
 * Show the constraints that were being solved when encountering a type error (@nwolverson, #4004)
+* Made the forall keyword optional in the instance header but gives warning if it is missing (@jrairigh, #1120)
 
 Internal:
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -145,6 +145,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@woody88](https://github.com/woody88) | Woodson Delhia | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mhmdanas](https://github.com/mhmdanas) | Mohammed Anas | [MIT license](http://opensource.org/licenses/MIT) |
 | [@kl0tl](https://github.com/kl0tl) | Cyril Sobierajewicz | [MIT license](http://opensource.org/licenses/MIT) |
+| [@jrairigh](https://github.com/jrairigh) | Josh Rairigh | [MIT license](http://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms
 

--- a/lib/purescript-cst/src/Language/PureScript/CST/Errors.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Errors.hs
@@ -63,6 +63,7 @@ data ParserWarningType
   | WarnDeprecatedConstraintInForeignImportSyntax
   | WarnDeprecatedKindImportSyntax
   | WarnDeprecatedKindExportSyntax
+  | WarnDeprecatedInstHeadForallSyntax
   deriving (Show, Eq, Ord)
 
 data ParserErrorInfo a = ParserErrorInfo
@@ -193,3 +194,5 @@ prettyPrintWarningMessage (ParserErrorInfo {..}) = case errType of
     "Kind imports are deprecated and will be removed in a future release. Omit the 'kind' keyword instead."
   WarnDeprecatedKindExportSyntax ->
     "Kind exports are deprecated and will be removed in a future release. Omit the 'kind' keyword instead."
+  WarnDeprecatedInstHeadForallSyntax ->
+    "Implicit 'forall' in the instance head is deprecated and will be removed in a future release. Add 'forall' keyword before any instance contraints."

--- a/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Parser.y
@@ -24,7 +24,7 @@ import qualified Data.List.NonEmpty as NE
 import Data.Text (Text)
 import Data.Traversable (for, sequence)
 import Language.PureScript.CST.Errors
-import Language.PureScript.CST.Flatten (flattenType)
+import Language.PureScript.CST.Flatten (flattenConstraint, flattenOneOrDelimited, flattenType)
 import Language.PureScript.CST.Lexer
 import Language.PureScript.CST.Monad
 import Language.PureScript.CST.Positions
@@ -737,7 +737,9 @@ classMember :: { Labeled (Name Ident) (Type ()) }
 
 instHead :: { InstanceHead () }
   : 'instance' ident '::' constraints '=>' qualProperName manyOrEmpty(typeAtom)
-      { InstanceHead $1 $2 $3 (Just ($4, $5)) (getQualifiedProperName $6) $7 }
+      {% addWarning (toList (flattenOneOrDelimited flattenConstraint $4)) WarnDeprecatedInstHeadForallSyntax *> pure (InstanceHead $1 $2 $3 (Just ($4, $5)) (getQualifiedProperName $6) $7) }
+  | 'instance' ident '::' forall many(typeVarBinding) '.' constraints '=>' qualProperName manyOrEmpty(typeAtom)
+      { InstanceHead $1 $2 $3 (Just ($7, $8)) (getQualifiedProperName $9) $10 }
   | 'instance' ident '::' qualProperName manyOrEmpty(typeAtom)
       { InstanceHead $1 $2 $3 Nothing (getQualifiedProperName $4) $5 }
 

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -513,6 +513,7 @@ errorSuggestion err =
           CST.WarnDeprecatedConstraintInForeignImportSyntax -> Nothing
           CST.WarnDeprecatedKindImportSyntax -> suggest $ CST.printTokens $ drop 1 toks
           CST.WarnDeprecatedKindExportSyntax -> suggest $ CST.printTokens $ drop 1 toks
+          CST.WarnDeprecatedInstHeadForallSyntax -> emptySuggestion
       _ -> Nothing
   where
     emptySuggestion = Just $ ErrorSuggestion ""

--- a/tests/purs/passing/InstanceHeadExplicitForall.purs
+++ b/tests/purs/passing/InstanceHeadExplicitForall.purs
@@ -1,0 +1,12 @@
+module Main where
+
+import Effect.Console (log)
+
+class Foo a where
+  foo :: a
+
+instance fooArray :: forall a. (Foo a) => Foo (Array a) where
+  foo :: Array a
+  foo = []
+
+main = log "Done"

--- a/tests/purs/warning/NewtypeInstance2.out
+++ b/tests/purs/warning/NewtypeInstance2.out
@@ -1,5 +1,5 @@
 Warning found:
-at tests/purs/warning/NewtypeInstance2.purs:15:1 - 15:86 (line 15, column 1 - line 15, column 86)
+at tests/purs/warning/NewtypeInstance2.purs:15:1 - 15:96 (line 15, column 1 - line 15, column 96)
 
   The derived newtype instance for
   [33m                               [0m

--- a/tests/purs/warning/NewtypeInstance2.purs
+++ b/tests/purs/warning/NewtypeInstance2.purs
@@ -7,9 +7,9 @@ import Data.Tuple (Tuple(..))
 class (Monad m, Monoid w) <= MonadWriter w m | m -> w where
   tell :: w -> m Unit
 
-instance monadWriterTuple :: Monoid w => MonadWriter w (Tuple w) where
+instance monadWriterTuple :: forall w. Monoid w => MonadWriter w (Tuple w) where
   tell w = Tuple w unit
 
 newtype MyWriter w a = MyWriter (Tuple w a)
 
-derive newtype instance monadWriterMyWriter :: Monoid w => MonadWriter w (MyWriter w)
+derive newtype instance monadWriterMyWriter :: forall w. Monoid w => MonadWriter w (MyWriter w)

--- a/tests/purs/warning/NewtypeInstance3.out
+++ b/tests/purs/warning/NewtypeInstance3.out
@@ -1,5 +1,5 @@
 Warning found:
-at tests/purs/warning/NewtypeInstance3.purs:21:1 - 21:86 (line 21, column 1 - line 21, column 86)
+at tests/purs/warning/NewtypeInstance3.purs:21:1 - 21:96 (line 21, column 1 - line 21, column 96)
 
   The derived newtype instance for
   [33m                               [0m

--- a/tests/purs/warning/NewtypeInstance3.purs
+++ b/tests/purs/warning/NewtypeInstance3.purs
@@ -10,12 +10,12 @@ class (Monad m, Monoid w) <= MonadTell w m | m -> w where
 class (MonadTell w m) <= MonadWriter w m | m -> w where
   listen :: forall a. m a -> m (Tuple w a)
 
-instance monadTellTuple :: Monoid w => MonadTell w (Tuple w) where
+instance monadTellTuple :: forall w. Monoid w => MonadTell w (Tuple w) where
   tell w = Tuple w unit
 
-instance monadWriterTuple :: Monoid w => MonadWriter w (Tuple w) where
+instance monadWriterTuple :: forall w. Monoid w => MonadWriter w (Tuple w) where
   listen (Tuple w a) = Tuple w (Tuple w a)
 
 newtype MyWriter w a = MyWriter (Tuple w a)
 
-derive newtype instance monadWriterMyWriter :: Monoid w => MonadWriter w (MyWriter w)
+derive newtype instance monadWriterMyWriter :: forall w. Monoid w => MonadWriter w (MyWriter w)

--- a/tests/purs/warning/NewtypeInstance4.out
+++ b/tests/purs/warning/NewtypeInstance4.out
@@ -1,5 +1,5 @@
 Warning found:
-at tests/purs/warning/NewtypeInstance4.purs:23:1 - 23:86 (line 23, column 1 - line 23, column 86)
+at tests/purs/warning/NewtypeInstance4.purs:23:1 - 23:96 (line 23, column 1 - line 23, column 96)
 
   The derived newtype instance for
   [33m                               [0m

--- a/tests/purs/warning/NewtypeInstance4.purs
+++ b/tests/purs/warning/NewtypeInstance4.purs
@@ -10,14 +10,14 @@ class Monoid w <= MonadTell w m where
 class (MonadTell w m) <= MonadWriter w m where
   listen :: forall a. m a -> m (Tuple w a)
 
-instance monadTellTuple :: Monoid w => MonadTell w (Tuple w) where
+instance monadTellTuple :: forall w. Monoid w => MonadTell w (Tuple w) where
   tell w = Tuple w unit
 
-instance monadWriterTuple :: Monoid w => MonadWriter w (Tuple w) where
+instance monadWriterTuple :: forall w. Monoid w => MonadWriter w (Tuple w) where
   listen (Tuple w a) = Tuple w (Tuple w a)
 
 newtype MyWriter w a = MyWriter (Tuple w a)
 
 -- No fundep means this is unverifiable
-derive newtype instance monadTellMyWriter :: Monoid w => MonadTell w (MyWriter w)
-derive newtype instance monadWriterMyWriter :: Monoid w => MonadWriter w (MyWriter w)
+derive newtype instance monadTellMyWriter :: forall w. Monoid w => MonadTell w (MyWriter w)
+derive newtype instance monadWriterMyWriter :: forall w. Monoid w => MonadWriter w (MyWriter w)


### PR DESCRIPTION
Made the forall keyword optional in the instance header but gives warning if it is missing #1120.  This change does not modify the actual meaning of the code.  To do that, I believe the InstanceHead type would need to include a TypeForall type.  This is a more difficult change than the ask for #1120, so hoping this can be worked in a separate issue.
