### PR TITLE
Add golden tests for self cycles in type class declarations, kind declarations and foreign data type declarations

### DIFF
--- a/CHANGELOG.d/internal_add-golden-tests-for-self-cycles.md
+++ b/CHANGELOG.d/internal_add-golden-tests-for-self-cycles.md
@@ -1,0 +1,1 @@
+* Add golden tests for self cycles in type class declarations, kind declarations and foreign data type declarations

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -786,7 +786,6 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             ]
       where
       cycleError = case names of
-        []   -> pure . line $ "A cycle appears in a set of type synonym definitions."
         [pn] -> pure . line $ "A cycle appears in the definition of type synonym " <> markCode (runProperName pn)
         _    -> [ line " A cycle appears in a set of type synonym definitions:"
                 , indent $ line $ "{" <> T.intercalate ", " (map (markCode . runProperName) names) <> "}"

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -19,6 +19,7 @@ import           Data.Foldable (fold)
 import           Data.Functor.Identity (Identity(..))
 import           Data.List (transpose, nubBy, partition, dropWhileEnd, sortOn)
 import qualified Data.List.NonEmpty as NEL
+import           Data.List.NonEmpty (NonEmpty((:|)))
 import           Data.Maybe (maybeToList, fromMaybe, mapMaybe)
 import qualified Data.Map as M
 import           Data.Ord (Down(..))
@@ -89,10 +90,10 @@ data SimpleErrorMessage
   | InvalidDoBind
   | InvalidDoLet
   | CycleInDeclaration Ident
-  | CycleInTypeSynonym [ProperName 'TypeName]
-  | CycleInTypeClassDeclaration [Qualified (ProperName 'ClassName)]
-  | CycleInKindDeclaration [Qualified (ProperName 'TypeName)]
-  | CycleInModules [ModuleName]
+  | CycleInTypeSynonym (NEL.NonEmpty (ProperName 'TypeName))
+  | CycleInTypeClassDeclaration (NEL.NonEmpty (Qualified (ProperName 'ClassName)))
+  | CycleInKindDeclaration (NEL.NonEmpty (Qualified (ProperName 'TypeName)))
+  | CycleInModules (NEL.NonEmpty ModuleName)
   | NameIsUndefined Ident
   | UndefinedTypeVariable (ProperName 'TypeName)
   | PartiallyAppliedSynonym (Qualified (ProperName 'TypeName))
@@ -773,11 +774,11 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       line $ "The value of " <> markCode (showIdent nm) <> " is undefined here, so this reference is not allowed."
     renderSimpleErrorMessage (CycleInModules mns) =
       case mns of
-        [mn] ->
+        mn :| [] ->
           line $ "Module " <> markCode (runModuleName mn) <> " imports itself."
         _ ->
           paras [ line "There is a cycle in module dependencies in these modules: "
-                , indent $ paras (map (line . markCode . runModuleName) mns)
+                , indent $ paras (line . markCode . runModuleName <$> NEL.toList mns)
                 ]
     renderSimpleErrorMessage (CycleInTypeSynonym names) =
       paras $ cycleError <>
@@ -786,22 +787,22 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
             ]
       where
       cycleError = case names of
-        [pn] -> pure . line $ "A cycle appears in the definition of type synonym " <> markCode (runProperName pn)
-        _    -> [ line " A cycle appears in a set of type synonym definitions:"
-                , indent $ line $ "{" <> T.intercalate ", " (map (markCode . runProperName) names) <> "}"
-                ]
-    renderSimpleErrorMessage (CycleInTypeClassDeclaration [name]) =
+        pn :| [] -> pure . line $ "A cycle appears in the definition of type synonym " <> markCode (runProperName pn)
+        _ -> [ line " A cycle appears in a set of type synonym definitions:"
+             , indent $ line $ "{" <> T.intercalate ", " (markCode . runProperName <$> NEL.toList names) <> "}"
+             ]
+    renderSimpleErrorMessage (CycleInTypeClassDeclaration (name :| [])) =
       paras [ line $ "A type class '" <> markCode (runProperName (disqualify name)) <> "' may not have itself as a superclass." ]
     renderSimpleErrorMessage (CycleInTypeClassDeclaration names) =
       paras [ line "A cycle appears in a set of type class definitions:"
-            , indent $ line $ "{" <> T.intercalate ", " (map (markCode . runProperName . disqualify) names) <> "}"
+            , indent $ line $ "{" <> T.intercalate ", " (markCode . runProperName . disqualify <$> NEL.toList names) <> "}"
             , line "Cycles are disallowed because they can lead to loops in the type checker."
             ]
-    renderSimpleErrorMessage (CycleInKindDeclaration [name]) =
+    renderSimpleErrorMessage (CycleInKindDeclaration (name :| [])) =
       paras [ line $ "A kind declaration '" <> markCode (runProperName (disqualify name)) <> "' may not refer to itself in its own signature." ]
     renderSimpleErrorMessage (CycleInKindDeclaration names) =
       paras [ line "A cycle appears in a set of kind declarations:"
-            , indent $ line $ "{" <> T.intercalate ", " (map (markCode . runProperName . disqualify) names) <> "}"
+            , indent $ line $ "{" <> T.intercalate ", " (markCode . runProperName . disqualify <$> NEL.toList names) <> "}"
             , line "Kind declarations may not refer to themselves in their own signatures."
             ]
     renderSimpleErrorMessage (NameIsUndefined ident) =

--- a/src/Language/PureScript/ModuleDependencies.hs
+++ b/src/Language/PureScript/ModuleDependencies.hs
@@ -83,7 +83,7 @@ toModule (CyclicSCC ms) =
     Just ms' ->
       throwError
         . errorMessage'' (fmap (sigSourceSpan . snd) ms')
-        $ CycleInModules (map (sigModuleName . snd) ms)
+        $ CycleInModules (map (sigModuleName . snd) ms')
 
 moduleSignature :: Module -> ModuleSignature
 moduleSignature (Module ss _ mn ds _) = ModuleSignature ss mn (ordNub (mapMaybe usedModules ds))

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -16,6 +16,7 @@ import Control.Monad.Error.Class (MonadError(..))
 
 import Data.Graph
 import Data.List (intersect, (\\))
+import Data.List.NonEmpty (NonEmpty((:|)), nonEmpty)
 import Data.Foldable (find)
 import Data.Maybe (isJust, mapMaybe)
 import qualified Data.List.NonEmpty as NEL
@@ -24,7 +25,7 @@ import qualified Data.Set as S
 import Language.PureScript.AST
 import Language.PureScript.Crash
 import Language.PureScript.Environment
-import Language.PureScript.Errors
+import Language.PureScript.Errors hiding (nonEmpty)
 import Language.PureScript.Names
 import Language.PureScript.Types
 
@@ -232,11 +233,11 @@ toDataBindingGroup
   -> m Declaration
 toDataBindingGroup (AcyclicSCC (d, _, _)) = return d
 toDataBindingGroup (CyclicSCC ds')
-  | kds@((ss, _):_) <- concatMap (kindDecl . getDecl) ds' = throwError . errorMessage' ss . CycleInKindDeclaration $ fmap snd kds
+  | Just kds@((ss, _):|_) <- nonEmpty $ concatMap (kindDecl . getDecl) ds' = throwError . errorMessage' ss . CycleInKindDeclaration $ fmap snd kds
   | not (null typeSynonymCycles) =
       throwError
         . MultipleErrors
-        . fmap (\syns -> ErrorMessage [positionedError . declSourceSpan . getDecl $ head syns] . CycleInTypeSynonym $ fmap (fst . getName) syns)
+        . fmap (\syns -> ErrorMessage [positionedError . declSourceSpan . getDecl $ NEL.head syns] . CycleInTypeSynonym $ fmap (fst . getName) syns)
         $ typeSynonymCycles
   | otherwise = return . DataBindingGroupDeclaration . NEL.fromList $ getDecl <$> ds'
   where
@@ -252,7 +253,7 @@ toDataBindingGroup (CyclicSCC ds')
     guard . isJust $ isTypeSynonym decl
     pure (decl, name, filter (maybe False (isJust . isTypeSynonym . getDecl) . lookupVert) deps)
 
-  isCycle (CyclicSCC c) = Just c
+  isCycle (CyclicSCC c) = nonEmpty c
   isCycle _ = Nothing
 
   typeSynonymCycles =

--- a/tests/purs/failing/SelfCycleInForeignDataKinds.out
+++ b/tests/purs/failing/SelfCycleInForeignDataKinds.out
@@ -1,0 +1,9 @@
+Error found:
+at tests/purs/failing/SelfCycleInForeignDataKinds.purs:4:1 - 4:31 (line 4, column 1 - line 4, column 31)
+
+  A kind declaration '[33mFoo[0m' may not refer to itself in its own signature.
+
+
+See https://github.com/purescript/documentation/blob/master/errors/CycleInKindDeclaration.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/SelfCycleInForeignDataKinds.purs
+++ b/tests/purs/failing/SelfCycleInForeignDataKinds.purs
@@ -1,0 +1,4 @@
+-- @shouldFailWith CycleInKindDeclaration
+module Main where
+
+foreign import data Foo :: Foo

--- a/tests/purs/failing/SelfCycleInKindDeclaration.out
+++ b/tests/purs/failing/SelfCycleInKindDeclaration.out
@@ -1,0 +1,9 @@
+Error found:
+at tests/purs/failing/SelfCycleInKindDeclaration.purs:4:1 - 4:24 (line 4, column 1 - line 4, column 24)
+
+  A kind declaration '[33mFoo[0m' may not refer to itself in its own signature.
+
+
+See https://github.com/purescript/documentation/blob/master/errors/CycleInKindDeclaration.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/SelfCycleInKindDeclaration.purs
+++ b/tests/purs/failing/SelfCycleInKindDeclaration.purs
@@ -1,0 +1,5 @@
+-- @shouldFailWith CycleInKindDeclaration
+module Main where
+
+data Foo :: Foo -> Type
+data Foo a = Foo

--- a/tests/purs/failing/SelfCycleInTypeClassDeclaration.out
+++ b/tests/purs/failing/SelfCycleInTypeClassDeclaration.out
@@ -1,0 +1,9 @@
+Error found:
+at tests/purs/failing/SelfCycleInTypeClassDeclaration.purs:4:1 - 4:23 (line 4, column 1 - line 4, column 23)
+
+  A type class '[33mFoo[0m' may not have itself as a superclass.
+
+
+See https://github.com/purescript/documentation/blob/master/errors/CycleInTypeClassDeclaration.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/SelfCycleInTypeClassDeclaration.purs
+++ b/tests/purs/failing/SelfCycleInTypeClassDeclaration.purs
@@ -1,0 +1,4 @@
+-- @shouldFailWith CycleInTypeClassDeclaration
+module Main where
+
+class (Foo a) <= Foo a


### PR DESCRIPTION
**Description of the change**

While moving role declarations and their data type to the same binding group in #4157 I noticed that some self cycles do not have golden tests already.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] ~Added myself to CONTRIBUTORS.md (if this is my first contribution)~
- [x] ~Linked any existing issues or proposals that this pull request should close~
- [x] ~Updated or added relevant documentation~
- [x] Added a test for the contribution (if applicable)
