### PR TITLE
Test for possible breaking changes by compiling the package set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false # do not cancel builds for other OSes if one fails
       matrix:
         # If upgrading Ubuntu, also upgrade it in the lint job below
+        # and the package-set job below
         os: [ "ubuntu-18.04", "macOS-10.15", "windows-2016" ]
 
     runs-on: "${{ matrix.os }}"
@@ -37,6 +38,7 @@ jobs:
         with:
           enable-stack: true
           # If upgrading Stack, also upgrade it in the lint job below
+          # and the package-set job below
           stack-version: "2.7.1"
           stack-no-global: true
 
@@ -123,3 +125,57 @@ jobs:
       - run: "stack --no-terminal --jobs=2 build --fast --test --no-run-tests --ghc-options -fwrite-ide-info"
 
       - run: "stack exec weeder"
+
+  package-set:
+    runs-on: "ubuntu-18.04"
+
+    steps:
+      - uses: "actions/checkout@v2"
+
+      - id: "haskell"
+        uses: "haskell/actions/setup@v1"
+        with:
+          enable-stack: true
+          stack-version: "2.7.1"
+          stack-no-global: true
+
+      - uses: "actions/cache@v2"
+        with:
+          path: |
+            ${{ steps.haskell.outputs.stack-root }}
+          key: "${{ runner.os }}-package-set-${{ hashFiles('stack.yaml') }}"
+
+      - run: "stack --no-terminal --jobs=2 build"
+
+      - run: "stack exec bash"
+
+      - name:
+        run: |
+          mkdir -p packageSetCI
+          cd packageSetCI
+
+          (echo "::group::Init Spago project") 2>/dev/null
+          spago init --no-comments
+          (echo "::endgroup::"; "::group::Upgrade to latest package set") 2>/dev/null
+
+          # Ensure we're on the latest package set
+          spago upgrade-set
+
+          (echo "::endgroup::"; "::group::Override metadata package version") 2>/dev/null
+
+          # Override the `metadata` package's version to match `purs` version
+          # so that `spago build` actually works
+          META_PACKAGE_VERSION="v$(purs --version | cut -d ' ' -f 1)"
+          echo $(head --lines=-1 packages.dhall) > packages.dhall
+          echo "in upstream with metadata.version = \"$META_PACKAGE_VERSION\"" >> packages.dhall
+
+          (echo "::endgroup::"; "::group::Install package set") 2>/dev/null
+          spago install $(spago ls packages | cut -d ' ' -f 1 | tr '\n' ' ')
+
+          (echo "::endgroup::"; "::group::Compile package set") 2>/dev/null
+          spago build
+
+          (echo "::endgroup::"; "::group::Document package set") 2>/dev/null
+          spago docs --no-search
+
+          (echo "::endgroup::") 2>/dev/null

--- a/CHANGELOG.d/internal_compile and produce docs for package set in ci.md
+++ b/CHANGELOG.d/internal_compile and produce docs for package set in ci.md
@@ -1,0 +1,3 @@
+* In CI, compile and produce docs for the entire latest package set
+
+  See [#4128](https://github.com/purescript/purescript/pull/4128).


### PR DESCRIPTION
**Description of the change**

Updates CI to also compile the entire package set in a separate job. I'm creating this so that issues like #4064, which we did not realize was a breaking change, will be caught sooner. 

This will cause problems for CI when we want to start merging breaking changes. The fastest way to deal with it would be to comment out the job during then.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
