### PR TITLE
Fix printing of hiding imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Bugfixes:
 * Make close punctuation printable in errors (#3982, @rhendric)
 * Desugar type operators in top-level kind signatures (#4027, @natefaubion)
 * Use type annotation hint only when needed (#4025, @rhendric)
+* Fix pretty printing of "hiding" imports (#4058, @natefaubion)
 
 * Instantiate polymorphic kinds when unwrapping newtypes while solving Coercible constraints (#4040, @kl0tl)
 

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -1668,7 +1668,7 @@ prettyPrintImport mn idt qual =
   let i = case idt of
             Implicit -> runModuleName mn
             Explicit refs -> runModuleName mn <> " (" <> T.intercalate ", " (mapMaybe prettyPrintRef refs) <> ")"
-            Hiding refs -> runModuleName mn <> " hiding (" <> T.intercalate "," (mapMaybe prettyPrintRef refs) <> ")"
+            Hiding refs -> runModuleName mn <> " hiding (" <> T.intercalate ", " (mapMaybe prettyPrintRef refs) <> ")"
   in i <> maybe "" (\q -> " as " <> runModuleName q) qual
 
 prettyPrintRef :: DeclarationRef -> Maybe Text

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -35,7 +35,7 @@ hidingFile :: [Text]
 hidingFile =
   [ "module Main where"
   , "import Prelude"
-  , "import Data.Maybe hiding (maybe)"
+  , "import Data.Maybe hiding (maybe, maybe')"
   , ""
   , "myFunc x y = x + y"
   ]
@@ -138,10 +138,10 @@ spec = do
         , ""
         , "import Data.Map as Map"
         ]
-    it "adds a qualified import and maintains proper grouping for implicit hiding imports" $
+    it "adds a qualified import and maintains proper grouping and formatting for implicit hiding imports" $
       shouldBe
         (addQualifiedImport' hidingFileImports (Test.mn "Data.Map") (Test.mn "Map"))
-        [ "import Data.Maybe hiding (maybe)"
+        [ "import Data.Maybe hiding (maybe, maybe')"
         , "import Prelude"
         , ""
         , "import Data.Map as Map"


### PR DESCRIPTION
**Description of the change**

Fixes pretty printing of `hiding` imports, which previously omitted a space after the comma.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
