### PR TITLE
Remove setup-win.cmd

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -29,7 +29,6 @@ extra-source-files:
   tests/purs/**/*.out
   tests/json-compat/**/*.json
   tests/support/*.json
-  tests/support/setup-win.cmd
   tests/support/psci/**/*.purs
   tests/support/psci/**/*.edit
   tests/support/pscide/src/**/*.purs

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -26,7 +26,6 @@ import Data.Time.Clock (UTCTime())
 import Data.Tuple (swap)
 import System.Process hiding (cwd)
 import System.Directory
-import System.Info
 import System.IO.UTF8 (readUTF8FileT)
 import System.Exit (exitFailure)
 import System.FilePath
@@ -51,15 +50,12 @@ findNodeProcess = runMaybeT . msum $ map (MaybeT . findExecutable) names
 updateSupportCode :: IO ()
 updateSupportCode = do
   setCurrentDirectory "tests/support"
-  if System.Info.os == "mingw32"
-    then callProcess "setup-win.cmd" []
-    else do
-      callProcess "npm" ["install"]
-      -- bower uses shebang "/usr/bin/env node", but we might have nodejs
-      node <- maybe cannotFindNode pure =<< findNodeProcess
-      -- Sometimes we run as a root (e.g. in simple docker containers)
-      -- And we are non-interactive: https://github.com/bower/bower/issues/1162
-      callProcess node ["node_modules/.bin/bower", "--allow-root", "install", "--config.interactive=false"]
+  callCommand "npm install"
+  -- bower uses shebang "/usr/bin/env node", but we might have nodejs
+  node <- maybe cannotFindNode pure =<< findNodeProcess
+  -- Sometimes we run as a root (e.g. in simple docker containers)
+  -- And we are non-interactive: https://github.com/bower/bower/issues/1162
+  callProcess node ["node_modules/bower/bin/bower", "--allow-root", "install", "--config.interactive=false"]
   setCurrentDirectory "../.."
   where
   cannotFindNode :: IO a

--- a/tests/support/setup-win.cmd
+++ b/tests/support/setup-win.cmd
@@ -1,3 +1,0 @@
-@echo off
-call npm install
-call node_modules\.bin\bower install --config.interactive=false


### PR DESCRIPTION
**Description of the change**

This is a small simplification of our pre-test setup. Shouldn't change anything other than the number of moving parts.

For reference, this was originally introduced in #1402. Using `callCommand` instead of `callProcess` might always have been the better way to go; I don't know. But it seems to work well enough today.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
