### PR TITLE
Include function declarations that are referenced by top-level function calls during bundling

### DIFF
--- a/CHANGELOG.d/fix_bundle-toplevel-function-calls.md
+++ b/CHANGELOG.d/fix_bundle-toplevel-function-calls.md
@@ -1,0 +1,1 @@
+* Do not remove function declarations that are referenced by top-level function calls when bundling

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -89,6 +89,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@noraesae](https://github.com/noraesae) | Hyunje Jun | [MIT license](http://opensource.org/licenses/MIT) |
 | [@nullobject](https://github.com/nullobject) | Josh Bassett | [MIT license](http://opensource.org/licenses/MIT) |
 | [@osa1](https://github.com/osa1) | Ömer Sinan Ağacan | MIT license |
+| [@ozkutuk](https://github.com/ozkutuk) | Berk Özkütük | [MIT license](http://opensource.org/licenses/MIT) |
 | [@paf31](https://github.com/paf31) | Phil Freeman | [MIT license](http://opensource.org/licenses/MIT) |
 | [@parsonsmatt](https://github.com/parsonsmatt) | Matt Parsons | [MIT license](http://opensource.org/licenses/MIT) |
 | [@passy](https://github.com/passy) | Pascal Hartig | [MIT license](http://opensource.org/licenses/MIT) |

--- a/tests/purs/bundle/FunctionDeclaration.js
+++ b/tests/purs/bundle/FunctionDeclaration.js
@@ -17,3 +17,9 @@ exports.qux = qux;
 var fs = require('fs');
 var source = fs.readFileSync(__filename, 'utf-8');
 exports.fooIsEliminated = !/^ *var foo/m.test(source);
+
+function localFunction() {
+  return true;
+}
+
+localFunction(); // this should cause localFunction to be bundled


### PR DESCRIPTION
**Description of the change**

Fixes #4181

As stated in #4181, #4044 introduced a regression to the bundler. Bundler only concerns itself with require statements, member declarations, and export lists; and it ignores everything else (leaving them in the bundle verbatim). Before #4044 was introduced, both the function declaration and the call to that function were falling back to "other" case, leaving them untouched in the bundler output. However, since #4044, the function declarations are treated specially and are now properly parsed as member declarations. This causes them to be subject to DCE check, and since bundler can't detect that the declaration is referenced by a top-level function call, it eliminates the declaration during DCE.

This PR fixes the issue by parsing top-level function calls as member declarations, and also specifies them as potential entry points to the module. This allows the DCE check to detect that the function declaration is indeed referenced.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [x] ~~Updated or added relevant documentation~~
- [x] Added a test for the contribution (if applicable)
