### PR TITLE
Prevent hangs on internal errors

### DIFF
--- a/CHANGELOG.d/internal_fix-internal-error-hangs.md
+++ b/CHANGELOG.d/internal_fix-internal-error-hangs.md
@@ -1,0 +1,1 @@
+* Prevent hangs on internal errors


### PR DESCRIPTION
**Description of the change**

Sometimes, when one of our unit tests results in an internal error, the entire test process hangs. This is mildly annoying, and I *think* this PR is the appropriate fix? I have to confess that I don't have as solid an understanding of how `MonadBaseControl` works as I'd like. Also, our whole internal error story is kind of confusing to me—we have `internalError`, but also `internalCompilerError`, and a few instances of `error` scattered about to boot. I don't know if further enabling using the exception-based error functions instead of encouraging more use of the monadic `internalCompilerError` is the right thing to do.

Buuuuuut... this fix is quick and not too disruptive to the status quo, so I'm proposing it!

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
