### PR TITLE
New command: purs codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Breaking changes:
 
 New features:
 
+* Add `purs codegen` command
+
+  Adds a new command, `purs codegen`, which generates JavaScript code
+  for the given files containing the CoreFn Module JSON representation.
+
 Bugfixes:
 
 * Unused identifier warnings now report smaller and more relevant source spans (#4088, @nwolverson)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -144,6 +144,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@woody88](https://github.com/woody88) | Woodson Delhia | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mhmdanas](https://github.com/mhmdanas) | Mohammed Anas | [MIT license](http://opensource.org/licenses/MIT) |
 | [@kl0tl](https://github.com/kl0tl) | Cyril Sobierajewicz | [MIT license](http://opensource.org/licenses/MIT) |
+| [@colinwahl](https://github.com/colinwahl) | Colin Wahl | [MIT license](http://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms
 
@@ -157,7 +158,6 @@ If you would prefer to use different terms, please use the section below instead
 | [@nagisa](https://github.com/nagisa) | nagisa | I hereby release my [only contribution](https://github.com/purescript/purescript/commit/80287a5d0de619862d3b4cda9c1ee276d18fdcd8) into public domain. |
 | [@puffnfresh](https://github.com/puffnfresh) | Brian McKenna | All contributions I made during June 2015 were during employment at [SlamData, Inc.](#companies) who owns the copyright. I assign copyright of all my personal contributions before June 2015 to the owners of the PureScript compiler. |
 | [@nwolverson](https://github.com/nwolverson) | Nicholas Wolverson | Contributions I made during March 2020 until further notice are in employment of [Id3as Company](#companies), who own the copyright. All other contributions remain Copyright Nicholas Wolverson, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT). |
-| [@colinwahl](https://github.com/colinwahl) | Colin Wahl | [MIT license](http://opensource.org/licenses/MIT) |
 
 
 ### Companies

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -157,7 +157,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@nagisa](https://github.com/nagisa) | nagisa | I hereby release my [only contribution](https://github.com/purescript/purescript/commit/80287a5d0de619862d3b4cda9c1ee276d18fdcd8) into public domain. |
 | [@puffnfresh](https://github.com/puffnfresh) | Brian McKenna | All contributions I made during June 2015 were during employment at [SlamData, Inc.](#companies) who owns the copyright. I assign copyright of all my personal contributions before June 2015 to the owners of the PureScript compiler. |
 | [@nwolverson](https://github.com/nwolverson) | Nicholas Wolverson | Contributions I made during March 2020 until further notice are in employment of [Id3as Company](#companies), who own the copyright. All other contributions remain Copyright Nicholas Wolverson, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT). |
-
+| [@colinwahl](https://github.com/colinwahl) | Colin Wahl | [MIT license](http://opensource.org/licenses/MIT) |
 
 
 ### Companies

--- a/app/Command/Codegen.hs
+++ b/app/Command/Codegen.hs
@@ -4,8 +4,23 @@ import Prelude
 
 import           Control.Applicative (many)
 import           Control.Monad (when, unless)
-import qualified Language.PureScript as P
+import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Supply
+
+import qualified Data.Aeson.Internal as A
+import           Data.Aeson.Parser (eitherDecodeWith, json)
+import qualified Data.ByteString.Lazy as BSL
+import           Data.Either (rights)
+import qualified Data.Set as S
+import qualified Data.Map as M
+
 import qualified Options.Applicative as Opts
+
+import qualified Language.PureScript.Docs.Types as Docs
+import qualified Language.PureScript as P
+import qualified Language.PureScript.CoreFn as CoreFn
+import qualified Language.PureScript.CoreFn.FromJSON as CoreFn
+
 import           System.Exit (exitFailure, exitSuccess)
 import           System.FilePath.Glob (glob)
 import           System.IO (hPutStr, hPutStrLn, stderr)
@@ -17,16 +32,54 @@ data CodegenOptions = CodegenOptions
 
 codegen :: CodegenOptions -> IO ()
 codegen CodegenOptions{..} = do
-  input <- globWarningOnMisses (unless codegenJSONErrors . warnFileTypeNotFound) codegenCoreFnInput
-  when (null input && not codegenJSONErrors) $ do
+  inputFiles <- globWarningOnMisses (unless codegenJSONErrors . warnFileTypeNotFound) codegenCoreFnInput
+  when (null inputFiles && not codegenJSONErrors) $ do
     hPutStr stderr $ unlines
       [ "purs codegen: No input files."
       , "Usage: For basic information, try the `--help` option."
       ]
     exitFailure
+  mods <- traverse parseCoreFn inputFiles
+  let
+    filePathMap =
+      M.fromList $ map (\m -> (CoreFn.moduleName m, Right $ CoreFn.modulePath m)) $ map snd $ rights mods
 
+  foreigns <- P.inferForeignModules filePathMap
+  _ <-
+    liftIO
+      $ P.runMake purescriptOptions
+      $ runSupplyT 0
+      $ traverse (runCodegen foreigns filePathMap) $ map snd $ rights mods
   exitSuccess
   where
+  parseCoreFn file = do
+    contents <- BSL.readFile file
+    case eitherDecodeWith json (A.iparse CoreFn.moduleFromJSON) contents of
+      Left (j, e) -> pure $ Left (file, j, e)
+      Right r -> pure $ Right r
+
+  makeActions foreigns filePathMap = P.buildMakeActions "output" filePathMap foreigns False
+
+  purescriptOptions :: P.Options
+  purescriptOptions = P.Options False False (S.fromList [ P.JS ])
+
+  runCodegen foreigns filePathMap m =
+    P.codegen (makeActions foreigns filePathMap) m
+      (Docs.Module (CoreFn.moduleName m) Nothing [] [])
+      (moduleToExternsFile m)
+
+  moduleToExternsFile :: CoreFn.Module a -> P.ExternsFile
+  moduleToExternsFile CoreFn.Module {CoreFn.moduleName} = P.ExternsFile {
+      P.efVersion      = mempty,
+      P.efModuleName   = moduleName,
+      P.efExports      = [],
+      P.efImports      = [],
+      P.efFixities     = [],
+      P.efTypeFixities = [],
+      P.efDeclarations = [],
+      P.efSourceSpan   = P.SourceSpan "none" (P.SourcePos 0 0) (P.SourcePos 0 0)
+    }
+
   warnFileTypeNotFound :: String -> IO ()
   warnFileTypeNotFound =
     hPutStrLn stderr . ("purs graph: No files found using pattern: " <>)

--- a/app/Command/Codegen.hs
+++ b/app/Command/Codegen.hs
@@ -34,6 +34,7 @@ import           System.IO (hPutStr, hPutStrLn, stderr)
 data CodegenOptions = CodegenOptions
   { codegenCoreFnInput :: [FilePath]
   , codegenJSONErrors :: Bool
+  , codegenOutputDir :: FilePath
   }
 
 codegen :: CodegenOptions -> IO ()
@@ -72,7 +73,7 @@ codegen CodegenOptions{..} = do
       Left (j, e) -> pure $ Left (file, j, e)
       Right r -> pure $ Right r
 
-  makeActions foreigns filePathMap = P.buildMakeActions "output" filePathMap foreigns False
+  makeActions foreigns filePathMap = P.buildMakeActions codegenOutputDir filePathMap foreigns False
 
   purescriptOptions :: P.Options
   purescriptOptions = P.Options False False (S.fromList [ P.JS ])
@@ -93,6 +94,7 @@ command = codegen <$> (Opts.helper <*> codegenOptions)
   codegenOptions =
     CodegenOptions <$> many inputFile
                    <*> jsonErrors
+                   <*> outputDirectory
 
   inputFile :: Opts.Parser FilePath
   inputFile =
@@ -105,6 +107,14 @@ command = codegen <$> (Opts.helper <*> codegenOptions)
     Opts.switch $
       Opts.long "json-errors" <>
       Opts.help "Print errors to stderr as JSON"
+
+  outputDirectory :: Opts.Parser FilePath
+  outputDirectory = Opts.strOption $
+    Opts.short 'o'
+      <> Opts.long "output"
+      <> Opts.value "output"
+      <> Opts.showDefault
+      <> Opts.help "The output directory"
 
 globWarningOnMisses :: (String -> IO ()) -> [FilePath] -> IO [FilePath]
 globWarningOnMisses warn = concatMapM globWithWarning

--- a/app/Command/Codegen.hs
+++ b/app/Command/Codegen.hs
@@ -1,0 +1,64 @@
+module Command.Codegen (command) where
+
+import Prelude
+
+import           Control.Applicative (many)
+import           Control.Monad (when, unless)
+import qualified Language.PureScript as P
+import qualified Options.Applicative as Opts
+import           System.Exit (exitFailure, exitSuccess)
+import           System.FilePath.Glob (glob)
+import           System.IO (hPutStr, hPutStrLn, stderr)
+
+data CodegenOptions = CodegenOptions
+  { codegenCoreFnInput :: [FilePath]
+  , codegenJSONErrors :: Bool
+  }
+
+codegen :: CodegenOptions -> IO ()
+codegen CodegenOptions{..} = do
+  input <- globWarningOnMisses (unless codegenJSONErrors . warnFileTypeNotFound) codegenCoreFnInput
+  when (null input && not codegenJSONErrors) $ do
+    hPutStr stderr $ unlines
+      [ "purs codegen: No input files."
+      , "Usage: For basic information, try the `--help` option."
+      ]
+    exitFailure
+
+  exitSuccess
+  where
+  warnFileTypeNotFound :: String -> IO ()
+  warnFileTypeNotFound =
+    hPutStrLn stderr . ("purs graph: No files found using pattern: " <>)
+
+command :: Opts.Parser (IO ())
+command = codegen <$> (Opts.helper <*> codegenOptions)
+  where
+  codegenOptions :: Opts.Parser CodegenOptions
+  codegenOptions =
+    CodegenOptions <$> many inputFile
+                   <*> jsonErrors
+
+  inputFile :: Opts.Parser FilePath
+  inputFile =
+    Opts.strArgument $
+      Opts.metavar "FILE" <>
+      Opts.help "The input corefn.json file(s)."
+
+  jsonErrors :: Opts.Parser Bool
+  jsonErrors =
+    Opts.switch $
+      Opts.long "json-errors" <>
+      Opts.help "Print errors to stderr as JSON"
+
+globWarningOnMisses :: (String -> IO ()) -> [FilePath] -> IO [FilePath]
+globWarningOnMisses warn = concatMapM globWithWarning
+  where
+  globWithWarning :: String -> IO [FilePath]
+  globWithWarning pattern' = do
+    paths <- glob pattern'
+    when (null paths) $ warn pattern'
+    return paths
+
+  concatMapM :: (a -> IO [b]) -> [a] -> IO [b]
+  concatMapM f = fmap concat . mapM f

--- a/app/Command/Codegen.hs
+++ b/app/Command/Codegen.hs
@@ -66,19 +66,7 @@ codegen CodegenOptions{..} = do
   runCodegen foreigns filePathMap m =
     P.codegen (makeActions foreigns filePathMap) m
       (Docs.Module (CoreFn.moduleName m) Nothing [] [])
-      (moduleToExternsFile m)
-
-  moduleToExternsFile :: CoreFn.Module a -> P.ExternsFile
-  moduleToExternsFile CoreFn.Module {CoreFn.moduleName} = P.ExternsFile {
-      P.efVersion      = mempty,
-      P.efModuleName   = moduleName,
-      P.efExports      = [],
-      P.efImports      = [],
-      P.efFixities     = [],
-      P.efTypeFixities = [],
-      P.efDeclarations = [],
-      P.efSourceSpan   = P.SourceSpan "none" (P.SourcePos 0 0) (P.SourcePos 0 0)
-    }
+      Nothing
 
   warnFileTypeNotFound :: String -> IO ()
   warnFileTypeNotFound =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,6 +10,7 @@ module Main where
 import Prelude
 
 import qualified Command.Bundle as Bundle
+import qualified Command.Codegen as Codegen
 import qualified Command.Compile as Compile
 import qualified Command.Docs as Docs
 import qualified Command.Graph as Graph
@@ -68,6 +69,9 @@ main = do
         [ Opts.command "bundle"
             (Opts.info Bundle.command
               (Opts.progDesc "Bundle compiled PureScript modules for the browser"))
+        , Opts.command "codegen"
+            (Opts.info Codegen.command
+              (Opts.progDesc "Generate JS from core functional representation"))
         , Opts.command "compile"
             (Opts.info Compile.command
               (Opts.progDesc "Compile PureScript source files"))

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -346,6 +346,7 @@ executable purs
       gitrev >=1.2.0 && <1.4
   other-modules:
     Command.Bundle
+    Command.Codegen
     Command.Compile
     Command.Docs
     Command.Docs.Html

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -116,7 +116,7 @@ rebuildModule' MakeActions{..} exEnv externs m@(Module _ _ moduleName _ _) = do
                  ++ "; details:\n" ++ prettyPrintMultipleErrors defaultPPEOptions errs
                Right d -> d
 
-  evalSupplyT nextVar' $ codegen renamed docs exts
+  evalSupplyT nextVar' $ codegen renamed docs (Just exts)
   return exts
 
 -- | Compiles in "make" mode, compiling each module separately to a @.js@ file and an @externs.cbor@ file.

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -97,7 +97,7 @@ data MakeActions m = MakeActions
   , readExterns :: ModuleName -> m (FilePath, Maybe ExternsFile)
   -- ^ Read the externs file for a module as a string and also return the actual
   -- path for the file.
-  , codegen :: CF.Module CF.Ann -> Docs.Module -> ExternsFile -> SupplyT m ()
+  , codegen :: CF.Module CF.Ann -> Docs.Module -> Maybe ExternsFile -> SupplyT m ()
   -- ^ Run the code generator for the module and write any required output files.
   , ffiCodegen :: CF.Module CF.Ann -> m ()
   -- ^ Check ffi and print it in the output directory.
@@ -218,10 +218,11 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
     when (S.member Docs codegenTargets) $ for_ Docs.Prim.primModules $ \docsMod@Docs.Module{..} ->
       writeJSONFile (outputFilename modName "docs.json") docsMod
 
-  codegen :: CF.Module CF.Ann -> Docs.Module -> ExternsFile -> SupplyT Make ()
-  codegen m docs exts = do
+  codegen :: CF.Module CF.Ann -> Docs.Module -> Maybe ExternsFile -> SupplyT Make ()
+  codegen m docs mbExts = do
     let mn = CF.moduleName m
-    lift $ writeCborFile (outputFilename mn externsFileName) exts
+    for_ mbExts $ \exts ->
+      lift $ writeCborFile (outputFilename mn externsFileName) exts
     codegenTargets <- lift $ asks optionsCodegenTargets
     when (S.member CoreFn codegenTargets) $ do
       let coreFnFile = targetFilename mn CoreFn


### PR DESCRIPTION
**Description of the change**

Implements a new command: `purs codegen`

`purs codegen` takes globs to filepaths containing the JSON representation of a CoreFn Module (this can be generated by `purs compile`). It parses the core functional representation out of these files, and passes them in to the standard `codegen` function.

This command allows for CoreFn transformations to be written outside of the compiler (even in PureScript!) without having to worry about using PureScript as a library.

Example usage of this would be:

```
$ purs compile glob/to/files.purs -g corefn,js
$ <execute pass over generated corefn.json files>
$ purs codegen glob/to/all/corefn.json
```

This intends to close #3339

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
