### PR TITLE
Include missing source spans for data constructors

### DIFF
--- a/CHANGELOG.d/fix_ctor-spans.md
+++ b/CHANGELOG.d/fix_ctor-spans.md
@@ -1,0 +1,1 @@
+* Add missing source spans to data constructors when generating docs

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -150,7 +150,7 @@ convertDeclaration (P.DataDeclaration sa dtype _ args ctors) title =
   children = map convertCtor ctors
   convertCtor :: P.DataConstructorDeclaration -> ChildDeclaration
   convertCtor P.DataConstructorDeclaration{..} =
-    ChildDeclaration (P.runProperName dataCtorName) (convertComments $ snd dataCtorAnn) Nothing (ChildDataConstructor (fmap (($> ()) . snd) dataCtorFields))
+    ChildDeclaration (P.runProperName dataCtorName) (convertComments $ snd dataCtorAnn) (Just $ fst dataCtorAnn) (ChildDataConstructor (fmap (($> ()) . snd) dataCtorFields))
 convertDeclaration (P.ExternDataDeclaration sa _ kind') title =
   basicDeclaration sa title (ExternDataDeclaration (kind' $> ()))
 convertDeclaration (P.TypeSynonymDeclaration sa _ args ty) title =

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -150,7 +150,8 @@ convertDeclaration (P.DataDeclaration sa dtype _ args ctors) title =
   children = map convertCtor ctors
   convertCtor :: P.DataConstructorDeclaration -> ChildDeclaration
   convertCtor P.DataConstructorDeclaration{..} =
-    ChildDeclaration (P.runProperName dataCtorName) (convertComments $ snd dataCtorAnn) (Just $ fst dataCtorAnn) (ChildDataConstructor (fmap (($> ()) . snd) dataCtorFields))
+    let (sourceSpan, comments) = dataCtorAnn
+    in ChildDeclaration (P.runProperName dataCtorName) (convertComments comments) (Just sourceSpan) (ChildDataConstructor (fmap (($> ()) . snd) dataCtorFields))
 convertDeclaration (P.ExternDataDeclaration sa _ kind') title =
   basicDeclaration sa title (ExternDataDeclaration (kind' $> ()))
 convertDeclaration (P.TypeSynonymDeclaration sa _ args ty) title =


### PR DESCRIPTION
This includes the missing source spans that weren't added in #3683. As such, this also allows purs to generate TAGS entries appropriately.



https://user-images.githubusercontent.com/66708316/140643875-8c17ba07-17db-4001-9723-c77eca2b9f78.mp4


---

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- ~~Added myself to CONTRIBUTORS.md (if this is my first contribution)~~
- ~~Linked any existing issues or proposals that this pull request should close~~
- ~~Updated or added relevant documentation~~
- ~~Added a test for the contribution (if applicable)~~
