### PR TITLE
Unused var tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ New features:
 
 Bugfixes:
 
+* Unused identifier warnings now report smaller and more relevant source spans (#4088, @nwolverson)
+  
+  Also fix incorrect warnings in cases involving a let-pattern binding shadowing
+  an existing identifier.
+
 Internal:
 
 * Drop libtinfo dependency (#3696, @hdgarrood)

--- a/lib/purescript-ast/src/Language/PureScript/AST/Binders.hs
+++ b/lib/purescript-ast/src/Language/PureScript/AST/Binders.hs
@@ -132,20 +132,24 @@ instance Ord Binder where
 -- Collect all names introduced in binders in an expression
 --
 binderNames :: Binder -> [Ident]
-binderNames = go []
+binderNames = map snd . binderNamesWithSpans
+
+binderNamesWithSpans :: Binder -> [(SourceSpan, Ident)]
+binderNamesWithSpans = go []
   where
   go ns (LiteralBinder _ b) = lit ns b
-  go ns (VarBinder _ name) = name : ns
+  go ns (VarBinder ss name) = (ss, name) : ns
   go ns (ConstructorBinder _ _ bs) = foldl go ns bs
   go ns (BinaryNoParensBinder b1 b2 b3) = foldl go ns [b1, b2, b3]
   go ns (ParensInBinder b) = go ns b
-  go ns (NamedBinder _ name b) = go (name : ns) b
+  go ns (NamedBinder ss name b) = go ((ss, name) : ns) b
   go ns (PositionedBinder _ _ b) = go ns b
   go ns (TypedBinder _ b) = go ns b
   go ns _ = ns
   lit ns (ObjectLiteral bs) = foldl go ns (map snd bs)
   lit ns (ArrayLiteral bs) = foldl go ns bs
   lit ns _ = ns
+
 
 isIrrefutable :: Binder -> Bool
 isIrrefutable NullBinder = True

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -220,15 +220,15 @@ lintUnused (Module modSS _ mn modDecls exports) =
             let bindNewNames = S.fromList (concatMap binderNamesWithSpans binders)
                 allExprs = concatMap unguard gexprs
             in
-                removeAndWarn bindNewNames $ mconcat $ map (go) allExprs
+                removeAndWarn bindNewNames $ mconcat $ map go allExprs
       in
-      mconcat $ map (go) vs ++ map f alts
+      mconcat $ map go vs ++ map f alts
 
     go (TypedValue _ v1 _) = go v1
     go (Do _ es) = doElts es Nothing
     go (Ado _ es v1) = doElts es (Just v1)
 
-    go (Literal _ (ArrayLiteral es)) = mconcat $ map (go) es
+    go (Literal _ (ArrayLiteral es)) = mconcat $ map go es
     go (Literal _ (ObjectLiteral oo)) = mconcat $ map (go . snd) oo
 
     go (PositionedValue _ _ v1) = go v1
@@ -254,7 +254,7 @@ lintUnused (Module modSS _ mn modDecls exports) =
       in removeAndWarn letNewNamesRec $
             mconcat (map underDecl ds)
             <> removeAndWarn letNewNames (doElts rest v)
-    doElts (PositionedDoNotationElement _ _ e : rest) v = doElts  (e : rest) v
+    doElts (PositionedDoNotationElement _ _ e : rest) v = doElts (e : rest) v
     doElts [] (Just e) = go e <> (rebindable, mempty)
     doElts [] Nothing = (rebindable, mempty)
 
@@ -269,7 +269,7 @@ lintUnused (Module modSS _ mn modDecls exports) =
       let bindNewNames = S.fromList (concatMap binderNamesWithSpans binders)
           allExprs = concatMap unguard gexprs
       in
-          removeAndWarn bindNewNames $ foldr1 (<>) $ map (go) allExprs
+          removeAndWarn bindNewNames $ foldr1 (<>) $ map go allExprs
     -- let {x} = e  -- no binding to check inside e
     underDecl (BoundValueDeclaration _ _ expr) = go expr
     underDecl _ = (mempty, mempty)

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -174,11 +174,10 @@ lintUnused (Module modSS _ mn modDecls exports) =
     where
 
     goDecl :: Declaration -> (S.Set Ident, MultipleErrors)
-    goDecl d@(ValueDeclaration vd) =
+    goDecl (ValueDeclaration vd) =
         let allExprs = concatMap unguard $ valdeclExpression vd
             bindNewNames = S.fromList (concatMap binderNamesWithSpans $ valdeclBinders vd)
-            ss = declSourceSpan d
-            (vars, errs) = removeAndWarn ss bindNewNames $ mconcat $ map (go ss) allExprs
+            (vars, errs) = removeAndWarn bindNewNames $ mconcat $ map go allExprs
             errs' = addHint (ErrorInValueDeclaration $ valdeclIdent vd) errs
         in
           (vars, errs')
@@ -186,78 +185,78 @@ lintUnused (Module modSS _ mn modDecls exports) =
     goDecl (TypeInstanceDeclaration _ _ _ _ _ _ _ (ExplicitInstance decls)) = mconcat $ map goDecl decls
     goDecl _ = mempty
 
-    go :: SourceSpan -> Expr -> (S.Set Ident, MultipleErrors)
-    go _ (Var _ (Qualified Nothing v)) = (S.singleton v, mempty)
-    go _ (Var _ _) = (S.empty, mempty)
+    go :: Expr -> (S.Set Ident, MultipleErrors)
+    go (Var _ (Qualified Nothing v)) = (S.singleton v, mempty)
+    go (Var _ _) = (S.empty, mempty)
 
-    go ss (Let _ ds e) =
+    go (Let _ ds e) =
       let (letNames, letNamesRec) = foldMap declIdents ds
-      in removeAndWarn ss letNamesRec $
-            removeAndWarn ss letNames (go ss e)
+      in removeAndWarn letNamesRec $
+            removeAndWarn letNames (go e)
             <> mconcat (map underDecl ds)
-    go ss (Abs binder v1) =
+    go (Abs binder v1) =
       let newNames = S.fromList (binderNamesWithSpans binder)
       in
-      removeAndWarn ss newNames $ go ss v1
+      removeAndWarn newNames $ go v1
 
-    go ss (UnaryMinus _ v1) = go ss v1
-    go ss (BinaryNoParens v0 v1 v2) = go ss v0 <> go ss v1 <> go ss v2
-    go ss (Parens v1) = go ss v1
-    go ss (TypeClassDictionaryConstructorApp _ v1) = go ss v1
-    go ss (Accessor _ v1) = go ss v1
+    go (UnaryMinus _ v1) = go v1
+    go (BinaryNoParens v0 v1 v2) = go v0 <> go v1 <> go v2
+    go (Parens v1) = go v1
+    go (TypeClassDictionaryConstructorApp _ v1) = go v1
+    go (Accessor _ v1) = go v1
 
-    go ss (ObjectUpdate obj vs) = mconcat (go ss obj : map (go ss . snd) vs)
-    go ss (ObjectUpdateNested obj vs) = go ss obj <> goTree vs
+    go (ObjectUpdate obj vs) = mconcat (go obj : map (go . snd) vs)
+    go (ObjectUpdateNested obj vs) = go obj <> goTree vs
       where
         goTree (PathTree tree) = mconcat $ map (goNode . snd) (runAssocList tree)
-        goNode (Leaf val) = go ss val
+        goNode (Leaf val) = go val
         goNode (Branch val) = goTree val
 
-    go ss (App v1 v2) = go ss v1 <> go ss v2
-    go ss (Unused v) = go ss v
-    go ss (IfThenElse v1 v2 v3) = go ss v1 <> go ss v2 <> go ss v3
-    go ss (Case vs alts) =
+    go (App v1 v2) = go v1 <> go v2
+    go (Unused v) = go v
+    go (IfThenElse v1 v2 v3) = go v1 <> go v2 <> go v3
+    go (Case vs alts) =
       let f (CaseAlternative binders gexprs) =
             let bindNewNames = S.fromList (concatMap binderNamesWithSpans binders)
                 allExprs = concatMap unguard gexprs
             in
-                removeAndWarn ss bindNewNames $ mconcat $ map (go ss) allExprs
+                removeAndWarn bindNewNames $ mconcat $ map (go) allExprs
       in
-      mconcat $ map (go ss) vs ++ map f alts
+      mconcat $ map (go) vs ++ map f alts
 
-    go ss (TypedValue _ v1 _) = go ss v1
-    go ss (Do _ es) = doElts ss es Nothing
-    go ss (Ado _ es v1) = doElts ss es (Just v1)
+    go (TypedValue _ v1 _) = go v1
+    go (Do _ es) = doElts es Nothing
+    go (Ado _ es v1) = doElts es (Just v1)
 
-    go ss (Literal _ (ArrayLiteral es)) = mconcat $ map (go ss) es
-    go ss (Literal _ (ObjectLiteral oo)) = mconcat $ map (go ss . snd) oo
+    go (Literal _ (ArrayLiteral es)) = mconcat $ map (go) es
+    go (Literal _ (ObjectLiteral oo)) = mconcat $ map (go . snd) oo
 
-    go _ (PositionedValue ss' _ v1) = go ss' v1
+    go (PositionedValue _ _ v1) = go v1
 
-    go _ (Literal _ _) = mempty
-    go _ (Op _ _) = mempty
-    go _ (Constructor _ _) = mempty
-    go _ (TypeClassDictionary _ _ _) = mempty
-    go _ (TypeClassDictionaryAccessor _ _) = mempty
-    go _ (DeferredDictionary _ _) = mempty
-    go _ AnonymousArgument = mempty
-    go _ (Hole _) = mempty
+    go (Literal _ _) = mempty
+    go (Op _ _) = mempty
+    go (Constructor _ _) = mempty
+    go (TypeClassDictionary _ _ _) = mempty
+    go (TypeClassDictionaryAccessor _ _) = mempty
+    go (DeferredDictionary _ _) = mempty
+    go AnonymousArgument = mempty
+    go (Hole _) = mempty
 
 
-    doElts :: SourceSpan -> [DoNotationElement] -> Maybe Expr -> (S.Set Ident, MultipleErrors)
-    doElts ss' (DoNotationValue e : rest) v = go ss' e <> doElts ss' rest v
-    doElts ss' (DoNotationBind binder e : rest) v =
+    doElts :: [DoNotationElement] -> Maybe Expr -> (S.Set Ident, MultipleErrors)
+    doElts (DoNotationValue e : rest) v = go e <> doElts rest v
+    doElts (DoNotationBind binder e : rest) v =
       let bindNewNames = S.fromList (binderNamesWithSpans binder)
-      in go ss' e <> removeAndWarn ss' bindNewNames (doElts ss' rest v)
+      in go e <> removeAndWarn bindNewNames (doElts rest v)
 
-    doElts ss' (DoNotationLet ds : rest) v =
+    doElts (DoNotationLet ds : rest) v =
       let (letNewNames, letNewNamesRec) = foldMap declIdents ds
-      in removeAndWarn ss' letNewNamesRec $
+      in removeAndWarn letNewNamesRec $
             mconcat (map underDecl ds)
-            <> removeAndWarn ss' letNewNames (doElts ss' rest v)
-    doElts _ (PositionedDoNotationElement ss'' _ e : rest) v = doElts ss'' (e : rest) v
-    doElts ss' [] (Just e) = go ss' e <> (rebindable, mempty)
-    doElts _ [] Nothing = (rebindable, mempty)
+            <> removeAndWarn letNewNames (doElts rest v)
+    doElts (PositionedDoNotationElement _ _ e : rest) v = doElts  (e : rest) v
+    doElts [] (Just e) = go e <> (rebindable, mempty)
+    doElts [] Nothing = (rebindable, mempty)
 
     -- (non-recursively, recursively) bound idents in decl
     declIdents :: Declaration -> (S.Set (SourceSpan, Ident), S.Set (SourceSpan, Ident))
@@ -266,23 +265,21 @@ lintUnused (Module modSS _ mn modDecls exports) =
     declIdents _ = (S.empty, S.empty)
 
     -- let f x = e  -- check the x in e (but not the f)
-    underDecl d@(ValueDecl _ _ _ binders gexprs) =
+    underDecl (ValueDecl _ _ _ binders gexprs) =
       let bindNewNames = S.fromList (concatMap binderNamesWithSpans binders)
           allExprs = concatMap unguard gexprs
-          ss = declSourceSpan d
       in
-          removeAndWarn ss bindNewNames $ foldr1 (<>) $ map (go ss) allExprs
+          removeAndWarn bindNewNames $ foldr1 (<>) $ map (go) allExprs
     -- let {x} = e  -- no binding to check inside e
-    underDecl d@(BoundValueDeclaration _ _ expr) =
-      go (declSourceSpan d) expr
+    underDecl (BoundValueDeclaration _ _ expr) = go expr
     underDecl _ = (mempty, mempty)
 
     unguard (GuardedExpr guards expr) = map unguard' guards ++ [expr]
     unguard' (ConditionGuard ee) = ee
     unguard' (PatternGuard _ ee) = ee
 
-    removeAndWarn :: SourceSpan -> S.Set (SourceSpan, Ident) -> (S.Set Ident, MultipleErrors) -> (S.Set Ident, MultipleErrors)
-    removeAndWarn _ newNamesWithSpans (used, errors) =
+    removeAndWarn :: S.Set (SourceSpan, Ident) -> (S.Set Ident, MultipleErrors) -> (S.Set Ident, MultipleErrors)
+    removeAndWarn newNamesWithSpans (used, errors) =
       let newNames = S.map snd newNamesWithSpans
           filteredUsed = used `S.difference` newNames
           warnUnused = S.filter (not . Text.isPrefixOf "_" . runIdent) (newNames `S.difference` used)

--- a/tests/purs/warning/UnusedVar.out
+++ b/tests/purs/warning/UnusedVar.out
@@ -1,7 +1,7 @@
 Warning 1 of 8:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:15:19 - 15:37 (line 15, column 19 - line 15, column 37)
+  at tests/purs/warning/UnusedVar.purs:15:20 - 15:32 (line 15, column 20 - line 15, column 32)
 
     Name [33mlambdaUnused[0m was introduced but not used.
 
@@ -13,7 +13,7 @@ Warning 1 of 8:
 Warning 2 of 8:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:19:3 - 20:4 (line 19, column 3 - line 20, column 4)
+  at tests/purs/warning/UnusedVar.purs:19:7 - 19:20 (line 19, column 7 - line 19, column 20)
 
     Name [33mletUnused[0m was introduced but not used.
 
@@ -25,7 +25,7 @@ Warning 2 of 8:
 Warning 3 of 8:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:24:3 - 24:4 (line 24, column 3 - line 24, column 4)
+  at tests/purs/warning/UnusedVar.purs:25:9 - 25:24 (line 25, column 9 - line 25, column 24)
 
     Name [33mwhereUnused[0m was introduced but not used.
 
@@ -37,7 +37,7 @@ Warning 3 of 8:
 Warning 4 of 8:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:29:7 - 29:27 (line 29, column 7 - line 29, column 27)
+  at tests/purs/warning/UnusedVar.purs:29:11 - 29:23 (line 29, column 11 - line 29, column 23)
 
     Name [33mletArgUnused[0m was introduced but not used.
 
@@ -49,7 +49,7 @@ Warning 4 of 8:
 Warning 5 of 8:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:42:3 - 43:20 (line 42, column 3 - line 43, column 20)
+  at tests/purs/warning/UnusedVar.purs:43:5 - 43:15 (line 43, column 5 - line 43, column 15)
 
     Name [33mcaseUnused[0m was introduced but not used.
 
@@ -61,7 +61,7 @@ Warning 5 of 8:
 Warning 6 of 8:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:61:1 - 63:9 (line 61, column 1 - line 63, column 9)
+  at tests/purs/warning/UnusedVar.purs:61:34 - 61:35 (line 61, column 34 - line 61, column 35)
 
     Name [33mx[0m was introduced but not used.
 
@@ -73,7 +73,7 @@ Warning 6 of 8:
 Warning 7 of 8:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:68:3 - 69:7 (line 68, column 3 - line 69, column 7)
+  at tests/purs/warning/UnusedVar.purs:68:8 - 68:9 (line 68, column 8 - line 68, column 9)
 
     Name [33mx[0m was introduced but not used.
 

--- a/tests/purs/warning/UnusedVar.out
+++ b/tests/purs/warning/UnusedVar.out
@@ -1,7 +1,7 @@
-Warning 1 of 5:
+Warning 1 of 8:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:12:19 - 12:37 (line 12, column 19 - line 12, column 37)
+  at tests/purs/warning/UnusedVar.purs:15:19 - 15:37 (line 15, column 19 - line 15, column 37)
 
     Name [33mlambdaUnused[0m was introduced but not used.
 
@@ -10,10 +10,10 @@ Warning 1 of 5:
   See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
   or to contribute content related to this warning.
 
-Warning 2 of 5:
+Warning 2 of 8:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:16:3 - 17:4 (line 16, column 3 - line 17, column 4)
+  at tests/purs/warning/UnusedVar.purs:19:3 - 20:4 (line 19, column 3 - line 20, column 4)
 
     Name [33mletUnused[0m was introduced but not used.
 
@@ -22,10 +22,10 @@ Warning 2 of 5:
   See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
   or to contribute content related to this warning.
 
-Warning 3 of 5:
+Warning 3 of 8:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:21:3 - 21:4 (line 21, column 3 - line 21, column 4)
+  at tests/purs/warning/UnusedVar.purs:24:3 - 24:4 (line 24, column 3 - line 24, column 4)
 
     Name [33mwhereUnused[0m was introduced but not used.
 
@@ -34,10 +34,10 @@ Warning 3 of 5:
   See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
   or to contribute content related to this warning.
 
-Warning 4 of 5:
+Warning 4 of 8:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:26:7 - 26:27 (line 26, column 7 - line 26, column 27)
+  at tests/purs/warning/UnusedVar.purs:29:7 - 29:27 (line 29, column 7 - line 29, column 27)
 
     Name [33mletArgUnused[0m was introduced but not used.
 
@@ -46,15 +46,51 @@ Warning 4 of 5:
   See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
   or to contribute content related to this warning.
 
-Warning 5 of 5:
+Warning 5 of 8:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:39:3 - 40:20 (line 39, column 3 - line 40, column 20)
+  at tests/purs/warning/UnusedVar.purs:42:3 - 43:20 (line 42, column 3 - line 43, column 20)
 
     Name [33mcaseUnused[0m was introduced but not used.
 
   in value declaration [33munusedCaseBinder[0m
 
   See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
+  or to contribute content related to this warning.
+
+Warning 6 of 8:
+
+  in module [33mMain[0m
+  at tests/purs/warning/UnusedVar.purs:61:1 - 63:9 (line 61, column 1 - line 63, column 9)
+
+    Name [33mx[0m was introduced but not used.
+
+  in value declaration [33munusedShadowedByRecursiveBinding[0m
+
+  See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
+  or to contribute content related to this warning.
+
+Warning 7 of 8:
+
+  in module [33mMain[0m
+  at tests/purs/warning/UnusedVar.purs:68:3 - 69:7 (line 68, column 3 - line 69, column 7)
+
+    Name [33mx[0m was introduced but not used.
+
+  in value declaration [33munusedShadowingLet[0m
+
+  See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
+  or to contribute content related to this warning.
+
+Warning 8 of 8:
+
+  in module [33mMain[0m
+  at tests/purs/warning/UnusedVar.purs:62:7 - 62:16 (line 62, column 7 - line 62, column 16)
+
+    Name [33mx[0m was shadowed.
+
+  in value declaration [33munusedShadowedByRecursiveBinding[0m
+
+  See https://github.com/purescript/documentation/blob/master/errors/ShadowedName.md for more information,
   or to contribute content related to this warning.
 

--- a/tests/purs/warning/UnusedVar.purs
+++ b/tests/purs/warning/UnusedVar.purs
@@ -3,6 +3,9 @@
 -- @shouldWarnWith UnusedName
 -- @shouldWarnWith UnusedName
 -- @shouldWarnWith UnusedName
+-- @shouldWarnWith UnusedName
+-- @shouldWarnWith UnusedName
+-- @shouldWarnWith ShadowedName
 module Main where
 
 data X = X
@@ -45,3 +48,22 @@ unusedObjUpdate =
       obj = { foo: X }
   in
   obj { foo = x }
+
+-- The outer x is used in the let-bound expression, the let-binding variable is used in the body
+notUnusedNonRecursiveBinding :: X -> X
+notUnusedNonRecursiveBinding x = 
+  let {x} = {x}
+  in x
+
+-- Almost like above but the outer x is not used, as x is bound recursively (Can also be true if there are no 
+-- arguments to x but in most cases this will error due to being cyclic)
+unusedShadowedByRecursiveBinding :: X -> X
+unusedShadowedByRecursiveBinding x = 
+  let x _ = x X
+  in x X
+
+-- In this case the outer x is used but the new x binding is not
+unusedShadowingLet :: X -> X
+unusedShadowingLet x = 
+  let (x) = x
+  in X

--- a/tests/purs/warning/UnusedVarDecls.out
+++ b/tests/purs/warning/UnusedVarDecls.out
@@ -1,7 +1,7 @@
 Warning 1 of 2:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVarDecls.purs:13:1 - 13:28 (line 13, column 1 - line 13, column 28)
+  at tests/purs/warning/UnusedVarDecls.purs:13:15 - 13:24 (line 13, column 15 - line 13, column 24)
 
     Name [33munusedArg[0m was introduced but not used.
 

--- a/tests/purs/warning/UnusedVarDo.out
+++ b/tests/purs/warning/UnusedVarDo.out
@@ -1,7 +1,7 @@
 Warning 1 of 4:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVarDo.purs:12:3 - 12:26 (line 12, column 3 - line 12, column 26)
+  at tests/purs/warning/UnusedVarDo.purs:12:3 - 12:15 (line 12, column 3 - line 12, column 15)
 
     Name [33munusedDoBind[0m was introduced but not used.
 
@@ -13,7 +13,7 @@ Warning 1 of 4:
 Warning 2 of 4:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVarDo.purs:24:3 - 24:23 (line 24, column 3 - line 24, column 23)
+  at tests/purs/warning/UnusedVarDo.purs:24:7 - 24:23 (line 24, column 7 - line 24, column 23)
 
     Name [33munusedDoLet[0m was introduced but not used.
 
@@ -25,7 +25,7 @@ Warning 2 of 4:
 Warning 3 of 4:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVarDo.purs:29:3 - 29:27 (line 29, column 3 - line 29, column 27)
+  at tests/purs/warning/UnusedVarDo.purs:29:3 - 29:16 (line 29, column 3 - line 29, column 16)
 
     Name [33munusedAdoBind[0m was introduced but not used.
 
@@ -37,7 +37,7 @@ Warning 3 of 4:
 Warning 4 of 4:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVarDo.purs:34:3 - 34:24 (line 34, column 3 - line 34, column 24)
+  at tests/purs/warning/UnusedVarDo.purs:34:7 - 34:24 (line 34, column 7 - line 34, column 24)
 
     Name [33munusedAdoLet[0m was introduced but not used.
 

--- a/tests/purs/warning/UnusedVarDo.purs
+++ b/tests/purs/warning/UnusedVarDo.purs
@@ -33,3 +33,8 @@ unusedAdoLetBinding :: Maybe Int
 unusedAdoLetBinding = ado
   let unusedAdoLet = 42
   in 17
+
+notUnusedNonRecursiveBinding :: Int -> Maybe Int
+notUnusedNonRecursiveBinding x = do
+  let {x} = {x}
+  pure x


### PR DESCRIPTION
Improvements to unused variable lint/warnings.

Fix a bad unused variable warning (fix #4083). The previous iteration was not distinguishing between variables bound recursively within the let binding, and those that are only bound inside the body.

Unchanged with this commit is that identifiers which are used recursively within a let binding will count as used (ie not warn), despite the fact that the binding could be removed - something more intelligent would be required to handle mutually recursive let blocks which may or may not be used externally.

Tighten the warning spans on unused variables (fix #4087).

This will scope to the identifier itself for binders, but a value declaration `let x = e in e2` will scope to the entire `x = e` as `ValueDecl` does not have a source span for the identifier alone.


**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
