### PR TITLE
Avoids redundant substitution in unifyTypes when possible

### DIFF
--- a/CHANGELOG.d/fix_avoids redundant substitution.md
+++ b/CHANGELOG.d/fix_avoids redundant substitution.md
@@ -1,0 +1,1 @@
+* Avoids unnecessary substitution checks when running `unifyTypes`. By only checking substitutions for unknown types, this leads to a 1.5-2x speedup for heavily constrained files.

--- a/CHANGELOG.d/fix_avoids redundant substitution.md
+++ b/CHANGELOG.d/fix_avoids redundant substitution.md
@@ -1,1 +1,3 @@
-* Avoids unnecessary substitution checks when running `unifyTypes`. By only checking substitutions for unknown types, this leads to a 1.5-2x speedup for heavily constrained files.
+* Avoids unnecessary substitution checks when running `unifyTypes`.
+
+By only checking substitutions when necessary (where "necessary" is defined in a comment above `unifyTypes`), this leads to a 1.5-2x speedup for heavily constrained files.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -75,6 +75,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@mcoffin](https://github.com/mcoffin) | Matt Coffin | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mhcurylo](https://github.com/mhcurylo) | Mateusz Curylo | [MIT license](http://opensource.org/licenses/MIT) |
 | [@MiracleBlue](https://github.com/MiracleBlue) | Nicholas Kircher | [MIT license](http://opensource.org/licenses/MIT) |
+| [@mikesol](https://github.com/mikesol) | Mike Solomon | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mrkgnao](https://github.com/mrkgnao) | Soham Chowdhury | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mgmeier](https://github.com/mgmeier) | Michael Gilliland | [MIT license](http://opensource.org/licenses/MIT) |
 | [@michaelficarra](https://github.com/michaelficarra) | Michael Ficarra | [MIT license](http://opensource.org/licenses/MIT) |

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -138,12 +138,12 @@ withScopedTypeVars mn ks ma = do
       tell . errorMessage $ ShadowedTypeVar name
   bindTypes (M.fromList (map (\(name, k) -> (Qualified (Just mn) (ProperName name), (k, ScopedTypeVar))) ks)) ma
 
-withErrorMessageHint'
+withErrorMessageHintM
   :: (MonadState CheckState m, MonadError MultipleErrors m)
   => m ErrorMessageHint
   -> m a
   -> m a
-withErrorMessageHint' hint' action = do
+withErrorMessageHintM hint' action = do
   hint <- hint'
   orig <- get
   modify $ \st -> st { checkHints = hint : checkHints st }
@@ -157,7 +157,7 @@ withErrorMessageHint
   => ErrorMessageHint
   -> m a
   -> m a
-withErrorMessageHint = withErrorMessageHint' . return
+withErrorMessageHint = withErrorMessageHintM . return
 
 -- | These hints are added at the front, so the most nested hint occurs
 -- at the front, but the simplifier assumes the reverse order.

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -109,7 +109,7 @@ unknownsInType t = everythingOnTypes (.) go t []
 -- | or only t2 is unknown. If we limit substitution to only the unknown, it results in an
 -- | ExitFailure (-9).
 unifyTypes :: (MonadError MultipleErrors m, MonadState CheckState m) => SourceType -> SourceType -> m ()
-unifyTypes t1 t2 = withErrorMessageHint' (do
+unifyTypes t1 t2 = withErrorMessageHintM (do
       sub <- gets checkSubstitution
       return (ErrorUnifyingTypes (substituteType sub t1) (substituteType sub t2))) (unifyTypes'' False t1 t2)
   where

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -105,6 +105,9 @@ unknownsInType t = everythingOnTypes (.) go t []
   go _ = id
 
 -- | Unify two types, updating the current substitution
+-- | TODO: it is not clear why substitution has to be done on _both_ t1 and t2 if only t1
+-- | or only t2 is unknown. If we limit substitution to only the unknown, it results in an
+-- | ExitFailure (-9).
 unifyTypes :: (MonadError MultipleErrors m, MonadState CheckState m) => SourceType -> SourceType -> m ()
 unifyTypes t1 t2 = withErrorMessageHint (ErrorUnifyingTypes t1 t2) $ unifyTypes'' False t1 t2
   where

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -104,10 +104,14 @@ unknownsInType t = everythingOnTypes (.) go t []
   go (TUnknown ann u) = ((ann, u) :)
   go _ = id
 
--- | Unify two types, updating the current substitution
--- | TODO: it is not clear why substitution has to be done on _both_ t1 and t2 if only t1
--- | or only t2 is unknown. If we limit substitution to only the unknown, it results in an
--- | ExitFailure (-9).
+-- | Unify two types, updating the current substitution.
+-- |
+-- | To optimize should only ever make substitutions to:
+-- | - unknown SourceTypes (TUnknown)
+-- | - types we are solving against via solveType
+-- | The second point above may be able to be further optimized,
+-- | meaning that we may be able to solve against types that have not gone through `checkSubstitutions`.
+-- | See https://github.com/purescript/purescript/pull/4163#issuecomment-883515152
 unifyTypes :: (MonadError MultipleErrors m, MonadState CheckState m) => SourceType -> SourceType -> m ()
 unifyTypes t1 t2 = withErrorMessageHintM (do
       sub <- gets checkSubstitution

--- a/tests/purs/failing/2534.out
+++ b/tests/purs/failing/2534.out
@@ -7,14 +7,13 @@ at tests/purs/failing/2534.purs:8:14 - 8:18 (line 8, column 14 - line 8, column 
   [33m  Array t0[0m
   [33m          [0m
 
-while trying to match type [33mArray t1[0m
+while trying to match type [33mArray t0[0m
   with type [33mt0[0m
 while checking that expression [33mxs[0m
   has type [33mt0[0m
 in value declaration [33mfoo[0m
 
-where [33mt1[0m is an unknown type
-      [33mt0[0m is an unknown type
+where [33mt0[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/InfiniteType.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/DuplicateProperties.out
+++ b/tests/purs/failing/DuplicateProperties.out
@@ -35,6 +35,7 @@ while checking that expression [33msubtractX hasX[0m
 in value declaration [33mbaz[0m
 
 where [33mt0[0m is an unknown type
+      [33mt1[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/DuplicateProperties.out
+++ b/tests/purs/failing/DuplicateProperties.out
@@ -16,10 +16,17 @@ at tests/purs/failing/DuplicateProperties.purs:12:18 - 12:32 (line 12, column 18
   [33m  )          [0m
   [33m             [0m
 
-while trying to match type [33mt1[0m
-  with type [33m( x :: Unit[0m
-            [33m| t0       [0m
-            [33m)          [0m
+while trying to match type [33m             [0m
+                           [33m  ( y :: Unit[0m
+                           [33m  ...        [0m
+                           [33m  )          [0m
+                           [33m             [0m
+  with type [33m             [0m
+            [33m  ( x :: Unit[0m
+            [33m  ...        [0m
+            [33m  | t0       [0m
+            [33m  )          [0m
+            [33m             [0m
 while checking that expression [33msubtractX hasX[0m
   has type [33mTest         [0m
            [33m  ( x :: Unit[0m
@@ -28,7 +35,6 @@ while checking that expression [33msubtractX hasX[0m
 in value declaration [33mbaz[0m
 
 where [33mt0[0m is an unknown type
-      [33mt1[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/DuplicateProperties.out
+++ b/tests/purs/failing/DuplicateProperties.out
@@ -16,11 +16,9 @@ at tests/purs/failing/DuplicateProperties.purs:12:18 - 12:32 (line 12, column 18
   [33m  )          [0m
   [33m             [0m
 
-while trying to match type [33m             [0m
-                           [33m  ( y :: Unit[0m
-                           [33m  ...        [0m
-                           [33m  )          [0m
-                           [33m             [0m
+while trying to match type [33m    [0m
+                           [33m  t1[0m
+                           [33m    [0m
   with type [33m             [0m
             [33m  ( x :: Unit[0m
             [33m  ...        [0m

--- a/tests/purs/failing/DuplicateProperties.out
+++ b/tests/purs/failing/DuplicateProperties.out
@@ -16,15 +16,10 @@ at tests/purs/failing/DuplicateProperties.purs:12:18 - 12:32 (line 12, column 18
   [33m  )          [0m
   [33m             [0m
 
-while trying to match type [33m    [0m
-                           [33m  t1[0m
-                           [33m    [0m
-  with type [33m             [0m
-            [33m  ( x :: Unit[0m
-            [33m  ...        [0m
-            [33m  | t0       [0m
-            [33m  )          [0m
-            [33m             [0m
+while trying to match type [33mt1[0m
+  with type [33m( x :: Unit[0m
+            [33m| t0       [0m
+            [33m)          [0m
 while checking that expression [33msubtractX hasX[0m
   has type [33mTest         [0m
            [33m  ( x :: Unit[0m

--- a/tests/purs/failing/SuggestComposition.out
+++ b/tests/purs/failing/SuggestComposition.out
@@ -14,7 +14,7 @@ at tests/purs/failing/SuggestComposition.purs:7:5 - 7:6 (line 7, column 5 - line
 while trying to match type [33m{ g :: t0[0m
                            [33m| t1     [0m
                            [33m}        [0m
-  with type [33mt2 -> t3[0m
+  with type [33mInt -> Int[0m
 while checking that expression [33mg[0m
   has type [33m{ g :: t0[0m
            [33m| t1     [0m
@@ -22,9 +22,7 @@ while checking that expression [33mg[0m
 while checking type of property accessor [33mg.g[0m
 in value declaration [33mf[0m
 
-where [33mt2[0m is an unknown type
-      [33mt3[0m is an unknown type
-      [33mt0[0m is an unknown type
+where [33mt0[0m is an unknown type
       [33mt1[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,

--- a/tests/purs/failing/SuggestComposition.out
+++ b/tests/purs/failing/SuggestComposition.out
@@ -7,9 +7,9 @@ at tests/purs/failing/SuggestComposition.purs:7:5 - 7:6 (line 7, column 5 - line
   [33m  Record[0m
   [33m        [0m
   with type
-  [33m              [0m
-  [33m  Function Int[0m
-  [33m              [0m
+  [33m             [0m
+  [33m  Function t2[0m
+  [33m             [0m
 
 while trying to match type [33m{ g :: t0[0m
                            [33m| t1     [0m

--- a/tests/purs/failing/SuggestComposition.out
+++ b/tests/purs/failing/SuggestComposition.out
@@ -7,9 +7,9 @@ at tests/purs/failing/SuggestComposition.purs:7:5 - 7:6 (line 7, column 5 - line
   [33m  Record[0m
   [33m        [0m
   with type
-  [33m             [0m
-  [33m  Function t2[0m
-  [33m             [0m
+  [33m              [0m
+  [33m  Function Int[0m
+  [33m              [0m
 
 while trying to match type [33m{ g :: t0[0m
                            [33m| t1     [0m


### PR DESCRIPTION
**Description of the change**

This change speeds up PureScript's compilation for programs that make heavy use of typeclasses. It is unclear the effect it has (if any) on the compilation of other programs.

**Benchmarks**

Compiling [Loops.purs](https://github.com/mikesol/purescript-wags-lib/blob/main/examples/loops/Loops.purs) on my ubuntu machine, I get the following result without this change:

```bash
$ time npx spago -x examples.dhall build
Compiling WAGS.Lib.Example.Loops
Warning 1 of 2:
  in module WAGS.Lib.Example.Loops
  at examples/loops/Loops.purs:73:1 - 74:165 (line 73, column 1 - line 74, column 165)
    The inferred kind for the type declaration Instruments'' contains polymorphic kinds.
    Consider adding a top-level kind signature as a form of documentation.
      type Instruments'' :: forall k. k -> Row k -> Row k
  in type synonym Instruments''
  See https://github.com/purescript/documentation/blob/master/errors/MissingKindDeclaration.md for more information,
  or to contribute content related to this warning.
Warning 2 of 2:
  in module WAGS.Lib.Example.Loops
  at examples/loops/Loops.purs:76:1 - 77:23 (line 76, column 1 - line 77, column 23)
    The inferred kind for the type declaration Instruments' contains polymorphic kinds.
    Consider adding a top-level kind signature as a form of documentation.
      type Instruments' :: forall k. k -> Row k
  in type synonym Instruments'
  See https://github.com/purescript/documentation/blob/master/errors/MissingKindDeclaration.md for more information,
  or to contribute content related to this warning.
[info] Build succeeded.
real    6m42,643s
user    51m26,103s
sys     11m33,138s
```
With this change, I get the following result:

```bash
07:49 meeshkan-abel@Abel:~/mike/purescript-wags-lib$ time npx spago -x examples.dhall build
Compiling WAGS.Lib.Example.Loops
Warning 1 of 5:

  in module WAGS.Lib.Example.Loops
  at examples/loops/Loops.purs:117:12 - 117:13 (line 117, column 12 - line 117, column 13)

    Name b was introduced but not used.

  in value declaration append

  See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
  or to contribute content related to this warning.

Warning 2 of 5:

  in module WAGS.Lib.Example.Loops
  at examples/loops/Loops.purs:240:37 - 240:41 (line 240, column 37 - line 240, column 41)

    Name time was introduced but not used.

  in value declaration piece

  See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
  or to contribute content related to this warning.

Warning 3 of 5:

  in module WAGS.Lib.Example.Loops
  at examples/loops/Loops.purs:308:8 - 308:13 (line 308, column 8 - line 308, column 13)

    Name state was introduced but not used.

  in value declaration render

  See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
  or to contribute content related to this warning.

Warning 4 of 5:

  in module WAGS.Lib.Example.Loops
  at examples/loops/Loops.purs:73:1 - 74:165 (line 73, column 1 - line 74, column 165)

    The inferred kind for the type declaration Instruments'' contains polymorphic kinds.
    Consider adding a top-level kind signature as a form of documentation.
                                                         
      type Instruments'' :: forall k. k -> Row k -> Row k
                                                         

  in type synonym Instruments''

  See https://github.com/purescript/documentation/blob/master/errors/MissingKindDeclaration.md for more information,
  or to contribute content related to this warning.

Warning 5 of 5:

  in module WAGS.Lib.Example.Loops
  at examples/loops/Loops.purs:76:1 - 77:23 (line 76, column 1 - line 77, column 23)

    The inferred kind for the type declaration Instruments' contains polymorphic kinds.
    Consider adding a top-level kind signature as a form of documentation.
                                               
      type Instruments' :: forall k. k -> Row k
                                               

  in type synonym Instruments'

  See https://github.com/purescript/documentation/blob/master/errors/MissingKindDeclaration.md for more information,
  or to contribute content related to this warning.


[info] Build succeeded.

real    3m27,583s
user    26m43,771s
sys     4m34,487s
```

These times are pretty consistent across several tests. In general, there is a 1.5-2x speedup for heavily-constrained files when using a `purs` built with this PR.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close (there are none)
- [x] Updated or added relevant documentation (added a comment)
- [x] Added a test for the contribution (not applicable)
