### PR TITLE
Require rebuild if any codegen targets are outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ Other improvements:
 
 * Show the constraints that were being solved when encountering a type error (@nwolverson, #4004)
 
+* Fix incorrect incremental builds with different `--codegen` options (#3911, #3914, @hdgarrood)
+
+  This bug meant that after invoking the compiler with different `--codegen`
+  options, it was easy to end up with (for example) an outdated docs.json or
+  corefn.json file in your output directory which would be incorrectly
+  considered up-to-date by the compiler.
+
 Internal:
 
 * Upgrade tests Bower dependencies (#4041, @kl0tl)

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -87,9 +87,13 @@ data MakeActions m = MakeActions
   -- The content hash is returned as a monadic action so that the file does not
   -- have to be read if it's not necessary.
   , getOutputTimestamp :: ModuleName -> m (Maybe UTCTime)
-  -- ^ Get the timestamp for the output files for a module. This should be the
-  -- timestamp for the oldest modified file, or 'Nothing' if any of the required
-  -- output files are missing.
+  -- ^ Get the time this module was last compiled, provided that all of the
+  -- requested codegen targets were also produced then. The defaultMakeActions
+  -- implementation uses the modification time of the externs file, because the
+  -- externs file is written first and we always write one. If there is no
+  -- externs file, or if any of the requested codegen targets were not produced
+  -- the last time this module was compiled, this function must return Nothing;
+  -- this indicates that the module will have to be recompiled.
   , readExterns :: ModuleName -> m (FilePath, Maybe ExternsFile)
   -- ^ Read the externs file for a module as a string and also return the actual
   -- path for the file.
@@ -178,9 +182,30 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
   getOutputTimestamp :: ModuleName -> Make (Maybe UTCTime)
   getOutputTimestamp mn = do
     codegenTargets <- asks optionsCodegenTargets
-    let outputPaths = [outputFilename mn externsFileName] <> fmap (targetFilename mn) (S.toList codegenTargets)
-    timestamps <- traverse getTimestampMaybe outputPaths
-    pure $ fmap minimum . NEL.nonEmpty =<< sequence timestamps
+    mExternsTimestamp <- getTimestampMaybe (outputFilename mn externsFileName)
+    case mExternsTimestamp of
+      Nothing ->
+        -- If there is no externs file, we will need to compile the module in
+        -- order to produce one.
+        pure Nothing
+      Just externsTimestamp ->
+        case NEL.nonEmpty (fmap (targetFilename mn) (S.toList codegenTargets)) of
+          Nothing ->
+            -- If the externs file exists and no other codegen targets have
+            -- been requested, then we can consider the module up-to-date
+            pure (Just externsTimestamp)
+          Just outputPaths -> do
+            -- If any of the other output paths are nonexistent or older than
+            -- the externs file, then they should be considered outdated, and
+            -- so the module will need rebuilding.
+            mmodTimes <- traverse getTimestampMaybe outputPaths
+            pure $ case sequence mmodTimes of
+              Nothing ->
+                Nothing
+              Just modTimes ->
+                if externsTimestamp <= minimum modTimes
+                  then Just externsTimestamp
+                  else Nothing
 
   readExterns :: ModuleName -> Make (FilePath, Maybe ExternsFile)
   readExterns mn = do

--- a/tests/TestMake.hs
+++ b/tests/TestMake.hs
@@ -9,6 +9,7 @@ import Prelude.Compat
 import qualified Language.PureScript as P
 import qualified Language.PureScript.CST as CST
 
+import Control.Concurrent (threadDelay)
 import Control.Monad
 import Control.Exception (tryJust)
 import Control.Monad.IO.Class (liftIO)
@@ -172,13 +173,16 @@ spec = do
           moduleContent2 = moduleContent1 <> "\ny :: Int\ny = 1"
           optsWithDocs = P.defaultOptions { P.optionsCodegenTargets = Set.fromList [P.JS, P.Docs] }
           go opts = compileWithOptions opts [modulePath] >>= assertSuccess
+          oneSecond = 10^(6::Int) -- microseconds
 
       writeFileWithTimestamp modulePath timestampA moduleContent1
       go optsWithDocs `shouldReturn` moduleNames ["Module"]
       writeFileWithTimestamp modulePath timestampB moduleContent2
+      threadDelay oneSecond
       go P.defaultOptions `shouldReturn` moduleNames ["Module"]
       -- Since the existing docs.json is now outdated, the module should be
       -- recompiled.
+      threadDelay oneSecond
       go optsWithDocs `shouldReturn` moduleNames ["Module"]
 
     it "recompiles if corefn is requested but not up to date" $ do
@@ -187,11 +191,14 @@ spec = do
           moduleContent2 = moduleContent1 <> "\ny :: Int\ny = 1"
           optsCorefnOnly = P.defaultOptions { P.optionsCodegenTargets = Set.singleton P.CoreFn }
           go opts = compileWithOptions opts [modulePath] >>= assertSuccess
+          oneSecond = 10^(6::Int) -- microseconds
 
       writeFileWithTimestamp modulePath timestampA moduleContent1
       go optsCorefnOnly `shouldReturn` moduleNames ["Module"]
       writeFileWithTimestamp modulePath timestampB moduleContent2
+      threadDelay oneSecond
       go P.defaultOptions `shouldReturn` moduleNames ["Module"]
+      threadDelay oneSecond
       go optsCorefnOnly `shouldReturn` moduleNames ["Module"]
 
 rimraf :: FilePath -> IO ()


### PR DESCRIPTION
**Description of the change**

Fixes #3911, #3914: prevents an issue where a module would be considered
up-to-date if only some of the requested codegen targets were up-to-date
(as opposed to all of them).

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] (n/a) Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
