### PR TITLE
Use GenIdent for anonymous instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Internal:
 
 * Update RELEASE_GUIDE.md with more details (#4104 by @JordanMartinez)
 
+* Use GenIdent for anonymous instances (#4096, @rhendric)
+
 ## v0.14.2
 
 New features:

--- a/lib/purescript-cst/src/Language/PureScript/CST/Convert.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Convert.hs
@@ -547,10 +547,11 @@ convertDeclaration fileName decl = case decl of
       genName = Text.take 25 (className <> typeArgs)
 
       className :: Text.Text
-      className = foldMap (uncurry Text.cons . first toLower)
-                . Text.uncons
-                . N.runProperName
-                $ qualName cls
+      className
+        = foldMap (uncurry Text.cons . first toLower)
+        . Text.uncons
+        . N.runProperName
+        $ qualName cls
 
       typeArgs :: Text.Text
       typeArgs = foldMap argName args

--- a/lib/purescript-cst/src/Language/PureScript/CST/Convert.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Convert.hs
@@ -18,6 +18,7 @@ module Language.PureScript.CST.Convert
 import Prelude hiding (take)
 
 import Data.Bifunctor (bimap, first)
+import Data.Char (toLower)
 import Data.Foldable (foldl', toList)
 import Data.Functor (($>))
 import qualified Data.List.NonEmpty as NE
@@ -540,13 +541,16 @@ convertDeclaration fileName decl = case decl of
     where
       -- truncate to 25 chars to reduce verbosity
       -- of name and still keep it readable
-      -- unique identifier will be appended to this name
-      -- in desugaring proces
+      -- name will be used to create a GenIdent
+      -- in desugaring process
       genName :: Text.Text
-      genName = "$_" <> Text.take 25 (className <> typeArgs) <> "_"
+      genName = Text.take 25 (className <> typeArgs)
 
       className :: Text.Text
-      className = N.runProperName $ qualName cls
+      className = foldMap (uncurry Text.cons . first toLower)
+                . Text.uncons
+                . N.runProperName
+                $ qualName cls
 
       typeArgs :: Text.Text
       typeArgs = foldMap argName args

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -188,7 +188,13 @@ applyExternsFileToEnvironment ExternsFile{..} = flip (foldl' applyDecl) efDeclar
   qual :: a -> Qualified a
   qual = Qualified (Just efModuleName)
 
--- | Generate an externs file for all declarations in a module
+-- | Generate an externs file for all declarations in a module.
+--
+-- The `Map Ident Ident` argument should contain any top-level `GenIdent`s that
+-- were rewritten to `Ident`s when the module was compiled; this rewrite only
+-- happens in the CoreFn, not the original module AST, so it needs to be
+-- applied to the exported names here also. (The appropriate map is returned by
+-- `L.P.Renamer.renameInModule`.)
 moduleToExternsFile :: Module -> Environment -> M.Map Ident Ident -> ExternsFile
 moduleToExternsFile (Module _ _ _ _ Nothing) _ _ = internalError "moduleToExternsFile: module exports were not elaborated"
 moduleToExternsFile (Module ss _ mn ds (Just exps)) env renamedIdents = ExternsFile{..}

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -100,8 +100,8 @@ rebuildModule' MakeActions{..} exEnv externs m@(Module _ _ moduleName _ _) = do
   let mod' = Module ss coms moduleName regrouped exps
       corefn = CF.moduleToCoreFn env' mod'
       optimized = CF.optimizeCoreFn corefn
-      [renamed] = renameInModules [optimized]
-      exts = moduleToExternsFile mod' env'
+      (renamedIdents, renamed) = renameInModule optimized
+      exts = moduleToExternsFile mod' env' renamedIdents
   ffiCodegen renamed
 
   -- It may seem more obvious to write `docs <- Docs.convertModule m env' here,

--- a/src/Language/PureScript/Renamer.hs
+++ b/src/Language/PureScript/Renamer.hs
@@ -1,14 +1,15 @@
 -- |
 -- Renaming pass that prevents shadowing of local identifiers.
 --
-module Language.PureScript.Renamer (renameInModules) where
+module Language.PureScript.Renamer (renameInModule) where
 
 import Prelude.Compat
 
 import Control.Monad.State
 
+import Data.Functor ((<&>))
 import Data.List (find)
-import Data.Maybe (fromJust, fromMaybe)
+import Data.Maybe (fromJust, fromMaybe, isNothing)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -39,8 +40,8 @@ initState scope = RenameState (M.fromList (zip scope scope)) (S.fromList scope)
 -- |
 -- Runs renaming starting with a list of idents for the initial scope.
 --
-runRename :: [Ident] -> Rename a -> a
-runRename scope = flip evalState (initState scope)
+runRename :: [Ident] -> Rename a -> (a, RenameState)
+runRename scope = flip runState (initState scope)
 
 -- |
 -- Creates a new renaming scope using the current as a basis. Used to backtrack
@@ -93,48 +94,68 @@ lookupIdent name = do
     Just name'' -> return name''
     Nothing -> error $ "Rename scope is missing ident '" ++ T.unpack (showIdent name) ++ "'"
 
--- |
--- Finds idents introduced by declarations.
---
-findDeclIdents :: [Bind Ann] -> [Ident]
-findDeclIdents = concatMap go
-  where
-  go (NonRec _ ident _) = [ident]
-  go (Rec ds) = map (snd . fst) ds
 
 -- |
--- Renames within each declaration in a module.
+-- Renames within each declaration in a module. Returns the map of renamed
+-- identifiers in the top-level scope, so that they can be renamed in the
+-- externs files as well.
 --
-renameInModules :: [Module Ann] -> [Module Ann]
-renameInModules = map go
+renameInModule :: Module Ann -> (M.Map Ident Ident, Module Ann)
+renameInModule m@(Module _ _ _ _ _ exports _ foreigns decls) = (rsBoundNames, m { moduleExports, moduleDecls })
   where
-  go :: Module Ann -> Module Ann
-  go m@(Module _ _ _ _ _ _ _ _ decls) = m { moduleDecls = map (renameInDecl' (findDeclIdents decls)) decls }
-
-  renameInDecl' :: [Ident] -> Bind Ann -> Bind Ann
-  renameInDecl' scope = runRename scope . renameInDecl True
+  ((moduleDecls, moduleExports), RenameState{..}) = runRename foreigns $
+    (,) <$> renameInDecls decls <*> traverse lookupIdent exports
 
 -- |
--- Renames within a declaration. isTopLevel is used to determine whether the
--- declaration is a module member or appearing within a Let. At the top level
--- declarations are not renamed or added to the scope (they should already have
--- been added), whereas in a Let declarations are renamed if their name shadows
--- another in the current scope.
+-- Renames within a list of declarations. The list is processed in three
+-- passes:
 --
-renameInDecl :: Bool -> Bind Ann -> Rename (Bind Ann)
-renameInDecl isTopLevel (NonRec a name val) = do
-  name' <- if isTopLevel then return name else updateScope name
-  NonRec a name' <$> renameInValue val
-renameInDecl isTopLevel (Rec ds) = do
-  ds' <- traverse updateNames ds
-  Rec <$> traverse updateValues ds'
+--  1) Declarations with user-provided names are added to the scope, renaming
+--     them only if necessary to prevent shadowing.
+--  2) Declarations with compiler-provided names are added to the scope,
+--     renaming them to prevent shadowing or collision with a user-provided
+--     name.
+--  3) The bodies of the declarations are processed recursively.
+--
+-- The distinction between passes 1 and 2 is critical in the top-level module
+-- scope, where declarations can be exported and named declarations must not
+-- be renamed. Below the top level, this only matters for programmers looking
+-- at the generated code or using a debugger; we want them to see the names
+-- they used as much as possible.
+--
+-- The distinction between the first two passes and pass 3 is important because
+-- a `GenIdent` can appear before its declaration in a depth-first traversal,
+-- and we need to visit the declaration first in order to rename all of its
+-- uses. Similarly, a plain `Ident` could shadow another declared in an outer
+-- scope but later in a depth-first traversal, and we need to visit the
+-- outer declaration first in order to know to rename the inner one.
+--
+renameInDecls :: [Bind Ann] -> Rename [Bind Ann]
+renameInDecls =
+      traverse (renameDecl False)
+  >=> traverse (renameDecl True)
+  >=> traverse renameValuesInDecl
+
   where
-  updateNames :: ((Ann, Ident), Expr Ann) -> Rename ((Ann, Ident), Expr Ann)
-  updateNames ((a, name), val) = do
-    name' <- if isTopLevel then return name else updateScope name
-    return ((a, name'), val)
-  updateValues :: ((Ann, Ident), Expr Ann) -> Rename ((Ann, Ident), Expr Ann)
-  updateValues (aname, val) = (aname, ) <$> renameInValue val
+
+  renameDecl :: Bool -> Bind Ann -> Rename (Bind Ann)
+  renameDecl isSecondPass = \case
+    NonRec a name val -> updateName name <&> \name' -> NonRec a name' val
+    Rec ds -> Rec <$> traverse updateNames ds
+    where
+    updateName :: Ident -> Rename Ident
+    updateName name = (if isSecondPass == isPlainIdent name then pure else updateScope) name
+
+    updateNames :: ((Ann, Ident), Expr Ann) -> Rename ((Ann, Ident), Expr Ann)
+    updateNames ((a, name), val) = updateName name <&> \name' -> ((a, name'), val)
+
+  renameValuesInDecl :: Bind Ann -> Rename (Bind Ann)
+  renameValuesInDecl = \case
+    NonRec a name val -> NonRec a name <$> renameInValue val
+    Rec ds -> Rec <$> traverse updateValues ds
+    where
+    updateValues :: ((Ann, Ident), Expr Ann) -> Rename ((Ann, Ident), Expr Ann)
+    updateValues (aname, val) = (aname, ) <$> renameInValue val
 
 -- |
 -- Renames within a value.
@@ -152,13 +173,17 @@ renameInValue (Abs ann name v) =
   newScope $ Abs ann <$> updateScope name <*> renameInValue v
 renameInValue (App ann v1 v2) =
   App ann <$> renameInValue v1 <*> renameInValue v2
-renameInValue (Var ann (Qualified Nothing name)) =
-  Var ann . Qualified Nothing <$> lookupIdent name
+renameInValue (Var ann (Qualified mn name)) | isNothing mn || not (isPlainIdent name) =
+  -- This should only rename identifiers local to the current module: either
+  -- they aren't qualified, or they are but they have a name that should not
+  -- have appeared in a module's externs, so they must be from this module's
+  -- top-level scope.
+  Var ann . Qualified mn <$> lookupIdent name
 renameInValue v@Var{} = return v
 renameInValue (Case ann vs alts) =
   newScope $ Case ann <$> traverse renameInValue vs <*> traverse renameInCaseAlternative alts
 renameInValue (Let ann ds v) =
-  newScope $ Let ann <$> traverse (renameInDecl False) ds <*> renameInValue v
+  newScope $ Let ann <$> renameInDecls ds <*> renameInValue v
 
 -- |
 -- Renames within literals.
@@ -189,3 +214,7 @@ renameInBinder (ConstructorBinder ann tctor dctor bs) =
   ConstructorBinder ann tctor dctor <$> traverse renameInBinder bs
 renameInBinder (NamedBinder ann name b) =
   NamedBinder ann <$> updateScope name <*> renameInBinder b
+
+isPlainIdent :: Ident -> Bool
+isPlainIdent Ident{} = True
+isPlainIdent _ = False

--- a/src/Language/PureScript/Sugar/TypeClasses/Instances.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Instances.hs
@@ -8,11 +8,11 @@ module Language.PureScript.Sugar.TypeClasses.Instances
 
 import Prelude.Compat hiding (take)
 
-import           Control.Monad.Error.Class (MonadError(..))
-import           Control.Monad.Supply.Class
-import           Data.Text (pack)
-import           Language.PureScript.Errors
-import           Language.PureScript.Names
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Supply.Class
+import Data.Functor ((<&>))
+import Language.PureScript.Errors
+import Language.PureScript.Names
 
 -- |
 -- Completes the name generation for type class instances that do not have
@@ -33,8 +33,7 @@ desugarTypeClassInstanceNames (Module ss coms name decls exps) = do
     => Declaration
     -> m Declaration
   desugarInstName = \case
-    TypeInstanceDeclaration sa chainId idx (Left genText) deps className tys bd -> do
-      uniqueIdent <- fresh
-      let finalName = Ident $ genText <> pack (show uniqueIdent)
-      pure $ TypeInstanceDeclaration sa chainId idx (Right finalName) deps className tys bd
+    TypeInstanceDeclaration sa chainId idx (Left genText) deps className tys bd ->
+      freshIdent genText <&> \ident ->
+        TypeInstanceDeclaration sa chainId idx (Right ident) deps className tys bd
     a -> pure a

--- a/tests/purs/failing/OverlapAcrossModulesUnnamedInstance.out
+++ b/tests/purs/failing/OverlapAcrossModulesUnnamedInstance.out
@@ -1,0 +1,24 @@
+Error found:
+in module [33mOverlapAcrossModules[0m
+at tests/purs/failing/OverlapAcrossModulesUnnamedInstance.purs:6:1 - 6:15 (line 6, column 1 - line 6, column 15)
+
+  Overlapping type class instances found for
+  [33m                                [0m
+  [33m  OverlapAcrossModules.Class.C X[0m
+  [33m                               Y[0m
+  [33m                                [0m
+  The following instances were found:
+
+    OverlapAcrossModules.X.cX
+    OverlapAcrossModules.$cXY0
+
+
+in type class instance
+[33m                                [0m
+[33m  OverlapAcrossModules.Class.C X[0m
+[33m                               Y[0m
+[33m                                [0m
+
+See https://github.com/purescript/documentation/blob/master/errors/OverlappingInstances.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/OverlapAcrossModulesUnnamedInstance.purs
+++ b/tests/purs/failing/OverlapAcrossModulesUnnamedInstance.purs
@@ -1,0 +1,7 @@
+-- @shouldFailWith OverlappingInstances
+module OverlapAcrossModules where
+import OverlapAcrossModules.Class
+import OverlapAcrossModules.X
+data Y
+instance C X Y
+

--- a/tests/purs/failing/OverlapAcrossModulesUnnamedInstance/Class.out
+++ b/tests/purs/failing/OverlapAcrossModulesUnnamedInstance/Class.out
@@ -1,0 +1,24 @@
+Error found:
+in module [33mOverlapAcrossModules[0m
+at tests/purs/failing/OverlapAcrossModules.purs:6:1 - 6:22 (line 6, column 1 - line 6, column 22)
+
+  Overlapping type class instances found for
+  [33m                                [0m
+  [33m  OverlapAcrossModules.Class.C X[0m
+  [33m                               Y[0m
+  [33m                                [0m
+  The following instances were found:
+
+    OverlapAcrossModules.X.cxy
+    OverlapAcrossModules.cxy
+
+
+in type class instance
+[33m                                [0m
+[33m  OverlapAcrossModules.Class.C X[0m
+[33m                               Y[0m
+[33m                                [0m
+
+See https://github.com/purescript/documentation/blob/master/errors/OverlappingInstances.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/OverlapAcrossModulesUnnamedInstance/Class.purs
+++ b/tests/purs/failing/OverlapAcrossModulesUnnamedInstance/Class.purs
@@ -1,0 +1,2 @@
+module OverlapAcrossModules.Class where
+class C x y

--- a/tests/purs/failing/OverlapAcrossModulesUnnamedInstance/X.purs
+++ b/tests/purs/failing/OverlapAcrossModulesUnnamedInstance/X.purs
@@ -1,0 +1,4 @@
+module OverlapAcrossModules.X where
+import OverlapAcrossModules.Class
+data X
+instance C X y

--- a/tests/purs/failing/OverlappingUnnamedInstances.out
+++ b/tests/purs/failing/OverlappingUnnamedInstances.out
@@ -1,0 +1,22 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/OverlappingUnnamedInstances.purs:10:1 - 11:13 (line 10, column 1 - line 11, column 13)
+
+  Overlapping type class instances found for
+  [33m               [0m
+  [33m  Main.Test Int[0m
+  [33m               [0m
+  The following instances were found:
+
+    Main.$test1
+    Main.$testInt2
+
+
+in type class instance
+[33m               [0m
+[33m  Main.Test Int[0m
+[33m               [0m
+
+See https://github.com/purescript/documentation/blob/master/errors/OverlappingInstances.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/OverlappingUnnamedInstances.purs
+++ b/tests/purs/failing/OverlappingUnnamedInstances.purs
@@ -4,10 +4,10 @@ module Main where
 class Test a where
   test :: a -> a
 
-instance testRefl :: Test a where
+instance Test a where
   test x = x
 
-instance testInt :: Test Int where
+instance Test Int where
   test _ = 0
 
 -- The OverlappingInstances instances error only arises when there are two

--- a/tests/purs/failing/PolykindUnnamedInstanceOverlapping.out
+++ b/tests/purs/failing/PolykindUnnamedInstanceOverlapping.out
@@ -1,0 +1,22 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/PolykindUnnamedInstanceOverlapping.purs:12:1 - 13:19 (line 12, column 1 - line 13, column 19)
+
+  Overlapping type class instances found for
+  [33m                      [0m
+  [33m  Main.ShowP (Proxy a)[0m
+  [33m                      [0m
+  The following instances were found:
+
+    Main.$showPProxy2
+    Main.$showPProxy3
+
+
+in type class instance
+[33m                             [0m
+[33m  Main.ShowP (Proxy (a :: k))[0m
+[33m                             [0m
+
+See https://github.com/purescript/documentation/blob/master/errors/OverlappingInstances.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/PolykindUnnamedInstanceOverlapping.purs
+++ b/tests/purs/failing/PolykindUnnamedInstanceOverlapping.purs
@@ -1,0 +1,13 @@
+-- @shouldFailWith OverlappingInstances
+module Main where
+
+data Proxy a = Proxy
+
+class ShowP a where
+  showP :: a -> String
+
+instance ShowP (Proxy ((a) :: k)) where
+  showP _ = "Type"
+
+instance ShowP (Proxy ((a) :: k)) where
+  showP _ = "Type"

--- a/tests/purs/failing/TypeSynonymsOverlappingUnnamedInstance.out
+++ b/tests/purs/failing/TypeSynonymsOverlappingUnnamedInstance.out
@@ -1,0 +1,24 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/TypeSynonymsOverlappingUnnamedInstance.purs:14:1 - 15:16 (line 14, column 1 - line 15, column 16)
+
+  Overlapping type class instances found for
+  [33m                     [0m
+  [33m  Main.Convert String[0m
+  [33m               String[0m
+  [33m                     [0m
+  The following instances were found:
+
+    Main.$convertStringBar0
+    Main.$convertStringString1
+
+
+in type class instance
+[33m                     [0m
+[33m  Main.Convert String[0m
+[33m               String[0m
+[33m                     [0m
+
+See https://github.com/purescript/documentation/blob/master/errors/OverlappingInstances.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/TypeSynonymsOverlappingUnnamedInstance.purs
+++ b/tests/purs/failing/TypeSynonymsOverlappingUnnamedInstance.purs
@@ -1,0 +1,15 @@
+-- @shouldFailWith OverlappingInstances
+module Main where
+
+import Prelude
+
+class Convert a b | a -> b where
+  convert :: a -> b
+
+type Bar = String
+
+instance Convert String Bar where
+  convert s = s
+
+instance Convert String String where
+  convert s = s

--- a/tests/purs/passing/InstanceNamesGenerated.purs
+++ b/tests/purs/passing/InstanceNamesGenerated.purs
@@ -1,7 +1,11 @@
 module Main where
 
+import Prelude
+
 import Effect.Console (log)
 import Data.Generic.Rep (class Generic)
+
+import Lib (namedExportStillWorksUnit)
 
 -- This file verifies that unnamed instances will produce
 -- completely-generated instance names without problems.
@@ -87,6 +91,8 @@ instance OverlappingStillCompiles x
 else instance OverlappingStillCompiles x
 
 
-main = log "Done"
+main = do
+  namedExportStillWorksUnit 0
+  log "Done"
 
 data Either l r = Left l | Right r

--- a/tests/purs/passing/InstanceNamesGenerated/Lib.purs
+++ b/tests/purs/passing/InstanceNamesGenerated/Lib.purs
@@ -1,0 +1,20 @@
+module Lib where
+
+import Prelude
+
+import Effect (Effect)
+
+class NamedExportStillWorks a where
+  doTest :: Effect a
+
+-- This test expects the generated name of this instance to be
+-- namedExportStillWorksUnit in the absence of another identifier with that
+-- name (as we have here).
+-- The test ensures that the instance doesn't preempt the named declaration.
+-- (If the naming scheme for unnamed instances ever changes, the name of the
+-- exported declaration in this test should change with it.)
+instance NamedExportStillWorks Unit where
+  doTest = pure unit
+
+namedExportStillWorksUnit :: Int -> Effect Unit
+namedExportStillWorksUnit _ = doTest

--- a/tests/purs/passing/TransitiveImportUnnamedInstance.purs
+++ b/tests/purs/passing/TransitiveImportUnnamedInstance.purs
@@ -1,0 +1,9 @@
+module Main where
+
+  import Prelude
+  import Middle
+  import Effect.Console
+
+  main = do
+    logShow (middle unit)
+    log "Done"

--- a/tests/purs/passing/TransitiveImportUnnamedInstance/Middle.purs
+++ b/tests/purs/passing/TransitiveImportUnnamedInstance/Middle.purs
@@ -1,0 +1,5 @@
+module Middle where
+
+import Test (test)
+
+middle = test

--- a/tests/purs/passing/TransitiveImportUnnamedInstance/Test.purs
+++ b/tests/purs/passing/TransitiveImportUnnamedInstance/Test.purs
@@ -1,0 +1,9 @@
+module Test where
+
+import Prelude
+
+class TestCls a where
+  test :: a -> a
+
+instance TestCls Unit where
+  test _ = unit


### PR DESCRIPTION
This fixes the limitation of the CoreFn renamer which prevented it from
renaming top-level GenIdents. As a consequence, we can now give unnamed
instances more idiomatic names and still guarantee that they will be
unique in their module.

**Description of the change**

With compliments to @JordanMartinez, follow-up from one of my suggestions on #4085.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
