### PR TITLE
Infer foreign modules from actual file in rebuild

### DIFF
--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -65,7 +65,7 @@ rebuildFile file actualFile codegenTargets runOpenBuild = do
   -- For rebuilding, we want to 'RebuildAlways', but for inferring foreign
   -- modules using their file paths, we need to specify the path in the 'Map'.
   let filePathMap = M.singleton moduleName (Left P.RebuildAlways)
-  foreigns <- P.inferForeignModules (M.singleton moduleName (Right file))
+  foreigns <- P.inferForeignModules (M.singleton moduleName (Right (fromMaybe file actualFile)))
   let makeEnv = P.buildMakeActions outputDirectory filePathMap foreigns False
   -- Rebuild the single module using the cached externs
   (result, warnings) <- logPerf (labelTimespec "Rebuilding Module") $


### PR DESCRIPTION
**Description of the change**

Without this change, a rebuild with a temporary file unsuccessfully looks for a foreign file in the same location as that temporary file instead of the FFI for the actual file. That always leads to errors about missing FFI files.


**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
