### PR TITLE
RELEASE_GUIDE.md: s/Or alternatively/Alternatively/

### DIFF
--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -43,7 +43,7 @@ projects whom we should probably at least notify. See below subsections:
 
 ### Libraries
 
-Are there breaking changes to the language? Or alternatively, are there
+Are there breaking changes to the language? Alternatively, are there
 language changes which require breaking changes in the relevant libraries to
 make use of? If so:
 


### PR DESCRIPTION
"Alternatively" replaces "[o]r alternatively"; "or alternatively" is redundant.