### PR TITLE
Replace Slack links with Discord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@
 When reporting issues, please be aware of the following:
 
 * Please use the appropriate issue template if there is one: filling out all of the sections in the template makes it much easier for us to understand what the problem is and how we might want to address it.
-* We prefer to reserve the issue tracker in this repository for tasks which involve work on the compiler. If your report or proposal doesn't involve work on the compiler, please open it on the repository where the work would be done. If you're unsure, you can always ask in [the #purescript channel in FP Slack][] or [Discourse][].
-* If you have a question or need help, please ask in [the #purescript channel in FP Slack][] or [Discourse][] instead.
+* We prefer to reserve the issue tracker in this repository for tasks which involve work on the compiler. If your report or proposal doesn't involve work on the compiler, please open it on the repository where the work would be done. If you're unsure, you can always ask on [Discord](https://discord.gg/sMqwYUbvz6) or [Discourse](https://discourse.purescript.org).
+* If you have a question or need help, please ask on [Discord](https://discord.gg/sMqwYUbvz6) or [Discourse](https://discourse.purescript.org) instead.
 * When submitting feature proposals, please be aware that we prefer to be conservative about adding things to the language/compiler. A feature proposal is much more likely to be accepted if it includes a clear description of the problem it intends to solve, as well as not only a strong justification for why adding the feature will solve that problem, but also for why any existing features or techniques that could be used to solve that problem are insufficient.
 
 We have defined some [Project Values](https://github.com/purescript/governance#project-values) in our organization's governance document; referring to these may help you get a better idea of what is likely to be accepted and what isn't.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,6 @@
 # Installation information
 
-If you are having difficulty installing the PureScript compiler, feel free to
-ask for help! A good place is the #purescript IRC channel on Freenode, the #purescript channel on [FPChat Slack](https://fpchat-invite.herokuapp.com/), or
-alternatively Stack Overflow.
+If you are having difficulty installing the PureScript compiler, feel free to ask for help! The best places are the [PureScript Discord](https://discord.gg/sMqwYUbvz6) or [PureScript Discourse](https://discourse.purescript.org).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ A small strongly typed programming language with expressive types that compiles 
 
 ## Help!
 
-- [#purescript @ FP Slack](https://functionalprogramming.slack.com/)
-- [PureScript Language Forum](https://discourse.purescript.org/)
+- [PureScript Discord](https://discord.gg/sMqwYUbvz6/)
+- [PureScript Discourse](https://discourse.purescript.org/)
 - [PureScript on StackOverflow](http://stackoverflow.com/questions/tagged/purescript)

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -136,5 +136,6 @@ Note: if a release does not go as planned (e.g. [`v0.14.3`](https://github.com/p
 - Update Try PureScript
 - Make release announcements:
   - Discourse
+  - Discord
   - Twitter
   - /r/purescript


### PR DESCRIPTION
**Description of the change**

This change replaces mentions of the FP Slack with our PureScript Discord community server. This PR shouldn't be merged until the server launches on July 26, 2021, but I've opened this PR early so it can be ready to go by then.

I haven't included anything in the CHANGELOG for this since it's such a tiny change that has nothing to do with the source code, but I can do so if desired.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
