### PR TITLE
Rearrange CHANGELOG entry for 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ Bugfixes:
 
 * Fix wildly off kind unification positions (#4050, @natefaubion)
 
+* Fix incorrect incremental builds with different `--codegen` options (#3911, #3914, @hdgarrood)
+
+  This bug meant that after invoking the compiler with different `--codegen`
+  options, it was easy to end up with (for example) an outdated docs.json or
+  corefn.json file in your output directory which would be incorrectly
+  considered up-to-date by the compiler.
+
 Other improvements:
 
 * Add white outline stroke to logo in README (#4003, @ptrfrncsmrph)
@@ -58,13 +65,6 @@ Other improvements:
   The previous `logo.png` was not legible against a dark background (#4001).
 
 * Show the constraints that were being solved when encountering a type error (@nwolverson, #4004)
-
-* Fix incorrect incremental builds with different `--codegen` options (#3911, #3914, @hdgarrood)
-
-  This bug meant that after invoking the compiler with different `--codegen`
-  options, it was easy to end up with (for example) an outdated docs.json or
-  corefn.json file in your output directory which would be incorrectly
-  considered up-to-date by the compiler.
 
 * Removed all shift/reduce conflicts in parser (#4063, @JordanMartinez).
 


### PR DESCRIPTION
Moves the incremental build fix entry in the changelog into the correct
section - it is a bug fix.