### PR TITLE
Display inferred kind signatures in HTML docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,37 +32,38 @@ New features:
   ```
 
   Now, these types' kind signatures are displayed above their declarations
-  in their docs, similar to what one would see in the source code.
+  in their docs, similar to what one would see in the source code. The only
+  exception to this are kind signatures whose kinds are "uninteresting"
+  (covered below).
 
-  But that's not all!
-
-  The two below types do not have explicit kind signatures, but the compiler
-  infers what their kind signature is anyway. "Interesting" kind signatures
-  will be displayed but "uninteresting" kind signatures (even if they are
-  explicit) will be removed.
+  Moreover, declarations without explicit kind signatures will still
+  display the kind signatures inferred by the compiler. For example,
+  `Foo`'s documentation will display the below (commented-out) inferred
+  kind signature:
 
   ```purescript
                                                   {-
   data Foo :: (Type -> Type) -> Type -> Type      -}
-  data Foo f a = Foo (f a)
-                                                  {-
-  data Tuple :: Type -> Type -> Type              -}
-  data Tuple a b = Tuple a b
+  data Foo f a = Foo (f Int) a
   ```
 
-  The docs will include the kind signature for `Foo`, but will
-  intentionally remove the kind signature for `Bar`, even if `Bar`'s
-  kind signature was explicitly defined by the developer. `Bar`'s
-  kind signature is considered "uninteresting" because all of the
-  type parameters have kind `Type`. `Foo`, on the other hand, has
-  at least one type parameter, `f`, whose kind is something other than
-  `Type`. Thus, `Foo`'s inferred kind signature will be displayed
-  in its docs.
-
-  An "uninteresting" kind signature is one that follows this form:
+  However, a kind signature for both explicit and inferred kinds will not
+  be displayed if that kind is considered "uninteresting." An "uninteresting"
+  kind is one that follows this form:
   - `Type`
   - `Constraint`
   - `Type -> K` where `K` refers to an "uninteresting" kind signature
+
+  Thus, both the `Bar` and `Baz` declarations below will not have their
+  explicit and inferred kind signatures displayed in their docs.
+  ```purescript
+  data Bar :: Type -> Type -> Type
+  data Bar a b = Bar a b
+                                                    {-
+  class Baz :: Type -> Type -> Constraint           -}
+  class Baz a b where
+    doBaz :: a -> b -> String
+  ```
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Breaking changes:
 
 New features:
 
-* Display kind signatures and their comments in documentation (#4100 by JordanMartinez)
+* Display kind signatures and their comments in documentation (#4100 and #4119 by JordanMartinez)
 
   Previously, data/newtype/type/class declarations that have explicit kind
   signatures would not display those kind signatures in their documentation.
@@ -33,6 +33,36 @@ New features:
 
   Now, these types' kind signatures are displayed above their declarations
   in their docs, similar to what one would see in the source code.
+
+  But that's not all!
+
+  The two below types do not have explicit kind signatures, but the compiler
+  infers what their kind signature is anyway. "Interesting" kind signatures
+  will be displayed but "uninteresting" kind signatures (even if they are
+  explicit) will be removed.
+
+  ```purescript
+                                                  {-
+  data Foo :: (Type -> Type) -> Type -> Type      -}
+  data Foo f a = Foo (f a)
+                                                  {-
+  data Tuple :: Type -> Type -> Type              -}
+  data Tuple a b = Tuple a b
+  ```
+
+  The docs will include the kind signature for `Foo`, but will
+  intentionally remove the kind signature for `Bar`, even if `Bar`'s
+  kind signature was explicitly defined by the developer. `Bar`'s
+  kind signature is considered "uninteresting" because all of the
+  type parameters have kind `Type`. `Foo`, on the other hand, has
+  at least one type parameter, `f`, whose kind is something other than
+  `Type`. Thus, `Foo`'s inferred kind signature will be displayed
+  in its docs.
+
+  An "uninteresting" kind signature is one that follows this form:
+  - `Type`
+  - `Constraint`
+  - `Type -> K` where `K` refers to an "uninteresting" kind signature
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,60 +10,18 @@ New features:
 
 * Display kind signatures and their comments in documentation (#4100 and #4119 by JordanMartinez)
 
-  Previously, data/newtype/type/class declarations that have explicit kind
-  signatures would not display those kind signatures in their documentation.
-  For example, the two below types...
+  The compiler now displays kind signatures for data, newtype, type
+  synonym, and type class declarations in generated documentation. The
+  compiler now also includes documentation-comments (i.e. those which start
+  with a `|` character) both above and below the associated kind signature
+  declaration (if any) in generated documentation, whereas previously
+  documentation-comments above a kind signature declaration were ignored.
 
-  ```purescript
-  data PolyProxy :: forall k. k -> Type
-  data PolyProxy a = PolyProxy
-
-  data TypeProxy :: Type -> Type
-  data TypeProxy a = TypeProxy
-  ```
-
-  ... would only show the following information in their docs. One cannot
-  be distinguished from another due to the missing kind signatures:
-
-  ```
-  data PolyProxy a = PolyProxy
-
-  data TypeProxy a = TypeProxy
-  ```
-
-  Now, these types' kind signatures are displayed above their declarations
-  in their docs, similar to what one would see in the source code. The only
-  exception to this are kind signatures whose kinds are "uninteresting"
-  (covered below).
-
-  Moreover, declarations without explicit kind signatures will still
-  display the kind signatures inferred by the compiler. For example,
-  `Foo`'s documentation will display the below (commented-out) inferred
-  kind signature:
-
-  ```purescript
-                                                  {-
-  data Foo :: (Type -> Type) -> Type -> Type      -}
-  data Foo f a = Foo (f Int) a
-  ```
-
-  However, a kind signature for both explicit and inferred kinds will not
-  be displayed if that kind is considered "uninteresting." An "uninteresting"
-  kind is one that follows this form:
-  - `Type`
-  - `Constraint`
-  - `Type -> K` where `K` refers to an "uninteresting" kind signature
-
-  Thus, both the `Bar` and `Baz` declarations below will not have their
-  explicit and inferred kind signatures displayed in their docs.
-  ```purescript
-  data Bar :: Type -> Type -> Type
-  data Bar a b = Bar a b
-                                                    {-
-  class Baz :: Type -> Type -> Constraint           -}
-  class Baz a b where
-    doBaz :: a -> b -> String
-  ```
+  Both explicitly declared and inferred kinds are included in documentation.
+  The compiler omits including a kind signature in generated documentation
+  only when the kind is considered "uninteresting". An uninteresting kind is
+  defined as one where all of the declaration's type parameters have kind
+  `Type`.
 
 Bugfixes:
 

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -39,15 +39,18 @@ convertModule ::
   P.Module ->
   m Module
 convertModule externs env checkEnv =
-  fmap (insertValueTypes checkEnv . convertSingleModule) . partiallyDesugar externs env
+  fmap (insertValueTypesAndInferredKinds checkEnv . convertSingleModule) . partiallyDesugar externs env
 
 -- |
 -- Updates all the types of the ValueDeclarations inside the module based on
 -- their types inside the given Environment.
 --
-insertValueTypes ::
+-- Also inserts inferred kind signatures into the corresponding declarations
+-- if no kind signatures were declared explicitly.
+--
+insertValueTypesAndInferredKinds ::
   P.Environment -> Module -> Module
-insertValueTypes env m =
+insertValueTypesAndInferredKinds env m =
   m { modDeclarations = map go (modDeclarations m) }
   where
   -- insert value types
@@ -57,6 +60,17 @@ insertValueTypes env m =
       ty = lookupName ident
     in
       d { declInfo = ValueDeclaration (ty $> ()) }
+
+  -- insert inferred kinds
+  go d@Declaration{..} | isNothing declKind = case declInfo of
+    DataDeclaration dataDeclType _ ->
+      insertInferredKind d declTitle $ toKindSignatureFor dataDeclType
+    TypeSynonymDeclaration _ _ ->
+      insertInferredKind d declTitle P.TypeSynonymSig
+    TypeClassDeclaration _ _ _ ->
+      insertInferredKind d declTitle P.ClassSig
+    _ -> d
+
   go other =
     other
 
@@ -70,6 +84,24 @@ insertValueTypes env m =
         ty
       Nothing ->
         err ("name not found: " ++ show key)
+
+  toKindSignatureFor :: P.DataDeclType -> P.KindSignatureFor
+  toKindSignatureFor = \case
+    P.Data -> P.DataSig
+    P.Newtype -> P.NewtypeSig
+
+  insertInferredKind :: Declaration -> Text -> P.KindSignatureFor -> Declaration
+  insertInferredKind d name keyword =
+    let
+      key = P.Qualified (Just (modName m)) (P.ProperName name)
+    in case Map.lookup key (P.types env) of
+      Just (inferredKind, _) ->
+        let
+          inferredKind' = inferredKind $> ()
+        in
+          d { declKind = Just $ KindInfo { kiKeyword  = keyword, kiKind = inferredKind' } }
+      Nothing ->
+        err ("type not found: " ++ show key)
 
   err msg =
     P.internalError ("Docs.Convert.insertValueTypes: " ++ msg)

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -65,17 +65,19 @@ insertValueTypesAndAdjustKinds env m =
     in
       d { declInfo = ValueDeclaration (ty $> ()) }
 
-  go d@Declaration{..} = maybe d hideOrInsert $ extractKeyword declInfo
-    where
-      hideOrInsert keyword = case declKind of
-        Just ks ->
-          -- hide explicit kind signatures that are "uninteresting"
-          if isUninteresting keyword $ kiKind ks
-            then d { declKind = Nothing }
-            else d
-        Nothing ->
-          -- insert inferred kinds so long as they are "interesting"
-          insertInferredKind d declTitle keyword
+  go d@Declaration{..} | Just keyword <- extractKeyword declInfo =
+    case declKind of
+      Just ks ->
+        -- hide explicit kind signatures that are "uninteresting"
+        if isUninteresting keyword $ kiKind ks
+          then d { declKind = Nothing }
+          else d
+      Nothing ->
+        -- insert inferred kinds so long as they are "interesting"
+        insertInferredKind d declTitle keyword
+
+  go other =
+    other
 
   parseIdent =
     either (err . ("failed to parse Ident: " ++)) identity . runParser CST.parseIdent

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -77,9 +77,6 @@ insertValueTypesAndAdjustKinds env m =
           -- insert inferred kinds so long as they are "interesting"
           insertInferredKind d declTitle keyword
 
-  go other =
-    other
-
   parseIdent =
     either (err . ("failed to parse Ident: " ++)) identity . runParser CST.parseIdent
 

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -774,9 +774,11 @@ testCases =
       -- if each type parameter in their inferred kind signature
       -- has kind `Type`.
       , ShouldNotHaveKindSignature (n "KindSignatureDocs") "DHidden"
+      , ShouldNotHaveKindSignature (n "KindSignatureDocs") "DNothing"
       , ShouldNotHaveKindSignature (n "KindSignatureDocs") "THidden"
       , ShouldNotHaveKindSignature (n "KindSignatureDocs") "NHidden"
       , ShouldNotHaveKindSignature (n "KindSignatureDocs") "CHidden"
+      , ShouldNotHaveKindSignature (n "KindSignatureDocs") "CNothing"
 
       -- expected docs
       , ShouldMergeDocComments (n "KindSignatureDocs") "DKindAndType" $ Just "dkatk\n\ndkatt\n"

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -740,6 +740,12 @@ testCases =
       , ShouldHaveKindSignature (n "KindSignatureDocs") "NTypeOnly" "newtype NTypeOnly :: forall k. k -> Type"
       , ShouldHaveKindSignature (n "KindSignatureDocs") "CTypeOnly" "class CTypeOnly :: forall k. (k -> Type) -> k -> Constraint"
 
+      -- Declarations with no explicit kind signatures should stlil have them implicitly.
+      , ShouldHaveKindSignature (n "KindSignatureDocs") "DImplicit" "data DImplicit :: forall k. k -> Type"
+      , ShouldHaveKindSignature (n "KindSignatureDocs") "TImplicit" "type TImplicit :: forall k. k -> Type"
+      , ShouldHaveKindSignature (n "KindSignatureDocs") "NImplicit" "newtype NImplicit :: forall k. k -> Type"
+      , ShouldHaveKindSignature (n "KindSignatureDocs") "CImplicit" "class CImplicit :: forall k1. (k1 -> Type) -> k1 -> Constraint"
+
       -- expected docs
       , ShouldMergeDocComments (n "KindSignatureDocs") "DKindAndType" $ Just "dkatk\n\ndkatt\n"
       , ShouldMergeDocComments (n "KindSignatureDocs") "TKindAndType" $ Just "tkatk\n\ntkatt\n"
@@ -755,6 +761,11 @@ testCases =
       , ShouldMergeDocComments (n "KindSignatureDocs") "TTypeOnly" $ Just "ttot\n"
       , ShouldMergeDocComments (n "KindSignatureDocs") "NTypeOnly" $ Just "ntot\n"
       , ShouldMergeDocComments (n "KindSignatureDocs") "CTypeOnly" $ Just "ctot\n"
+
+      , ShouldMergeDocComments (n "KindSignatureDocs") "DImplicit" $ Just "dit\n"
+      , ShouldMergeDocComments (n "KindSignatureDocs") "TImplicit" $ Just "tit\n"
+      , ShouldMergeDocComments (n "KindSignatureDocs") "NImplicit" $ Just "nit\n"
+      , ShouldMergeDocComments (n "KindSignatureDocs") "CImplicit" $ Just "cit\n"
       ]
     )
   ]

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -786,7 +786,7 @@ testCases =
       , ShouldHaveKindSignature (n "KindSignatureDocs") "DShown" "data DShown :: Type -> Type -> (Type -> Type) -> Type"
       , ShouldHaveKindSignature (n "KindSignatureDocs") "TShown" "type TShown :: (Type -> Type) -> Type -> Type -> Type"
       , ShouldHaveKindSignature (n "KindSignatureDocs") "NShown" "newtype NShown :: Type -> (Type -> Type) -> Type -> Type"
-      , ShouldHaveKindSignature (n "KindSignatureDocs") "CShown" "class CShown :: (Type -> Type) -> Type -> Type -> Type"
+      , ShouldHaveKindSignature (n "KindSignatureDocs") "CShown" "class CShown :: (Type -> Type) -> Type -> Type -> Constraint"
 
       -- expected docs
       , ShouldMergeDocComments (n "KindSignatureDocs") "DKindAndType" $ Just "dkatk\n\ndkatt\n"

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -780,6 +780,14 @@ testCases =
       , ShouldNotHaveKindSignature (n "KindSignatureDocs") "CHidden"
       , ShouldNotHaveKindSignature (n "KindSignatureDocs") "CNothing"
 
+      -- Declarations with no explicit kind signatures should be displayed
+      -- if at least one type parameter has a kind other than `Type`
+      -- despite all others having kind `Type`.
+      , ShouldHaveKindSignature (n "KindSignatureDocs") "DShown" "data DShown :: Type -> Type -> (Type -> Type) -> Type"
+      , ShouldHaveKindSignature (n "KindSignatureDocs") "TShown" "data TShown :: (Type -> Type) -> Type -> Type -> Type"
+      , ShouldHaveKindSignature (n "KindSignatureDocs") "NShown" "data NShown :: Type -> (Type -> Type) -> Type -> Type"
+      , ShouldHaveKindSignature (n "KindSignatureDocs") "CShown" "data CShown :: (Type -> Type) -> Type -> Type -> Type"
+
       -- expected docs
       , ShouldMergeDocComments (n "KindSignatureDocs") "DKindAndType" $ Just "dkatk\n\ndkatt\n"
       , ShouldMergeDocComments (n "KindSignatureDocs") "TKindAndType" $ Just "tkatk\n\ntkatt\n"

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -784,9 +784,9 @@ testCases =
       -- if at least one type parameter has a kind other than `Type`
       -- despite all others having kind `Type`.
       , ShouldHaveKindSignature (n "KindSignatureDocs") "DShown" "data DShown :: Type -> Type -> (Type -> Type) -> Type"
-      , ShouldHaveKindSignature (n "KindSignatureDocs") "TShown" "data TShown :: (Type -> Type) -> Type -> Type -> Type"
-      , ShouldHaveKindSignature (n "KindSignatureDocs") "NShown" "data NShown :: Type -> (Type -> Type) -> Type -> Type"
-      , ShouldHaveKindSignature (n "KindSignatureDocs") "CShown" "data CShown :: (Type -> Type) -> Type -> Type -> Type"
+      , ShouldHaveKindSignature (n "KindSignatureDocs") "TShown" "type TShown :: (Type -> Type) -> Type -> Type -> Type"
+      , ShouldHaveKindSignature (n "KindSignatureDocs") "NShown" "newtype NShown :: Type -> (Type -> Type) -> Type -> Type"
+      , ShouldHaveKindSignature (n "KindSignatureDocs") "CShown" "class CShown :: (Type -> Type) -> Type -> Type -> Type"
 
       -- expected docs
       , ShouldMergeDocComments (n "KindSignatureDocs") "DKindAndType" $ Just "dkatk\n\ndkatt\n"

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -108,6 +108,8 @@ data DocsAssertion
   | ShouldComeBefore P.ModuleName Text Text
   -- | Assert that a given declaration has the given kind signature
   | ShouldHaveKindSignature P.ModuleName Text Text
+  -- | Assert that a given declaration does not have a kind signature
+  | ShouldNotHaveKindSignature P.ModuleName Text
   -- | Assert that a given declaration with doc-comments on its
   -- kind signature and type declaration are properly merged into one
   -- doc-comment.
@@ -169,6 +171,8 @@ displayAssertion = \case
     " in the docs"
   ShouldHaveKindSignature mn decl expected ->
     showQual mn decl <> " should have the kind signature `" <> expected <> "`"
+  ShouldNotHaveKindSignature mn decl ->
+    showQual mn decl <> " should not have a kind signature."
   ShouldMergeDocComments mn decl _ ->
     showQual mn decl <> " should merge its kind declaration and type declaration's doc-comments"
 
@@ -232,6 +236,10 @@ data DocsAssertionFailure
   -- Fields: module name, declaration title, expected kind signature (text),
   -- actual kind signature (text), actual kind signature (structure)
   | KindSignatureMismatch P.ModuleName Text Text Text (P.Type ())
+  -- | A kind signature was found where none was expected.
+  -- Fields: module name, declaration title, actual kind signature (text),
+  -- actual kind signature (structure)
+  | KindSignaturePresent P.ModuleName Text Text (P.Type ())
   -- | The doc comments for the kind signature and type declaration were
   -- not properly merged into the expected one.
   -- Fields: module name, declaration title, expected doc-comments,
@@ -293,6 +301,10 @@ displayAssertionFailure = \case
     "expected the kind signature for " <> decl <> "\n" <>
     "to be `" <> expected <> "`\n" <>
     "  got `" <> actualTxt <> "`\n" <>
+    "Structure of kind: " <> T.pack (show actualKind)
+  KindSignaturePresent _ decl actualTxt actualKind ->
+    "the kind signature for " <> decl <> "was not empty.\n" <>
+    "got `" <> actualTxt <> "`\n" <>
     "Structure of kind: " <> T.pack (show actualKind)
   DocCommentMergeFailure _ decl expected actual ->
     "Expected the doc-comment for " <> decl <> " to merge comments and be `" <>
@@ -478,6 +490,15 @@ runAssertion assertion linksCtx Docs.Module{..} =
             actual = codeToString $ Docs.renderKindSig decl $
               Docs.KindInfo kiKeyword kiKind
         Nothing -> Fail (KindSignatureMissing mn decl)
+
+    ShouldNotHaveKindSignature mn decl ->
+      findDeclKinds mn decl $ \case
+        Just Docs.KindInfo{..} ->
+          Fail (KindSignaturePresent mn decl actual kiKind)
+          where
+            actual = codeToString $ Docs.renderKindSig decl $
+              Docs.KindInfo kiKeyword kiKind
+        Nothing -> Pass
 
     ShouldMergeDocComments mn decl expected ->
       findDecl mn decl $ \Docs.Declaration{..} ->
@@ -741,11 +762,21 @@ testCases =
       , ShouldHaveKindSignature (n "KindSignatureDocs") "NTypeOnly" "newtype NTypeOnly :: forall k. k -> Type"
       , ShouldHaveKindSignature (n "KindSignatureDocs") "CTypeOnly" "class CTypeOnly :: forall k. (k -> Type) -> k -> Constraint"
 
-      -- Declarations with no explicit kind signatures should stlil have them implicitly.
+      -- Declarations with no explicit kind signatures should still have
+      -- their inferred kind signatures displayed as long as at least one
+      -- type parameter does not have kind `Type`.
       , ShouldHaveKindSignature (n "KindSignatureDocs") "DImplicit" "data DImplicit :: forall k. k -> Type"
       , ShouldHaveKindSignature (n "KindSignatureDocs") "TImplicit" "type TImplicit :: forall k. k -> Type"
       , ShouldHaveKindSignature (n "KindSignatureDocs") "NImplicit" "newtype NImplicit :: forall k. k -> Type"
       , ShouldHaveKindSignature (n "KindSignatureDocs") "CImplicit" "class CImplicit :: forall k1. (k1 -> Type) -> k1 -> Constraint"
+
+      -- Declarations with no explicit kind signatures should not be displayed
+      -- if each type parameter in their inferred kind signature
+      -- has kind `Type`.
+      , ShouldNotHaveKindSignature (n "KindSignatureDocs") "DHidden"
+      , ShouldNotHaveKindSignature (n "KindSignatureDocs") "THidden"
+      , ShouldNotHaveKindSignature (n "KindSignatureDocs") "NHidden"
+      , ShouldNotHaveKindSignature (n "KindSignatureDocs") "CHidden"
 
       -- expected docs
       , ShouldMergeDocComments (n "KindSignatureDocs") "DKindAndType" $ Just "dkatk\n\ndkatt\n"

--- a/tests/purs/docs/src/KindSignatureDocs.purs
+++ b/tests/purs/docs/src/KindSignatureDocs.purs
@@ -73,3 +73,18 @@ newtype NImplicit a = NImplicit Int
 -- | cit
 class CImplicit a k where
   fooImplicit :: a k -> String
+
+----------
+
+-- | dit
+data DHidden a b c = DHidden a b c
+
+-- | tit
+type THidden a b c = DHidden b c a
+
+-- | nit
+newtype NHidden a b c = NHidden (DHidden a c b)
+
+-- | cit
+class CHidden a b c where
+  fooHidden :: a -> b -> c -> String

--- a/tests/purs/docs/src/KindSignatureDocs.purs
+++ b/tests/purs/docs/src/KindSignatureDocs.purs
@@ -58,3 +58,18 @@ class CTypeOnly :: forall k. (k -> Type) -> k -> Constraint
 -- | ctot
 class CTypeOnly a k where
   fooTypeOnly :: a k -> String
+
+----------
+
+-- | dit
+data DImplicit a = DImplicit
+
+-- | tit
+type TImplicit a = Int
+
+-- | nit
+newtype NImplicit a = NImplicit Int
+
+-- | cit
+class CImplicit a k where
+  fooImplicit :: a k -> String

--- a/tests/purs/docs/src/KindSignatureDocs.purs
+++ b/tests/purs/docs/src/KindSignatureDocs.purs
@@ -79,6 +79,8 @@ class CImplicit a k where
 -- | dit
 data DHidden a b c = DHidden a b c
 
+data DNothing
+
 -- | tit
 type THidden a b c = DHidden b c a
 
@@ -88,3 +90,6 @@ newtype NHidden a b c = NHidden (DHidden a c b)
 -- | cit
 class CHidden a b c where
   fooHidden :: a -> b -> c -> String
+
+class CNothing
+

--- a/tests/purs/docs/src/KindSignatureDocs.purs
+++ b/tests/purs/docs/src/KindSignatureDocs.purs
@@ -93,3 +93,17 @@ class CHidden a b c where
 
 class CNothing
 
+----------
+
+-- | dit
+data DShown a b f = DShown (f Int) a b
+
+-- | tit
+type TShown f b c = DShown b c f
+
+-- | nit
+newtype NShown a f c = NShown (DShown a c f)
+
+-- | cit
+class CShown f a b where
+  fooShown :: f Int -> a -> b -> String


### PR DESCRIPTION
**Description of the change**

Fixes #4117. 

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)

Work done so far:
- The `forall (k :: Type). k -> Type` has been simplified to `forall k. k -> Type`.

Pending work
- whether to display inferred kind signatures if all type parameters' kinds are `Type` (decision pending)
- updating the changelog