### PR TITLE
Export `rebuildModule'` to speed up Try PureScript! slightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ Internal:
 
 * Follow more HLint suggestions (#4090, @rhendric)
 
+* Export `rebuildModule'` to speed up Try PureScript! slightly (#4095 by @JordanMartinez)
+
 ## v0.14.1
 
 New features:

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -2,6 +2,7 @@ module Language.PureScript.Make
   (
   -- * Make API
   rebuildModule
+  , rebuildModule'
   , make
   , inferForeignModules
   , module Monad


### PR DESCRIPTION
**Description of the change**

See [the need for `rebuildModule'` in the `trypurescript`](https://github.com/purescript/trypurescript/pull/224#issuecomment-850718063) project. Exporting this function enables us to speed up the server slightly.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
