### PR TITLE
Fix UnusedName for multiple non-recursive let bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Bugfixes:
 
 * Ensure unnamed instances appear in documentation (#4109 by @JordanMartinez)
 
+* Fix UnusedName warnings for multiple non-recursive let bindings (#4114 by @nwolverson)
+
 Internal:
 
 * Fix for Haddock (#4072 by @ncaq and @JordanMartinez)

--- a/tests/purs/warning/UnusedVar.out
+++ b/tests/purs/warning/UnusedVar.out
@@ -1,7 +1,7 @@
-Warning 1 of 8:
+Warning 1 of 9:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:15:20 - 15:32 (line 15, column 20 - line 15, column 32)
+  at tests/purs/warning/UnusedVar.purs:16:20 - 16:32 (line 16, column 20 - line 16, column 32)
 
     Name [33mlambdaUnused[0m was introduced but not used.
 
@@ -10,10 +10,10 @@ Warning 1 of 8:
   See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
   or to contribute content related to this warning.
 
-Warning 2 of 8:
+Warning 2 of 9:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:19:7 - 19:20 (line 19, column 7 - line 19, column 20)
+  at tests/purs/warning/UnusedVar.purs:20:7 - 20:20 (line 20, column 7 - line 20, column 20)
 
     Name [33mletUnused[0m was introduced but not used.
 
@@ -22,10 +22,10 @@ Warning 2 of 8:
   See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
   or to contribute content related to this warning.
 
-Warning 3 of 8:
+Warning 3 of 9:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:25:9 - 25:24 (line 25, column 9 - line 25, column 24)
+  at tests/purs/warning/UnusedVar.purs:26:9 - 26:24 (line 26, column 9 - line 26, column 24)
 
     Name [33mwhereUnused[0m was introduced but not used.
 
@@ -34,10 +34,10 @@ Warning 3 of 8:
   See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
   or to contribute content related to this warning.
 
-Warning 4 of 8:
+Warning 4 of 9:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:29:11 - 29:23 (line 29, column 11 - line 29, column 23)
+  at tests/purs/warning/UnusedVar.purs:30:11 - 30:23 (line 30, column 11 - line 30, column 23)
 
     Name [33mletArgUnused[0m was introduced but not used.
 
@@ -46,10 +46,10 @@ Warning 4 of 8:
   See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
   or to contribute content related to this warning.
 
-Warning 5 of 8:
+Warning 5 of 9:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:43:5 - 43:15 (line 43, column 5 - line 43, column 15)
+  at tests/purs/warning/UnusedVar.purs:44:5 - 44:15 (line 44, column 5 - line 44, column 15)
 
     Name [33mcaseUnused[0m was introduced but not used.
 
@@ -58,10 +58,10 @@ Warning 5 of 8:
   See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
   or to contribute content related to this warning.
 
-Warning 6 of 8:
+Warning 6 of 9:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:61:34 - 61:35 (line 61, column 34 - line 61, column 35)
+  at tests/purs/warning/UnusedVar.purs:62:34 - 62:35 (line 62, column 34 - line 62, column 35)
 
     Name [33mx[0m was introduced but not used.
 
@@ -70,10 +70,10 @@ Warning 6 of 8:
   See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
   or to contribute content related to this warning.
 
-Warning 7 of 8:
+Warning 7 of 9:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:68:8 - 68:9 (line 68, column 8 - line 68, column 9)
+  at tests/purs/warning/UnusedVar.purs:69:8 - 69:9 (line 69, column 8 - line 69, column 9)
 
     Name [33mx[0m was introduced but not used.
 
@@ -82,10 +82,22 @@ Warning 7 of 8:
   See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
   or to contribute content related to this warning.
 
-Warning 8 of 8:
+Warning 8 of 9:
 
   in module [33mMain[0m
-  at tests/purs/warning/UnusedVar.purs:62:7 - 62:16 (line 62, column 7 - line 62, column 16)
+  at tests/purs/warning/UnusedVar.purs:87:7 - 87:8 (line 87, column 7 - line 87, column 8)
+
+    Name [33mx[0m was introduced but not used.
+
+  in value declaration [33mnotOops[0m
+
+  See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
+  or to contribute content related to this warning.
+
+Warning 9 of 9:
+
+  in module [33mMain[0m
+  at tests/purs/warning/UnusedVar.purs:63:7 - 63:16 (line 63, column 7 - line 63, column 16)
 
     Name [33mx[0m was shadowed.
 

--- a/tests/purs/warning/UnusedVar.purs
+++ b/tests/purs/warning/UnusedVar.purs
@@ -5,6 +5,7 @@
 -- @shouldWarnWith UnusedName
 -- @shouldWarnWith UnusedName
 -- @shouldWarnWith UnusedName
+-- @shouldWarnWith UnusedName
 -- @shouldWarnWith ShadowedName
 module Main where
 
@@ -67,3 +68,37 @@ unusedShadowingLet :: X -> X
 unusedShadowingLet x = 
   let (x) = x
   in X
+
+-- 4110
+oops ∷ { inner :: String } → String
+oops box =
+  let
+    { inner } = box
+    val = inner
+  in
+    val
+
+-- like oops but switching order to show we don't 
+notOops ∷ { x :: String } -> String → String
+notOops box x =
+  let
+    val = x
+    _blah = x
+    { x } = box
+  in
+    val
+
+bindingGroupsNotRecognised :: Int
+bindingGroupsNotRecognised =
+  let
+    f n = g n
+    g n = f n
+    
+    -- Second f is unused because this is multiple recursive binding groups, we don't warn because we assume
+    -- it might be one binding group so there is a usage. If it would be 1 binding group there would be an error
+    -- Shadowed variable warnings are similarly not aware of binding groups
+    { x } = { x: 2 }
+    h n = n
+    f x = x
+  in 
+    h x

--- a/tests/purs/warning/UnusedVarDo.purs
+++ b/tests/purs/warning/UnusedVarDo.purs
@@ -38,3 +38,11 @@ notUnusedNonRecursiveBinding :: Int -> Maybe Int
 notUnusedNonRecursiveBinding x = do
   let {x} = {x}
   pure x
+
+-- 4110 in do syntax
+oops ∷ { inner :: String } → String
+oops box = do
+  let
+    { inner } = box
+    val = inner
+  val


### PR DESCRIPTION
Fix #4110

**Description of the change**

- When there are multiple let bindings in a single let declaration,
  ensure that non-recursive bindings are checked properly with respect
  to subsequent declarations

Essentially the problem is that at the point of this linting, let declarations have not been split into recursive binding groups, but the code essentially treated the `[Declaration]` as a single recursive binding group. 

This change threads the state through the individual declarations for non-recursive binders, and still deals with recursive bindings over the whole group of declarations. This means that recursive bindings which are split into multiple groups by a pattern binding can be unused without a warning (see example added to test), in the case that one is shadowed - the shadowing warning is also omitted. 

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
