### PR TITLE
Can't solve constraints in values which came from constructor binders where the constructor was polymorphic

### DIFF
--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -710,7 +710,8 @@ check' v@(Var _ var) ty = do
   checkVisibility var
   repl <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< lookupVariable $ var
   ty' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ ty
-  elaborate <- subsumes repl ty'
+  currentSubst <- gets checkSubstitution
+  elaborate <- subsumes (substituteType currentSubst repl) ty'
   return $ TypedValue' True (elaborate v) ty'
 check' (DeferredDictionary className tys) ty = do
   {-

--- a/tests/purs/failing/3765.out
+++ b/tests/purs/failing/3765.out
@@ -4,31 +4,32 @@ at tests/purs/failing/3765.purs:6:23 - 6:24 (line 6, column 23 - line 6, column 
 
   Could not match type
   [33m            [0m
-  [33m  ( b :: Int[0m
+  [33m  ( a :: Int[0m
   [33m  ...       [0m
   [33m  | t0      [0m
   [33m  )         [0m
   [33m            [0m
   with type
   [33m            [0m
-  [33m  ( a :: Int[0m
+  [33m  ( b :: Int[0m
   [33m  ...       [0m
   [33m  | t0      [0m
   [33m  )         [0m
   [33m            [0m
 
-while trying to match type [33m{ b :: Int[0m
-                           [33m| t0      [0m
-                           [33m}         [0m
-  with type [33mt1[0m
+while checking that type [33m{ a :: Int[0m
+                         [33m| t0      [0m
+                         [33m}         [0m
+  is at least as general as type [33m{ b :: Int[0m
+                                 [33m| t0      [0m
+                                 [33m}         [0m
 while checking that expression [33mx[0m
   has type [33m{ b :: Int[0m
            [33m| t0      [0m
            [33m}         [0m
 in value declaration [33mmkTricky[0m
 
-where [33mt1[0m is an unknown type
-      [33mt0[0m is an unknown type
+where [33mt0[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/SuggestComposition.out
+++ b/tests/purs/failing/SuggestComposition.out
@@ -14,7 +14,7 @@ at tests/purs/failing/SuggestComposition.purs:7:5 - 7:6 (line 7, column 5 - line
 while trying to match type [33m{ g :: t0[0m
                            [33m| t1     [0m
                            [33m}        [0m
-  with type [33mt2 -> t3[0m
+  with type [33mInt -> Int[0m
 while checking that expression [33mg[0m
   has type [33m{ g :: t0[0m
            [33m| t1     [0m
@@ -22,9 +22,7 @@ while checking that expression [33mg[0m
 while checking type of property accessor [33mg.g[0m
 in value declaration [33mf[0m
 
-where [33mt2[0m is an unknown type
-      [33mt3[0m is an unknown type
-      [33mt0[0m is an unknown type
+where [33mt0[0m is an unknown type
       [33mt1[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,

--- a/tests/purs/passing/BoundVariableSubsumption.purs
+++ b/tests/purs/passing/BoundVariableSubsumption.purs
@@ -5,7 +5,7 @@ import Effect.Console (log)
 
 class Con
 
-data Identity a = Identity a
+newtype Identity a = Identity a
 
 test :: Con => Identity (Con => Int) -> Int
 test (Identity a) = a

--- a/tests/purs/passing/BoundVariableSubsumption.purs
+++ b/tests/purs/passing/BoundVariableSubsumption.purs
@@ -1,0 +1,14 @@
+module Main where
+
+import Prelude
+import Effect.Console (log)
+
+class Con
+
+data Identity a = Identity a
+
+test :: Con => Identity (Con => Int) -> Int
+test (Identity a) = a
+
+main = do
+  log "Done"


### PR DESCRIPTION
Before this change, you couldn't solve constraints in values which came from constructor binders where the constructor was polymorphic:

```haskell

class Con

newtype Identity a = Identity a

-- works
test1 :: Con => (Con => Int) -> Int
test1 a = a

-- fails
test2 :: Con => Identity (Con => Int) -> Int
test2 (Identity a) = a
```

This is because we weren't applying substitutions when checking the types of 'Var' exprs before subsumption, and polymorphic types like Identity get instantiated with unknowns during binder inference. This change adds the substitution in.


**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
