### PR TITLE
Fixup docs for libtinfo change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Bugfixes:
 
 Internal:
 
+* Drop libtinfo dependency (#3696, @hdgarrood)
+
+  Changes the build configuration so that by default, compiler binaries will
+  not have a dynamic library dependency on libncurses/libtinfo. This should
+  alleviate one of the most common pains in getting the compiler successfully
+  installed, especially on Linux. The cost is a slight degradation in the REPL
+  experience when editing long lines, but this can be avoided by building the
+  compiler with the libtinfo dependency by setting the `terminfo` flag of the
+  `haskeline` library to `true`.
+
 ## v0.14.1
 
 New features:
@@ -71,16 +81,6 @@ Other improvements:
   Happy defaults to using "shift" rather than "reduce" in shift/reduce
   conflicts. This change merely makes explicit what is already happening
   implicitly.
-
-* Drop libtinfo dependency (#3696, @hdgarrood)
-
-  Changes the build configuration so that by default, compiler binaries will
-  not have a dynamic library dependency on libncurses/libtinfo. This should
-  alleviate one of the most common pains in getting the compiler successfully
-  installed, especially on Linux. The cost is a slight degradation in the REPL
-  experience when editing long lines, but this can be avoided by building the
-  compiler with the libtinfo dependency by setting the `terminfo` flag of the
-  `haskeline` library to `true`.
 
 Internal:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,10 +43,10 @@ If you don't have stack installed, please see the [stack install documentation](
 
 ## The "curses" library
 
-Prior to version vX.Y.Z __TODO: fill in when known__, the PureScript REPL
-depends on the `curses` library (via the Haskell package `terminfo`). If you
-are having difficulty running the compiler, it may be because the `curses`
-library is missing. This problem may appear as a `libtinfo` error:
+Prior to version v0.14.2, the PureScript REPL depends on the `curses` library
+by default (via the Haskell package `terminfo`). If you are having difficulty
+running the compiler, it may be because the `curses` library is missing. This
+problem may appear as a `libtinfo` error:
 ```
 error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory
 ```
@@ -56,6 +56,12 @@ example, this can be done by running:
 ```
 $ sudo apt install libtinfo5 libncurses5-dev
 ```
+
+As of v0.14.2, this should no longer be necessary if you are using the prebuilt
+binaries or building the compiler from source with the default configuration.
+However, you can still opt into using `curses` by setting the Haskeline
+`terminfo` flag to `true`. This may improve the REPL experience slightly - for
+example, by providing better editing of long input lines.
 
 ## EACCES error
 


### PR DESCRIPTION
- Move the libtinfo changelog entry out of v0.14.1 into 'unreleased'
- Add the correct version in INSTALL.md
- Explain that you can still depend on `curses` if you want to in
  INSTALL.md
---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
