### PR TITLE
Check role declarations arity during type checking

### DIFF
--- a/CHANGELOG.d/fix_check-role-declarations-arity-during-typechecking.md
+++ b/CHANGELOG.d/fix_check-role-declarations-arity-during-typechecking.md
@@ -1,0 +1,1 @@
+* Check role declarations arity during type checking

--- a/lib/purescript-cst/src/Language/PureScript/AST/Declarations.hs
+++ b/lib/purescript-cst/src/Language/PureScript/AST/Declarations.hs
@@ -96,6 +96,7 @@ data HintCategory
   | CheckHint
   | PositionHint
   | SolverHint
+  | DeclarationHint
   | OtherHint
   deriving (Show, Eq)
 

--- a/lib/purescript-cst/src/Language/PureScript/Environment.hs
+++ b/lib/purescript-cst/src/Language/PureScript/Environment.hs
@@ -35,11 +35,6 @@ data Environment = Environment
   , dataConstructors :: M.Map (Qualified (ProperName 'ConstructorName)) (DataDeclType, ProperName 'TypeName, SourceType, [Ident])
   -- ^ Data constructors currently in scope, along with their associated type
   -- constructor name, argument types and return type.
-  , roleDeclarations :: M.Map (Qualified (ProperName 'TypeName)) (SourceSpan, [Role])
-  -- ^ Explicit role declarations currently in scope. Note that this field is
-  -- only used to store declared roles temporarily until they can be checked;
-  -- to find a type's real checked and/or inferred roles, refer to the TypeKind
-  -- in the `types` field.
   , typeSynonyms :: M.Map (Qualified (ProperName 'TypeName)) ([(Text, Maybe SourceType)], SourceType)
   -- ^ Type synonyms currently in scope
   , typeClassDictionaries :: M.Map (Maybe ModuleName) (M.Map (Qualified (ProperName 'ClassName)) (M.Map (Qualified Ident) (NEL.NonEmpty NamedDict)))
@@ -103,7 +98,7 @@ instance A.ToJSON FunctionalDependency where
 
 -- | The initial environment with no values and only the default javascript types defined
 initEnvironment :: Environment
-initEnvironment = Environment M.empty allPrimTypes M.empty M.empty M.empty M.empty allPrimClasses
+initEnvironment = Environment M.empty allPrimTypes M.empty M.empty M.empty allPrimClasses
 
 -- | A constructor for TypeClassData that computes which type class arguments are fully determined
 -- and argument covering sets.

--- a/lib/purescript-cst/src/Language/PureScript/Environment.hs
+++ b/lib/purescript-cst/src/Language/PureScript/Environment.hs
@@ -35,7 +35,7 @@ data Environment = Environment
   , dataConstructors :: M.Map (Qualified (ProperName 'ConstructorName)) (DataDeclType, ProperName 'TypeName, SourceType, [Ident])
   -- ^ Data constructors currently in scope, along with their associated type
   -- constructor name, argument types and return type.
-  , roleDeclarations :: M.Map (Qualified (ProperName 'TypeName)) [Role]
+  , roleDeclarations :: M.Map (Qualified (ProperName 'TypeName)) (SourceSpan, [Role])
   -- ^ Explicit role declarations currently in scope. Note that this field is
   -- only used to store declared roles temporarily until they can be checked;
   -- to find a type's real checked and/or inferred roles, refer to the TypeKind

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -1638,6 +1638,10 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       where
       isSolverHint ErrorSolvingConstraint{} = True
       isSolverHint _ = False
+    stripRedundantHints RoleDeclarationArityMismatch{} = filter (not . isTyConHint)
+      where
+      isTyConHint ErrorInTypeConstructor{} = True
+      isTyConHint _ = False
     stripRedundantHints _ = id
 
     stripFirst :: (ErrorMessageHint -> Bool) -> [ErrorMessageHint] -> [ErrorMessageHint]

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -1638,10 +1638,6 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       where
       isSolverHint ErrorSolvingConstraint{} = True
       isSolverHint _ = False
-    stripRedundantHints RoleDeclarationArityMismatch{} = filter (not . isTyConHint)
-      where
-      isTyConHint ErrorInTypeConstructor{} = True
-      isTyConHint _ = False
     stripRedundantHints _ = id
 
     stripFirst :: (ErrorMessageHint -> Bool) -> [ErrorMessageHint] -> [ErrorMessageHint]

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -1658,6 +1658,17 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
   hintCategory ErrorCheckingKind{}                  = CheckHint
   hintCategory ErrorSolvingConstraint{}             = SolverHint
   hintCategory PositionedError{}                    = PositionHint
+  hintCategory ErrorInDataConstructor{}             = DeclarationHint
+  hintCategory ErrorInTypeConstructor{}             = DeclarationHint
+  hintCategory ErrorInBindingGroup{}                = DeclarationHint
+  hintCategory ErrorInDataBindingGroup{}            = DeclarationHint
+  hintCategory ErrorInTypeSynonym{}                 = DeclarationHint
+  hintCategory ErrorInValueDeclaration{}            = DeclarationHint
+  hintCategory ErrorInTypeDeclaration{}             = DeclarationHint
+  hintCategory ErrorInTypeClassDeclaration{}        = DeclarationHint
+  hintCategory ErrorInKindDeclaration{}             = DeclarationHint
+  hintCategory ErrorInRoleDeclaration{}             = DeclarationHint
+  hintCategory ErrorInForeignImport{}               = DeclarationHint
   hintCategory _                                    = OtherHint
 
   prettyPrintPlainIdent :: Ident -> Text

--- a/src/Language/PureScript/Sugar/TypeDeclarations.hs
+++ b/src/Language/PureScript/Sugar/TypeDeclarations.hs
@@ -81,7 +81,6 @@ desugarTypeDeclarationsModule (Module modSS coms name ds exps) =
   checkRoleDeclarations (Just d) (rd@(RoleDeclaration RoleDeclarationData{..}) : rest) = do
     unless (matchesDeclaration d) . throwError . errorMessage' (fst rdeclSourceAnn) $ OrphanRoleDeclaration rdeclIdent
     unless (isSupported d) . throwError . errorMessage' (fst rdeclSourceAnn) $ UnsupportedRoleDeclaration
-    checkRoleDeclarationArity d
     checkRoleDeclarations (Just rd) rest
     where
     isSupported :: Declaration -> Bool
@@ -94,17 +93,5 @@ desugarTypeDeclarationsModule (Module modSS coms name ds exps) =
     matchesDeclaration (TypeSynonymDeclaration _ name' _ _) = rdeclIdent == name'
     matchesDeclaration (TypeClassDeclaration _ name' _ _ _ _) = rdeclIdent == coerceProperName name'
     matchesDeclaration _ = False
-    checkRoleDeclarationArity :: Declaration -> m ()
-    checkRoleDeclarationArity (DataDeclaration _ _ _ args _) =
-      throwRoleDeclarationArityMismatch $ length args
-    checkRoleDeclarationArity (ExternDataDeclaration _ _ kind) =
-      throwRoleDeclarationArityMismatch $ kindArity kind
-    checkRoleDeclarationArity _ = return ()
-    throwRoleDeclarationArityMismatch :: Int -> m ()
-    throwRoleDeclarationArityMismatch expected = do
-      let actual = length rdeclRoles
-      unless (expected == actual) $
-        throwError . errorMessage' (fst rdeclSourceAnn) $
-          RoleDeclarationArityMismatch rdeclIdent expected actual
   checkRoleDeclarations _ (d : rest) = checkRoleDeclarations (Just d) rest
   checkRoleDeclarations _ [] = return ()

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -84,20 +84,25 @@ addDataConstructor moduleName dtype name dctor dctorArgs polyType = do
   checkTypeSynonyms polyType
   putEnv $ env { dataConstructors = M.insert (Qualified (Just moduleName) dctor) (dtype, name, polyType, fields) (dataConstructors env) }
 
--- | Add an explicit role declaration to the Environment. The idea is that we
--- do this before encountering the data type which it refers to; we don't check
--- that the role declaration is valid until we encounter the data type's own
--- declaration.
-addExplicitRoleDeclaration
-  :: (MonadState CheckState m, MonadError MultipleErrors m)
+checkRoleDeclaration
+  :: (MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
   => ModuleName
-  -> SourceSpan
-  -> ProperName 'TypeName
-  -> [Role]
+  -> RoleDeclarationData
   -> m ()
-addExplicitRoleDeclaration moduleName ss name roles = do
-  env <- getEnv
-  putEnv $ env { roleDeclarations = M.insert (Qualified (Just moduleName) name) (ss, roles) (roleDeclarations env) }
+checkRoleDeclaration moduleName (RoleDeclarationData (ss, _) name declaredRoles) = do
+  warnAndRethrow (addHint (ErrorInRoleDeclaration name) . addHint (positionedError ss)) $ do
+    env <- getEnv
+    let qualName = Qualified (Just moduleName) name
+    case M.lookup qualName (types env) of
+      Just (kind, DataType dtype args dctors) -> do
+        checkRoleDeclarationArity name declaredRoles (length args)
+        checkRoles args declaredRoles
+        let args' = zipWith (\(v, k, _) r -> (v, k, r)) args declaredRoles
+        putEnv $ env { types = M.insert qualName (kind, DataType dtype args' dctors) (types env) }
+      Just (kind, ExternData _) -> do
+        checkRoleDeclarationArity name declaredRoles (kindArity kind)
+        putEnv $ env { types = M.insert qualName (kind, ExternData declaredRoles) (types env) }
+      _ -> internalError "Unsupported role declaration"
 
 addTypeSynonym
   :: (MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
@@ -283,14 +288,14 @@ typeCheckAll moduleName _ = traverse go
       let args' = args `withKinds` ctorKind
       env <- getEnv
       dctors' <- traverse (replaceTypeSynonymsInDataConstructor . fst) dataCtors
-      roles <- checkRoles env moduleName name args' dctors'
-      let args'' = args' `withRoles` roles
+      let args'' = args' `withRoles` inferRoles env moduleName name args' dctors'
       addDataType moduleName dtype name args'' dataCtors ctorKind
     return $ DataDeclaration sa dtype name args dctors
   go d@(DataBindingGroupDeclaration tys) = do
     let tysList = NEL.toList tys
         syns = mapMaybe toTypeSynonym tysList
         dataDecls = mapMaybe toDataDecl tysList
+        roleDecls = mapMaybe toRoleDecl tysList
         clss = mapMaybe toClassDecl tysList
         bindingGroupNames = ordNub ((syns^..traverse._2) ++ (dataDecls^..traverse._2._2) ++ fmap coerceProperName (clss^..traverse._2._2))
         sss = fmap declSourceSpan tys
@@ -303,15 +308,15 @@ typeCheckAll moduleName _ = traverse go
         addTypeSynonym moduleName name args' elabTy kind
       let dataDeclsWithKinds = zipWith (\(dtype, (_, name, args, _)) (dataCtors, ctorKind) ->
             (dtype, name, args `withKinds` ctorKind, dataCtors, ctorKind)) dataDecls data_ks
-      checkRoles' <- fmap (checkDataBindingGroupRoles env moduleName) .
+      inferRoles' <- fmap (inferDataBindingGroupRoles env moduleName roleDecls) .
         forM dataDeclsWithKinds $ \(_, name, args, dataCtors, _) ->
           (name, args,) <$> traverse (replaceTypeSynonymsInDataConstructor . fst) dataCtors
       for_ dataDeclsWithKinds $ \(dtype, name, args', dataCtors, ctorKind) -> do
         when (dtype == Newtype) $ checkNewtype name (map fst dataCtors)
         checkDuplicateTypeArguments $ map fst args'
-        roles <- checkRoles' name args'
-        let args'' = args' `withRoles` roles
+        let args'' = args' `withRoles` inferRoles' name args'
         addDataType moduleName dtype name args'' dataCtors ctorKind
+      for_ roleDecls $ checkRoleDeclaration moduleName
       for_ (zip clss cls_ks) $ \((deps, (sa, pn, _, _, _)), (args', implies', tys', kind)) -> do
         let qualifiedClassName = Qualified (Just moduleName) pn
         guardWith (errorMessage (DuplicateTypeClass pn (fst sa))) $
@@ -323,6 +328,8 @@ typeCheckAll moduleName _ = traverse go
     toTypeSynonym _ = Nothing
     toDataDecl (DataDeclaration sa dtype nm args dctors) = Just (dtype, (sa, nm, args, dctors))
     toDataDecl _ = Nothing
+    toRoleDecl (RoleDeclaration rdd) = Just rdd
+    toRoleDecl _ = Nothing
     toClassDecl (TypeClassDeclaration sa nm args implies deps decls) = Just (deps, (sa, nm, args, implies, decls))
     toClassDecl _ = Nothing
   go (TypeSynonymDeclaration sa@(ss, _) name args ty) = do
@@ -338,8 +345,8 @@ typeCheckAll moduleName _ = traverse go
       env <- getEnv
       putEnv $ env { types = M.insert (Qualified (Just moduleName) name) (elabTy, LocalTypeVariable) (types env) }
       return $ KindDeclaration sa kindFor name elabTy
-  go d@(RoleDeclaration (RoleDeclarationData (ss, _) name roles)) = do
-    addExplicitRoleDeclaration moduleName ss name roles
+  go d@(RoleDeclaration rdd) = do
+    checkRoleDeclaration moduleName rdd
     return d
   go TypeDeclaration{} =
     internalError "Type declarations should have been removed before typeCheckAlld"
@@ -374,10 +381,7 @@ typeCheckAll moduleName _ = traverse go
     elabKind <- withFreshSubstitution $ checkKindDeclaration moduleName kind
     env <- getEnv
     let qualName = Qualified (Just moduleName) name
-    -- If there's an explicit role declaration, check only its arity
-    let declaredRoles = M.lookup qualName (roleDeclarations env)
-    for_ declaredRoles $ \(ss, roles) -> checkRoleDeclarationArity ss name roles (kindArity elabKind)
-    let roles = maybe (nominalRolesForKind elabKind) snd declaredRoles
+        roles = nominalRolesForKind elabKind
     putEnv $ env { types = M.insert qualName (elabKind, ExternData roles) (types env) }
     return d
   go d@(ExternDeclaration (ss, _) name ty) = do

--- a/src/Language/PureScript/TypeChecker/Roles.hs
+++ b/src/Language/PureScript/TypeChecker/Roles.hs
@@ -6,13 +6,15 @@
 module Language.PureScript.TypeChecker.Roles
   ( lookupRoles
   , checkRoles
-  , checkDataBindingGroupRoles
   , checkRoleDeclarationArity
+  , inferRoles
+  , inferDataBindingGroupRoles
   ) where
 
 import Prelude.Compat
 
-import Control.Monad (unless)
+import Control.Arrow ((&&&))
+import Control.Monad (unless, when, zipWithM_)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State (MonadState(..), runState, state)
 import Data.Coerce (coerce)
@@ -82,18 +84,42 @@ lookupRoles
 lookupRoles env tyName =
   fromMaybe [] $ M.lookup tyName (types env) >>= typeKindRoles . snd
 
--- | This function does the following:
---
--- * Infers roles for the given data type declaration
---
--- * Compares the inferred roles to the explicitly declared roles (if any) and
---   ensures that the explicitly declared roles are not more permissive than
---   the inferred ones
+-- |
+-- Compares the inferred roles to the explicitly declared roles and ensures
+-- that the explicitly declared roles are not more permissive than the
+-- inferred ones.
 --
 checkRoles
   :: forall m
    . (MonadError MultipleErrors m)
-  => Environment
+  => [(Text, Maybe SourceType, Role)]
+    -- ^ type parameters for the data type whose roles we are checking
+  -> [Role]
+    -- ^ roles declared for the data type
+  -> m ()
+checkRoles tyArgs declaredRoles = do
+  let k (var, _, inf) dec =
+        when (inf < dec) . throwError . errorMessage $ RoleMismatch var inf dec
+  zipWithM_ k tyArgs declaredRoles
+
+checkRoleDeclarationArity
+  :: forall m
+   . (MonadError MultipleErrors m)
+  => ProperName 'TypeName
+  -> [Role]
+  -> Int
+  -> m ()
+checkRoleDeclarationArity tyName roles expected = do
+  let actual = length roles
+  unless (expected == actual) $
+    throwError . errorMessage $
+      RoleDeclarationArityMismatch tyName expected actual
+
+-- |
+-- Infers roles for the given data type declaration.
+--
+inferRoles
+  :: Environment
   -> ModuleName
   -> ProperName 'TypeName
     -- ^ The name of the data type whose roles we are checking
@@ -101,9 +127,27 @@ checkRoles
     -- ^ type parameters for the data type whose roles we are checking
   -> [DataConstructorDeclaration]
     -- ^ constructors of the data type whose roles we are checking
-  -> m [Role]
-checkRoles env moduleName tyName tyArgs ctors =
-  checkDataBindingGroupRoles env moduleName [(tyName, tyArgs, ctors)] tyName tyArgs
+  -> [Role]
+inferRoles env moduleName tyName tyArgs ctors =
+  inferDataBindingGroupRoles env moduleName [] [(tyName, tyArgs, ctors)] tyName tyArgs
+
+inferDataBindingGroupRoles
+  :: Environment
+  -> ModuleName
+  -> [RoleDeclarationData]
+  -> [DataDeclaration]
+  -> ProperName 'TypeName
+  -> [(Text, Maybe SourceType)]
+  -> [Role]
+inferDataBindingGroupRoles env moduleName roleDeclarations group =
+  let declaredRoleEnv = M.fromList $ map (Qualified (Just moduleName) . rdeclIdent &&& rdeclRoles) roleDeclarations
+      inferredRoleEnv = getRoleEnv env
+      initialRoleEnv = declaredRoleEnv `M.union` inferredRoleEnv
+      inferredRoleEnv' = inferDataBindingGroupRoles' moduleName group initialRoleEnv
+  in \tyName tyArgs ->
+        let qualTyName = Qualified (Just moduleName) tyName
+            inferredRoles = M.lookup qualTyName inferredRoleEnv'
+        in fromMaybe (Phantom <$ tyArgs) inferredRoles
 
 type DataDeclaration =
   ( ProperName 'TypeName
@@ -111,66 +155,16 @@ type DataDeclaration =
   , [DataConstructorDeclaration]
   )
 
-checkDataBindingGroupRoles
-  :: forall m
-   . (MonadError MultipleErrors m)
-  => Environment
-  -> ModuleName
-  -> [DataDeclaration]
-  -> ProperName 'TypeName
-  -> [(Text, Maybe SourceType)]
-  -> m [Role]
-checkDataBindingGroupRoles env moduleName group =
-  let initialRoleEnv = M.union (snd <$> roleDeclarations env) (getRoleEnv env)
-      inferredRoleEnv = inferDataBindingGroupRoles moduleName group initialRoleEnv
-  in \tyName tyArgs -> do
-    let qualTyName = Qualified (Just moduleName) tyName
-        inferredRoles = M.lookup qualTyName inferredRoleEnv
-    case M.lookup qualTyName (roleDeclarations env) of
-      Just (ss, declaredRoles) -> do
-        checkRoleDeclarationArity ss tyName declaredRoles (length tyArgs)
-        let
-          k (var, _) inf dec =
-            if inf < dec
-              then throwErrorInRoleDeclaration tyName . errorMessage $ RoleMismatch var inf dec
-              else pure dec
-        sequence $ zipWith3 k tyArgs (fromMaybe (repeat Phantom) inferredRoles) declaredRoles
-      Nothing ->
-        pure $ fromMaybe (Phantom <$ tyArgs) inferredRoles
-
-checkRoleDeclarationArity
-  :: forall m
-   . (MonadError MultipleErrors m)
-  => SourceSpan
-  -> ProperName 'TypeName
-  -> [Role]
-  -> Int
-  -> m ()
-checkRoleDeclarationArity ss tyName roles expected = do
-  let actual = length roles
-  unless (expected == actual) $
-    throwErrorInRoleDeclaration tyName . errorMessage' ss $
-      RoleDeclarationArityMismatch tyName expected actual
-
-throwErrorInRoleDeclaration
-  :: forall m a
-   . (MonadError MultipleErrors m)
-  => ProperName 'TypeName
-  -> MultipleErrors
-  -> m a
-throwErrorInRoleDeclaration tyName =
-  throwError . addHint (ErrorInRoleDeclaration tyName)
-
-inferDataBindingGroupRoles
+inferDataBindingGroupRoles'
   :: ModuleName
   -> [DataDeclaration]
   -> RoleEnv
   -> RoleEnv
-inferDataBindingGroupRoles moduleName group roleEnv =
+inferDataBindingGroupRoles' moduleName group roleEnv =
   let (Any didRolesChange, roleEnv') = flip runState roleEnv $
         mconcat <$> traverse (state . inferDataDeclarationRoles moduleName) group
   in if didRolesChange
-     then inferDataBindingGroupRoles moduleName group roleEnv'
+     then inferDataBindingGroupRoles' moduleName group roleEnv'
      else roleEnv'
 
 -- |

--- a/tests/purs/failing/CoercibleRoleMismatch1.out
+++ b/tests/purs/failing/CoercibleRoleMismatch1.out
@@ -8,7 +8,6 @@ at tests/purs/failing/CoercibleRoleMismatch1.purs:6:1 - 6:27 (line 6, column 1 -
 
 
 in role declaration for [33mIdentity[0m
-in data binding group Identity
 
 See https://github.com/purescript/documentation/blob/master/errors/RoleMismatch.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/CoercibleRoleMismatch1.out
+++ b/tests/purs/failing/CoercibleRoleMismatch1.out
@@ -1,6 +1,6 @@
 Error found:
 in module [33mMain[0m
-at tests/purs/failing/CoercibleRoleMismatch1.purs:4:1 - 4:29 (line 4, column 1 - line 4, column 29)
+at tests/purs/failing/CoercibleRoleMismatch1.purs:6:1 - 6:27 (line 6, column 1 - line 6, column 27)
 
   Role mismatch for the type parameter [33ma[0m:
 
@@ -8,7 +8,7 @@ at tests/purs/failing/CoercibleRoleMismatch1.purs:4:1 - 4:29 (line 4, column 1 -
 
 
 in role declaration for [33mIdentity[0m
-in type constructor [33mIdentity[0m
+in data binding group Identity
 
 See https://github.com/purescript/documentation/blob/master/errors/RoleMismatch.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/CoercibleRoleMismatch2.out
+++ b/tests/purs/failing/CoercibleRoleMismatch2.out
@@ -1,6 +1,6 @@
 Error found:
 in module [33mMain[0m
-at tests/purs/failing/CoercibleRoleMismatch2.purs:8:1 - 8:23 (line 8, column 1 - line 8, column 23)
+at tests/purs/failing/CoercibleRoleMismatch2.purs:10:1 - 10:20 (line 10, column 1 - line 10, column 20)
 
   Role mismatch for the type parameter [33ma[0m:
 
@@ -8,7 +8,7 @@ at tests/purs/failing/CoercibleRoleMismatch2.purs:8:1 - 8:23 (line 8, column 1 -
 
 
 in role declaration for [33mV[0m
-in type constructor [33mV[0m
+in data binding group V
 
 See https://github.com/purescript/documentation/blob/master/errors/RoleMismatch.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/CoercibleRoleMismatch2.out
+++ b/tests/purs/failing/CoercibleRoleMismatch2.out
@@ -8,7 +8,6 @@ at tests/purs/failing/CoercibleRoleMismatch2.purs:10:1 - 10:20 (line 10, column 
 
 
 in role declaration for [33mV[0m
-in data binding group V
 
 See https://github.com/purescript/documentation/blob/master/errors/RoleMismatch.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/CoercibleRoleMismatch3.out
+++ b/tests/purs/failing/CoercibleRoleMismatch3.out
@@ -1,6 +1,6 @@
 Error found:
 in module [33mMain[0m
-at tests/purs/failing/CoercibleRoleMismatch3.purs:8:1 - 8:23 (line 8, column 1 - line 8, column 23)
+at tests/purs/failing/CoercibleRoleMismatch3.purs:10:1 - 10:29 (line 10, column 1 - line 10, column 29)
 
   Role mismatch for the type parameter [33ma[0m:
 
@@ -8,7 +8,7 @@ at tests/purs/failing/CoercibleRoleMismatch3.purs:8:1 - 8:23 (line 8, column 1 -
 
 
 in role declaration for [33mU[0m
-in type constructor [33mU[0m
+in data binding group U
 
 See https://github.com/purescript/documentation/blob/master/errors/RoleMismatch.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/CoercibleRoleMismatch3.out
+++ b/tests/purs/failing/CoercibleRoleMismatch3.out
@@ -8,7 +8,6 @@ at tests/purs/failing/CoercibleRoleMismatch3.purs:10:1 - 10:29 (line 10, column 
 
 
 in role declaration for [33mU[0m
-in data binding group U
 
 See https://github.com/purescript/documentation/blob/master/errors/RoleMismatch.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/CoercibleRoleMismatch4.out
+++ b/tests/purs/failing/CoercibleRoleMismatch4.out
@@ -1,6 +1,6 @@
 Error found:
 in module [33mMain[0m
-at tests/purs/failing/CoercibleRoleMismatch4.purs:4:1 - 4:19 (line 4, column 1 - line 4, column 19)
+at tests/purs/failing/CoercibleRoleMismatch4.purs:5:1 - 5:29 (line 5, column 1 - line 5, column 29)
 
   Role mismatch for the type parameter [33ma[0m:
 

--- a/tests/purs/failing/CoercibleRoleMismatch4.out
+++ b/tests/purs/failing/CoercibleRoleMismatch4.out
@@ -8,7 +8,6 @@ at tests/purs/failing/CoercibleRoleMismatch4.purs:5:1 - 5:29 (line 5, column 1 -
 
 
 in role declaration for [33mF[0m
-in data binding group F, G
 
 See https://github.com/purescript/documentation/blob/master/errors/RoleMismatch.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/CoercibleRoleMismatch5.out
+++ b/tests/purs/failing/CoercibleRoleMismatch5.out
@@ -8,7 +8,6 @@ at tests/purs/failing/CoercibleRoleMismatch5.purs:5:1 - 5:20 (line 5, column 1 -
 
 
 in role declaration for [33mF[0m
-in data binding group F, G
 
 See https://github.com/purescript/documentation/blob/master/errors/RoleMismatch.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/CoercibleRoleMismatch5.out
+++ b/tests/purs/failing/CoercibleRoleMismatch5.out
@@ -1,6 +1,6 @@
 Error found:
 in module [33mMain[0m
-at tests/purs/failing/CoercibleRoleMismatch5.purs:4:1 - 4:21 (line 4, column 1 - line 4, column 21)
+at tests/purs/failing/CoercibleRoleMismatch5.purs:5:1 - 5:20 (line 5, column 1 - line 5, column 20)
 
   Role mismatch for the type parameter [33ma[0m:
 

--- a/tests/purs/failing/RoleDeclarationArityMismatch.out
+++ b/tests/purs/failing/RoleDeclarationArityMismatch.out
@@ -5,7 +5,6 @@ at tests/purs/failing/RoleDeclarationArityMismatch.purs:5:1 - 5:20 (line 5, colu
   The type [33mA[0m expects 0 arguments but its role declaration lists 1 role.
 
 in role declaration for [33mA[0m
-in data binding group A
 
 See https://github.com/purescript/documentation/blob/master/errors/RoleDeclarationArityMismatch.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/RoleDeclarationArityMismatch.out
+++ b/tests/purs/failing/RoleDeclarationArityMismatch.out
@@ -5,6 +5,7 @@ at tests/purs/failing/RoleDeclarationArityMismatch.purs:5:1 - 5:20 (line 5, colu
   The type [33mA[0m expects 0 arguments but its role declaration lists 1 role.
 
 in role declaration for [33mA[0m
+in data binding group A
 
 See https://github.com/purescript/documentation/blob/master/errors/RoleDeclarationArityMismatch.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/RoleDeclarationArityMismatchForeign.out
+++ b/tests/purs/failing/RoleDeclarationArityMismatchForeign.out
@@ -4,6 +4,7 @@ at tests/purs/failing/RoleDeclarationArityMismatchForeign.purs:5:1 - 5:20 (line 
 
   The type [33mA[0m expects 0 arguments but its role declaration lists 1 role.
 
+in role declaration for [33mA[0m
 
 See https://github.com/purescript/documentation/blob/master/errors/RoleDeclarationArityMismatch.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/RoleDeclarationArityMismatchForeign2.out
+++ b/tests/purs/failing/RoleDeclarationArityMismatchForeign2.out
@@ -1,8 +1,8 @@
 Error found:
 in module [33mMain[0m
-at tests/purs/failing/RoleDeclarationArityMismatch.purs:5:1 - 5:20 (line 5, column 1 - line 5, column 20)
+at tests/purs/failing/RoleDeclarationArityMismatchForeign2.purs:5:1 - 5:20 (line 5, column 1 - line 5, column 20)
 
-  The type [33mA[0m expects 0 arguments but its role declaration lists 1 role.
+  The type [33mA[0m expects 2 arguments but its role declaration lists only 1 role.
 
 in role declaration for [33mA[0m
 

--- a/tests/purs/failing/RoleDeclarationArityMismatchForeign2.purs
+++ b/tests/purs/failing/RoleDeclarationArityMismatchForeign2.purs
@@ -1,0 +1,5 @@
+-- @shouldFailWith RoleDeclarationArityMismatch
+module Main where
+
+foreign import data A :: Type -> (Type -> Type)
+type role A nominal

--- a/tests/purs/failing/RoleDeclarationArityMismatchForeign3.out
+++ b/tests/purs/failing/RoleDeclarationArityMismatchForeign3.out
@@ -1,8 +1,8 @@
 Error found:
 in module [33mMain[0m
-at tests/purs/failing/RoleDeclarationArityMismatch.purs:5:1 - 5:20 (line 5, column 1 - line 5, column 20)
+at tests/purs/failing/RoleDeclarationArityMismatchForeign3.purs:5:1 - 5:20 (line 5, column 1 - line 5, column 20)
 
-  The type [33mA[0m expects 0 arguments but its role declaration lists 1 role.
+  The type [33mA[0m expects 2 arguments but its role declaration lists only 1 role.
 
 in role declaration for [33mA[0m
 

--- a/tests/purs/failing/RoleDeclarationArityMismatchForeign3.purs
+++ b/tests/purs/failing/RoleDeclarationArityMismatchForeign3.purs
@@ -1,0 +1,5 @@
+-- @shouldFailWith RoleDeclarationArityMismatch
+module Main where
+
+foreign import data A :: (Type -> Type -> Type)
+type role A nominal

--- a/tests/purs/failing/RoleDeclarationArityMismatchForeign4.out
+++ b/tests/purs/failing/RoleDeclarationArityMismatchForeign4.out
@@ -1,8 +1,8 @@
 Error found:
 in module [33mMain[0m
-at tests/purs/failing/RoleDeclarationArityMismatch.purs:5:1 - 5:20 (line 5, column 1 - line 5, column 20)
+at tests/purs/failing/RoleDeclarationArityMismatchForeign4.purs:7:1 - 7:20 (line 7, column 1 - line 7, column 20)
 
-  The type [33mA[0m expects 0 arguments but its role declaration lists 1 role.
+  The type [33mA[0m expects 2 arguments but its role declaration lists only 1 role.
 
 in role declaration for [33mA[0m
 

--- a/tests/purs/failing/RoleDeclarationArityMismatchForeign4.purs
+++ b/tests/purs/failing/RoleDeclarationArityMismatchForeign4.purs
@@ -1,0 +1,7 @@
+-- @shouldFailWith RoleDeclarationArityMismatch
+module Main where
+
+type To = Function
+
+foreign import data A :: To Type (To Type Type)
+type role A nominal

--- a/tests/purs/warning/2140.out
+++ b/tests/purs/warning/2140.out
@@ -5,7 +5,6 @@ at tests/purs/warning/2140.purs:5:3 - 5:36 (line 5, column 3 - line 5, column 36
   Type variable [33ma[0m was shadowed.
 
 in type declaration for [33mf[0m
-in type class declaration for [33mTest[0m
 
 See https://github.com/purescript/documentation/blob/master/errors/ShadowedTypeVar.md for more information,
 or to contribute content related to this warning.


### PR DESCRIPTION
**Description of the change**

As Jordan noticed in https://github.com/purescript/purescript/pull/4121#discussion_r667256491 we incorrectly infer the arity of foreign data types whose kind contains parens (and type synonyms) while checking their role declaration arity. We ought to check role declarations arity during type checking, so that parens and type synonyms are desugared away.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] ~Added myself to CONTRIBUTORS.md (if this is my first contribution)~
- [x] ~Linked any existing issues or proposals that this pull request should close~
- [x] ~Updated or added relevant documentation~
- [x] Added a test for the contribution (if applicable)
