### PR TITLE
Avoid compiling tests with diagnostics twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Internal:
 
 * Remove tasty from test suite and just use hspec (#4056, @hdgarrood)
 
+* Avoid compiling tests with diagnostics twice in test suite (#4079, @hdgarrood)
+
 ## v0.14.1
 
 New features:

--- a/tests/TestBundle.hs
+++ b/tests/TestBundle.hs
@@ -10,7 +10,7 @@ import Prelude ()
 import Prelude.Compat
 
 import qualified Language.PureScript as P
-import Language.PureScript.Bundle 
+import Language.PureScript.Bundle
 
 import Data.Function (on)
 import Data.List (minimumBy)
@@ -35,14 +35,14 @@ spec :: Spec
 spec = do
   (supportModules, supportExterns, supportForeigns) <- runIO $ setupSupportModules
   bundleTestCases <- runIO $ getTestFiles "bundle"
-  outputFile <- runIO $ createOutputFile logfile 
+  outputFile <- runIO $ createOutputFile logfile
 
   context "Bundle examples" $
     forM_ bundleTestCases $ \testPurs -> do
       it ("'" <> takeFileName (getTestMain testPurs) <> "' should compile, bundle and run without error") $
         assertBundles supportModules supportExterns supportForeigns testPurs outputFile
   where
-  
+
   -- Takes the test entry point from a group of purs files - this is determined
   -- by the file with the shortest path name, as everything but the main file
   -- will be under a subdirectory.
@@ -56,36 +56,34 @@ assertBundles
   -> [FilePath]
   -> Handle
   -> Expectation
-assertBundles supportModules supportExterns supportForeigns inputFiles outputFile =
-  assert supportModules supportExterns supportForeigns inputFiles checkMain $ \e ->
-    case e of
-      Left errs -> return . Just . P.prettyPrintMultipleErrors P.defaultPPEOptions $ errs
-      Right _ -> do
-        process <- findNodeProcess
-        jsFiles <- Glob.globDir1 (Glob.compile "**/*.js") modulesDir
-        let entryPoint = modulesDir </> "index.js"
-        let entryModule = map (`ModuleIdentifier` Regular) ["Main"] 
-        bundled <- runExceptT $ do
-          input <- forM jsFiles $ \filename -> do
-            js <- liftIO $ readUTF8File filename
-            mid <- guessModuleIdentifier filename
-            length js `seq` return (mid, Just filename, js) 
-          bundleSM input entryModule (Just $ "Main") "PS" (Just entryPoint) Nothing
-        case bundled of
-            Right (_, js) -> do
-              writeUTF8File entryPoint js
-              result <- traverse (\node -> readProcessWithExitCode node [entryPoint] "") process
-              hPutStrLn outputFile $ "\n" <> takeFileName (last inputFiles) <> ":"
-              case result of
-                Just (ExitSuccess, out, err)
-                 | not (null err) -> return $ Just $ "Test wrote to stderr:\n\n" <> err
-                 | not (null out) && trim (last (lines out)) == "Done" -> do
-                     hPutStr outputFile out
-                     return Nothing
-                 | otherwise -> return $ Just $ "Test did not finish with 'Done':\n\n" <> out
-                Just (ExitFailure _, _, err) -> return $ Just err
-                Nothing -> return $ Just "Couldn't find node.js executable"
-            Left err -> return . Just $ "Coud not bundle: " ++ show err
+assertBundles supportModules supportExterns supportForeigns inputFiles outputFile = do
+  (result, _) <- compile supportModules supportExterns supportForeigns inputFiles
+  case result of
+    Left errs -> expectationFailure . P.prettyPrintMultipleErrors P.defaultPPEOptions $ errs
+    Right _ -> do
+      process <- findNodeProcess
+      jsFiles <- Glob.globDir1 (Glob.compile "**/*.js") modulesDir
+      let entryPoint = modulesDir </> "index.js"
+      let entryModule = map (`ModuleIdentifier` Regular) ["Main"]
+      bundled <- runExceptT $ do
+        input <- forM jsFiles $ \filename -> do
+          js <- liftIO $ readUTF8File filename
+          mid <- guessModuleIdentifier filename
+          length js `seq` return (mid, Just filename, js)
+        bundleSM input entryModule (Just $ "Main") "PS" (Just entryPoint) Nothing
+      case bundled of
+          Right (_, js) -> do
+            writeUTF8File entryPoint js
+            nodeResult <- traverse (\node -> readProcessWithExitCode node [entryPoint] "") process
+            hPutStrLn outputFile $ "\n" <> takeFileName (last inputFiles) <> ":"
+            case nodeResult of
+              Just (ExitSuccess, out, err)
+               | not (null err) -> expectationFailure $ "Test wrote to stderr:\n\n" <> err
+               | not (null out) && trim (last (lines out)) == "Done" -> hPutStr outputFile out
+               | otherwise -> expectationFailure $ "Test did not finish with 'Done':\n\n" <> out
+              Just (ExitFailure _, _, err) -> expectationFailure err
+              Nothing -> expectationFailure "Couldn't find node.js executable"
+          Left err -> expectationFailure $ "Could not bundle: " ++ show err
 
 logfile :: FilePath
 logfile = "bundle-tests.out"


### PR DESCRIPTION
Previously we compiled every warning and failing test example twice. Now
we just do it once. This speeds up the tests.

I've taken the opportunity to simplify the API provided by TestUtils
slightly. I've removed the callback-style API provided by `assert`
(because imo it just wasn't pulling its weight and isn't needed when we
already have `compile`, and also it encouraged ignoring warnings). I've
also removed the `check` argument to `compile`. The only way it was
being used was in the passing tests, to assert that we had a module
called `Main` in each test. However, there's not really any need for
this check: if a test has no `Main` module, we'll find that out (and the
test will fail) when we try to run it under `node`.

These changes shave about 20s off the test suite for me locally - from
125s down to 105s. That's not quite as much as I'd hoped but still nice.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
