### PR TITLE
Update unnamed instances changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,9 +76,8 @@ New features:
   instance Foo Int String
   ```
 
-  and the compiler will generate a unique name for the instance. Note that
-  generated instance names contain numeric suffixes which can change without
-  warning, and should therefore not be relied on.
+  Note that generated instance names can change without warning as a result of changes
+  elsewhere in your code, so do not rely upon these names in any FFI code.
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,22 +76,9 @@ New features:
   instance Foo Int String
   ```
 
-  and the compiler will generate a unique name for the instance
-  (e.g. `$dollar_FooIntString_4` where `4` is a randomly-generated number
-  that can change across compiler runs). This version of the instance name
-  is not intended for use in FFI.
-
-  Note: if one wrote
-
-  ```purescript
-  instance ReallyLongClassName Int String
-  ```
-
-  the generated name would be something like
-  `$dollar_ReallyLongClassNameIntStr_87` rather than
-  `$dollar_ReallyLongClassNameIntString_87` as the generated part
-  of the name will be truncated to 25 characters (long enough to be readable
-  without being too verbose).
+  and the compiler will generate a unique name for the instance. Note that
+  generated instance names contain numeric suffixes which can change without
+  warning, and should therefore not be relied on.
 
 Bugfixes:
 


### PR DESCRIPTION
I know this has already gone out, but the current treatment of this feature in the changelog is slightly inaccurate - it's not true that these numbers are randomly generated, they should actually be deterministic - if the module hasn't otherwise changed, you should always get the same number out. I don't think we should document the scheme for what generated instance names look like, because we shouldn't consider it part of the compiler's public API; documenting it could be read as telling users that they can rely on this not changing, which is not the case.

**Description of the change**

Clearly and concisely describe the purpose of the pull request. If this PR relates to an existing issue or change proposal, please link to it. Include any other background context that would help reviewers understand the motivation for this PR.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
