### PR TITLE
Prompt to add to CONTRIBUTORS.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@ Clearly and concisely describe the purpose of the pull request. If this PR relat
 **Checklist:**
 
 - [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
+- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
 - [ ] Linked any existing issues or proposals that this pull request should close
 - [ ] Updated or added relevant documentation
 - [ ] Added a test for the contribution (if applicable)


### PR DESCRIPTION
Prompts new contributors to add themselves to CONTRIBUTORS.md in the pull request template. Hopefully this will make it easier for maintainers to remember about this when reviewing PRs, as well as for making contributors aware of the file in the first place.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
