### PR TITLE
WIP: CSS variables + dark theme

### DIFF
--- a/app/static/pursuit.css
+++ b/app/static/pursuit.css
@@ -47,6 +47,36 @@
  ** ************************************************************************* */
 /* Section: Variables
  * ========================================================================== */
+:root {
+  --background: #ffffff;
+  --foreground: #000000;
+  --separator: #cccccc;
+  --banner_background: #1d222d;
+  --package_banner_background: #3b3f4c;
+  --dark_foreground: #f0f0f0;
+  --link: #c4953a;
+  --link_active: #7b5904;
+  --error_background: #fff0f0;
+  --error_border: #c85050;
+  --not_available_background: #f0f096;
+  --not_available_border: #e3e33d;
+  --code_foreground: #194a5b;
+  --code_background: #f1f5f9;
+  --light_glyph: #a0a0a0;
+  --light_type: #666666;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #000000;
+    --foreground: #ffffff;
+    --separator: #3c3c3c;
+    --link: #deaa45;
+    --link_active: #986416;
+    --code_background: #121212;
+    --code_foreground: #fcfcfc;
+    --light_type: #aaaaaa;
+  }
+}
 /* Section: Document Styles
  * ========================================================================== */
 html {
@@ -63,7 +93,9 @@ html {
 }
 body {
   background-color: #ffffff;
-  color: #000;
+  background-color: var(--background, #ffffff);
+  color: #000000;
+  color: var(--foreground, #000000);
   font-family: "Roboto", sans-serif;
   font-size: 87.5%;
   line-height: 1.563;
@@ -71,6 +103,21 @@ body {
 @media (min-width: 38em) {
   body {
     font-size: 100%;
+  }
+}
+@media (prefer-color-scheme: dark) {
+  body {
+    font-weight: 350;
+  }
+  b,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  strong {
+    font-weight: 650;
   }
 }
 /* Section: Utility Classes
@@ -156,7 +203,9 @@ body {
   width: 100%;
   text-align: center;
   background-color: #1d222d;
+  background-color: var(--banner_background, #1d222d);
   color: #f0f0f0;
+  color: var(--dark_foreground, #f0f0f0);
 }
 .footer * {
   margin-bottom: 0;
@@ -168,28 +217,36 @@ body {
  * ========================================================================== */
 :target {
   background-color: #f1f5f9;
+  background-color: var(--code_background, #f1f5f9);
 }
 a,
 a:visited {
   color: #c4953a;
+  color: var(--link, #c4953a);
   text-decoration: none;
   font-weight: bold;
 }
 a:hover {
   color: #7b5904;
+  color: var(--link_active, #7b5904);
   text-decoration: none;
 }
 code,
-pre {
+kbd,
+pre,
+samp {
   background-color: #f1f5f9;
+  background-color: var(--code_background, #f1f5f9);
   border-radius: 3px;
   color: #194a5b;
+  color: var(--code_foreground, #194a5b);
   font-family: "Roboto Mono", monospace;
   font-size: 87.5%;
 }
 :target code,
 :target pre {
-  background-color: #dfe8f1;
+  background-color: #eaeef2;
+  background-color: var(--code_background_targeted, #eaeef2);
 }
 code {
   padding: 0.2em 0;
@@ -255,14 +312,14 @@ h1 {
 h2 {
   font-size: 1.953em;
   font-weight: normal;
-  line-height: 1.250;
+  line-height: 1.25;
   margin-top: 3.052rem;
   margin-bottom: 1rem;
 }
 h3 {
   font-size: 1.563em;
   font-weight: normal;
-  line-height: 1.250;
+  line-height: 1.25;
   margin-top: 2.441rem;
   margin-bottom: 1rem;
 }
@@ -284,6 +341,7 @@ hr {
   border: none;
   height: 1px;
   background-color: #cccccc;
+  background-color: var(--separator, #cccccc);
 }
 img {
   border-style: none;
@@ -296,6 +354,7 @@ p {
 }
 table {
   border-bottom: 1px solid #cccccc;
+  border-color: var(--separator, #cccccc);
   border-collapse: collapse;
   border-spacing: 0;
   margin-top: 1rem;
@@ -309,6 +368,7 @@ th {
 }
 td {
   border-top: 1px solid #cccccc;
+  border-color: var(--separator, #cccccc);
 }
 td:first-child,
 th:first-child {
@@ -326,15 +386,16 @@ ul {
 }
 ul li {
   position: relative;
-  padding-left: 1.250em;
+  padding-left: 1.25em;
 }
 ul li::before {
   position: absolute;
   color: #a0a0a0;
+  color: var(--light_glyph, #a0a0a0);
   content: "–";
   display: inline-block;
   margin-left: -1.25em;
-  width: 1.250em;
+  width: 1.25em;
 }
 /* Tying this tightly to ul at the moment because it's a slight variation thereof */
 ul.ul--search li::before {
@@ -345,11 +406,19 @@ ul.ul--search li::before {
 ol {
   margin-top: 1rem;
   margin-bottom: 1rem;
-  padding-left: 1.250em;
+  padding-left: 1.25em;
 }
 ol li {
   position: relative;
   padding-left: 0;
+}
+input:not([type="checkbox"]):not([type="radio"]):not([type="submit"]),
+select,
+textarea {
+  background: #ffffff;
+  background: var(--background, #ffffff);
+  color: #000000;
+  color: var(--foreground, #000000);
 }
 /* Section: Components
  * ========================================================================== */
@@ -371,10 +440,11 @@ ol li {
 }
 .badge.badge--package {
   background-color: #c4953a;
+  background-color: var(--link, #c4953a);
   letter-spacing: -0.1em;
 }
 .badge.badge--module {
-  background-color: #75B134;
+  background-color: #75b134;
 }
 /* Component: Declarations
  * -------------------------------------------------------------------------- */
@@ -402,9 +472,11 @@ ol li {
 .decl__signature {
   background-color: transparent;
   border-radius: 0;
-  border-top: 1px solid #cccccc;
-  border-bottom: 1px solid #cccccc;
-  padding: 0;
+  border-width: 1px 0 1px 0;
+  border-style: solid;
+  border-color: #cccccc;
+  border-color: var(--separator, #cccccc);
+  padding: 0.328em 0;
 }
 .decl__signature code {
   display: block;
@@ -423,7 +495,7 @@ ol li {
 }
 .decl__body .keyword,
 .decl__body .syntax {
-  color: #0B71B4;
+  color: #0b71b4;
 }
 .decl__child_comments {
   margin-top: 1rem;
@@ -440,6 +512,7 @@ ol li {
 }
 .deplink__version {
   color: #666666;
+  color: var(--light_type, #666666);
   display: inline-block;
   font-size: 0.8em;
   line-height: 1;
@@ -448,10 +521,12 @@ ol li {
  * -------------------------------------------------------------------------- */
 .grouped-list {
   border-top: 1px solid #cccccc;
+  border-color: var(--separator, #cccccc);
   margin: 0 0 2.44em 0;
 }
 .grouped-list__title {
   color: #666666;
+  color: var(--light_type, #666666);
   font-size: 0.8em;
   font-weight: 300;
   letter-spacing: 1px;
@@ -470,11 +545,14 @@ ol li {
 }
 .message.message--error {
   background-color: #fff0f0;
+  background-color: var(--error_background, #fff0f0);
   border-color: #c85050;
+  border-color: var(--error_border, #c85050);
 }
 .message.message--not-available {
   background-color: #f0f096;
   border-color: #e3e33d;
+  border-color: var(--not_available_border, #e3e33d);
 }
 /* Component: Multi Col
  * Multiple columns side by side
@@ -493,7 +571,7 @@ ol li {
     float: left;
     width: 50%;
   }
-  .multi-col__col:nth-child(2n+3) {
+  .multi-col__col:nth-child(2n + 3) {
     clear: both;
   }
 }
@@ -502,7 +580,7 @@ ol li {
     float: left;
     width: 33.333333%;
   }
-  .multi-col__col:nth-child(3n+4) {
+  .multi-col__col:nth-child(3n + 4) {
     clear: both;
   }
 }
@@ -520,6 +598,7 @@ ol li {
 .page-title__label {
   position: relative;
   color: #666666;
+  color: var(--light_type, #666666);
   font-size: 0.8rem;
   font-weight: 300;
   letter-spacing: 1px;
@@ -531,13 +610,16 @@ ol li {
  * -------------------------------------------------------------------------- */
 .top-banner {
   background-color: #1d222d;
+  background-color: var(--banner_background, #1d222d);
   color: #f0f0f0;
+  color: var(--dark_foreground, #f0f0f0);
   font-weight: normal;
 }
 .top-banner__logo,
 .top-banner__logo:visited {
   float: left;
   color: #f0f0f0;
+  color: var(--dark_foreground, #f0f0f0);
   font-size: 2.44em;
   font-weight: 300;
   line-height: 90px;
@@ -545,15 +627,17 @@ ol li {
 }
 .top-banner__logo:hover {
   color: #c4953a;
+  color: var(--link, #c4953a);
   text-decoration: none;
 }
 .top-banner__form {
   margin-bottom: 1.25em;
 }
 .top-banner__form input {
-  border: 1px solid #1d222d;
+  border: 1px solid currentColor;
   border-radius: 3px;
   color: #1d222d;
+  color: var(--banner_background, #1d222d);
   font-weight: 300;
   line-height: 2;
   padding: 0.21em 0.512em;
@@ -575,9 +659,11 @@ ol li {
 .top-banner__actions__item a,
 .top-banner__actions__item a:visited {
   color: #f0f0f0;
+  color: var(--dark_foreground, #f0f0f0);
 }
 .top-banner__actions__item a:hover {
   color: #c4953a;
+  color: var(--link, #c4953a);
 }
 @media (min-width: 38em) {
   .top-banner__logo {
@@ -608,16 +694,18 @@ ol li {
   margin-left: -0.1em;
 }
 .result__body > *:first-child {
-  margin-top: 0!important;
+  margin-top: 0 !important;
 }
 .result__body > *:last-child {
-  margin-bottom: 0!important;
+  margin-bottom: 0 !important;
 }
 .result__signature {
   background-color: transparent;
   border-radius: 0;
-  border-top: 1px solid #cccccc;
-  border-bottom: 1px solid #cccccc;
+  border-width: 1px 0 1px 0;
+  border-style: solid;
+  border-color: #cccccc;
+  border-color: var(--separator, #cccccc);
   padding: 0.328em 0;
 }
 .result__signature code {

--- a/app/static/pursuit.less
+++ b/app/static/pursuit.less
@@ -49,18 +49,55 @@
 /* Section: Variables
  * ========================================================================== */
 @background: rgb(255, 255, 255);
+@foreground: rgb(0, 0, 0);
+@separator: rgb(204, 204, 204);
 @banner_background: rgb(29, 34, 45);
-@package_banner_background: lighten(@banner_background, 30%);
+@package_banner_background: rgb(59, 63, 76);
 @dark_foreground: rgb(240, 240, 240);
 @link: rgb(196, 149, 58);
 @link_active: rgb(123, 89, 4);
 @error_background: rgb(255, 240, 240);
 @error_border: rgb(200, 80, 80);
 @not_available_background: rgb(240, 240, 150);
+@not_available_border: darken(@not_available_background, 20%);
 @code_foreground: rgb(25, 74, 91);
 @code_background: rgb(241, 245, 249);
+@code_background_targeted: rgb(234, 238, 242);
 @light_glyph: rgb(160, 160, 160);
 @light_type: rgb(102, 102, 102);
+
+:root {
+  --background: @background;
+  --foreground: @foreground;
+  --separator: @separator;
+  --banner_background: @banner_background;
+  --package_banner_background: @package_banner_background;
+  --dark_foreground: @dark_foreground;
+  --link: @link;
+  --link_active: @link_active;
+  --error_background: @error_background;
+  --error_border: @error_border;
+  --not_available_background: @not_available_background;
+  --not_available_border: @not_available_border;
+  --code_foreground: @code_foreground;
+  --code_background: @code_background;
+  --light_glyph: @light_glyph;
+  --light_type: @light_type;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: rgb(0, 0, 0);
+    --foreground: rgb(255, 255, 255);
+    --separator: rgb(60, 60, 60);
+    --link: rgb(222, 170, 69);
+    --link_active: rgb(152, 100, 22);
+    --code_background: rgb(18, 18, 18);
+    --code_foreground: rgb(252, 252, 252);
+    --light_type: rgb(170, 170, 170);
+  }
+}
+
 
 /* Section: Document Styles
  * ========================================================================== */
@@ -80,7 +117,9 @@ html {
 
 body {
   background-color: @background;
-  color: #000;
+  background-color: var(--background, ~"@{background}");
+  color: @foreground;
+  color: var(--foreground, ~"@{foreground}");
   font-family: "Roboto", sans-serif;
   font-size: 87.5%;
   line-height: 1.563;
@@ -89,6 +128,22 @@ body {
 @media (min-width: 38em) {
   body {
     font-size: 100%;
+  }
+}
+
+@media (prefer-color-scheme: dark) {
+  body {
+    font-weight: 350;
+  }
+  b,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  strong {
+    font-weight: 650;
   }
 }
 
@@ -177,7 +232,8 @@ body {
  * Except we don't support IE6
  * -------------------------------------------------------------------------- */
 
-html, body {
+html,
+body {
   height: 100%;
 }
 
@@ -193,7 +249,9 @@ html, body {
   width: 100%;
   text-align: center;
   background-color: @banner_background;
+  background-color: var(--banner_background, ~"@{banner_background}");
   color: @dark_foreground;
+  color: var(--dark_foreground, ~"@{dark_foreground}");
 }
 
 .footer * {
@@ -209,30 +267,36 @@ html, body {
 
 :target {
   background-color: @code_background;
+  background-color: var(--code_background, ~"@{code_background}");
 }
 
 a, a:visited {
   color: @link;
+  color: var(--link, ~"@{link}");
   text-decoration: none;
   font-weight: bold;
 }
 
 a:hover {
   color: @link_active;
+  color: var(--link_active, ~"@{link_active}");
   text-decoration: none;
 }
 
-code, pre {
+code, kbd, pre, samp {
   background-color: @code_background;
+  background-color: var(--code_background, ~"@{code_background}");
   border-radius: 3px;
   color: @code_foreground;
+  color: var(--code_foreground, ~"@{code_foreground}");
   font-family: "Roboto Mono", monospace;
   font-size: 87.5%;
 }
 
 :target code,
 :target pre {
-  background-color: darken(@code_background, 5%);
+  background-color: @code_background_targeted;
+  background-color: var(--code_background_targeted, ~"@{code_background_targeted}");
 }
 
 code {
@@ -308,7 +372,7 @@ h1 {
 h2 {
   font-size: 1.953em;
   font-weight: normal;
-  line-height: 1.250;
+  line-height: 1.25;
   margin-top: 3.052rem;
   margin-bottom: 1rem;
 }
@@ -316,7 +380,7 @@ h2 {
 h3 {
   font-size: 1.563em;
   font-weight: normal;
-  line-height: 1.250;
+  line-height: 1.25;
   margin-top: 2.441rem;
   margin-bottom: 1rem;
 }
@@ -340,7 +404,8 @@ h3 + h4 {
 hr {
   border: none;
   height: 1px;
-  background-color: darken(@background, 20%);
+  background-color: @separator;
+  background-color: var(--separator, ~"@{separator}");
 }
 
 img {
@@ -355,7 +420,8 @@ p {
 }
 
 table {
-  border-bottom: 1px solid darken(@background, 20%);
+  border-bottom: 1px solid @separator;
+  border-color: var(--separator, ~"@{separator}");
   border-collapse: collapse;
   border-spacing: 0;
   margin-top: 1rem;
@@ -369,7 +435,8 @@ td, th {
 }
 
 td {
-  border-top: 1px solid darken(@background, 20%);
+  border-top: 1px solid @separator;
+  border-color: var(--separator, ~"@{separator}");
 }
 
 td:first-child, th:first-child {
@@ -389,16 +456,17 @@ ul {
 
 ul li {
   position: relative;
-  padding-left: 1.250em;
+  padding-left: 1.25em;
 }
 
 ul li::before {
   position: absolute;
   color: @light_glyph;
+  color: var(--light_glyph, ~"@{light_glyph}");
   content: "–";
   display: inline-block;
-  margin-left: -1.250em;
-  width: 1.250em;
+  margin-left: -1.25em;
+  width: 1.25em;
 }
 
 /* Tying this tightly to ul at the moment because it's a slight variation thereof */
@@ -411,12 +479,21 @@ ul.ul--search li::before {
 ol {
   margin-top: 1rem;
   margin-bottom: 1rem;
-  padding-left: 1.250em;
+  padding-left: 1.25em;
 }
 
 ol li {
   position: relative;
   padding-left: 0;
+}
+
+input:not([type="checkbox"]):not([type="radio"]):not([type="submit"]),
+select,
+textarea {
+  background: @background;
+  background: var(--background, ~"@{background}");
+  color: @foreground;
+  color: var(--foreground, ~"@{foreground}");
 }
 
 
@@ -443,11 +520,12 @@ ol li {
 
 .badge.badge--package {
   background-color: @link;
+  background-color: var(--link, ~"@{link}");
   letter-spacing: -0.1em;
 }
 
 .badge.badge--module {
-  background-color: #75B134;
+  background-color: #75b134;
 }
 
 
@@ -483,9 +561,11 @@ ol li {
 .decl__signature {
   background-color: transparent;
   border-radius: 0;
-  border-top: 1px solid darken(@background, 20%);
-  border-bottom: 1px solid darken(@background, 20%);
-  padding: 0;
+  border-width: 1px 0 1px 0;
+  border-style: solid;
+  border-color: @separator;
+  border-color: var(--separator, ~"@{separator}");
+  padding: 0.328em 0;
 }
 
 .decl__signature code {
@@ -508,7 +588,7 @@ ol li {
 
 .decl__body .keyword,
 .decl__body .syntax {
-  color: #0B71B4;
+  color: #0b71b4;
 }
 
 .decl__child_comments {
@@ -516,10 +596,13 @@ ol li {
   margin-bottom: 1rem;
 }
 
+
 /* Component: Dependency Link
  * -------------------------------------------------------------------------- */
 
-.deplink { /* Currently no root styles, but keep the class as a namespace */ }
+.deplink {
+  /* Currently no root styles, but keep the class as a namespace */
+}
 
 .deplink__link {
   display: inline-block;
@@ -528,6 +611,7 @@ ol li {
 
 .deplink__version {
   color: @light_type;
+  color: var(--light_type, ~"@{light_type}");
   display: inline-block;
   font-size: 0.8em;
   line-height: 1;
@@ -538,12 +622,14 @@ ol li {
  * -------------------------------------------------------------------------- */
 
 .grouped-list {
-  border-top: 1px solid darken(@background, 20%);
+  border-top: 1px solid @separator;
+  border-color: var(--separator, ~"@{separator}");
   margin: 0 0 2.44em 0;
 }
 
 .grouped-list__title {
   color: @light_type;
+  color: var(--light_type, ~"@{light_type}");
   font-size: 0.8em;
   font-weight: 300;
   letter-spacing: 1px;
@@ -567,12 +653,15 @@ ol li {
 
 .message.message--error {
   background-color: @error_background;
+  background-color: var(--error_background, ~"@{error_background}");
   border-color: @error_border;
+  border-color: var(--error_border, ~"@{error_border}");
 }
 
 .message.message--not-available {
   background-color: @not_available_background;
-  border-color: darken(@not_available_background, 20%);
+  border-color: @not_available_border;
+  border-color: var(--not_available_border, ~"@{not_available_border}");
 }
 
 
@@ -597,7 +686,7 @@ ol li {
     width: 50%;
   }
 
-  .multi-col__col:nth-child(2n+3) {
+  .multi-col__col:nth-child(2n + 3) {
     clear: both;
   }
 }
@@ -608,7 +697,7 @@ ol li {
     width: 33.333333%;
   }
 
-  .multi-col__col:nth-child(3n+4) {
+  .multi-col__col:nth-child(3n + 4) {
     clear: both;
   }
 }
@@ -630,6 +719,7 @@ ol li {
 .page-title__label {
   position: relative;
   color: @light_type;
+  color: var(--light_type, ~"@{light_type}");
   font-size: 0.8rem;
   font-weight: 300;
   letter-spacing: 1px;
@@ -644,7 +734,9 @@ ol li {
 
 .top-banner {
   background-color: @banner_background;
+  background-color: var(--banner_background, ~"@{banner_background}");
   color: @dark_foreground;
+  color: var(--dark_foreground, ~"@{dark_foreground}");
   font-weight: normal;
 }
 
@@ -652,6 +744,7 @@ ol li {
 .top-banner__logo:visited {
   float: left;
   color: @dark_foreground;
+  color: var(--dark_foreground, ~"@{dark_foreground}");
   font-size: 2.44em;
   font-weight: 300;
   line-height: 90px;
@@ -660,6 +753,7 @@ ol li {
 
 .top-banner__logo:hover {
   color: @link;
+  color: var(--link, ~"@{link}");
   text-decoration: none;
 }
 
@@ -668,9 +762,10 @@ ol li {
 }
 
 .top-banner__form input {
-  border: 1px solid @banner_background;
+  border: 1px solid currentColor;
   border-radius: 3px;
   color: @banner_background;
+  color: var(--banner_background, ~"@{banner_background}");
   font-weight: 300;
   line-height: 2;
   padding: 0.21em 0.512em;
@@ -696,10 +791,12 @@ ol li {
 .top-banner__actions__item a,
 .top-banner__actions__item a:visited {
   color: @dark_foreground;
+  color: var(--dark_foreground, ~"@{dark_foreground}");
 }
 
 .top-banner__actions__item a:hover {
   color: @link;
+  color: var(--link, ~"@{link}");
 }
 
 @media (min-width: 38em) {
@@ -741,18 +838,20 @@ ol li {
 }
 
 .result__body > *:first-child {
-  margin-top: 0!important;
+  margin-top: 0 !important;
 }
 
 .result__body > *:last-child {
-  margin-bottom: 0!important;
+  margin-bottom: 0 !important;
 }
 
 .result__signature {
   background-color: transparent;
   border-radius: 0;
-  border-top: 1px solid darken(@background, 20%);
-  border-bottom: 1px solid darken(@background, 20%);
+  border-width: 1px 0 1px 0;
+  border-style: solid;
+  border-color: @separator;
+  border-color: var(--separator, ~"@{separator}");
   padding: 0.328em 0;
 }
 
@@ -802,7 +901,8 @@ ol li {
   padding: 5px 0;
 }
 
-.help h3 { /* FIXME: target with class */
+.help h3 {
+  /* FIXME: target with class */
   margin-top: 16px;
 }
 
@@ -820,11 +920,11 @@ ol li {
   word-wrap: break-word;
 }
 
-.markdown-body>*:first-child {
+.markdown-body > *:first-child {
   margin-top: 0 !important;
 }
 
-.markdown-body>*:last-child {
+.markdown-body > *:last-child {
   margin-bottom: 0 !important;
 }
 
@@ -840,11 +940,11 @@ ol li {
   border-left: 0.25em solid #ddd;
 }
 
-.markdown-body blockquote>:first-child {
+.markdown-body blockquote > :first-child {
   margin-top: 0;
 }
 
-.markdown-body blockquote>:last-child {
+.markdown-body blockquote > :last-child {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
**Description of the change**

In an attempt to support users' preferences as well as making theming/overriding easier, I've started with this WIP draft PR using [approach #3 I left on Discourse](https://discourse.purescript.org/t/pursuit-styling-variables-dark-mode/2333/4). I went with that approach because it doesn't change tooling and maintains backwards compatibility with both old browsers, and up-coming and lightweight browsers that don't support CSS3 (and given than columns are made of floats and there not even a mention to `flex`, this must be the target). This particular dark theme is targeting for OLED screen to save power (so background is `#000` black).

This is a WIP because I have a number of questions

1. Does anyone even care? There was a tiniest amount of interest on Discourse but no :-1: or :+1: from anyone of the top-contributors category
2. Is this approach 3 the best?
3. What is the code syntax highlighting supposed to look like? New completely, or just tweak existing colors?
4. Where do I find the `light_glyph` and the error messages, etc. on the variables missing? I believe this is being used in a couple of places, but I can't remember where.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
