### PR TITLE
Fix Discord link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ A small strongly typed programming language with expressive types that compiles 
 
 ## Help!
 
-- [PureScript Discord](https://discord.gg/sMqwYUbvz6/)
+- [PureScript Discord](https://discord.gg/sMqwYUbvz6)
 - [PureScript Discourse](https://discourse.purescript.org/)
 - [PureScript on StackOverflow](http://stackoverflow.com/questions/tagged/purescript)


### PR DESCRIPTION
**Description of the change**

The link doesn't work with a trailing slash, which is unfortunate. The other links were input correctly; it's only the main README that didn't go through.