### PR TITLE
Drop libtinfo dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,16 @@ Other improvements:
   conflicts. This change merely makes explicit what is already happening
   implicitly.
 
+* Drop libtinfo dependency (#3696, @hdgarrood)
+
+  Changes the build configuration so that by default, compiler binaries will
+  not have a dynamic library dependency on libncurses/libtinfo. This should
+  alleviate one of the most common pains in getting the compiler successfully
+  installed, especially on Linux. The cost is a slight degradation in the REPL
+  experience when editing long lines, but this can be avoided by building the
+  compiler with the libtinfo dependency by setting the `terminfo` flag of the
+  `haskeline` library to `true`.
+
 Internal:
 
 * Upgrade tests Bower dependencies (#4041, @kl0tl)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,10 +43,10 @@ If you don't have stack installed, please see the [stack install documentation](
 
 ## The "curses" library
 
-The PureScript REPL depends on the `curses` library (via the Haskell package
-`terminfo`). If you are having difficulty running the compiler, it may be
-because the `curses` library is missing. This problem may appear as a `libtinfo`
-error:
+Prior to version vX.Y.Z __TODO: fill in when known__, the PureScript REPL
+depends on the `curses` library (via the Haskell package `terminfo`). If you
+are having difficulty running the compiler, it may be because the `curses`
+library is missing. This problem may appear as a `libtinfo` error:
 ```
 error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory
 ```

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,3 +22,6 @@ flags:
     lib-only: true
   these:
     assoc: false
+  haskeline:
+    # Avoids a libtinfo dynamic library dependency
+    terminfo: false


### PR DESCRIPTION
Resolves #3696. (Note that #3696 says "use static linking in binary
distributions", and this doesn't actually do that as there are still a
number of other dynamic library dependencies. However all of the
remaining ones are very common and likely to already exist on the user's
system, so that users hopefully shouldn't need to worry about dynamic
library dependencies at all after this change, which hopefully does
resolve the issue in practice.)

We regularly hear from beginners who are having difficulty installing
the compiler because of the libtinfo dependency, so let's drop it.

The REPL experience is only very marginally degraded by this change, and
I suspect a large chunk of users don't even use the REPL anyway -
certainly CI environments, where the libtinfo dependency is often an
issue, don't care about the REPL. If people do want the terminfo-based
REPL they can still build their own version of the compiler with the
haskeline `terminfo` flag enabled.

See https://github.com/purescript/purescript/issues/3696#issuecomment-657282303
for a comparison.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
