### PR TITLE
Optimizes type unification by avoiding a double traversal during substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ Other improvements:
   corefn.json file in your output directory which would be incorrectly
   considered up-to-date by the compiler.
 
+ * Optimizes type unification for faster performance (#4062, @mikesol)
+
 Internal:
 
 * Upgrade tests Bower dependencies (#4041, @kl0tl)

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -113,8 +113,12 @@ unifyTypes t1 t2 = do
   withErrorMessageHint (ErrorUnifyingTypes t1 t2) $ unifyTypes' sub t1 t2
   where
   unifyTypes' _ (TUnknown _ u1) (TUnknown _ u2) | u1 == u2 = return ()
-  unifyTypes' sub (TUnknown x u) t = unifyTypes' sub (substituteType sub (TUnknown x u)) t
-  unifyTypes' sub t (TUnknown x u) = unifyTypes' sub t (substituteType sub (TUnknown x u)) 
+  unifyTypes' sub (TUnknown _ u) ty
+    | Just ty' <- M.lookup u (substType sub) = unifyTypes' sub ty' ty
+    | otherwise = solveType u ty
+  unifyTypes' sub ty (TUnknown _ u)
+    | Just ty' <- M.lookup u (substType sub) = unifyTypes' sub ty ty'
+    | otherwise = solveType u ty
   unifyTypes' _ (ForAll ann1 ident1 mbK1 ty1 sc1) (ForAll ann2 ident2 mbK2 ty2 sc2) =
     case (sc1, sc2) of
       (Just sc1', Just sc2') -> do

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -114,10 +114,10 @@ unifyTypes t1 t2 = do
   where
   unifyTypes' _ (TUnknown _ u1) (TUnknown _ u2) | u1 == u2 = return ()
   unifyTypes' sub (TUnknown _ u) ty
-    | Just ty' <- M.lookup u (substType sub) = unifyTypes' sub ty' ty
+    | Just ty' <- M.lookup u (substType sub) = unifyTypes ty' ty
     | otherwise = solveType u (substituteType sub ty)
   unifyTypes' sub ty (TUnknown _ u)
-    | Just ty' <- M.lookup u (substType sub) = unifyTypes' sub ty ty'
+    | Just ty' <- M.lookup u (substType sub) = unifyTypes ty ty'
     | otherwise = solveType u (substituteType sub ty)
   unifyTypes' _ (ForAll ann1 ident1 mbK1 ty1 sc1) (ForAll ann2 ident2 mbK2 ty2 sc2) =
     case (sc1, sc2) of

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -110,12 +110,12 @@ unknownsInType t = everythingOnTypes (.) go t []
 unifyTypes :: (MonadError MultipleErrors m, MonadState CheckState m) => SourceType -> SourceType -> m ()
 unifyTypes t1 t2 = do
   sub <- gets checkSubstitution
-  withErrorMessageHint (ErrorUnifyingTypes t1 t2) $ unifyTypes' (substituteType sub t1) (substituteType sub t2)
+  withErrorMessageHint (ErrorUnifyingTypes t1 t2) $ unifyTypes' sub t1 t2
   where
-  unifyTypes' (TUnknown _ u1) (TUnknown _ u2) | u1 == u2 = return ()
-  unifyTypes' (TUnknown _ u) t = solveType u t
-  unifyTypes' t (TUnknown _ u) = solveType u t
-  unifyTypes' (ForAll ann1 ident1 mbK1 ty1 sc1) (ForAll ann2 ident2 mbK2 ty2 sc2) =
+  unifyTypes' _ (TUnknown _ u1) (TUnknown _ u2) | u1 == u2 = return ()
+  unifyTypes' sub (TUnknown x u) t = unifyTypes' sub (substituteType sub (TUnknown x u)) t
+  unifyTypes' sub t (TUnknown x u) = unifyTypes' sub t (substituteType sub (TUnknown x u)) 
+  unifyTypes' _ (ForAll ann1 ident1 mbK1 ty1 sc1) (ForAll ann2 ident2 mbK2 ty2 sc2) =
     case (sc1, sc2) of
       (Just sc1', Just sc2') -> do
         sko <- newSkolemConstant
@@ -123,37 +123,37 @@ unifyTypes t1 t2 = do
         let sk2 = skolemize ann2 ident2 mbK2 sko sc2' ty2
         sk1 `unifyTypes` sk2
       _ -> internalError "unifyTypes: unspecified skolem scope"
-  unifyTypes' (ForAll ann ident mbK ty1 (Just sc)) ty2 = do
+  unifyTypes' _ (ForAll ann ident mbK ty1 (Just sc)) ty2 = do
     sko <- newSkolemConstant
     let sk = skolemize ann ident mbK sko sc ty1
     sk `unifyTypes` ty2
-  unifyTypes' ForAll{} _ = internalError "unifyTypes: unspecified skolem scope"
-  unifyTypes' ty f@ForAll{} = f `unifyTypes` ty
-  unifyTypes' (TypeVar _ v1) (TypeVar _ v2) | v1 == v2 = return ()
-  unifyTypes' ty1@(TypeConstructor _ c1) ty2@(TypeConstructor _ c2) =
+  unifyTypes' _ ForAll{} _ = internalError "unifyTypes: unspecified skolem scope"
+  unifyTypes' _ ty f@ForAll{} = f `unifyTypes` ty
+  unifyTypes' _ (TypeVar _ v1) (TypeVar _ v2) | v1 == v2 = return ()
+  unifyTypes' _ ty1@(TypeConstructor _ c1) ty2@(TypeConstructor _ c2) =
     guardWith (errorMessage (TypesDoNotUnify ty1 ty2)) (c1 == c2)
-  unifyTypes' (TypeLevelString _ s1) (TypeLevelString _ s2) | s1 == s2 = return ()
-  unifyTypes' (TypeApp _ t3 t4) (TypeApp _ t5 t6) = do
+  unifyTypes' _ (TypeLevelString _ s1) (TypeLevelString _ s2) | s1 == s2 = return ()
+  unifyTypes' _ (TypeApp _ t3 t4) (TypeApp _ t5 t6) = do
     t3 `unifyTypes` t5
     t4 `unifyTypes` t6
-  unifyTypes' (KindApp _ t3 t4) (KindApp _ t5 t6) = do
+  unifyTypes' _ (KindApp _ t3 t4) (KindApp _ t5 t6) = do
     t3 `unifyKinds'` t5
     t4 `unifyTypes` t6
-  unifyTypes' (Skolem _ _ _ s1 _) (Skolem _ _ _ s2 _) | s1 == s2 = return ()
-  unifyTypes' (KindedType _ ty1 _) ty2 = ty1 `unifyTypes` ty2
-  unifyTypes' ty1 (KindedType _ ty2 _) = ty1 `unifyTypes` ty2
-  unifyTypes' r1@RCons{} r2 = unifyRows r1 r2
-  unifyTypes' r1 r2@RCons{} = unifyRows r1 r2
-  unifyTypes' r1@REmptyKinded{} r2 = unifyRows r1 r2
-  unifyTypes' r1 r2@REmptyKinded{} = unifyRows r1 r2
-  unifyTypes' (ConstrainedType _ c1 ty1) (ConstrainedType _ c2 ty2)
+  unifyTypes' _ (Skolem _ _ _ s1 _) (Skolem _ _ _ s2 _) | s1 == s2 = return ()
+  unifyTypes' _ (KindedType _ ty1 _) ty2 = ty1 `unifyTypes` ty2
+  unifyTypes' _ ty1 (KindedType _ ty2 _) = ty1 `unifyTypes` ty2
+  unifyTypes' _ r1@RCons{} r2 = unifyRows r1 r2
+  unifyTypes' _ r1 r2@RCons{} = unifyRows r1 r2
+  unifyTypes' _ r1@REmptyKinded{} r2 = unifyRows r1 r2
+  unifyTypes' _ r1 r2@REmptyKinded{} = unifyRows r1 r2
+  unifyTypes' _ (ConstrainedType _ c1 ty1) (ConstrainedType _ c2 ty2)
     | constraintClass c1 == constraintClass c2 && constraintData c1 == constraintData c2 = do
         traverse_ (uncurry unifyTypes) (constraintArgs c1 `zip` constraintArgs c2)
         ty1 `unifyTypes` ty2
-  unifyTypes' ty1@ConstrainedType{} ty2 =
+  unifyTypes' _ ty1@ConstrainedType{} ty2 =
     throwError . errorMessage $ ConstrainedTypeUnified ty1 ty2
-  unifyTypes' t3 t4@ConstrainedType{} = unifyTypes' t4 t3
-  unifyTypes' t3 t4 =
+  unifyTypes' sub t3 t4@ConstrainedType{} = unifyTypes' sub t4 t3
+  unifyTypes' _ t3 t4 =
     throwError . errorMessage $ TypesDoNotUnify t3 t4
 
 -- | Unify two rows, updating the current substitution

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -115,10 +115,10 @@ unifyTypes t1 t2 = do
   unifyTypes' _ (TUnknown _ u1) (TUnknown _ u2) | u1 == u2 = return ()
   unifyTypes' sub (TUnknown _ u) ty
     | Just ty' <- M.lookup u (substType sub) = unifyTypes' sub ty' ty
-    | otherwise = solveType u ty
+    | otherwise = solveType u (substituteType sub ty)
   unifyTypes' sub ty (TUnknown _ u)
     | Just ty' <- M.lookup u (substType sub) = unifyTypes' sub ty ty'
-    | otherwise = solveType u ty
+    | otherwise = solveType u (substituteType sub ty)
   unifyTypes' _ (ForAll ann1 ident1 mbK1 ty1 sc1) (ForAll ann2 ident2 mbK2 ty2 sc2) =
     case (sc1, sc2) of
       (Just sc1', Just sc2') -> do


### PR DESCRIPTION
**Description of the change**

This PR seeks to optimize type unification. Still needs work before review.
****
Here's the banter on the list about it:

Mike Solomon  2 days ago
This morning I launched a purescript compilation job for a single ~400 line file that :boom:  time-wise. When I Ctrl-C'd it, it was already at 35 minutes.
$ time npx spago -x examples.dhall bundle-app   --main WAGS.Example.WTK   --to examples/wtk/index.js
Compiling WAGS.Example.HelloWorld
Compiling WAGS.Example.WTK
^C
real    35m20,274s
user    0m0,064s
sys     0m0,005s
I'm wondering if there is a way to peek inside the compiler to know what the bottleneck is? The file makes use of some gnarly typeclasses, so one of them is the culprit. It'd be good to know which one so I can optimize and/or omit it.

natefaubion  1 day ago
Sounds like an infinite loop somewhere?

natefaubion  1 day ago
I can’t imagine any crazy type classes taking 35m to run without triggering the solver depth limit, which is relatively low, so to me sounds like some sort of infinite type synonym expansion or something that isn’t caught. (edited) 

Mike Solomon  1 day ago
Is there a profiling mode I could compile purescript with? It'd be good to have more visibility into where it gets stuck. Even with a downsized example, it still takes 6m to compile 400 lines, so I'll definitely need to optimize.

natefaubion  1 day ago
If it actually completes then it’s the constraint solver.

Mike Solomon  1 day ago
That's my hunch as well. If you're interested in reproducing:
git clone https://github.com/mikesol/purescript-wags && cd purescript-wags
npm install
npx spago -x examples.dhall bundle-app --main WAGS.Example.WTK --to examples/wtk/index.js
Almost everything compiles in a reasonable timeframe, but WAGS.Example.WTK is the one that takes a small eternity. I'll put some work into getting the compile time down, & I'll start with trying to monitor the constraint solver so I know what the biggest bottlenecks are.

natefaubion  24 hours ago
I think it is likely there is quadratic behavior when doing induction. If you have very large types, I suspect it gets slower and slower the larger the types.

Mike Solomon  23 hours ago
Would this be the place to start adding debug messages: https://github.com/purescript/purescript/tree/bc56a90059a49d9f65f7df85fd7389faeb72de70/src/Language/PureScript/TypeChecker ?
Also, does the type checker run in a monadic context where debug logging is possible? Glancing at it, I see that a lot of the functions are pure (ie checkSubsume), so I'm guessing that debugging & profiling is tricky there. But I'm also rusty in Haskell, so I forget if there is a logging "hack" that one can use when not in an effectful context (sort of like spy in PS).

natefaubion  23 hours ago
The constraint solver is in Entailment.hs

natefaubion  23 hours ago
There is Debug.Trace like in PS

Mike Solomon  22 hours ago
One question from reading over Entailment.hs - in general, will one get better performance by working with Row constraints instead of constraints on custom row-esque types? By row-esque I mean a type that behaves like a Row but has a different index (ie a Peano integer as an index instead of a Symbol). I use a lot of those, ie NodeList instead of RowList because it is indexed by an auto-incremented typelevel integer. But I can also auto-increment Symbols instead, ie by going from a-z and then using Symbol append once I hit the end of the alphabet. That may fix my problem without much extra work.

Mike Solomon  22 hours ago
That said, I'm doing a fair amount of pointer arithmetic at the type level to manage the allocation and deallocation of web-audio units, which is easy with integers but harder with symbols, so it'd be preferable to keep the current setup if possible.

natefaubion  22 hours ago
Are your integers stricly a Succ/Zero Peano?

natefaubion  22 hours ago
If you are doing arithmetic on succ/zero peano’s it’s probably going to be excruciatingly slow at scale.

Mike Solomon  21 hours ago
No, the integers are binary, so they have O(log(n)) behavior at runtime and assumedly at compile time as well. https://github.com/mikesol/purescript-wags/blob/main/src/WAGS/Universe/Bin.purs (edited) 

natefaubion  21 hours ago
ok

Mike Solomon  11 hours ago
Here's a profile: https://transfer.sh/KFph0/purs.prof
It looks like the biggest gains to be had are in unifyTypes.unifyTypes' and everywhereOnTypes.go. While Entailment.hs is present, it's only responsible for ~4% of the computation.

Mike Solomon  9 hours ago
And not for the faint of heart, but here is a 1.6 gb log of the following debug trace in unifyTypes:
unifyTypes :: (MonadError MultipleErrors m, MonadState CheckState m) => SourceType -> SourceType -> m ()
unifyTypes t1 t2 = do
  sub <- gets checkSubstitution
  let
    lhs = substituteType sub t1
    rhs = substituteType sub t2
  withErrorMessageHint (ErrorUnifyingTypes t1 t2) $ unifyTypes' (trace ("left of unification: " <> show lhs) lhs) (trace ("right of unification: " <> show rhs) rhs)
https://meeshkan-public-assets.s3-eu-west-1.amazonaws.com/purescript/wags/unify.log
I'll try to run some vanilla scikit-learn clustering algos on it to see if there are any chunks that repeat. I'm wondering if YOLO-fying unifyTypes by caching more stuff in CheckState would decrease compilation time. I say this having looked at the code for 5m, so it very well could be that this is already optimized & I'm barking up the wrong tree.

natefaubion  2 hours ago
It’s not optimized. Almost nothing in the compiler is. Unify types can be optimized by not substituting so much, but it’s pretty subtle.

natefaubion  2 hours ago
Basically you only need to substitute unknowns when you get to them. You also need to substitute when solving a unification variable.

Mike Solomon  42 minutes ago
Are there enough tests that if I changed unifyTypes' (substituteType sub t1) (substituteType sub t2) to unifyTypes' t1 t2 and then called substitute type inline in all the branches of unifyTypes' the tests would catch what breaks? By inline, I mean:
unifyTypes' (TUnknown _ u) t = solveType (substituteType sub u) (substituteType sub t)
Basically, there are ~16 pattern-matching branches of unifyTypes', each of which takes two arguments, so I could create 32 GH branches where each one omits a call to substituteType in a different place and then see for which ones the automated tests pass and for which ones the tests fail. It's not the most analytic approach, but it could work.

natefaubion  41 minutes ago
I mean, I don’t think there’s a need to guess :smile:

natefaubion  40 minutes ago
The point of substitution like this is so that you don’t unify against an unknown that has already been solved.

Mike Solomon  40 minutes ago
These three branches were easy to spot:
  unifyTypes' (TUnknown _ u1) (TUnknown _ u2) | u1 == u2 = return ()
  unifyTypes' (TUnknown _ u) t = solveType u t
  unifyTypes' t (TUnknown _ u) = solveType u t
But...
You also need to substitute when solving a unification variable.
I'm not sure which branches contain this solving

natefaubion  39 minutes ago
solveType :stuck_out_tongue:

natefaubion  38 minutes ago
You never want to solve a u that has already been solved, and the t you put in as the solution needs to be substituted.

natefaubion  38 minutes ago
Always substituting at the top is just a kludgy way to make sure nothing leaks through.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
