### PR TITLE
Add `--strict` flag to `purs compile`, so that `src/` warnings count as errors

### DIFF
--- a/CHANGELOG.d/feature_promote src warnings to errors.md
+++ b/CHANGELOG.d/feature_promote src warnings to errors.md
@@ -1,0 +1,4 @@
+* Port the `--strict` flag from [`purescript-psa`](https://github.com/natefaubion/purescript-psa) to `purs compile`
+
+  This flag promotes warnings emitted from files in the `src/` directory
+  to errors.

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -64,7 +64,7 @@ promoteSrcWarnings False w e = (w, e)
 promoteSrcWarnings True w e = (P.MultipleErrors nonSrcWarnings, srcWarningsAndErrors)
   where
   srcWarningsAndErrors = case e of
-    Left errors -> Left $ P.MultipleErrors $ srcWarnings <> (P.runMultipleErrors errors)
+    Left errors -> Left $ P.MultipleErrors $ srcWarnings <> P.runMultipleErrors errors
     r@(Right _)
       | null srcWarnings -> r
       | otherwise -> Left $ P.MultipleErrors srcWarnings

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -7,7 +7,9 @@ import           Control.Monad
 import qualified Data.Aeson as A
 import           Data.Bool (bool)
 import qualified Data.ByteString.Lazy.UTF8 as LBU8
-import           Data.List (intercalate)
+import           Data.Maybe (fromMaybe)
+import           Data.List (intercalate, isPrefixOf, partition)
+import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -30,26 +32,54 @@ data PSCMakeOptions = PSCMakeOptions
   , pscmOpts         :: P.Options
   , pscmUsePrefix    :: Bool
   , pscmJSONErrors   :: Bool
+  , pscmStrict       :: Bool
   }
 
--- | Arguments: verbose, use JSON, warnings, errors
-printWarningsAndErrors :: Bool -> Bool -> P.MultipleErrors -> Either P.MultipleErrors a -> IO ()
-printWarningsAndErrors verbose False warnings errors = do
+-- | Arguments: verbose, use JSON, strict, warnings, errors
+printWarningsAndErrors :: Bool -> Bool -> Bool -> P.MultipleErrors -> Either P.MultipleErrors a -> IO ()
+printWarningsAndErrors verbose False strict warnings errors = do
   pwd <- getCurrentDirectory
   cc <- bool Nothing (Just P.defaultCodeColor) <$> ANSI.hSupportsANSI stdout
   let ppeOpts = P.defaultPPEOptions { P.ppeCodeColor = cc, P.ppeFull = verbose, P.ppeRelativeDirectory = pwd }
-  when (P.nonEmpty warnings) $
-    putStrLn (P.prettyPrintMultipleWarnings ppeOpts warnings)
-  case errors of
+      (warnings', errors') = promoteSrcWarnings strict warnings errors
+  when (P.nonEmpty warnings') $
+    putStrLn (P.prettyPrintMultipleWarnings ppeOpts warnings')
+  case errors' of
     Left errs -> do
       putStrLn (P.prettyPrintMultipleErrors ppeOpts errs)
       exitFailure
     Right _ -> return ()
-printWarningsAndErrors verbose True warnings errors = do
+printWarningsAndErrors verbose True strict warnings errors = do
+  let (warnings', errors') = promoteSrcWarnings strict warnings errors
   putStrLn . LBU8.toString . A.encode $
-    JSONResult (toJSONErrors verbose P.Warning warnings)
-               (either (toJSONErrors verbose P.Error) (const []) errors)
-  either (const exitFailure) (const (return ())) errors
+    JSONResult (toJSONErrors verbose P.Warning warnings')
+               (either (toJSONErrors verbose P.Error) (const []) errors')
+  either (const exitFailure) (const (return ())) errors'
+
+-- |
+-- Moves all warnings emitted from files in the `src/` directory
+-- into the errors.
+promoteSrcWarnings :: Bool -> P.MultipleErrors -> Either P.MultipleErrors a -> (P.MultipleErrors, Either P.MultipleErrors a)
+promoteSrcWarnings False w e = (w, e)
+promoteSrcWarnings True w e = (P.MultipleErrors nonSrcWarnings, srcWarningsAndErrors)
+  where
+  srcWarningsAndErrors = case e of
+    Left errors -> Left $ P.MultipleErrors $ srcWarnings <> (P.runMultipleErrors errors)
+    r@(Right _)
+      | null srcWarnings -> r
+      | otherwise -> Left $ P.MultipleErrors srcWarnings
+
+  (srcWarnings, nonSrcWarnings) =
+    partition isSrcWarning $ P.runMultipleErrors w
+
+  isSrcWarning :: P.ErrorMessage -> Bool
+  isSrcWarning warning = fromSourceDir $ fromMaybe "" $ do
+    spans <- P.errorSpan warning
+    pure $ P.spanName $ NEL.head spans
+    where
+    -- account for both POSIX and Windows path separators
+    fromSourceDir fileName =
+      isPrefixOf "src/" fileName || isPrefixOf "src\\" fileName
 
 compile :: PSCMakeOptions -> IO ()
 compile PSCMakeOptions{..} = do
@@ -66,7 +96,7 @@ compile PSCMakeOptions{..} = do
     foreigns <- inferForeignModules filePathMap
     let makeActions = buildMakeActions pscmOutputDir filePathMap foreigns pscmUsePrefix
     P.make makeActions (map snd ms)
-  printWarningsAndErrors (P.optionsVerboseErrors pscmOpts) pscmJSONErrors makeWarnings makeErrors
+  printWarningsAndErrors (P.optionsVerboseErrors pscmOpts) pscmJSONErrors pscmStrict makeWarnings makeErrors
   exitSuccess
 
 warnFileTypeNotFound :: String -> IO ()
@@ -151,12 +181,18 @@ options =
     handleTargets :: [P.CodegenTarget] -> S.Set P.CodegenTarget
     handleTargets ts = S.fromList (if P.JSSourceMap `elem` ts then P.JS : ts else ts)
 
+strictFlag :: Opts.Parser Bool
+strictFlag = Opts.switch $
+     Opts.long "strict"
+  <> Opts.help "Promotes `src/` warnings to errors"
+
 pscMakeOptions :: Opts.Parser PSCMakeOptions
 pscMakeOptions = PSCMakeOptions <$> many inputFile
                                 <*> outputDirectory
                                 <*> options
                                 <*> (not <$> noPrefix)
                                 <*> jsonErrors
+                                <*> strictFlag
 
 command :: Opts.Parser (IO ())
 command = compile <$> (Opts.helper <*> pscMakeOptions)

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -36,7 +36,7 @@ data PSCMakeOptions = PSCMakeOptions
   , pscmLibDirs      :: S.Set T.Text
   }
 
--- | Arguments: verbose, use JSON, strict, warnings, errors
+-- | Arguments: verbose, use JSON, warnings, errors
 printWarningsAndErrors :: Bool -> Bool -> P.MultipleErrors -> Either P.MultipleErrors a -> IO ()
 printWarningsAndErrors verbose False warnings errors = do
   pwd <- getCurrentDirectory


### PR DESCRIPTION
**Description of the change**

Fixes #4153.

How should I write a test for this? `TestCompiler.hs` doesn't call `purs` directly.

Example output:
```bash
$ stack build --fast
...
$ stack exec bash
$ mkdir -p ztest/src
$ cd ztest
$ cat <<EOF > src/Main.purs
module Main where

test :: Int -> String
test triggerUnusedWarning = ""
EOF

$ purs compile --json-errors "src/**/*.purs"
Compiling Main
{"warnings":[{"position":{"startLine":4,"startColumn":6,"endLine":4,"endColumn":26},"message":"  Name triggerUnusedWarning was introduced but not used.\n\nin value declaration test\n","errorCode":"UnusedName","errorLink":"https://github.com/purescript/documentation/blob/master/errors/UnusedName.md","filename":"src/Main.purs","moduleName":"Main","suggestion":null,"allSpans":[{"start":[4,6],"name":"src/Main.purs","end":[4,26]}]}],"errors":[]}

$ rm -rf output/
$ purs compile --json-errors --strict "src/**/*.purs"
Compiling Main
{"warnings":[],"errors":[{"position":{"startLine":4,"startColumn":6,"endLine":4,"endColumn":26},"message":"  Name triggerUnusedWarning was introduced but not used.\n\nin value declaration test\n","errorCode":"UnusedName","errorLink":"https://github.com/purescript/documentation/blob/master/errors/UnusedName.md","filename":"src/Main.purs","moduleName":"Main","suggestion":null,"allSpans":[{"start":[4,6],"name":"src/Main.purs","end":[4,26]}]}]}
```

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Added a test for the contribution (if applicable)
