### PR TITLE
Implement Typeable

### DIFF
--- a/src/Language/PureScript/Constants/Prelude.hs
+++ b/src/Language/PureScript/Constants/Prelude.hs
@@ -376,6 +376,17 @@ pattern DataSymbol = ModuleName "Data.Symbol"
 pattern IsSymbol :: Qualified (ProperName 'ClassName)
 pattern IsSymbol = Qualified (Just DataSymbol) (ProperName "IsSymbol")
 
+-- Type.Rep
+
+pattern TypeRep :: ModuleName
+pattern TypeRep = ModuleName "Type.Rep"
+
+pattern Typeable :: Qualified (ProperName 'ClassName)
+pattern Typeable = Qualified (Just TypeRep) (ProperName "Typeable")
+
+typeRep :: forall a. (IsString a) => a
+typeRep = "typeRep"
+
 prelude :: forall a. (IsString a) => a
 prelude = "Prelude"
 

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -21,14 +21,16 @@ import Control.Monad.Writer
 import Data.Foldable (for_, fold, toList)
 import Data.Function (on)
 import Data.Functor (($>))
-import Data.List (findIndices, minimumBy, groupBy, nubBy, sortOn)
+import Data.List (findIndices, foldl', minimumBy, groupBy, nubBy, sortOn)
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
+import Data.String (fromString)
 import Data.Traversable (for)
 import Data.Text (Text, stripPrefix, stripSuffix)
 import qualified Data.Text as T
 import qualified Data.List.NonEmpty as NEL
+import GHC.Fingerprint (Fingerprint, fingerprintString)
 
 import Language.PureScript.AST
 import Language.PureScript.Crash
@@ -42,7 +44,7 @@ import Language.PureScript.TypeChecker.Unify
 import Language.PureScript.TypeClassDictionaries
 import Language.PureScript.Types
 import Language.PureScript.Label (Label(..))
-import Language.PureScript.PSString (PSString, mkString, decodeString)
+import Language.PureScript.PSString (PSString, mkString, decodeString, decodeStringEither)
 import qualified Language.PureScript.Constants.Prelude as C
 import qualified Language.PureScript.Constants.Prim as C
 
@@ -54,6 +56,7 @@ data Evidence
   -- | Computed instances
   | WarnInstance SourceType -- ^ Warn type class with a user-defined warning message
   | IsSymbolInstance PSString -- ^ The IsSymbol type class for a given Symbol literal
+  | TypeableInstance Fingerprint -- ^ The Typeable type class for a given type
   | EmptyClassInstance        -- ^ For any solved type class with no members
   deriving (Show, Eq)
 
@@ -176,6 +179,7 @@ entails SolverOptions{..} constraint context hints =
       -- This allows us to defer a warning by propagating the constraint.
       findDicts ctx cn Nothing ++ [TypeClassDictionaryInScope Nothing 0 (WarnInstance msg) [] C.Warn [] [] [msg] Nothing]
     forClassName _ _ C.IsSymbol _ args | Just dicts <- solveIsSymbol args = dicts
+    forClassName _ _ C.Typeable kinds args | Just dicts <- solveTypeable kinds args = dicts
     forClassName _ _ C.SymbolCompare _ args | Just dicts <- solveSymbolCompare args = dicts
     forClassName _ _ C.SymbolAppend _ args | Just dicts <- solveSymbolAppend args = dicts
     forClassName _ _ C.SymbolCons _ args | Just dicts <- solveSymbolCons args = dicts
@@ -379,6 +383,9 @@ entails SolverOptions{..} constraint context hints =
             mkDictionary (IsSymbolInstance sym) _ =
               let fields = [ ("reflectSymbol", Abs (VarBinder nullSourceSpan UnusedIdent) (Literal nullSourceSpan (StringLiteral sym))) ] in
               return $ TypeClassDictionaryConstructorApp C.IsSymbol (Literal nullSourceSpan (ObjectLiteral fields))
+            mkDictionary (TypeableInstance fp) _ =
+              let fields = [ (C.typeRep, Literal nullSourceSpan $ StringLiteral $ fromString $ show fp) ] in
+              return $ TypeClassDictionaryConstructorApp C.Typeable (Literal nullSourceSpan (ObjectLiteral fields))
 
             unknownsInAllCoveringSets :: [SourceType] -> S.Set (S.Set Int) -> Bool
             unknownsInAllCoveringSets tyArgs = all (\s -> any (`S.member` s) unkIndices)
@@ -415,6 +422,38 @@ entails SolverOptions{..} constraint context hints =
     solveIsSymbol :: [SourceType] -> Maybe [TypeClassDict]
     solveIsSymbol [TypeLevelString ann sym] = Just [TypeClassDictionaryInScope Nothing 0 (IsSymbolInstance sym) [] C.IsSymbol [] [] [TypeLevelString ann sym] Nothing]
     solveIsSymbol _ = Nothing
+
+    solveTypeable :: [SourceType] -> [SourceType] -> Maybe [TypeClassDict]
+    solveTypeable [kind] [type_]
+      | Just tS <- normalizedTypeS type_ = Just
+        [TypeClassDictionaryInScope Nothing 0 (TypeableInstance $ fingerprintString $ tS "") [] C.Typeable [] [kind] [type_] Nothing]
+     where
+      normalizedTypeS t = case rowToSortedList t of
+        ([], t') -> case t' of
+          TypeLevelString _ s -> Just $ shows s
+          TypeConstructor _ (Qualified mn (ProperName cn)) -> Just $
+            maybe id ((. showString ".") . showString . T.unpack . runModuleName) mn . showString (T.unpack cn)
+          TypeApp _ t1 t2 -> do
+            t1S <- normalizedTypeS t1
+            t2S <- normalizedTypeS t2
+            Just $ showString "(" . t1S . showString ")(" . t2S . showString ")"
+          KindApp _ t1 t2 -> do
+            t1S <- normalizedTypeS t1
+            t2S <- normalizedTypeS t2
+            Just $ showString "(" . t1S . showString ")@(" . t2S . showString ")"
+          REmpty _ -> Just $ showString "()"
+          _ -> Nothing
+        (row, isREmpty -> True) -> do
+          rowS <- normalizedRowS row
+          Just $ showString "(" . rowS . showString ")"
+        _ -> Nothing
+      normalizedRowS = foldl' go (Just id) where
+        go s (RowListItem _ (Label n) t) = do
+          s'  <- s
+          lbl <- traverse (either (\_ -> Nothing) Just) $ decodeStringEither n
+          tS  <- normalizedTypeS t
+          Just $ s' . showString lbl . showString "::" . tS . showString ","
+    solveTypeable _ _ = Nothing
 
     solveSymbolCompare :: [SourceType] -> Maybe [TypeClassDict]
     solveSymbolCompare [arg0@(TypeLevelString _ lhs), arg1@(TypeLevelString _ rhs), _] =


### PR DESCRIPTION
**Description of the change**

Purescript currently doesn't have `Typeable` constraint in style of Haskell, which makes it basically impossible to implement some functionality, e.g. safe dynamically typed values or memoizing in VDOM where memoized nodes change type of argument. `Generic` doesn't help there, because it doesn't see difference between constructors defined in different modules, and external libraries don't help either, because they would require users to implement instances for possibly huge amount of types and would prohibit them from using it with external types (because of orphans being dissallowed).

This PR implements minimal version of `Typeable` dictionary generation, expecting API to be defined as follows, e.g. in `prelude`:
```haskell
module Type.Rep (TypeRep, class Typeable, typeRep, sameTypeRep) where

import Data.Eq ((==))
import Data.Monoid ((<>))
import Data.Show (class Show, show)
import Prim.TypeError (class Fail, Text, Quote, Above, Beside)

newtype TypeRep a = TypeRep String

type role TypeRep nominal

instance showTypeRep :: Show (TypeRep a) where
  show (TypeRep n) = "(TypeRep " <> n <> ")"

class Typeable :: forall k. k -> Constraint
class Typeable a where
  typeRep :: TypeRep a

instance typeableFallback :: Fail (InvalidTypeable a) => Typeable a where
  typeRep = typeRep

type InvalidTypeable a = Above
  (Text "Cannot create `Typeable` instance")
  (Text "Make sure no type or kind variables appear in the type")

sameTypeRep :: forall a b. TypeRep a -> TypeRep b -> Boolean
sameTypeRep (TypeRep a) (TypeRep b) = a == b
```
where `Typeable` gets resolved automatically in style of `IsSymbol`. `TypeRep` contains statically generated hash created from normalized string representation of the type (using `GHC.Fingerprint`).

I figured that the change is small enough that instead of just talking about it, I can create prototype that can be either dismissed or refined, so I've created PR instead of an issue. Technically, it fixes #2243, though using much more minimal interface as described above, only providing what's needed to implement functionality like `Dynamic` or
```haskell
cast :: forall a b. Typeable a => Typeable b => a -> Maybe b
```
in some external library.

As far as implementation goes, things I'm not completely sure about are whether it may interact badly with redundant syntax (seems like kind annotations, parens, operators, synonyms and rows passed to `rowToSortedList` get normalized at that point?) and whether `PolyKinds` may create some unexpected problems (they're hashed too by extracting them from `KindApp` right now).

When it comes to compatibility guarantees, I would expect same hashes when building using the same compiler version modulo bugfixes - this means that changes to `GHC.Fingeprint` should probably result in minor version change.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
