### PR TITLE
Improve row type error messages

### DIFF
--- a/CHANGELOG.d/fix_3701.md
+++ b/CHANGELOG.d/fix_3701.md
@@ -1,0 +1,4 @@
+* Improve row type error messages
+  * Remove a redundant hint that repeats the types in the error
+  * Correctly diff rows containing duplicate items
+  * Erase kind applications from rows in errors (by default)

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -175,8 +175,7 @@ unifyRows r1 r2 = sequence_ matches *> uncurry unifyTails rest where
     solveType u1 (rowFromList (sd2, rest'))
     solveType u2 (rowFromList (sd1, rest'))
   unifyTails _ _ =
-    withErrorMessageHint (ErrorUnifyingTypes r1 r2) $
-      throwError . errorMessage $ TypesDoNotUnify r1 r2
+    throwError . errorMessage $ TypesDoNotUnify r1 r2
 
 -- |
 -- Replace type wildcards with unknowns

--- a/tests/purs/failing/3701.out
+++ b/tests/purs/failing/3701.out
@@ -1,0 +1,64 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/3701.purs:39:8 - 39:34 (line 39, column 8 - line 39, column 34)
+
+  Could not match type
+  [33m         [0m
+  [33m  ( ... )[0m
+  [33m         [0m
+  with type
+  [33m                    [0m
+  [33m  ( thing1 :: String[0m
+  [33m  ...               [0m
+  [33m  )                 [0m
+  [33m                    [0m
+
+while solving type class constraint
+[33m                                 [0m
+[33m  Prim.Row.Nub ( thing1 :: String[0m
+[33m               , thing1 :: String[0m
+[33m               , thing2 :: Int   [0m
+[33m               )                 [0m
+[33m               ( thing1 :: String[0m
+[33m               , thing1 :: String[0m
+[33m               , thing2 :: Int   [0m
+[33m               )                 [0m
+[33m                                 [0m
+while applying a function [33mfooMerge[0m
+  of type [33mUnion @Type t0               [0m
+          [33m  ( thing1 :: String         [0m
+          [33m  , thing2 :: Int            [0m
+          [33m  )                          [0m
+          [33m  ( thing1 :: String         [0m
+          [33m  , thing2 :: Int            [0m
+          [33m  | t0                       [0m
+          [33m  )                          [0m
+          [33m => Nub @Type                [0m
+          [33m      ( thing1 :: String     [0m
+          [33m      , thing2 :: Int        [0m
+          [33m      | t0                   [0m
+          [33m      )                      [0m
+          [33m      ( thing1 :: String     [0m
+          [33m      , thing2 :: Int        [0m
+          [33m      | t0                   [0m
+          [33m      )                      [0m
+          [33m     => Record t0            [0m
+          [33m        -> { thing1 :: String[0m
+          [33m           , thing2 :: Int   [0m
+          [33m           | t0              [0m
+          [33m           }                 [0m
+  to argument [33m{ thing1: "foo"[0m
+              [33m}              [0m
+while checking that expression [33mfooMerge { thing1: "foo"[0m
+                               [33m         }              [0m
+  has type [33m{ thing1 :: String[0m
+           [33m, thing1 :: String[0m
+           [33m, thing2 :: Int   [0m
+           [33m}                 [0m
+in value declaration [33mfoo2[0m
+
+where [33mt0[0m is an unknown type
+
+See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/3701.purs
+++ b/tests/purs/failing/3701.purs
@@ -1,0 +1,39 @@
+-- @shouldFailWith TypesDoNotUnify
+module Main where
+
+import Prim.Row as Row
+
+merge
+  :: forall r1 r2 r3 r4
+   . Row.Union r1 r2 r3
+  => Row.Nub r3 r4
+  => Record r1
+  -> Record r2
+  -> Record r4
+merge r = merge r
+
+
+type FooRow r =
+  ( thing1 :: String
+  , thing2 :: Int
+  | r
+  )
+
+type AddedRow =
+  ( thing3 :: String )
+
+type AddedRow2 =
+  ( thing1 :: String )
+
+fooMerge :: forall addedRow.
+  Row.Union addedRow (FooRow ()) (FooRow addedRow) =>
+  Row.Nub (FooRow addedRow) (FooRow addedRow) =>
+  Record addedRow ->
+  Record (FooRow addedRow)
+fooMerge addedRow = merge addedRow {thing1: "foo", thing2: 1}
+
+foo1 :: Record (FooRow (AddedRow))
+foo1 = fooMerge { thing3: "foo" }
+
+foo2 :: Record (FooRow (AddedRow2))
+foo2 = fooMerge { thing1: "foo" }

--- a/tests/purs/failing/3765.out
+++ b/tests/purs/failing/3765.out
@@ -17,25 +17,18 @@ at tests/purs/failing/3765.purs:6:23 - 6:24 (line 6, column 23 - line 6, column 
   [33m  )         [0m
   [33m            [0m
 
-while trying to match type [33m            [0m
-                           [33m  ( b :: Int[0m
-                           [33m  ...       [0m
-                           [33m  | t0      [0m
-                           [33m  )         [0m
-                           [33m            [0m
-  with type [33m            [0m
-            [33m  ( a :: Int[0m
-            [33m  ...       [0m
-            [33m  | t0      [0m
-            [33m  )         [0m
-            [33m            [0m
+while trying to match type [33m{ b :: Int[0m
+                           [33m| t0      [0m
+                           [33m}         [0m
+  with type [33mt1[0m
 while checking that expression [33mx[0m
   has type [33m{ b :: Int[0m
            [33m| t0      [0m
            [33m}         [0m
 in value declaration [33mmkTricky[0m
 
-where [33mt0[0m is an unknown type
+where [33mt1[0m is an unknown type
+      [33mt0[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/DuplicateProperties.out
+++ b/tests/purs/failing/DuplicateProperties.out
@@ -16,17 +16,11 @@ at tests/purs/failing/DuplicateProperties.purs:12:18 - 12:32 (line 12, column 18
   [33m  )          [0m
   [33m             [0m
 
-while trying to match type [33m             [0m
-                           [33m  ( y :: Unit[0m
-                           [33m  ...        [0m
-                           [33m  )          [0m
-                           [33m             [0m
-  with type [33m             [0m
+while trying to match type [33mTest t1[0m
+  with type [33mTest         [0m
             [33m  ( x :: Unit[0m
-            [33m  ...        [0m
             [33m  | t0       [0m
             [33m  )          [0m
-            [33m             [0m
 while checking that expression [33msubtractX hasX[0m
   has type [33mTest         [0m
            [33m  ( x :: Unit[0m
@@ -35,6 +29,7 @@ while checking that expression [33msubtractX hasX[0m
 in value declaration [33mbaz[0m
 
 where [33mt0[0m is an unknown type
+      [33mt1[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
 or to contribute content related to this error.


### PR DESCRIPTION
* Remove a redundant hint that repeats the types in the error
* Correctly diff rows containing duplicate items
* Erase kind applications from rows in errors (by default)

**Description of the change**

Fixes #3701.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Added a test for the contribution (if applicable)