### PR TITLE
Fix backtick offside rule

### DIFF
--- a/CHANGELOG.d/fix_4171.md
+++ b/CHANGELOG.d/fix_4171.md
@@ -1,0 +1,1 @@
+* Fix backtick operator rule

--- a/lib/purescript-cst/src/Language/PureScript/CST/Layout.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Layout.hs
@@ -265,7 +265,7 @@ insertLayout src@(SourceToken tokAnn tok) nextPos stack =
         ((_, LytTick) : stk', acc') ->
           (stk', acc') & insertToken src
         _ ->
-          state & insertDefault & pushStack tokPos LytTick
+          state & collapse offsideEndP & insertSep & insertToken src & pushStack tokPos LytTick
 
     -- In general, commas should close all indented contexts.
     --     example = [ do foo

--- a/tests/purs/layout/BacktickOperator.out
+++ b/tests/purs/layout/BacktickOperator.out
@@ -12,5 +12,5 @@ example3 =
   case _ of{
     Foo a -> 1;
     Bar b -> 2}
-  `append` 3}
+    `append` 3}
   <eof>

--- a/tests/purs/layout/BacktickOperator.out
+++ b/tests/purs/layout/BacktickOperator.out
@@ -1,0 +1,16 @@
+module Test where{
+
+example1 = do{
+  foo bar}
+  <|> baz;
+
+example2 = do{
+  foo bar}
+  `wat` baz;
+
+example3 =
+  case _ of{
+    Foo a -> 1;
+    Bar b -> 2}
+  `append` 3}
+  <eof>

--- a/tests/purs/layout/BacktickOperator.out
+++ b/tests/purs/layout/BacktickOperator.out
@@ -12,5 +12,11 @@ example3 =
   case _ of{
     Foo a -> 1;
     Bar b -> 2}
-    `append` 3}
-  <eof>
+    `append` 3;
+
+example4 =
+  case _ of{
+    Foo a -> 1;
+    Bar b -> 2}
+    + 3}
+<eof>

--- a/tests/purs/layout/BacktickOperator.purs
+++ b/tests/purs/layout/BacktickOperator.purs
@@ -12,5 +12,5 @@ example3 =
   case _ of
     Foo a -> 1
     Bar b -> 2
-  `append` 3
+    `append` 3
   

--- a/tests/purs/layout/BacktickOperator.purs
+++ b/tests/purs/layout/BacktickOperator.purs
@@ -1,0 +1,16 @@
+module Test where
+
+example1 = do
+  foo bar
+  <|> baz
+
+example2 = do
+  foo bar
+  `wat` baz
+
+example3 =
+  case _ of
+    Foo a -> 1
+    Bar b -> 2
+  `append` 3
+  

--- a/tests/purs/layout/BacktickOperator.purs
+++ b/tests/purs/layout/BacktickOperator.purs
@@ -13,4 +13,9 @@ example3 =
     Foo a -> 1
     Bar b -> 2
     `append` 3
-  
+
+example4 =
+  case _ of
+    Foo a -> 1
+    Bar b -> 2
+    + 3


### PR DESCRIPTION
**Description of the change**

Fixes #4171 by applying the change suggested by Nate in that issue. 

I'm guessing this is not entirely correct because one of the other golden tests was affected by this change, too.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
