### PR TITLE
remove explicit disabling of Nix in stack.yaml

### DIFF
--- a/CHANGELOG.d/internal_no-explicit-disable-nix.md
+++ b/CHANGELOG.d/internal_no-explicit-disable-nix.md
@@ -1,4 +1,5 @@
-* The explicit disabling of Nix has been removed from `stack.yaml`.  For
-  developers on NixOS, this means that you should be able to build PureScript
-  by running `stack build` instead of `stack build --nix`.  For other
-  developers, this shouldn't affect you.
+* The explicit disabling of Nix has been removed from `stack.yaml`.  
+  
+  For developers on NixOS, this means that you should be able to build 
+  PureScript by running `stack build` instead of `stack build --nix`.  
+  For other developers, this shouldn't affect you.

--- a/CHANGELOG.d/internal_no-explicit-disable-nix.md
+++ b/CHANGELOG.d/internal_no-explicit-disable-nix.md
@@ -1,0 +1,4 @@
+* The explicit disabling of Nix has been removed from `stack.yaml`.  For
+  developers on NixOS, this means that you should be able to build PureScript
+  by running `stack build` instead of `stack build --nix`.  For other
+  developers, this shouldn't affect you.

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,6 @@ extra-deps:
 - hspec-core-2.8.3
 - hspec-discover-2.8.3
 nix:
-  enable: false
   packages:
   - zlib
   # Test dependencies


### PR DESCRIPTION
**Description of the change**

The current `stack.yaml` in this repo explicitly disables using Nix for building.

In my experience, it is better to just remove the `nix.enable: false` line from `stack.yaml`, rather than explicitly disabling it.

With `stack`, Nix is "required" for building on NixOS.  If you explicitly disable Nix support in `stack.yaml`, you won't be able to build on NixOS without using `stack build --nix`.  It is a little annoying to have to remember to always pass `--nix` (even though this should basically be the default on NixOS).

For all other distros, `stack` defaults to not using Nix, so removing `nix.enable: false` shouldn't change anything.

The only people who may be negatively affected by this change are people who are running a non-NixOS Linux distro _and_ have `nix.enable: false` in their `~/.stack/config.yaml` _and_ also rely on `stack` building PureScript without using Nix.  I imagine this group of people is either small or non-existent.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
