### PR TITLE
Represent class dictionaries as newtypes

### DIFF
--- a/CHANGELOG.d/internal_typeclasses-are-newtypes.md
+++ b/CHANGELOG.d/internal_typeclasses-are-newtypes.md
@@ -1,0 +1,1 @@
+* Represent class dictionaries as newtypes

--- a/lib/purescript-cst/src/Language/PureScript/AST/Declarations.hs
+++ b/lib/purescript-cst/src/Language/PureScript/AST/Declarations.hs
@@ -719,11 +719,6 @@ data Expr
   --
   | Ado (Maybe ModuleName) [DoNotationElement] Expr
   -- |
-  -- An application of a typeclass dictionary constructor. The value should be
-  -- an ObjectLiteral.
-  --
-  | TypeClassDictionaryConstructorApp (Qualified (ProperName 'ClassName)) Expr
-  -- |
   -- A placeholder for a type class dictionary to be inserted later. At the end of type checking, these
   -- placeholders will be replaced with actual expressions representing type classes dictionaries which
   -- can be evaluated at runtime. The constructor arguments represent (in order): whether or not to look
@@ -733,10 +728,6 @@ data Expr
   | TypeClassDictionary SourceConstraint
                         (M.Map (Maybe ModuleName) (M.Map (Qualified (ProperName 'ClassName)) (M.Map (Qualified Ident) (NEL.NonEmpty NamedDict))))
                         [ErrorMessageHint]
-  -- |
-  -- A typeclass dictionary accessor, the implementation is left unspecified until CoreFn desugaring.
-  --
-  | TypeClassDictionaryAccessor (Qualified (ProperName 'ClassName)) Ident
   -- |
   -- A placeholder for a superclass dictionary to be turned into a TypeClassDictionary during typechecking
   --

--- a/lib/purescript-cst/src/Language/PureScript/AST/Traversals.hs
+++ b/lib/purescript-cst/src/Language/PureScript/AST/Traversals.hs
@@ -67,7 +67,6 @@ everywhereOnValues f g h = (f', g', h')
   g' (UnaryMinus ss v) = g (UnaryMinus ss (g' v))
   g' (BinaryNoParens op v1 v2) = g (BinaryNoParens (g' op) (g' v1) (g' v2))
   g' (Parens v) = g (Parens (g' v))
-  g' (TypeClassDictionaryConstructorApp name v) = g (TypeClassDictionaryConstructorApp name (g' v))
   g' (Accessor prop v) = g (Accessor prop (g' v))
   g' (ObjectUpdate obj vs) = g (ObjectUpdate (g' obj) (fmap (fmap g') vs))
   g' (ObjectUpdateNested obj vs) = g (ObjectUpdateNested (g' obj) (fmap g' vs))
@@ -142,7 +141,6 @@ everywhereOnValuesTopDownM f g h = (f' <=< f, g' <=< g, h' <=< h)
   g' (UnaryMinus ss v) = UnaryMinus ss <$> (g v >>= g')
   g' (BinaryNoParens op v1 v2) = BinaryNoParens <$> (g op >>= g') <*> (g v1 >>= g') <*> (g v2 >>= g')
   g' (Parens v) = Parens <$> (g v >>= g')
-  g' (TypeClassDictionaryConstructorApp name v) = TypeClassDictionaryConstructorApp name <$> (g v >>= g')
   g' (Accessor prop v) = Accessor prop <$> (g v >>= g')
   g' (ObjectUpdate obj vs) = ObjectUpdate <$> (g obj >>= g') <*> traverse (sndM (g' <=< g)) vs
   g' (ObjectUpdateNested obj vs) = ObjectUpdateNested <$> (g obj >>= g') <*> traverse (g' <=< g) vs
@@ -212,7 +210,6 @@ everywhereOnValuesM f g h = (f', g', h')
   g' (UnaryMinus ss v) = (UnaryMinus ss <$> g' v) >>= g
   g' (BinaryNoParens op v1 v2) = (BinaryNoParens <$> g' op <*> g' v1 <*> g' v2) >>= g
   g' (Parens v) = (Parens <$> g' v) >>= g
-  g' (TypeClassDictionaryConstructorApp name v) = (TypeClassDictionaryConstructorApp name <$> g' v) >>= g
   g' (Accessor prop v) = (Accessor prop <$> g' v) >>= g
   g' (ObjectUpdate obj vs) = (ObjectUpdate <$> g' obj <*> traverse (sndM g') vs) >>= g
   g' (ObjectUpdateNested obj vs) = (ObjectUpdateNested <$> g' obj <*> traverse g' vs) >>= g
@@ -285,7 +282,6 @@ everythingOnValues (<>.) f g h i j = (f', g', h', i', j')
   g' v@(UnaryMinus _ v1) = g v <>. g' v1
   g' v@(BinaryNoParens op v1 v2) = g v <>. g' op <>. g' v1 <>. g' v2
   g' v@(Parens v1) = g v <>. g' v1
-  g' v@(TypeClassDictionaryConstructorApp _ v1) = g v <>. g' v1
   g' v@(Accessor _ v1) = g v <>. g' v1
   g' v@(ObjectUpdate obj vs) = foldl (<>.) (g v <>. g' obj) (fmap (g' . snd) vs)
   g' v@(ObjectUpdateNested obj vs) = foldl (<>.) (g v <>. g' obj) (fmap g' vs)
@@ -367,7 +363,6 @@ everythingWithContextOnValues s0 r0 (<>.) f g h i j = (f'' s0, g'' s0, h'' s0, i
   g' s (UnaryMinus _ v1) = g'' s v1
   g' s (BinaryNoParens op v1 v2) = g'' s op <>. g'' s v1 <>. g'' s v2
   g' s (Parens v1) = g'' s v1
-  g' s (TypeClassDictionaryConstructorApp _ v1) = g'' s v1
   g' s (Accessor _ v1) = g'' s v1
   g' s (ObjectUpdate obj vs) = foldl (<>.) (g'' s obj) (fmap (g'' s . snd) vs)
   g' s (ObjectUpdateNested obj vs) = foldl (<>.) (g'' s obj) (fmap (g'' s) vs)
@@ -453,7 +448,6 @@ everywhereWithContextOnValuesM s0 f g h i j = (f'' s0, g'' s0, h'' s0, i'' s0, j
   g' s (UnaryMinus ss v) = UnaryMinus ss <$> g'' s v
   g' s (BinaryNoParens op v1 v2) = BinaryNoParens <$> g'' s op <*> g'' s v1 <*> g'' s v2
   g' s (Parens v) = Parens <$> g'' s v
-  g' s (TypeClassDictionaryConstructorApp name v) = TypeClassDictionaryConstructorApp name <$> g'' s v
   g' s (Accessor prop v) = Accessor prop <$> g'' s v
   g' s (ObjectUpdate obj vs) = ObjectUpdate <$> g'' s obj <*> traverse (sndM (g'' s)) vs
   g' s (ObjectUpdateNested obj vs) = ObjectUpdateNested <$> g'' s obj <*> traverse (g'' s) vs
@@ -547,7 +541,6 @@ everythingWithScope f g h i j = (f'', g'', h'', i'', \s -> snd . j'' s)
   g' s (UnaryMinus _ v1) = g'' s v1
   g' s (BinaryNoParens op v1 v2) = g'' s op <> g'' s v1 <> g'' s v2
   g' s (Parens v1) = g'' s v1
-  g' s (TypeClassDictionaryConstructorApp _ v1) = g'' s v1
   g' s (Accessor _ v1) = g'' s v1
   g' s (ObjectUpdate obj vs) = g'' s obj <> foldMap (g'' s . snd) vs
   g' s (ObjectUpdateNested obj vs) = g'' s obj <> foldMap (g'' s) vs

--- a/lib/purescript-cst/src/Language/PureScript/Environment.hs
+++ b/lib/purescript-cst/src/Language/PureScript/Environment.hs
@@ -360,7 +360,7 @@ primClass name mkKind =
   [ let k = mkKind kindConstraint
     in (name, (k, ExternData (nominalRolesForKind k)))
   , let k = mkKind kindType
-    in (dictSynonymName <$> name, (k, TypeSynonym))
+    in (dictTypeName <$> name, (k, TypeSynonym))
   ]
 
 -- | The primitive types in the external environment with their
@@ -604,14 +604,14 @@ isNewtypeConstructor e ctor = case lookupConstructor e ctor of
 lookupValue :: Environment -> Qualified Ident -> Maybe (SourceType, NameKind, NameVisibility)
 lookupValue env ident = ident `M.lookup` names env
 
-dictSynonymName' :: Text -> Text
-dictSynonymName' = (<> "$Dict")
+dictTypeName' :: Text -> Text
+dictTypeName' = (<> "$Dict")
 
-dictSynonymName :: ProperName a -> ProperName a
-dictSynonymName = ProperName . dictSynonymName' . runProperName
+dictTypeName :: ProperName a -> ProperName a
+dictTypeName = ProperName . dictTypeName' . runProperName
 
-isDictSynonym :: ProperName a -> Bool
-isDictSynonym = T.isSuffixOf "$Dict" . runProperName
+isDictTypeName :: ProperName a -> Bool
+isDictTypeName = T.isSuffixOf "$Dict" . runProperName
 
 -- |
 -- Given the kind of a type, generate a list @Nominal@ roles. This is used for

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -161,6 +161,10 @@ moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreign_ =
   -- Generate code in the simplified JavaScript intermediate representation for a declaration
   --
   bindToJs :: Bind Ann -> m [AST]
+  bindToJs (NonRec (_, _, _, Just IsTypeClassConstructor) _ _) = pure []
+    -- Unlike other newtype constructors, type class constructors are only
+    -- ever applied; it's not possible to use them as values. So it's safe to
+    -- erase them.
   bindToJs (NonRec ann ident val) = return <$> nonRecToJS ann ident val
   bindToJs (Rec vals) = forM vals (uncurry . uncurry $ nonRecToJS)
 
@@ -220,16 +224,6 @@ moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreign_ =
     obj <- valueToJs o
     sts <- mapM (sndM valueToJs) ps
     extendObj obj sts
-  valueToJs' e@(Abs (_, _, _, Just IsTypeClassConstructor) _ _) =
-    let args = unAbs e
-    in return $ AST.Function Nothing Nothing (map identToJs args) (AST.Block Nothing $ map assign args)
-    where
-    unAbs :: Expr Ann -> [Ident]
-    unAbs (Abs _ arg val) = arg : unAbs val
-    unAbs _ = []
-    assign :: Ident -> AST
-    assign name = AST.Assignment Nothing (accessorString (mkString $ runIdent name) (AST.Var Nothing "this"))
-                               (var name)
   valueToJs' (Abs _ arg val) = do
     ret <- valueToJs val
     let jsArg = case arg of
@@ -242,8 +236,6 @@ moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreign_ =
     case f of
       Var (_, _, _, Just IsNewtype) _ -> return (head args')
       Var (_, _, _, Just (IsConstructor _ fields)) name | length args == length fields ->
-        return $ AST.Unary Nothing AST.New $ AST.App Nothing (qualifiedToJS id name) args'
-      Var (_, _, _, Just IsTypeClassConstructor) name ->
         return $ AST.Unary Nothing AST.New $ AST.App Nothing (qualifiedToJS id name) args'
       _ -> flip (foldl (\fn a -> AST.App Nothing fn [a])) args' <$> valueToJs f
     where

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -1,12 +1,11 @@
 module Language.PureScript.CoreFn.Desugar (moduleToCoreFn) where
 
 import Prelude.Compat
-import Protolude (ordNub)
+import Protolude (ordNub, orEmpty)
 
 import Control.Arrow (second)
 
 import Data.Function (on)
-import Data.List (sort, sortOn)
 import Data.Maybe (mapMaybe)
 import Data.Tuple (swap)
 import qualified Data.List.NonEmpty as NEL
@@ -24,9 +23,7 @@ import Language.PureScript.CoreFn.Module
 import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Names
-import Language.PureScript.Sugar.TypeClasses (typeClassMemberName, superClassDictionaryNames)
 import Language.PureScript.Types
-import Language.PureScript.PSString (mkString)
 import qualified Language.PureScript.AST as A
 import qualified Language.PureScript.Constants.Prim as C
 
@@ -65,8 +62,10 @@ moduleToCoreFn env (A.Module modSS coms mn decls (Just exps)) =
   -- | Desugars member declarations from AST to CoreFn representation.
   declToCoreFn :: A.Declaration -> [Bind Ann]
   declToCoreFn (A.DataDeclaration (ss, com) Newtype _ _ [ctor]) =
-    [NonRec (ssA ss) (properToIdent $ A.dataCtorName ctor) $
+    [NonRec (ss, [], Nothing, declMeta) (properToIdent $ A.dataCtorName ctor) $
       Abs (ss, com, Nothing, Just IsNewtype) (Ident "x") (Var (ssAnn ss) $ Qualified Nothing (Ident "x"))]
+    where
+    declMeta = isDictTypeName (A.dataCtorName ctor) `orEmpty` IsTypeClassConstructor
   declToCoreFn d@(A.DataDeclaration _ Newtype _ _ _) =
     error $ "Found newtype with multiple constructors: " ++ show d
   declToCoreFn (A.DataDeclaration (ss, com) Data tyName _ ctors) =
@@ -81,8 +80,6 @@ moduleToCoreFn env (A.Module modSS coms mn decls (Just exps)) =
     [NonRec (ssA ss) name (exprToCoreFn ss com Nothing e)]
   declToCoreFn (A.BindingGroupDeclaration ds) =
     [Rec . NEL.toList $ fmap (\(((ss, com), name), _, e) -> ((ssA ss, name), exprToCoreFn ss com Nothing e)) ds]
-  declToCoreFn (A.TypeClassDeclaration sa@(ss, _) name _ supers _ members) =
-    [NonRec (ssA ss) (properToIdent name) $ mkTypeClassConstructor sa supers members]
   declToCoreFn _ = []
 
   -- | Desugars expressions from AST to CoreFn representation.
@@ -117,15 +114,6 @@ moduleToCoreFn env (A.Module modSS coms mn decls (Just exps)) =
     exprToCoreFn ss com (Just ty) v
   exprToCoreFn ss com ty (A.Let w ds v) =
     Let (ss, com, ty, getLetMeta w) (concatMap declToCoreFn ds) (exprToCoreFn ss [] Nothing v)
-  exprToCoreFn ss com ty (A.TypeClassDictionaryConstructorApp name (A.TypedValue _ lit@(A.Literal _ (A.ObjectLiteral _)) _)) =
-    exprToCoreFn ss com ty (A.TypeClassDictionaryConstructorApp name lit)
-  exprToCoreFn ss com _ (A.TypeClassDictionaryConstructorApp name (A.Literal _ (A.ObjectLiteral vs))) =
-    let args = exprToCoreFn ss [] Nothing . snd <$> sortOn fst vs
-        ctor = Var (ss, [], Nothing, Just IsTypeClassConstructor) (fmap properToIdent name)
-    in foldl (App (ss, com, Nothing, Nothing)) ctor args
-  exprToCoreFn ss com ty  (A.TypeClassDictionaryAccessor _ ident) =
-    Abs (ss, com, ty, Nothing) (Ident "dict")
-      (Accessor (ssAnn ss) (mkString $ runIdent ident) (Var (ssAnn ss) $ Qualified Nothing (Ident "dict")))
   exprToCoreFn _ com ty (A.PositionedValue ss com1 v) =
     exprToCoreFn ss (com ++ com1) ty v
   exprToCoreFn _ _ _ e =
@@ -221,10 +209,6 @@ findQualModules decls =
   fqValues :: A.Expr -> [ModuleName]
   fqValues (A.Var _ q) = getQual' q
   fqValues (A.Constructor _ q) = getQual' q
-  -- Some instances are automatically solved and have their class dictionaries
-  -- built inline instead of having a named instance defined and imported.
-  -- We therefore need to import these constructors if they aren't already.
-  fqValues (A.TypeClassDictionaryConstructorApp c _) = getQual' c
   fqValues _ = []
 
   fqBinders :: A.Binder -> [ModuleName]
@@ -245,31 +229,18 @@ externToCoreFn (A.ExternDeclaration _ name _) = Just name
 externToCoreFn _ = Nothing
 
 -- | Desugars export declarations references from AST to CoreFn representation.
--- CoreFn modules only export values, so all data constructors, class
--- constructor, instances and values are flattened into one list.
+-- CoreFn modules only export values, so all data constructors, instances and
+-- values are flattened into one list.
 exportToCoreFn :: A.DeclarationRef -> [Ident]
 exportToCoreFn (A.TypeRef _ _ (Just dctors)) = fmap properToIdent dctors
 exportToCoreFn (A.TypeRef _ _ Nothing) = []
 exportToCoreFn (A.TypeOpRef _ _) = []
 exportToCoreFn (A.ValueRef _ name) = [name]
 exportToCoreFn (A.ValueOpRef _ _) = []
-exportToCoreFn (A.TypeClassRef _ name) = [properToIdent name]
+exportToCoreFn (A.TypeClassRef _ _) = []
 exportToCoreFn (A.TypeInstanceRef _ name _) = [name]
 exportToCoreFn (A.ModuleRef _ _) = []
 exportToCoreFn (A.ReExportRef _ _ _) = []
-
--- | Makes a typeclass dictionary constructor function. The returned expression
--- is a function that accepts the superclass instances and member
--- implementations and returns a record for the instance dictionary.
-mkTypeClassConstructor :: SourceAnn -> [SourceConstraint] -> [A.Declaration] -> Expr Ann
-mkTypeClassConstructor (ss, com) [] [] = Literal (ss, com, Nothing, Just IsTypeClassConstructor) (ObjectLiteral [])
-mkTypeClassConstructor (ss, com) supers members =
-  let args@(a:as) = sort $ fmap typeClassMemberName members ++ superClassDictionaryNames supers
-      props = [ (mkString arg, Var (ssAnn ss) $ Qualified Nothing (Ident arg)) | arg <- args ]
-      dict = Literal (ssAnn ss) (ObjectLiteral props)
-  in Abs (ss, com, Nothing, Just IsTypeClassConstructor)
-         (Ident a)
-         (foldr (Abs (ssAnn ss) . Ident) dict as)
 
 -- | Converts a ProperName to an Ident.
 properToIdent :: ProperName a -> Ident

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -246,14 +246,14 @@ moduleToExternsFile (Module ss _ mn ds (Just exps)) env renamedIdents = ExternsF
     | Just (ty, _, _) <- Qualified (Just mn) ident `M.lookup` names env
     = [ EDValue (lookupRenamedIdent ident) ty ]
   toExternsDeclaration (TypeClassRef _ className)
-    | let dictName = dictSynonymName . coerceProperName $ className
+    | let dictName = dictTypeName . coerceProperName $ className
     , Just TypeClassData{..} <- Qualified (Just mn) className `M.lookup` typeClasses env
-    , Just (kind, ExternData rs) <- Qualified (Just mn) (coerceProperName className) `M.lookup` types env
-    , Just (synKind, TypeSynonym) <- Qualified (Just mn) dictName `M.lookup` types env
-    , Just (synArgs, synTy) <- Qualified (Just mn) dictName `M.lookup` typeSynonyms env
-    = [ EDType (coerceProperName className) kind (ExternData rs)
-      , EDType dictName synKind TypeSynonym
-      , EDTypeSynonym dictName synArgs synTy
+    , Just (kind, tk) <- Qualified (Just mn) (coerceProperName className) `M.lookup` types env
+    , Just (dictKind, dictData@(DataType _ _ [(dctor, _)])) <- Qualified (Just mn) dictName `M.lookup` types env
+    , Just (dty, _, ty, args) <- Qualified (Just mn) dctor `M.lookup` dataConstructors env
+    = [ EDType (coerceProperName className) kind tk
+      , EDType dictName dictKind dictData
+      , EDDataConstructor dctor dty dictName ty args
       , EDClass className typeClassArguments typeClassMembers typeClassSuperclasses typeClassDependencies typeClassIsEmpty
       ]
   toExternsDeclaration (TypeInstanceRef ss' ident ns)

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -109,11 +109,11 @@ convertDecl ed = case ed of
     if isNothing (Text.find (== '$') (edTypeSynonymName^.properNameT))
       then Left (SynonymToResolve edTypeSynonymName edTypeSynonymType)
       else Right Nothing
-  P.EDDataConstructor{..} ->
-    Right
-      (Just
-        (IdeDeclDataConstructor
-          (IdeDataConstructor edDataCtorName edDataCtorTypeCtor edDataCtorType)))
+  P.EDDataConstructor{..} -> Right do
+    guard (isNothing (Text.find (== '$') (edDataCtorName^.properNameT)))
+    Just
+      (IdeDeclDataConstructor
+        (IdeDataConstructor edDataCtorName edDataCtorTypeCtor edDataCtorType))
   P.EDValue{..} ->
     Right (Just (IdeDeclValue (IdeValue edValueName edValueType)))
   P.EDClass{..} ->

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -199,7 +199,6 @@ lintUnused (Module modSS _ mn modDecls exports) =
     go (UnaryMinus _ v1) = go v1
     go (BinaryNoParens v0 v1 v2) = go v0 <> go v1 <> go v2
     go (Parens v1) = go v1
-    go (TypeClassDictionaryConstructorApp _ v1) = go v1
     go (Accessor _ v1) = go v1
 
     go (ObjectUpdate obj vs) = mconcat (go obj : map (go . snd) vs)
@@ -234,7 +233,6 @@ lintUnused (Module modSS _ mn modDecls exports) =
     go (Op _ _) = mempty
     go (Constructor _ _) = mempty
     go (TypeClassDictionary _ _ _) = mempty
-    go (TypeClassDictionaryAccessor _ _) = mempty
     go (DeferredDictionary _ _) = mempty
     go AnonymousArgument = mempty
     go (Hole _) = mempty

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -338,7 +338,6 @@ checkExhaustiveExpr initSS env mn = onExpr initSS
   onExpr _ (UnaryMinus ss e) = UnaryMinus ss <$> onExpr ss e
   onExpr _ (Literal ss (ArrayLiteral es)) = Literal ss . ArrayLiteral <$> mapM (onExpr ss) es
   onExpr _ (Literal ss (ObjectLiteral es)) = Literal ss . ObjectLiteral <$> mapM (sndM (onExpr ss)) es
-  onExpr ss (TypeClassDictionaryConstructorApp x e) = TypeClassDictionaryConstructorApp x <$> onExpr ss e
   onExpr ss (Accessor x e) = Accessor x <$> onExpr ss e
   onExpr ss (ObjectUpdate o es) = ObjectUpdate <$> onExpr ss o <*> mapM (sndM (onExpr ss)) es
   onExpr ss (Abs x e) = Abs x <$> onExpr ss e

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -68,8 +68,6 @@ prettyPrintValue d (ObjectUpdateNested o ps) = prettyPrintValueAtom (d - 1) o `b
 prettyPrintValue d (App val arg) = prettyPrintValueAtom (d - 1) val `beforeWithSpace` prettyPrintValueAtom (d - 1) arg
 prettyPrintValue d (Unused val) = prettyPrintValue d val
 prettyPrintValue d (Abs arg val) = text ('\\' : T.unpack (prettyPrintBinder arg) ++ " -> ") // moveRight 2 (prettyPrintValue (d - 1) val)
-prettyPrintValue d (TypeClassDictionaryConstructorApp className ps) =
-  text (T.unpack (runProperName (disqualify className)) ++ " ") <> prettyPrintValueAtom (d - 1) ps
 prettyPrintValue d (Case values binders) =
   (text "case " <> foldr beforeWithSpace (text "of") (map (prettyPrintValueAtom (d - 1)) values)) //
     moveRight 2 (vcat left (map (prettyPrintCaseAlternative (d - 1)) binders))
@@ -89,8 +87,6 @@ prettyPrintValue d (Ado m els yield) =
 -- TODO: constraint kind args
 prettyPrintValue d (TypeClassDictionary (Constraint _ name _ tys _) _ _) = foldl1 beforeWithSpace $ text ("#dict " ++ T.unpack (runProperName (disqualify name))) : map (typeAtomAsBox d) tys
 prettyPrintValue _ (DeferredDictionary name _) = text $ "#dict " ++ T.unpack (runProperName (disqualify name))
-prettyPrintValue _ (TypeClassDictionaryAccessor className ident) =
-    text "#dict-accessor " <> text (T.unpack (runProperName (disqualify className))) <> text "." <> text (T.unpack (showIdent ident)) <> text ">"
 prettyPrintValue d (TypedValue _ val _) = prettyPrintValue d val
 prettyPrintValue d (PositionedValue _ _ val) = prettyPrintValue d val
 prettyPrintValue d (Literal _ l) = prettyPrintLiteralValue d l

--- a/src/Language/PureScript/Renamer.hs
+++ b/src/Language/PureScript/Renamer.hs
@@ -168,7 +168,6 @@ renameInValue (Accessor ann prop v) =
   Accessor ann prop <$> renameInValue v
 renameInValue (ObjectUpdate ann obj vs) =
   ObjectUpdate ann <$> renameInValue obj <*> traverse (\(name, v) -> (name, ) <$> renameInValue v) vs
-renameInValue e@(Abs (_, _, _, Just IsTypeClassConstructor) _ _) = return e
 renameInValue (Abs ann name v) =
   newScope $ Abs ann <$> updateScope name <*> renameInValue v
 renameInValue (App ann v1 v2) =

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -54,7 +54,7 @@ import Language.PureScript.TypeChecker.Synonyms (SynonymMap)
 --
 --  * Rebracket user-defined binary operators
 --
---  * Introduce type synonyms for type class dictionaries
+--  * Introduce newtypes for type class dictionaries and value declarations for instances
 --
 --  * Group mutually recursive value and data declarations into binding groups.
 --

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -1,6 +1,6 @@
 -- |
--- This module implements the desugaring pass which creates type synonyms for type class dictionaries
--- and dictionary expressions for type class instances.
+-- This module implements the desugaring pass which creates newtypes for type class dictionaries
+-- and value declarations for type class instances.
 --
 module Language.PureScript.Sugar.TypeClasses
   ( desugarTypeClasses
@@ -108,7 +108,7 @@ desugarModule _ _ _ = internalError "Exports should have been elaborated in name
 
 {- Desugar type class and type class instance declarations
 --
--- Type classes become type synonyms for their dictionaries, and type instances become dictionary declarations.
+-- Type classes become newtypes for their dictionaries, and type instances become dictionary declarations.
 -- Additional values are generated to access individual members of a dictionary, with the appropriate type.
 --
 -- E.g. the following
@@ -136,68 +136,64 @@ desugarModule _ _ _ = internalError "Exports should have been elaborated in name
 --
 --   <TypeClassDeclaration Foo ...>
 --
---   type Foo a = { foo :: a -> a }
+--   newtype Foo$Dict a = Foo$Dict { foo :: a -> a }
 --
 --   -- this following type is marked as not needing to be checked so a new Abs
 --   -- is not introduced around the definition in type checking, but when
 --   -- called the dictionary value is still passed in for the `dict` argument
---   foo :: forall a. (Foo a) => a -> a
---   foo dict = dict.foo
+--   foo :: forall a. (Foo$Dict a) => a -> a
+--   foo (Foo$Dict dict) = dict.foo
 --
---   fooString :: {} -> Foo String
---   fooString _ = <TypeClassDictionaryConstructorApp Foo { foo: \s -> s ++ s }>
+--   fooString :: Foo$Dict String
+--   fooString = Foo$Dict { foo: \s -> s ++ s }
 --
---   fooArray :: forall a. (Foo a) => Foo [a]
---   fooArray = <TypeClassDictionaryConstructorApp Foo { foo: map foo }>
+--   fooArray :: forall a. (Foo$Dict a) => Foo$Dict [a]
+--   fooArray = Foo$Dict { foo: map foo }
 --
 --   {- Superclasses -}
 --
 --   <TypeClassDeclaration Sub ...>
 --
---   type Sub a = { sub :: a
---                , "Foo0" :: {} -> Foo a
---                }
+--   newtype Sub$Dict a = Sub$Dict { sub :: a
+--                                 , "Foo0" :: {} -> Foo$Dict a
+--                                 }
 --
 --   -- As with `foo` above, this type is unchecked at the declaration
---   sub :: forall a. (Sub a) => a
---   sub dict = dict.sub
+--   sub :: forall a. (Sub$Dict a) => a
+--   sub (Sub$Dict dict) = dict.sub
 --
---   subString :: {} -> Sub String
---   subString _ = { sub: "",
---                 , "Foo0": \_ -> <DeferredDictionary Foo String>
---                 }
+--   subString :: Sub$Dict String
+--   subString = Sub$Dict { sub: "",
+--                        , "Foo0": \_ -> <DeferredDictionary Foo String>
+--                        }
 --
 -- and finally as the generated javascript:
---
---   function Foo(foo) {
---       this.foo = foo;
---   };
 --
 --   var foo = function (dict) {
 --       return dict.foo;
 --   };
 --
---   var fooString = function (_) {
---       return new Foo(function (s) {
---           return s + s;
---       });
+--   var fooString = {
+--      foo: function (s) {
+--          return s + s;
+--      }
 --   };
 --
---   var fooArray = function (__dict_Foo_15) {
---       return new Foo(map(foo(__dict_Foo_15)));
---   };
---
---   function Sub(Foo0, sub) {
---       this["Foo0"] = Foo0;
---       this.sub = sub;
+--   var fooArray = function (dictFoo) {
+--       return {
+--           foo: map(foo(dictFoo))
+--       };
 --   };
 --
 --   var sub = function (dict) {
 --       return dict.sub;
 --   };
 --
---   var subString = function (_) {
---       return new Sub(fooString, "");
+--   var subString = {
+--       sub: "",
+--       Foo0: function () {
+--           return fooString;
+--       }
 --   };
 -}
 desugarDecl
@@ -225,7 +221,7 @@ desugarDecl syns kinds mn exps = go
     return (expRef name' className tys, [d, dictDecl])
   go (TypeInstanceDeclaration sa chainId idx name deps className tys (NewtypeInstanceWithDictionary dict)) = do
     name' <- desugarInstName name
-    let dictTy = foldl srcTypeApp (srcTypeConstructor (fmap (coerceProperName . dictSynonymName) className)) tys
+    let dictTy = foldl srcTypeApp (srcTypeConstructor (fmap (coerceProperName . dictTypeName) className)) tys
         constrainedTy = quantify (foldr srcConstrainedType dictTy deps)
         d = TypeInstanceDeclaration sa chainId idx (Right name') deps className tys (NewtypeInstanceWithDictionary dict)
     return (expRef name' className tys, [d, ValueDecl sa name' Private [] [MkUnguarded (TypedValue True dict constrainedTy)]])
@@ -281,13 +277,15 @@ typeClassDictionaryDeclaration
   -> Declaration
 typeClassDictionaryDeclaration sa name args implies members =
   let superclassTypes = superClassDictionaryNames implies `zip`
-        [ function unit (foldl srcTypeApp (srcTypeConstructor (fmap (coerceProperName . dictSynonymName) superclass)) tyArgs)
+        [ function unit (foldl srcTypeApp (srcTypeConstructor (fmap (coerceProperName . dictTypeName) superclass)) tyArgs)
         | (Constraint _ superclass _ tyArgs _) <- implies
         ]
       members' = map (first runIdent . memberToNameAndType) members
       mtys = members' ++ superclassTypes
       toRowListItem (l, t) = srcRowListItem (Label $ mkString l) t
-  in TypeSynonymDeclaration sa (coerceProperName $ dictSynonymName name) args (srcTypeApp tyRecord $ rowFromList (map toRowListItem mtys, srcREmpty))
+      ctor = DataConstructorDeclaration sa (coerceProperName $ dictTypeName name)
+        [(Ident "dict", srcTypeApp tyRecord $ rowFromList (map toRowListItem mtys, srcREmpty))]
+  in DataDeclaration sa Newtype (coerceProperName $ dictTypeName name) args [ctor]
 
 typeClassMemberToDictionaryAccessor
   :: ModuleName
@@ -295,11 +293,15 @@ typeClassMemberToDictionaryAccessor
   -> [(Text, Maybe SourceType)]
   -> Declaration
   -> Declaration
-typeClassMemberToDictionaryAccessor mn name args (TypeDeclaration (TypeDeclarationData sa ident ty)) =
+typeClassMemberToDictionaryAccessor mn name args (TypeDeclaration (TypeDeclarationData sa@(ss, _) ident ty)) =
   let className = Qualified (Just mn) name
+      dictIdent = Ident "dict"
+      dictObjIdent = Ident "v"
+      ctor = ConstructorBinder ss (coerceProperName . dictTypeName <$> className) [VarBinder ss dictObjIdent]
+      acsr = Accessor (mkString $ runIdent ident) (Var ss (Qualified Nothing dictObjIdent))
   in ValueDecl sa ident Private []
     [MkUnguarded (
-     TypedValue False (TypeClassDictionaryAccessor className ident) $
+     TypedValue False (Abs (VarBinder ss dictIdent) (Case [Var ss $ Qualified Nothing dictIdent] [CaseAlternative [ctor] [MkUnguarded acsr]])) $
        moveQuantifiersToFront (quantify (srcConstrainedType (srcConstraint className [] (map (srcTypeVar . fst) args) Nothing) ty))
     )]
 typeClassMemberToDictionaryAccessor _ _ _ _ = internalError "Invalid declaration in type class definition"
@@ -351,9 +353,9 @@ typeInstanceDictionaryDeclaration syns kinds sa@(ss, _) name mn deps className t
       let superclasses = superClassDictionaryNames typeClassSuperclasses `zip` superclassesDicts
 
       let props = Literal ss $ ObjectLiteral $ map (first mkString) (members ++ superclasses)
-          dictTy = foldl srcTypeApp (srcTypeConstructor (fmap (coerceProperName . dictSynonymName) className)) tys
+          dictTy = foldl srcTypeApp (srcTypeConstructor (fmap (coerceProperName . dictTypeName) className)) tys
           constrainedTy = quantify (foldr srcConstrainedType dictTy deps)
-          dict = TypeClassDictionaryConstructorApp className props
+          dict = App (Constructor ss (fmap (coerceProperName . dictTypeName) className)) props
           result = ValueDecl sa name Private [] [MkUnguarded (TypedValue True dict constrainedTy)]
       return result
 

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -63,7 +63,7 @@ addDataType moduleName dtype name args dctors ctorKind = do
       qualName = Qualified (Just moduleName) name
       hasSig = qualName `M.member` types env
   putEnv $ env { types = M.insert qualName (ctorKind, DataType dtype args (map (mapDataCtor . fst) dctors)) (types env) }
-  unless (hasSig || not (containsForAll ctorKind)) $ do
+  unless (hasSig || isDictTypeName name || not (containsForAll ctorKind)) $ do
     tell . errorMessage $ MissingKindDeclaration (if dtype == Newtype then NewtypeSig else DataSig) name ctorKind
   for_ dctors $ \(DataConstructorDeclaration _ dctor fields, polyType) ->
     warnAndRethrow (addHint (ErrorInDataConstructor dctor)) $
@@ -111,7 +111,7 @@ addTypeSynonym moduleName name args ty kind = do
   checkTypeSynonyms ty
   let qualName = Qualified (Just moduleName) name
       hasSig = qualName `M.member` types env
-  unless (hasSig || isDictSynonym name || not (containsForAll kind)) $ do
+  unless (hasSig || not (containsForAll kind)) $ do
     tell . errorMessage $ MissingKindDeclaration TypeSynonymSig name kind
   putEnv $ env { types = M.insert qualName (kind, TypeSynonym) (types env)
                , typeSynonyms = M.insert qualName (args, ty) (typeSynonyms env) }

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -385,7 +385,7 @@ entails SolverOptions{..} constraint context hints =
               return (useEmptyDict args)
             mkDictionary (IsSymbolInstance sym) _ =
               let fields = [ ("reflectSymbol", Abs (VarBinder nullSourceSpan UnusedIdent) (Literal nullSourceSpan (StringLiteral sym))) ] in
-              return $ TypeClassDictionaryConstructorApp C.IsSymbol (Literal nullSourceSpan (ObjectLiteral fields))
+              return $ App (Constructor nullSourceSpan (coerceProperName . dictTypeName <$> C.IsSymbol)) (Literal nullSourceSpan (ObjectLiteral fields))
 
             unknownsInAllCoveringSets :: [SourceType] -> S.Set (S.Set Int) -> Bool
             unknownsInAllCoveringSets tyArgs = all (\s -> any (`S.member` s) unkIndices)

--- a/tests/purs/failing/InstanceSigsDifferentTypes.out
+++ b/tests/purs/failing/InstanceSigsDifferentTypes.out
@@ -1,20 +1,20 @@
 Error found:
 in module [33mMain[0m
-at tests/purs/failing/InstanceSigsDifferentTypes.purs:8:1 - 10:12 (line 8, column 1 - line 10, column 12)
+at tests/purs/failing/InstanceSigsDifferentTypes.purs:10:9 - 10:12 (line 10, column 9 - line 10, column 12)
 
   Could not match type
-  [33m     [0m
-  [33m  Int[0m
-  [33m     [0m
-  with type
   [33m        [0m
   [33m  Number[0m
   [33m        [0m
+  with type
+  [33m     [0m
+  [33m  Int[0m
+  [33m     [0m
 
-while checking that type [33mInt[0m
-  is at least as general as type [33mNumber[0m
+while checking that type [33mNumber[0m
+  is at least as general as type [33mInt[0m
 while checking that expression [33m0.0[0m
-  has type [33mNumber[0m
+  has type [33mInt[0m
 in value declaration [33mfooNumber[0m
 
 See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,

--- a/tests/purs/failing/InstanceSigsIncorrectType.out
+++ b/tests/purs/failing/InstanceSigsIncorrectType.out
@@ -11,11 +11,14 @@ at tests/purs/failing/InstanceSigsIncorrectType.purs:8:1 - 10:13 (line 8, column
   [33m  Number[0m
   [33m        [0m
 
-while checking that type [33mBoolean[0m
-  is at least as general as type [33mNumber[0m
-while checking that expression [33mtrue[0m
-  has type [33mNumber[0m
+while trying to match type [33mFoo$Dict t0[0m
+  with type [33mFoo$Dict Number[0m
+while checking that expression [33mFoo$Dict { foo: true[0m
+                               [33m         }          [0m
+  has type [33mFoo$Dict Number[0m
 in value declaration [33mfooNumber[0m
+
+where [33mt0[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/Superclasses1.out
+++ b/tests/purs/failing/Superclasses1.out
@@ -8,9 +8,10 @@ at tests/purs/failing/Superclasses1.purs:12:1 - 13:17 (line 12, column 1 - line 
   [33m                [0m
 
 while checking that expression [33m#dict Su[0m
-  has type [33m{ su :: Number -> Number[0m
-           [33m}                       [0m
+  has type [33mSu$Dict t0[0m
 in value declaration [33mclNumber[0m
+
+where [33mt0[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/Superclasses3.out
+++ b/tests/purs/failing/Superclasses3.out
@@ -13,7 +13,7 @@ while inferring the kind of [33m( "Foo0" :: Record () -> Foo$Dict b[0m
                             [33m)                                  [0m
 while inferring the kind of [33m{ "Foo0" :: Record () -> Foo$Dict b[0m
                             [33m}                                  [0m
-in type synonym [33mBar$Dict[0m
+in type constructor [33mBar$Dict[0m
 
 where [33mt0[0m is an unknown type
 

--- a/tests/purs/failing/Superclasses5.out
+++ b/tests/purs/failing/Superclasses5.out
@@ -10,20 +10,17 @@ at tests/purs/failing/Superclasses5.purs:17:1 - 18:18 (line 17, column 1 - line 
   Alternatively, add a Partial constraint to the type of the enclosing value.
 
 while applying a function [33m$__unused[0m
-  of type [33mPartial => t1 -> t1[0m
+  of type [33mPartial => t0 -> t0[0m
   to argument [33mcase $0 of       [0m
               [33m  [ x ] -> [ su x[0m
               [33m           ]     [0m
-while checking that expression [33m$__unused (case $0 of      [0m
-                               [33m             [ x ] -> [ ...[0m
-                               [33m                      ]    [0m
-                               [33m          )                [0m
-  has type [33mArray a0[0m
+while inferring the type of [33m$__unused (case $0 of      [0m
+                            [33m             [ x ] -> [ ...[0m
+                            [33m                      ]    [0m
+                            [33m          )                [0m
 in value declaration [33msuArray[0m
 
-where [33ma0[0m is a rigid type variable
-        bound at (line 0, column 0 - line 0, column 0)
-      [33mt1[0m is an unknown type
+where [33mt0[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
 or to contribute content related to this error.


### PR DESCRIPTION
Class dictionaries are now represented as newtype wrappers of records.
This drops the awkward TypeClassDictionaryConstructorApp and
TypeClassDictionaryAccessor expressions in favor of regular newtype
constructors and record accessors.

**Description of the change**

This is mostly motivated by an attempt-in-progress at #4086, but I think it stands on its own merits.

Previously: #3567 and #781. I'm tempted to say that this PR closes those, but maybe there are reasons to prefer the data representation over the newtype one I've implemented? I quite like how simple the generated code for the newtype representation is, and how it means that the newtype constructors can be completely erased (with other newtypes, the constructors still have to be exported in case some code references them in a way that isn't an erased application, but with typeclass newtypes that's not possible). But adapting this PR to use data instead of newtype would be easy and would also suffice for my #4086 purposes.

This newly-updated comment describes the details:

https://github.com/purescript/purescript/blob/cd869ebfd5745d2ab2223d8ddce147061dc5aa7b/src/Language/PureScript/Sugar/TypeClasses.hs#L109-L198

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
