### PR TITLE
Add a hint for errors in foreign data type declarations

### DIFF
--- a/CHANGELOG.d/fix_error-in-foreign-import-data-hint.md
+++ b/CHANGELOG.d/fix_error-in-foreign-import-data-hint.md
@@ -1,0 +1,1 @@
+* Add a hint for errors in foreign data type declarations

--- a/lib/purescript-cst/src/Language/PureScript/AST/Declarations.hs
+++ b/lib/purescript-cst/src/Language/PureScript/AST/Declarations.hs
@@ -84,6 +84,7 @@ data ErrorMessageHint
   | ErrorInKindDeclaration (ProperName 'TypeName)
   | ErrorInRoleDeclaration (ProperName 'TypeName)
   | ErrorInForeignImport Ident
+  | ErrorInForeignImportData (ProperName 'TypeName)
   | ErrorSolvingConstraint SourceConstraint
   | MissingConstructorImportForCoercible (Qualified (ProperName 'ConstructorName))
   | PositionedError (NEL.NonEmpty SourceSpan)

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -1492,6 +1492,10 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       paras [ detail
             , line $ "in foreign import " <> markCode (showIdent nm)
             ]
+    renderHint (ErrorInForeignImportData nm) detail =
+      paras [ detail
+            , line $ "in foreign data type declaration for " <> markCode (runProperName nm)
+            ]
     renderHint (ErrorSolvingConstraint (Constraint _ nm _ ts _)) detail =
       paras [ detail
             , line "while solving type class constraint"

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -369,14 +369,15 @@ typeCheckAll moduleName _ = traverse go
         addValue moduleName name ty nameKind
         return (sai, nameKind, val)
       return . BindingGroupDeclaration $ NEL.fromList vals''
-  go d@(ExternDataDeclaration _ name kind) = do
-    elabKind <- withFreshSubstitution $ checkKindDeclaration moduleName kind
-    env <- getEnv
-    let qualName = Qualified (Just moduleName) name
-    -- If there's an explicit role declaration, just trust it
-    let roles = fromMaybe (nominalRolesForKind elabKind) $ M.lookup qualName (roleDeclarations env)
-    putEnv $ env { types = M.insert qualName (elabKind, ExternData roles) (types env) }
-    return d
+  go d@(ExternDataDeclaration (ss, _) name kind) = do
+    warnAndRethrow (addHint (ErrorInForeignImportData name) . addHint (positionedError ss)) $ do
+      elabKind <- withFreshSubstitution $ checkKindDeclaration moduleName kind
+      env <- getEnv
+      let qualName = Qualified (Just moduleName) name
+      -- If there's an explicit role declaration, just trust it
+      let roles = fromMaybe (nominalRolesForKind elabKind) $ M.lookup qualName (roleDeclarations env)
+      putEnv $ env { types = M.insert qualName (elabKind, ExternData roles) (types env) }
+      return d
   go d@(ExternDeclaration (ss, _) name ty) = do
     warnAndRethrow (addHint (ErrorInForeignImport name) . addHint (positionedError ss)) $ do
       env <- getEnv

--- a/tests/purs/failing/UnsupportedTypeInKind.out
+++ b/tests/purs/failing/UnsupportedTypeInKind.out
@@ -8,6 +8,7 @@ at tests/purs/failing/UnsupportedTypeInKind.purs:7:28 - 7:38 (line 7, column 28 
 
   is not supported in kinds.
 
+in foreign data type declaration for [33mBad[0m
 
 See https://github.com/purescript/documentation/blob/master/errors/UnsupportedTypeInKind.md for more information,
 or to contribute content related to this error.


### PR DESCRIPTION
**Description of the change**

While adding a hint category for declarations in #4157 I noticed that foreign data type declarations, unlike foreign imports, don’t have such hint already. This seems to be an oversight.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] ~Added myself to CONTRIBUTORS.md (if this is my first contribution)~
- [x] ~Linked any existing issues or proposals that this pull request should close~
- [x] ~Updated or added relevant documentation~
- [x] Added a test for the contribution (if applicable)
