### PR TITLE
Update Discord link to remove explicit invite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@
 When reporting issues, please be aware of the following:
 
 * Please use the appropriate issue template if there is one: filling out all of the sections in the template makes it much easier for us to understand what the problem is and how we might want to address it.
-* We prefer to reserve the issue tracker in this repository for tasks which involve work on the compiler. If your report or proposal doesn't involve work on the compiler, please open it on the repository where the work would be done. If you're unsure, you can always ask on [Discord](https://discord.gg/sMqwYUbvz6) or [Discourse](https://discourse.purescript.org).
-* If you have a question or need help, please ask on [Discord](https://discord.gg/sMqwYUbvz6) or [Discourse](https://discourse.purescript.org) instead.
+* We prefer to reserve the issue tracker in this repository for tasks which involve work on the compiler. If your report or proposal doesn't involve work on the compiler, please open it on the repository where the work would be done. If you're unsure, you can always ask on [Discord](https://purescript.org/chat) or [Discourse](https://discourse.purescript.org).
+* If you have a question or need help, please ask on [Discord](https://purescript.org/chat) or [Discourse](https://discourse.purescript.org) instead.
 * When submitting feature proposals, please be aware that we prefer to be conservative about adding things to the language/compiler. A feature proposal is much more likely to be accepted if it includes a clear description of the problem it intends to solve, as well as not only a strong justification for why adding the feature will solve that problem, but also for why any existing features or techniques that could be used to solve that problem are insufficient.
 
 We have defined some [Project Values](https://github.com/purescript/governance#project-values) in our organization's governance document; referring to these may help you get a better idea of what is likely to be accepted and what isn't.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installation information
 
-If you are having difficulty installing the PureScript compiler, feel free to ask for help! The best places are the [PureScript Discord](https://discord.gg/sMqwYUbvz6) or [PureScript Discourse](https://discourse.purescript.org).
+If you are having difficulty installing the PureScript compiler, feel free to ask for help! The best places are the [PureScript Discord](https://purescript.org/chat) or [PureScript Discourse](https://discourse.purescript.org).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ A small strongly typed programming language with expressive types that compiles 
 
 ## Help!
 
-- [PureScript Discord](https://discord.gg/sMqwYUbvz6)
+- [PureScript Discord](https://purescript.org/chat)
 - [PureScript Discourse](https://discourse.purescript.org/)
 - [PureScript on StackOverflow](http://stackoverflow.com/questions/tagged/purescript)


### PR DESCRIPTION
**Description of the change**

After some discussion with the infrastructure team, we've decided to implement a redirect from `purescript.org/chat` to the Discord invite link, so that resources that provide a link to the Discord don't have to update if anything were to happen with that particular invite link (for example, it is accidentally deactivated, or the channel moves, or the server owner leaves).