### PR TITLE
Minor edits to RELEASE_GUIDE.md

### DIFF
--- a/CHANGELOG.d/internal_miscellaneous updates to release guide.md
+++ b/CHANGELOG.d/internal_miscellaneous updates to release guide.md
@@ -1,0 +1,1 @@
+* Miscellaneous updates/clarifications to the release guide

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -88,9 +88,8 @@ considering what effects this may have:
   - If `purescript-cst` has changed at all since the last release:
 
       - The `version` field in `lib/purescript-cst/purescript-cst.cabal` (note
-        that the new version should be based on the PVP, according to what
-        changed since the previous release, and not on the actual compiler
-        version)
+        that the new version should be based on the [PVP](https://pvp.haskell.org/),
+        according to what changed since the previous release, and not on the actual compiler version)
 
       - The versions table in `lib/purescript-cst/README.md`,
 

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -99,6 +99,8 @@ considering what effects this may have:
 - Run `stack update-changelog.hs`, which will move the entries in `CHANGELOG.d`
   to a new section in `CHANGELOG.md` labeled with the new version.
 
+- Submit a PR with the above commits and get it merged.
+
 - Create a release from the releases tab in GitHub and copy in the release
   notes. This will also create a tag, which will kick off a CI build, which
   will upload prebuilt compiler binaries to the release on GitHub when it


### PR DESCRIPTION
**Description of the change**

The guide never reminds us to submit and merge the PR bumping the versions and editing the CHANGELOG.md file before triggering the CI build. I also thought I'd directly link to the PVP specification while I was at it.

This can wait until after v0.14.3 gets released.

---

**Checklist:**

- [x] Added a file in the CHANGELOG.d
