### PR TITLE
Remove generated names from errors about instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Bugfixes:
 
 * Fix UnusedName warnings for multiple non-recursive let bindings (#4114 by @nwolverson)
 
+* Remove generated names from errors about instances (#4118 by @rhendric)
+
 Internal:
 
 * Fix for Haddock (#4072 by @ncaq and @JordanMartinez)

--- a/lib/purescript-cst/src/Language/PureScript/AST/Declarations.hs
+++ b/lib/purescript-cst/src/Language/PureScript/AST/Declarations.hs
@@ -147,6 +147,9 @@ importPrim =
     addDefaultImport (Qualified (Just primModName) primModName)
       . addDefaultImport (Qualified Nothing primModName)
 
+data NameSource = UserNamed | CompilerNamed
+  deriving (Show, Generic, NFData, Serialise)
+
 -- |
 -- An item in a list of explicit imports or exports
 --
@@ -172,9 +175,9 @@ data DeclarationRef
   --
   | ValueOpRef SourceSpan (OpName 'ValueOpName)
   -- |
-  -- A type class instance, created during typeclass desugaring (name, class name, instance types)
+  -- A type class instance, created during typeclass desugaring
   --
-  | TypeInstanceRef SourceSpan Ident
+  | TypeInstanceRef SourceSpan Ident NameSource
   -- |
   -- A module, in its entirety
   --
@@ -192,7 +195,7 @@ instance Eq DeclarationRef where
   (TypeRef _ name dctors) == (TypeRef _ name' dctors') = name == name' && dctors == dctors'
   (ValueRef _ name) == (ValueRef _ name') = name == name'
   (ValueOpRef _ name) == (ValueOpRef _ name') = name == name'
-  (TypeInstanceRef _ name) == (TypeInstanceRef _ name') = name == name'
+  (TypeInstanceRef _ name _) == (TypeInstanceRef _ name' _) = name == name'
   (ModuleRef _ name) == (ModuleRef _ name') = name == name'
   (ReExportRef _ mn ref) == (ReExportRef _ mn' ref') = mn == mn' && ref == ref'
   _ == _ = False
@@ -203,7 +206,7 @@ instance Ord DeclarationRef where
   TypeRef _ name dctors `compare` TypeRef _ name' dctors' = compare name name' <> compare dctors dctors'
   ValueRef _ name `compare` ValueRef _ name' = compare name name'
   ValueOpRef _ name `compare` ValueOpRef _ name' = compare name name'
-  TypeInstanceRef _ name `compare` TypeInstanceRef _ name' = compare name name'
+  TypeInstanceRef _ name _ `compare` TypeInstanceRef _ name' _ = compare name name'
   ModuleRef _ name `compare` ModuleRef _ name' = compare name name'
   ReExportRef _ mn ref `compare` ReExportRef _ mn' ref' = compare mn mn' <> compare ref ref'
   compare ref ref' =
@@ -232,7 +235,7 @@ declRefSourceSpan (TypeOpRef ss _) = ss
 declRefSourceSpan (ValueRef ss _) = ss
 declRefSourceSpan (ValueOpRef ss _) = ss
 declRefSourceSpan (TypeClassRef ss _) = ss
-declRefSourceSpan (TypeInstanceRef ss _) = ss
+declRefSourceSpan (TypeInstanceRef ss _ _) = ss
 declRefSourceSpan (ModuleRef ss _) = ss
 declRefSourceSpan (ReExportRef ss _ _) = ss
 
@@ -242,7 +245,7 @@ declRefName (TypeOpRef _ n) = TyOpName n
 declRefName (ValueRef _ n) = IdentName n
 declRefName (ValueOpRef _ n) = ValOpName n
 declRefName (TypeClassRef _ n) = TyClassName n
-declRefName (TypeInstanceRef _ n) = IdentName n
+declRefName (TypeInstanceRef _ n _) = IdentName n
 declRefName (ModuleRef _ n) = ModName n
 declRefName (ReExportRef _ _ ref) = declRefName ref
 
@@ -830,6 +833,7 @@ data PathNode t = Leaf t | Branch (PathTree t)
 newtype AssocList k t = AssocList { runAssocList :: [(k, t)] }
   deriving (Show, Eq, Ord, Foldable, Functor, Traversable)
 
+$(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''NameSource)
 $(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''DeclarationRef)
 $(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''ImportDeclarationType)
 $(deriveJSON (defaultOptions { sumEncoding = ObjectWithSingleField }) ''ExportSource)

--- a/lib/purescript-cst/src/Language/PureScript/Names.hs
+++ b/lib/purescript-cst/src/Language/PureScript/Names.hs
@@ -97,6 +97,10 @@ freshIdent name = GenIdent (Just name) <$> fresh
 freshIdent' :: MonadSupply m => m Ident
 freshIdent' = GenIdent Nothing <$> fresh
 
+isPlainIdent :: Ident -> Bool
+isPlainIdent Ident{} = True
+isPlainIdent _ = False
+
 -- |
 -- Operator alias names.
 --

--- a/lib/purescript-cst/src/Language/PureScript/TypeClassDictionaries.hs
+++ b/lib/purescript-cst/src/Language/PureScript/TypeClassDictionaries.hs
@@ -33,6 +33,9 @@ data TypeClassDictionaryInScope v
     , tcdInstanceTypes :: [SourceType]
     -- | Type class dependencies which must be satisfied to construct this dictionary
     , tcdDependencies :: Maybe [SourceConstraint]
+    -- | If this instance was unnamed, the type to use when describing it in
+    -- error messages
+    , tcdDescription :: Maybe SourceType
     }
     deriving (Show, Functor, Foldable, Traversable, Generic)
 

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -254,7 +254,7 @@ exportToCoreFn (A.TypeOpRef _ _) = []
 exportToCoreFn (A.ValueRef _ name) = [name]
 exportToCoreFn (A.ValueOpRef _ _) = []
 exportToCoreFn (A.TypeClassRef _ name) = [properToIdent name]
-exportToCoreFn (A.TypeInstanceRef _ name) = [name]
+exportToCoreFn (A.TypeInstanceRef _ name _) = [name]
 exportToCoreFn (A.ModuleRef _ _) = []
 exportToCoreFn (A.ReExportRef _ _ _) = []
 

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -218,8 +218,10 @@ handleShowImportedModules print' = do
     Just $ N.showOp op
   showRef (P.TypeClassRef _ pn) =
     Just $ "class " <> N.runProperName pn
-  showRef (P.TypeInstanceRef _ ident) =
+  showRef (P.TypeInstanceRef _ ident P.UserNamed) =
     Just $ N.runIdent ident
+  showRef (P.TypeInstanceRef _ _ P.CompilerNamed) =
+    Nothing
   showRef (P.ModuleRef _ name) =
     Just $ "module " <> N.runModuleName name
   showRef (P.ReExportRef _ _ _) =

--- a/src/Language/PureScript/Renamer.hs
+++ b/src/Language/PureScript/Renamer.hs
@@ -214,7 +214,3 @@ renameInBinder (ConstructorBinder ann tctor dctor bs) =
   ConstructorBinder ann tctor dctor <$> traverse renameInBinder bs
 renameInBinder (NamedBinder ann name b) =
   NamedBinder ann <$> updateScope name <*> renameInBinder b
-
-isPlainIdent :: Ident -> Bool
-isPlainIdent Ident{} = True
-isPlainIdent _ = False

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -239,7 +239,7 @@ desugarDecl syns kinds mn exps = go
 
   expRef :: Ident -> Qualified (ProperName 'ClassName) -> [SourceType] -> Maybe DeclarationRef
   expRef name className tys
-    | isExportedClass className && all isExportedType (getConstructors `concatMap` tys) = Just $ TypeInstanceRef genSpan name
+    | isExportedClass className && all isExportedType (getConstructors `concatMap` tys) = Just $ TypeInstanceRef genSpan name UserNamed
     | otherwise = Nothing
 
   isExportedClass :: Qualified (ProperName 'ClassName) -> Bool

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -174,7 +174,7 @@ entails SolverOptions{..} constraint context hints =
     forClassName _ ctx cn@C.Warn _ [msg] =
       -- Prefer a warning dictionary in scope if there is one available.
       -- This allows us to defer a warning by propagating the constraint.
-      findDicts ctx cn Nothing ++ [TypeClassDictionaryInScope Nothing 0 (WarnInstance msg) [] C.Warn [] [] [msg] Nothing]
+      findDicts ctx cn Nothing ++ [TypeClassDictionaryInScope Nothing 0 (WarnInstance msg) [] C.Warn [] [] [msg] Nothing Nothing]
     forClassName _ _ C.IsSymbol _ args | Just dicts <- solveIsSymbol args = dicts
     forClassName _ _ C.SymbolCompare _ args | Just dicts <- solveSymbolCompare args = dicts
     forClassName _ _ C.SymbolAppend _ args | Just dicts <- solveSymbolAppend args = dicts
@@ -333,8 +333,15 @@ entails SolverOptions{..} constraint context hints =
             unique _ _ [(a, dict)] _ = return $ Solved a dict
             unique _ tyArgs tcds _
               | pairwiseAny overlapping (map snd tcds) =
-                  throwError . errorMessage $ OverlappingInstances className' tyArgs (tcds >>= (toList . namedInstanceIdentifier . tcdValue . snd))
+                  throwError . errorMessage $ OverlappingInstances className' tyArgs (tcds >>= (toList . tcdToInstanceDescription . snd))
               | otherwise = return $ uncurry Solved (minimumBy (compare `on` length . tcdPath . snd) tcds)
+
+            tcdToInstanceDescription :: TypeClassDict -> Maybe (Qualified (Either SourceType Ident))
+            tcdToInstanceDescription TypeClassDictionaryInScope{ tcdDescription, tcdValue } =
+              let nii = namedInstanceIdentifier tcdValue
+              in case tcdDescription of
+                Just ty -> flip Qualified (Left ty) <$> fmap getQual nii
+                Nothing -> fmap Right <$> nii
 
             canBeGeneralized :: Type a -> Bool
             canBeGeneralized TUnknown{} = True
@@ -407,13 +414,13 @@ entails SolverOptions{..} constraint context hints =
       -- We may have collected hints for the solving failure along the way, in
       -- which case we decorate the error with the first one.
       maybe id addHint (listToMaybe hints') `rethrow` case inertWanteds of
-        [] -> pure $ Just [TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.Coercible [] kinds [a, b] Nothing]
+        [] -> pure $ Just [TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.Coercible [] kinds [a, b] Nothing Nothing]
         (k, a', b') : _ | a' == b && b' == a -> throwError $ insoluble k b' a'
         (k, a', b') : _ -> throwError $ insoluble k a' b'
     solveCoercible _ _ _ _ = pure Nothing
 
     solveIsSymbol :: [SourceType] -> Maybe [TypeClassDict]
-    solveIsSymbol [TypeLevelString ann sym] = Just [TypeClassDictionaryInScope Nothing 0 (IsSymbolInstance sym) [] C.IsSymbol [] [] [TypeLevelString ann sym] Nothing]
+    solveIsSymbol [TypeLevelString ann sym] = Just [TypeClassDictionaryInScope Nothing 0 (IsSymbolInstance sym) [] C.IsSymbol [] [] [TypeLevelString ann sym] Nothing Nothing]
     solveIsSymbol _ = Nothing
 
     solveSymbolCompare :: [SourceType] -> Maybe [TypeClassDict]
@@ -423,14 +430,14 @@ entails SolverOptions{..} constraint context hints =
                   EQ -> C.orderingEQ
                   GT -> C.orderingGT
           args' = [arg0, arg1, srcTypeConstructor ordering]
-      in Just [TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.SymbolCompare [] [] args' Nothing]
+      in Just [TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.SymbolCompare [] [] args' Nothing Nothing]
     solveSymbolCompare _ = Nothing
 
     solveSymbolAppend :: [SourceType] -> Maybe [TypeClassDict]
     solveSymbolAppend [arg0, arg1, arg2] = do
       (arg0', arg1', arg2') <- appendSymbols arg0 arg1 arg2
       let args' = [arg0', arg1', arg2']
-      pure [TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.SymbolAppend [] [] args' Nothing]
+      pure [TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.SymbolAppend [] [] args' Nothing Nothing]
     solveSymbolAppend _ = Nothing
 
     -- | Append type level symbols, or, run backwards, strip a prefix or suffix
@@ -452,7 +459,7 @@ entails SolverOptions{..} constraint context hints =
     solveSymbolCons [arg0, arg1, arg2] = do
       (arg0', arg1', arg2') <- consSymbol arg0 arg1 arg2
       let args' = [arg0', arg1', arg2']
-      pure [TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.SymbolCons [] [] args' Nothing]
+      pure [TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.SymbolCons [] [] args' Nothing Nothing]
     solveSymbolCons _ = Nothing
 
     consSymbol :: SourceType -> SourceType -> SourceType -> Maybe (SourceType, SourceType, SourceType)
@@ -470,7 +477,7 @@ entails SolverOptions{..} constraint context hints =
     solveUnion :: [SourceType] -> [SourceType] -> Maybe [TypeClassDict]
     solveUnion kinds [l, r, u] = do
       (lOut, rOut, uOut, cst, vars) <- unionRows kinds l r u
-      pure [ TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.RowUnion vars kinds [lOut, rOut, uOut] cst ]
+      pure [ TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.RowUnion vars kinds [lOut, rOut, uOut] cst Nothing ]
     solveUnion _ _ = Nothing
 
     -- | Left biased union of two row types
@@ -501,13 +508,13 @@ entails SolverOptions{..} constraint context hints =
 
     solveRowCons :: [SourceType] -> [SourceType] -> Maybe [TypeClassDict]
     solveRowCons kinds [TypeLevelString ann sym, ty, r, _] =
-      Just [ TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.RowCons [] kinds [TypeLevelString ann sym, ty, r, srcRCons (Label sym) ty r] Nothing ]
+      Just [ TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.RowCons [] kinds [TypeLevelString ann sym, ty, r, srcRCons (Label sym) ty r] Nothing Nothing ]
     solveRowCons _ _ = Nothing
 
     solveRowToList :: [SourceType] -> [SourceType] -> Maybe [TypeClassDict]
     solveRowToList [kind] [r, _] = do
       entries <- rowToRowList kind r
-      pure [ TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.RowToList [] [kind] [r, entries] Nothing ]
+      pure [ TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.RowToList [] [kind] [r, entries] Nothing Nothing ]
     solveRowToList _ _ = Nothing
 
     -- | Convert a closed row to a sorted list of entries
@@ -526,7 +533,7 @@ entails SolverOptions{..} constraint context hints =
     solveNub :: [SourceType] -> [SourceType] -> Maybe [TypeClassDict]
     solveNub kinds [r, _] = do
       r' <- nubRows r
-      pure [ TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.RowNub [] kinds [r, r'] Nothing ]
+      pure [ TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.RowNub [] kinds [r, r'] Nothing Nothing ]
     solveNub _ _ = Nothing
 
     nubRows :: SourceType -> Maybe SourceType
@@ -538,10 +545,10 @@ entails SolverOptions{..} constraint context hints =
 
     solveLacks :: [SourceType] -> [SourceType] -> Maybe [TypeClassDict]
     solveLacks kinds tys@[_, REmptyKinded _ _] =
-      pure [ TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.RowLacks [] kinds tys Nothing ]
+      pure [ TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.RowLacks [] kinds tys Nothing Nothing ]
     solveLacks kinds [TypeLevelString ann sym, r] = do
       (r', cst) <- rowLacks kinds sym r
-      pure [ TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.RowLacks [] kinds [TypeLevelString ann sym, r'] cst ]
+      pure [ TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.RowLacks [] kinds [TypeLevelString ann sym, r'] cst Nothing ]
     solveLacks _ _ = Nothing
 
     rowLacks :: [SourceType] -> PSString -> SourceType -> Maybe (SourceType, Maybe [SourceConstraint])
@@ -698,7 +705,7 @@ newDictionaries path name (Constraint _ className instanceKinds instanceTy _) = 
                                                         (replaceAllTypeVars sub <$> supArgs)
                                                         Nothing)
                                   ) typeClassSuperclasses [0..]
-    return (TypeClassDictionaryInScope Nothing 0 name path className [] instanceKinds instanceTy Nothing : supDicts)
+    return (TypeClassDictionaryInScope Nothing 0 name path className [] instanceKinds instanceTy Nothing Nothing : supDicts)
 
 mkContext :: [NamedDict] -> InstanceContext
 mkContext = foldr combineContexts M.empty . map fromDict where

--- a/tests/Language/PureScript/Ide/StateSpec.hs
+++ b/tests/Language/PureScript/Ide/StateSpec.hs
@@ -68,6 +68,10 @@ ef = P.ExternsFile
       Nothing
       -- , edInstanceChainIndex =
       0
+      -- , edInstanceNameSource =
+      P.UserNamed
+      -- , edInstanceSourceSpan =
+      P.NullSourceSpan
  --     }
     ]
   --, efSourceSpan =

--- a/tests/purs/failing/OrphanUnnamedInstance.out
+++ b/tests/purs/failing/OrphanUnnamedInstance.out
@@ -1,8 +1,8 @@
 Error found:
 in module [33mTest[0m
-at tests/purs/failing/OrphanInstance.purs:6:1 - 7:11 (line 6, column 1 - line 7, column 11)
+at tests/purs/failing/OrphanUnnamedInstance.purs:6:1 - 7:11 (line 6, column 1 - line 7, column 11)
 
-  Orphan instance [33mcBoolean[0m found for
+  Orphan instance found for
   [33m                 [0m
   [33m  Class.C Boolean[0m
   [33m                 [0m

--- a/tests/purs/failing/OrphanUnnamedInstance.purs
+++ b/tests/purs/failing/OrphanUnnamedInstance.purs
@@ -1,0 +1,7 @@
+-- @shouldFailWith OrphanInstance
+module Test where
+
+import Class
+
+instance C Boolean where
+  op a = a

--- a/tests/purs/failing/OrphanUnnamedInstance/Class.purs
+++ b/tests/purs/failing/OrphanUnnamedInstance/Class.purs
@@ -1,0 +1,4 @@
+module Class where
+
+class C a where
+  op :: a -> a

--- a/tests/purs/failing/OverlapAcrossModules.out
+++ b/tests/purs/failing/OverlapAcrossModules.out
@@ -9,8 +9,8 @@ at tests/purs/failing/OverlapAcrossModules.purs:6:1 - 6:22 (line 6, column 1 - l
   [33m                                [0m
   The following instances were found:
 
-    OverlapAcrossModules.X.cxy
-    OverlapAcrossModules.cxy
+    [33mOverlapAcrossModules.X.cxy[0m
+    [33mOverlapAcrossModules.cxy[0m
 
 
 in type class instance

--- a/tests/purs/failing/OverlapAcrossModulesUnnamedInstance.out
+++ b/tests/purs/failing/OverlapAcrossModulesUnnamedInstance.out
@@ -9,8 +9,8 @@ at tests/purs/failing/OverlapAcrossModulesUnnamedInstance.purs:6:1 - 6:15 (line 
   [33m                                [0m
   The following instances were found:
 
-    OverlapAcrossModules.X.cX
-    OverlapAcrossModules.$cXY0
+    [33mOverlapAcrossModules.X.cX[0m
+    instance in module [33mOverlapAcrossModules[0m with type [33mC X Y[0m (line 6, column 1 - line 6, column 15)
 
 
 in type class instance

--- a/tests/purs/failing/OverlappingInstances.out
+++ b/tests/purs/failing/OverlappingInstances.out
@@ -8,8 +8,8 @@ at tests/purs/failing/OverlappingInstances.purs:10:1 - 11:13 (line 10, column 1 
   [33m               [0m
   The following instances were found:
 
-    Main.testRefl
-    Main.testInt
+    [33mMain.testRefl[0m
+    [33mMain.testInt[0m
 
 
 in type class instance

--- a/tests/purs/failing/OverlappingUnnamedInstances.out
+++ b/tests/purs/failing/OverlappingUnnamedInstances.out
@@ -8,8 +8,8 @@ at tests/purs/failing/OverlappingUnnamedInstances.purs:10:1 - 11:13 (line 10, co
   [33m               [0m
   The following instances were found:
 
-    Main.$test1
-    Main.$testInt2
+    instance in module [33mMain[0m with type [33mforall a. Test a[0m (line 7, column 1 - line 8, column 13)
+    instance in module [33mMain[0m with type [33mTest Int[0m (line 10, column 1 - line 11, column 13)
 
 
 in type class instance

--- a/tests/purs/failing/PolykindInstanceOverlapping.out
+++ b/tests/purs/failing/PolykindInstanceOverlapping.out
@@ -8,8 +8,8 @@ at tests/purs/failing/PolykindInstanceOverlapping.purs:12:1 - 13:19 (line 12, co
   [33m                      [0m
   The following instances were found:
 
-    Main.test1
-    Main.test2
+    [33mMain.test1[0m
+    [33mMain.test2[0m
 
 
 in type class instance

--- a/tests/purs/failing/PolykindUnnamedInstanceOverlapping.out
+++ b/tests/purs/failing/PolykindUnnamedInstanceOverlapping.out
@@ -8,8 +8,8 @@ at tests/purs/failing/PolykindUnnamedInstanceOverlapping.purs:12:1 - 13:19 (line
   [33m                      [0m
   The following instances were found:
 
-    Main.$showPProxy2
-    Main.$showPProxy3
+    instance in module [33mMain[0m with type [33mforall a. ShowP (Proxy a)[0m (line 9, column 1 - line 10, column 19)
+    instance in module [33mMain[0m with type [33mforall a. ShowP (Proxy a)[0m (line 12, column 1 - line 13, column 19)
 
 
 in type class instance

--- a/tests/purs/failing/TooFewUnnamedClassInstanceArgs.out
+++ b/tests/purs/failing/TooFewUnnamedClassInstanceArgs.out
@@ -1,0 +1,15 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/TooFewUnnamedClassInstanceArgs.purs:8:1 - 8:20 (line 8, column 1 - line 8, column 20)
+
+  The type class [33mMain.Foo[0m expects 2 arguments.
+  But the instance only provided 1.
+
+in type class instance
+[33m                 [0m
+[33m  Main.Foo String[0m
+[33m                 [0m
+
+See https://github.com/purescript/documentation/blob/master/errors/ClassInstanceArityMismatch.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/TooFewUnnamedClassInstanceArgs.purs
+++ b/tests/purs/failing/TooFewUnnamedClassInstanceArgs.purs
@@ -1,0 +1,8 @@
+-- @shouldFailWith ClassInstanceArityMismatch
+module Main where
+
+import Prelude
+
+class Foo a b
+
+instance Foo String

--- a/tests/purs/failing/TypeSynonymsOverlappingInstance.out
+++ b/tests/purs/failing/TypeSynonymsOverlappingInstance.out
@@ -9,8 +9,8 @@ at tests/purs/failing/TypeSynonymsOverlappingInstance.purs:14:1 - 15:16 (line 14
   [33m                     [0m
   The following instances were found:
 
-    Main.convertSB
-    Main.convertSS
+    [33mMain.convertSB[0m
+    [33mMain.convertSS[0m
 
 
 in type class instance

--- a/tests/purs/failing/TypeSynonymsOverlappingUnnamedInstance.out
+++ b/tests/purs/failing/TypeSynonymsOverlappingUnnamedInstance.out
@@ -9,8 +9,8 @@ at tests/purs/failing/TypeSynonymsOverlappingUnnamedInstance.purs:14:1 - 15:16 (
   [33m                     [0m
   The following instances were found:
 
-    Main.$convertStringBar0
-    Main.$convertStringString1
+    instance in module [33mMain[0m with type [33mConvert String String[0m (line 11, column 1 - line 12, column 16)
+    instance in module [33mMain[0m with type [33mConvert String String[0m (line 14, column 1 - line 15, column 16)
 
 
 in type class instance


### PR DESCRIPTION
**Description of the change**

This is the PR I expressed an intention to make in https://github.com/purescript/purescript/pull/4096#discussion_r643282717; see also https://github.com/purescript/purescript/pull/4096#discussion_r654928683.

The intent here is to exclude any instance names that the user wouldn't recognize because they were generated by the compiler. Either these names can be dropped altogether because the error message is positioned on the offending instance, or they should be replaced with a suitable description of the instance.

I believe this covers all of the error messages that currently mention instance names.

The specific formatting of the errors is very much up for discussion. I'm not thrilled with how verbose they are, but I also don't know what I'd cut from them.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
