### PR TITLE
Check for partially applied synonyms in ctors

### DIFF
--- a/CHANGELOG.d/feature_partially-applied-synonym-check.md
+++ b/CHANGELOG.d/feature_partially-applied-synonym-check.md
@@ -1,0 +1,7 @@
+* Check for partially applied syns in kinds, ctors
+
+  This check doesn't prevent any programs from compiling; it just makes
+  sure that a more specific PartiallyAppliedSynonym error is raised
+  instead of a KindsDoNotUnify error, which could be interpreted as
+  implying that a partially applied synonym has a valid kind and would be
+  supported elsewhere if that kind is expected.

--- a/tests/purs/failing/PASTrumpsKDNU1.out
+++ b/tests/purs/failing/PASTrumpsKDNU1.out
@@ -1,0 +1,17 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/PASTrumpsKDNU1.purs:14:33 - 14:43 (line 14, column 33 - line 14, column 43)
+
+  Type synonym [33mData.NaturalTransformation.NaturalTransformation[0m is partially applied.
+  Type synonyms must be applied to all of their type arguments.
+
+while checking that type [33mNaturalTransformation Array[0m
+  has kind [33mType[0m
+while inferring the kind of [33mShow a => NaturalTransformation Array[0m
+while inferring the kind of [33mProxy (Show a => NaturalTransformation Array)[0m
+while inferring the kind of [33mforall a. Proxy (Show a => NaturalTransformation Array)[0m
+in value declaration [33mf[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/PASTrumpsKDNU1.purs
+++ b/tests/purs/failing/PASTrumpsKDNU1.purs
@@ -1,0 +1,15 @@
+-- @shouldFailWith PartiallyAppliedSynonym
+module Main where
+
+import Prelude
+
+-- The PASTrumpsKDNU series of tests check a number of situations in which
+-- both PartiallyAppliedSynonym and KindsDoNotUnify would be reasonable
+-- errors to show; in these situtations, PartiallyAppliedSynonym is likely to
+-- be the more useful error.
+
+data Proxy :: forall k. k -> Type
+data Proxy a = Proxy
+
+f :: forall a. Proxy (Show a => (~>) Array)
+f = Proxy

--- a/tests/purs/failing/PASTrumpsKDNU2.out
+++ b/tests/purs/failing/PASTrumpsKDNU2.out
@@ -1,0 +1,15 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/PASTrumpsKDNU2.purs:9:19 - 9:29 (line 9, column 19 - line 9, column 29)
+
+  Type synonym [33mData.NaturalTransformation.NaturalTransformation[0m is partially applied.
+  Type synonyms must be applied to all of their type arguments.
+
+while checking that type [33mNaturalTransformation Array[0m
+  has kind [33mType[0m
+while inferring the kind of [33mforall (a :: NaturalTransformation Array). Proxy a -> Proxy a[0m
+in value declaration [33mf[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/PASTrumpsKDNU2.purs
+++ b/tests/purs/failing/PASTrumpsKDNU2.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith PartiallyAppliedSynonym
+module Main where
+
+import Prelude
+
+data Proxy :: forall k. k -> Type
+data Proxy a = Proxy
+
+f :: forall (a :: (~>) Array). Proxy a -> Proxy a
+f x = x

--- a/tests/purs/failing/PASTrumpsKDNU3.out
+++ b/tests/purs/failing/PASTrumpsKDNU3.out
@@ -1,0 +1,16 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/PASTrumpsKDNU3.purs:9:23 - 9:33 (line 9, column 23 - line 9, column 33)
+
+  Type synonym [33mData.NaturalTransformation.NaturalTransformation[0m is partially applied.
+  Type synonyms must be applied to all of their type arguments.
+
+while checking that type [33mNaturalTransformation Array[0m
+  has kind [33mType[0m
+while inferring the kind of [33mforall a. NaturalTransformation Array[0m
+while inferring the kind of [33mProxy (forall a. NaturalTransformation Array)[0m
+in value declaration [33mp[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/PASTrumpsKDNU3.purs
+++ b/tests/purs/failing/PASTrumpsKDNU3.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith PartiallyAppliedSynonym
+module Main where
+
+import Prelude
+
+data Proxy :: forall k. k -> Type
+data Proxy a = Proxy
+
+p :: Proxy (forall a. (~>) Array)
+p = Proxy

--- a/tests/purs/failing/PASTrumpsKDNU4.out
+++ b/tests/purs/failing/PASTrumpsKDNU4.out
@@ -1,0 +1,14 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/PASTrumpsKDNU4.purs:6:14 - 6:24 (line 6, column 14 - line 6, column 24)
+
+  Type synonym [33mData.NaturalTransformation.NaturalTransformation[0m is partially applied.
+  Type synonyms must be applied to all of their type arguments.
+
+while checking that type [33mNaturalTransformation Array[0m
+  has kind [33mType[0m
+in type constructor [33mD[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/PASTrumpsKDNU4.purs
+++ b/tests/purs/failing/PASTrumpsKDNU4.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith PartiallyAppliedSynonym
+module Main where
+
+import Prelude
+
+data D (a :: (~>) Array) = D

--- a/tests/purs/failing/PASTrumpsKDNU5.out
+++ b/tests/purs/failing/PASTrumpsKDNU5.out
@@ -1,0 +1,14 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/PASTrumpsKDNU5.purs:6:16 - 6:26 (line 6, column 16 - line 6, column 26)
+
+  Type synonym [33mData.NaturalTransformation.NaturalTransformation[0m is partially applied.
+  Type synonyms must be applied to all of their type arguments.
+
+while checking that type [33mNaturalTransformation Array[0m
+  has kind [33mType[0m
+in type constructor [33mN[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/PASTrumpsKDNU5.purs
+++ b/tests/purs/failing/PASTrumpsKDNU5.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith PartiallyAppliedSynonym
+module Main where
+
+import Prelude
+
+newtype N = N ((~>) Array)

--- a/tests/purs/failing/PASTrumpsKDNU6.out
+++ b/tests/purs/failing/PASTrumpsKDNU6.out
@@ -1,0 +1,14 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/PASTrumpsKDNU6.purs:6:14 - 6:24 (line 6, column 14 - line 6, column 24)
+
+  Type synonym [33mData.NaturalTransformation.NaturalTransformation[0m is partially applied.
+  Type synonyms must be applied to all of their type arguments.
+
+while checking that type [33mNaturalTransformation Array[0m
+  has kind [33mType[0m
+in type synonym [33mT[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/PASTrumpsKDNU6.purs
+++ b/tests/purs/failing/PASTrumpsKDNU6.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith PartiallyAppliedSynonym
+module Main where
+
+import Prelude
+
+type T (a :: (~>) Array) = Int

--- a/tests/purs/failing/PASTrumpsKDNU7.out
+++ b/tests/purs/failing/PASTrumpsKDNU7.out
@@ -1,0 +1,14 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/PASTrumpsKDNU7.purs:6:15 - 6:25 (line 6, column 15 - line 6, column 25)
+
+  Type synonym [33mData.NaturalTransformation.NaturalTransformation[0m is partially applied.
+  Type synonyms must be applied to all of their type arguments.
+
+while checking that type [33mNaturalTransformation Array[0m
+  has kind [33mType[0m
+in type constructor [33mC$Dict[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/PASTrumpsKDNU7.purs
+++ b/tests/purs/failing/PASTrumpsKDNU7.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith PartiallyAppliedSynonym
+module Main where
+
+import Prelude
+
+class C (a :: (~>) Array)

--- a/tests/purs/failing/RowConstructors2.out
+++ b/tests/purs/failing/RowConstructors2.out
@@ -2,20 +2,14 @@ Error found:
 in module [33mMain[0m
 at tests/purs/failing/RowConstructors2.purs:7:16 - 7:19 (line 7, column 16 - line 7, column 19)
 
-  Could not match kind
-  [33m                     [0m
-  [33m  Function (Row Type)[0m
-  [33m                     [0m
-  with kind
-  [33m     [0m
-  [33m  Row[0m
-  [33m     [0m
+  Type synonym [33mMain.Foo[0m is partially applied.
+  Type synonyms must be applied to all of their type arguments.
 
 while checking that type [33mFoo[0m
   has kind [33mRow Type[0m
 while inferring the kind of [33mRecord Foo[0m
 in type synonym [33mBar[0m
 
-See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
+See https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md for more information,
 or to contribute content related to this error.
 

--- a/tests/purs/failing/RowConstructors2.purs
+++ b/tests/purs/failing/RowConstructors2.purs
@@ -1,4 +1,4 @@
--- @shouldFailWith KindsDoNotUnify
+-- @shouldFailWith PartiallyAppliedSynonym
 module Main where
 
 import Effect.Console (log)

--- a/tests/purs/failing/TypeSynonyms10.out
+++ b/tests/purs/failing/TypeSynonyms10.out
@@ -1,0 +1,21 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/TypeSynonyms10.purs:8:19 - 8:23 (line 8, column 19 - line 8, column 23)
+
+  Could not match kind
+  [33m                        [0m
+  [33m  (Type -> Type) -> Type[0m
+  [33m                        [0m
+  with kind
+  [33m      [0m
+  [33m  Type[0m
+  [33m      [0m
+
+while checking that type [33mNaturalTransformation Array[0m
+  has kind [33mType[0m
+while inferring the kind of [33mF (NaturalTransformation Array)[0m
+in type constructor [33mN[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/TypeSynonyms10.purs
+++ b/tests/purs/failing/TypeSynonyms10.purs
@@ -1,0 +1,8 @@
+-- @shouldFailWith KindsDoNotUnify
+module Main where
+
+import Prelude
+
+type F (a :: Type) = a
+
+newtype N = N (F ((~>) Array))

--- a/tests/purs/failing/TypeSynonyms8.out
+++ b/tests/purs/failing/TypeSynonyms8.out
@@ -1,0 +1,14 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/TypeSynonyms8.purs:6:15 - 6:16 (line 6, column 15 - line 6, column 16)
+
+  Type synonym [33mMain.S[0m is partially applied.
+  Type synonyms must be applied to all of their type arguments.
+
+while checking that type [33mS[0m
+  has kind [33mType[0m
+in type constructor [33mN[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/TypeSynonyms8.purs
+++ b/tests/purs/failing/TypeSynonyms8.purs
@@ -1,0 +1,6 @@
+-- @shouldFailWith PartiallyAppliedSynonym
+module Main where
+
+data D a
+type S a = D a
+newtype N = N S

--- a/tests/purs/failing/TypeSynonyms9.out
+++ b/tests/purs/failing/TypeSynonyms9.out
@@ -1,0 +1,15 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/TypeSynonyms9.purs:7:19 - 7:29 (line 7, column 19 - line 7, column 29)
+
+  Type synonym [33mData.NaturalTransformation.NaturalTransformation[0m is partially applied.
+  Type synonyms must be applied to all of their type arguments.
+
+while checking that type [33mNaturalTransformation Array[0m
+  has kind [33m(Type -> Type) -> Type -> Type[0m
+while inferring the kind of [33mA (NaturalTransformation Array)[0m
+in type constructor [33mB[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/TypeSynonyms9.purs
+++ b/tests/purs/failing/TypeSynonyms9.purs
@@ -1,0 +1,7 @@
+-- @shouldFailWith PartiallyAppliedSynonym
+module Main where
+
+import Prelude
+
+newtype A (a :: (Type -> Type) -> Type -> Type) = A String
+newtype B = B (A ((~>) Array))

--- a/tests/purs/passing/TypeSynonyms.purs
+++ b/tests/purs/passing/TypeSynonyms.purs
@@ -25,4 +25,6 @@ fst =
 test1 :: forall a b c. Lens (Pair (Pair a b) c) a
 test1 = composeLenses fst fst
 
+newtype N = N (Array ~> Array)
+
 main = log "Done"


### PR DESCRIPTION
This check doesn't prevent any programs from compiling; it just makes
sure that a more specific PartiallyAppliedSynonym error is raised
instead of a KindsDoNotUnify error, which could be interpreted as
implying that a partially applied synonym has a valid kind and would be
supported elsewhere if that kind is expected.

**Description of the change**

Another stepping stone on the path to #4086. This is fairly superficial but without it, some test outputs would change from `PartiallyAppliedSynonym` to `KindsDoNotUnify` when type checking and instance deriving are combined, and I figure that'd be a regression.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- <s>Added myself to CONTRIBUTORS.md (if this is my first contribution)</s>
- <s>Linked any existing issues or proposals that this pull request should close</s>
- <s>Updated or added relevant documentation</s>
- [x] Added a test for the contribution (if applicable)
