### PR TITLE
Defer synonym expansion from type class desugaring

### DIFF
--- a/CHANGELOG.d/fix_4101.md
+++ b/CHANGELOG.d/fix_4101.md
@@ -1,0 +1,3 @@
+* Fix bad interaction between superclasses and type synonyms
+
+  See #4101.

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -84,8 +84,8 @@ desugar externs =
       -- We cannot prevent ill-kinded expansions of type synonyms without
       -- knowing their kinds but they're not available yet.
           kinds = mempty
-       in deriveInstances externs syns kinds m
-      >>= desugarTypeClasses externs syns kinds)
+       in deriveInstances externs syns kinds m)
+    >=> desugarTypeClasses externs
     >=> createBindingGroupsModule
 
 findTypeSynonyms :: [ExternsFile] -> ModuleName -> [Declaration] -> SynonymMap

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -38,6 +38,7 @@ import Language.PureScript.Names
 import Language.PureScript.TypeChecker.Entailment.Coercible
 import Language.PureScript.TypeChecker.Kinds (elaborateKind, unifyKinds')
 import Language.PureScript.TypeChecker.Monad
+import Language.PureScript.TypeChecker.Synonyms (replaceAllTypeSynonyms)
 import Language.PureScript.TypeChecker.Unify
 import Language.PureScript.TypeClassDictionaries
 import Language.PureScript.Types
@@ -161,7 +162,7 @@ entails
   -- ^ Error message hints to apply to any instance errors
   -> WriterT (Any, [(Ident, InstanceContext, SourceConstraint)]) (StateT InstanceContext m) Expr
 entails SolverOptions{..} constraint context hints =
-    solve constraint
+  overConstraintArgsAll (lift . lift . traverse replaceAllTypeSynonyms) constraint >>= solve
   where
     forClassNameM :: Environment -> InstanceContext -> Qualified (ProperName 'ClassName) -> [SourceType] -> [SourceType] -> m [TypeClassDict]
     forClassNameM env ctx cn@C.Coercible kinds args =

--- a/tests/purs/passing/4101.purs
+++ b/tests/purs/passing/4101.purs
@@ -1,0 +1,20 @@
+module Main where
+
+import Effect.Console (log)
+
+import Lib
+
+class ClassA :: Type -> Type -> Constraint
+class ClassA t a
+
+class ClassB :: Type -> Type -> Constraint
+class ClassA t a <= ClassB t a
+
+data VariantF :: (Type -> Type) -> Type
+data VariantF fs
+data Expr
+
+instance a :: ClassA Expr (VariantF UNIT)
+instance b :: ClassB Expr (VariantF UNIT)
+
+main = log "Done"

--- a/tests/purs/passing/4101/Lib.purs
+++ b/tests/purs/passing/4101/Lib.purs
@@ -1,0 +1,9 @@
+module Lib where
+
+newtype Const :: forall k. Type -> k -> Type
+newtype Const a b = Const a
+
+data Unit = Unit
+
+type CONST = Const
+type UNIT = CONST Unit


### PR DESCRIPTION
Instead of expanding type synonyms when type classes are desugared into
their more primitive representation, we leave them in place and expand
them when constraints are solved by the type checker instead.

**Description of the change**

Fixes #4101. Also makes progress on #4086, but the deriving half of that will come in another PR.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- <s>Added myself to CONTRIBUTORS.md (if this is my first contribution)</s>
- [x] Linked any existing issues or proposals that this pull request should close
- <s>Updated or added relevant documentation</s>
- [x] Added a test for the contribution (if applicable)
