### PR TITLE
Do less work in test initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Internal:
 
 * Avoid compiling tests with diagnostics twice in test suite (#4079, @hdgarrood)
 
+* Do less work in test initialization (#4080, @rhendric)
+
 ## v0.14.1
 
 New features:

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -31,26 +31,19 @@ main = do
   hSetEncoding stdout utf8
   hSetEncoding stderr utf8
 
-  heading "Updating support code"
   TestUtils.updateSupportCode
 
   hspec $ do
     describe "cst" TestCst.spec
     describe "ide" TestIde.spec
-    describe "compiler" TestCompiler.spec
+    beforeAll TestUtils.setupSupportModules $ do
+      describe "compiler" TestCompiler.spec
+      describe "bundle" TestBundle.spec
     describe "make" TestMake.spec
     describe "psci" TestPsci.spec
-    describe "bundle" TestBundle.spec
     describe "corefn" TestCoreFn.spec
     describe "docs" TestDocs.spec
     describe "prim-docs" TestPrimDocs.spec
     describe "publish" TestPscPublish.spec
     describe "hierarchy" TestHierarchy.spec
     describe "graph" TestGraph.spec
-  where
-  heading msg = do
-    putStrLn ""
-    putStrLn $ replicate 79 '#'
-    putStrLn $ "# " ++ msg
-    putStrLn $ replicate 79 '#'
-    putStrLn ""

--- a/tests/TestBundle.hs
+++ b/tests/TestBundle.hs
@@ -31,16 +31,14 @@ import qualified System.FilePath.Glob as Glob
 import TestUtils
 import Test.Hspec
 
-spec :: Spec
-spec = do
-  (supportModules, supportExterns, supportForeigns) <- runIO $ setupSupportModules
-  bundleTestCases <- runIO $ getTestFiles "bundle"
-  outputFile <- runIO $ createOutputFile logfile
-
+spec :: SpecWith ([P.Module], [P.ExternsFile], M.Map P.ModuleName FilePath)
+spec =
   context "Bundle examples" $
-    forM_ bundleTestCases $ \testPurs -> do
-      it ("'" <> takeFileName (getTestMain testPurs) <> "' should compile, bundle and run without error") $
-        assertBundles supportModules supportExterns supportForeigns testPurs outputFile
+    beforeAllWith ((<$> createOutputFile logfile) . (,)) $ do
+      bundleTestCases <- runIO $ getTestFiles "bundle"
+      forM_ bundleTestCases $ \testPurs -> do
+        it ("'" <> takeFileName (getTestMain testPurs) <> "' should compile, bundle and run without error") $ \((supportModules, supportExterns, supportForeigns), outputFile) ->
+          assertBundles supportModules supportExterns supportForeigns testPurs outputFile
   where
 
   -- Takes the test entry point from a group of purs files - this is determined

--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -7,6 +7,7 @@ import Prelude.Compat
 import Test.Hspec
 
 import           Control.Monad.Trans.State.Strict (evalStateT)
+import           Data.Functor ((<&>))
 import           Data.List (sort)
 import qualified Data.Text as T
 import qualified Language.PureScript as P
@@ -15,93 +16,93 @@ import           TestPsci.TestEnv (initTestPSCiEnv)
 import           TestUtils (getSupportModuleNames)
 
 completionTests :: Spec
-completionTests = context "completionTests" $ do
-  mns       <- runIO getSupportModuleNames
-  psciState <- runIO getPSCiStateForCompletion
-  mapM_ (assertCompletedOk psciState) (completionTestData mns)
+completionTests = context "completionTests" $
+  beforeAll getPSCiStateForCompletion $
+    mapM_ assertCompletedOk completionTestData
 
 -- If the cursor is at the right end of the line, with the 1st element of the
 -- pair as the text in the line, then pressing tab should offer all the
 -- elements of the list (which is the 2nd element) as completions.
-completionTestData :: [T.Text] -> [(String, [String])]
-completionTestData supportModuleNames =
+completionTestData :: [(String, IO [String])]
+completionTestData =
   -- basic directives
-  [ (":h",  [":help"])
-  , (":r",  [":reload"])
-  , (":c",  [":clear", ":complete"])
-  , (":q",  [":quit"])
-  , (":b",  [":browse"])
+  [ (":h",  pure [":help"])
+  , (":r",  pure [":reload"])
+  , (":c",  pure [":clear", ":complete"])
+  , (":q",  pure [":quit"])
+  , (":b",  pure [":browse"])
 
   -- :browse should complete module names
-  , (":b Eff",    map (":b Effect" ++) ["", ".Unsafe", ".Class", ".Class.Console", ".Console", ".Uncurried", ".Ref"])
-  , (":b Effect.", map (":b Effect" ++) [".Unsafe", ".Class", ".Class.Console", ".Console", ".Uncurried", ".Ref"])
+  , (":b Eff",    pure $ map (":b Effect" ++) ["", ".Unsafe", ".Class", ".Class.Console", ".Console", ".Uncurried", ".Ref"])
+  , (":b Effect.", pure $ map (":b Effect" ++) [".Unsafe", ".Class", ".Class.Console", ".Console", ".Uncurried", ".Ref"])
 
   -- import should complete module names
-  , ("import Eff",    map ("import Effect" ++) ["", ".Unsafe", ".Class", ".Class.Console", ".Console", ".Uncurried", ".Ref"])
-  , ("import Effect.", map ("import Effect" ++) [".Unsafe", ".Class", ".Class.Console", ".Console", ".Uncurried", ".Ref"])
+  , ("import Eff",    pure $ map ("import Effect" ++) ["", ".Unsafe", ".Class", ".Class.Console", ".Console", ".Uncurried", ".Ref"])
+  , ("import Effect.", pure $ map ("import Effect" ++) [".Unsafe", ".Class", ".Class.Console", ".Console", ".Uncurried", ".Ref"])
 
   -- :quit, :help, :reload, :clear should not complete
-  , (":help ", [])
-  , (":quit ", [])
-  , (":reload ", [])
-  , (":clear ", [])
+  , (":help ", pure [])
+  , (":quit ", pure [])
+  , (":reload ", pure [])
+  , (":clear ", pure [])
 
   -- :show should complete its available arguments
-  , (":show ", [":show import", ":show loaded", ":show print"])
-  , (":show a", [])
+  , (":show ", pure [":show import", ":show loaded", ":show print"])
+  , (":show a", pure [])
 
   -- :type should complete next word from values and constructors in scope
-  , (":type uni", [":type unit"])
-  , (":type E", [":type EQ"])
-  , (":type P.", map (":type P." ++) ["EQ", "GT", "LT", "unit"]) -- import Prelude (unit, Ordering(..)) as P
-  , (":type Effect.Console.lo", [])
-  , (":type voi", [])
+  , (":type uni", pure [":type unit"])
+  , (":type E", pure [":type EQ"])
+  , (":type P.", pure $ map (":type P." ++) ["EQ", "GT", "LT", "unit"]) -- import Prelude (unit, Ordering(..)) as P
+  , (":type Effect.Console.lo", pure [])
+  , (":type voi", pure [])
 
   -- :kind should complete next word from types in scope
-  , (":kind Str", [":kind String"])
-  , (":kind ST.", [":kind ST.Region", ":kind ST.ST"]) -- import Control.Monad.ST as ST
-  , (":kind STRef.", [":kind STRef.STRef"]) -- import Control.Monad.ST.Ref as STRef
-  , (":kind Effect.", [])
+  , (":kind Str", pure [":kind String"])
+  , (":kind ST.", pure [":kind ST.Region", ":kind ST.ST"]) -- import Control.Monad.ST as ST
+  , (":kind STRef.", pure [":kind STRef.STRef"]) -- import Control.Monad.ST.Ref as STRef
+  , (":kind Effect.", pure [])
 
   -- Only one argument for these directives should be completed
-  , (":show import ", [])
-  , (":browse Data.List ", [])
+  , (":show import ", pure [])
+  , (":browse Data.List ", pure [])
 
   -- These directives take any number of completable terms
-  , (":type const compa", [":type const compare", ":type const comparing"])
-  , (":kind Array In", [":kind Array Int"])
+  , (":type const compa", pure [":type const compare", ":type const comparing"])
+  , (":kind Array In", pure [":kind Array Int"])
 
   -- a few other import tests
-  , ("impor", ["import"])
-  , ("import ", map (T.unpack . mappend "import ") supportModuleNames)
-  , ("import Prelude ", [])
+  , ("impor", pure ["import"])
+  , ("import ", getSupportModuleNames <&> map (T.unpack . mappend "import "))
+  , ("import Prelude ", pure [])
 
   -- String and number literals should not be completed
-  , ("\"hi", [])
-  , ("34", [])
+  , ("\"hi", pure [])
+  , ("34", pure [])
 
   -- Identifiers and data constructors in scope should be completed
-  , ("uni", ["unit"])
-  , ("G", ["GT"])
-  , ("P.G", ["P.GT"])
-  , ("P.uni", ["P.unit"])
-  , ("voi", []) -- import Prelude hiding (void)
-  , ("Effect.Class.", [])
+  , ("uni", pure ["unit"])
+  , ("G", pure ["GT"])
+  , ("P.G", pure ["P.GT"])
+  , ("P.uni", pure ["P.unit"])
+  , ("voi", pure []) -- import Prelude hiding (void)
+  , ("Effect.Class.", pure [])
 
   -- complete first name after type annotation symbol
-  , ("1 :: I", ["1 :: Int"])
-  , ("1 ::I",  ["1 ::Int"])
-  , ("1:: I",  ["1:: Int"])
-  , ("1::I",   ["1::Int"])
-  , ("(1::Int) uni", ["(1::Int) unit"]) -- back to completing values
+  , ("1 :: I", pure ["1 :: Int"])
+  , ("1 ::I",  pure ["1 ::Int"])
+  , ("1:: I",  pure ["1:: Int"])
+  , ("1::I",   pure ["1::Int"])
+  , ("(1::Int) uni", pure ["(1::Int) unit"]) -- back to completing values
 
   -- Parens and brackets aren't considered part of the current identifier
-  , ("map id [uni", ["map id [unit"])
-  , ("map (cons", ["map (const"])
+  , ("map id [uni", pure ["map id [unit"])
+  , ("map (cons", pure ["map (const"])
   ]
 
-assertCompletedOk :: PSCiState -> (String, [String]) -> Spec
-assertCompletedOk psciState (line, expecteds) = specify line $ do
+assertCompletedOk :: (String, IO [String]) -> SpecWith PSCiState
+assertCompletedOk (line, expectedsM) = specify line $ \psciState -> do
+  expecteds <- expectedsM
   results <- runCM psciState (completion' (reverse line, ""))
   let actuals = formatCompletions results
   sort actuals `shouldBe` sort expecteds

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -26,7 +26,7 @@ import qualified Data.Map as M
 import Data.Maybe (isJust)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import Data.Time.Clock (UTCTime())
+import Data.Time.Clock (UTCTime(), diffUTCTime, getCurrentTime, nominalDay)
 import Data.Tuple (swap)
 import System.Directory
 import System.Exit (exitFailure)
@@ -53,20 +53,54 @@ findNodeProcess = runMaybeT . msum $ map (MaybeT . findExecutable) names
 -- updating.
 --
 updateSupportCode :: IO ()
-updateSupportCode = do
-  setCurrentDirectory "tests/support"
-  callCommand "npm install"
-  -- bower uses shebang "/usr/bin/env node", but we might have nodejs
-  node <- maybe cannotFindNode pure =<< findNodeProcess
-  -- Sometimes we run as a root (e.g. in simple docker containers)
-  -- And we are non-interactive: https://github.com/bower/bower/issues/1162
-  callProcess node ["node_modules/bower/bin/bower", "--allow-root", "install", "--config.interactive=false"]
-  setCurrentDirectory "../.."
+updateSupportCode = withCurrentDirectory "tests/support" $ do
+  let lastUpdatedFile = ".last_updated"
+  skipUpdate <- fmap isJust . runMaybeT $ do
+    -- We skip the update if: `.last_updated` exists,
+    lastUpdated <- MaybeT $ getModificationTimeMaybe lastUpdatedFile
+
+    -- ... and it was modified less than a day ago (no particular reason why
+    -- "one day" specifically),
+    now <- lift $ getCurrentTime
+    guard $ now `diffUTCTime` lastUpdated < nominalDay
+
+    -- ... and the needed directories exist,
+    contents <- lift $ listDirectory "."
+    guard $ "node_modules" `elem` contents && "bower_components" `elem` contents
+
+    -- ... and everything else in `tests/support` is at least as old as
+    -- `.last_updated`.
+    modTimes <- lift $ traverse getModificationTime . filter (/= lastUpdatedFile) $ contents
+    guard $ all (<= lastUpdated) modTimes
+
+    pure ()
+
+  unless skipUpdate $ do
+    heading "Updating support code"
+    callCommand "npm install"
+    -- bower uses shebang "/usr/bin/env node", but we might have nodejs
+    node <- maybe cannotFindNode pure =<< findNodeProcess
+    -- Sometimes we run as a root (e.g. in simple docker containers)
+    -- And we are non-interactive: https://github.com/bower/bower/issues/1162
+    callProcess node ["node_modules/bower/bin/bower", "--allow-root", "install", "--config.interactive=false"]
+    writeFile lastUpdatedFile ""
   where
   cannotFindNode :: IO a
   cannotFindNode = do
     hPutStrLn stderr "Cannot find node (or nodejs) executable"
     exitFailure
+
+  getModificationTimeMaybe :: FilePath -> IO (Maybe UTCTime)
+  getModificationTimeMaybe f = catch (Just <$> getModificationTime f) $ \case
+    e | isDoesNotExistError e -> pure Nothing
+      | otherwise             -> throw e
+
+  heading msg = do
+    putStrLn ""
+    putStrLn $ replicate 79 '#'
+    putStrLn $ "# " ++ msg
+    putStrLn $ replicate 79 '#'
+    putStrLn ""
 
 readInput :: [FilePath] -> IO [(FilePath, T.Text)]
 readInput inputFiles = forM inputFiles $ \inputFile -> do

--- a/tests/support/.gitignore
+++ b/tests/support/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 bower_components/
+/.last_updated


### PR DESCRIPTION
The goal of this commit is to minimize the amount of time it takes for
Hspec to get from the starting line to a complete spec tree, and thus to
improve the time it takes to run individual or small numbers of tests
from the suite. First, Hspec `beforeAll`/`beforeAllWith` hooks are used
to defer some work until Hspec actually runs the tests that require that
work. Second, the `npm install` and `bower install` pre-test steps are
throttled to run once a day, provided that the output directories
already exist and that their input files haven't changed.

**Description of the change**

See above.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
