### PR TITLE
Inline newtype constructor applications with ($)

### DIFF
--- a/CHANGELOG.d/fix_newtype_dollar.md
+++ b/CHANGELOG.d/fix_newtype_dollar.md
@@ -1,0 +1,1 @@
+* Optimize newtype applications with the ($) operator

--- a/CHANGELOG.d/internal_optimization_golden_tests.md
+++ b/CHANGELOG.d/internal_optimization_golden_tests.md
@@ -1,0 +1,5 @@
+* Create test machinery for optimizations
+
+  This adds machinery for testing code generation for optimizations.
+
+  Partially extracted from #3915 to add tests for #4205.

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -245,6 +245,7 @@ moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreign_ =
     unApp (App _ val arg) args = unApp val (arg : args)
     unApp other args = (other, args)
 
+    mkApp :: Expr Ann -> [Expr Ann] -> m AST
     mkApp f args = do
       args' <- mapM valueToJs args
       case f of

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -39,6 +39,7 @@ import Language.PureScript.Options
 import Language.PureScript.PSString (PSString, mkString)
 import Language.PureScript.Traversals (sndM)
 import qualified Language.PureScript.Constants.Prim as C
+import qualified Language.PureScript.Constants.Prelude as C
 
 import System.FilePath.Posix ((</>))
 
@@ -233,9 +234,11 @@ moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreign_ =
   valueToJs' e@App{} = do
     let (f, args) = unApp e []
     case f of
-      Var _ (Qualified _ (Ident "apply")) -> do
-        let (f', args') = unApp (head args) (tail args)
-        mkApp f' args'
+      Var _ (Qualified (Just applyFnModule) (Ident applyFn))
+        | moduleNameToJs applyFnModule == C.dataFunction
+        , applyFn == C.apply -> do
+            let (f', args') = unApp (head args) (tail args)
+            mkApp f' args'
       _ -> mkApp f args
     where
     unApp :: Expr Ann -> [Expr Ann] -> (Expr Ann, [Expr Ann])

--- a/src/Language/PureScript/CoreFn/Optimizer.hs
+++ b/src/Language/PureScript/CoreFn/Optimizer.hs
@@ -60,7 +60,7 @@ optimizeUnusedPartialFn (Let _
   originalCoreFn
 optimizeUnusedPartialFn e = e
 
-optimizeDataFunctionApply :: Expr Ann -> Expr Ann
+optimizeDataFunctionApply :: Expr a -> Expr a
 optimizeDataFunctionApply e = case e of
   (App a (App _ (Var _ (Qualified (Just (ModuleName mn)) (Ident fn))) x) y)
     | mn == dataFunction && fn == C.apply -> App a x y

--- a/src/Language/PureScript/CoreFn/Optimizer.hs
+++ b/src/Language/PureScript/CoreFn/Optimizer.hs
@@ -53,7 +53,7 @@ closedRecordFields (TypeApp _ (TypeConstructor _ C.Record) row) =
 closedRecordFields _ = Nothing
 
 -- | See https://github.com/purescript/purescript/issues/3157
-optimizeUnusedPartialFn :: Expr Ann -> Expr Ann
+optimizeUnusedPartialFn :: Expr a -> Expr a
 optimizeUnusedPartialFn (Let _
   [NonRec _ UnusedIdent _]
   (App _ (App _ (Var _ (Qualified _ UnusedIdent)) _) originalCoreFn)) =

--- a/src/Language/PureScript/CoreFn/Optimizer.hs
+++ b/src/Language/PureScript/CoreFn/Optimizer.hs
@@ -3,6 +3,7 @@ module Language.PureScript.CoreFn.Optimizer (optimizeCoreFn) where
 import Protolude hiding (Type)
 
 import Data.List (lookup)
+import qualified Data.Text as T
 import Language.PureScript.AST.Literals
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.CoreFn.Ann
@@ -12,6 +13,7 @@ import Language.PureScript.CoreFn.Traversals
 import Language.PureScript.Names (Ident(..), ModuleName(..), Qualified(..))
 import Language.PureScript.Label
 import Language.PureScript.Types
+import qualified Language.PureScript.Constants.Prelude as C
 import qualified Language.PureScript.Constants.Prim as C
 
 -- |
@@ -58,10 +60,12 @@ optimizeUnusedPartialFn (Let _
   originalCoreFn
 optimizeUnusedPartialFn e = e
 
--- | TODO: Fixup the annotations here.
 optimizeDataFunctionApply :: Expr Ann -> Expr Ann
 optimizeDataFunctionApply e = case e of
-  (App a (App _ (Var _ (Qualified (Just (ModuleName dataFunction)) (Ident applyFn))) x) y)
-    | dataFunction == "Data.Function" && applyFn == "apply" -> App a x y
-    | dataFunction == "Data.Function" && applyFn == "applyFlipped" -> App a y x
+  (App a (App _ (Var _ (Qualified (Just (ModuleName mn)) (Ident fn))) x) y)
+    | mn == dataFunction && fn == C.apply -> App a x y
+    | mn == dataFunction && fn == C.applyFlipped -> App a y x
   _ -> e
+  where
+  dataFunction :: Text
+  dataFunction = T.replace "_" "." C.dataFunction

--- a/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
@@ -164,8 +164,6 @@ inlineCommonOperators = everywhereTopDown $ applyAll $
   , binary' C.dataIntBits C.zshr ZeroFillShiftRight
   , unary'  C.dataIntBits C.complement BitwiseNot
 
-  , inlineNonClassFunction (isModFn (C.dataFunction, C.apply)) $ \f x -> App Nothing f [x]
-  , inlineNonClassFunction (isModFn (C.dataFunction, C.applyFlipped)) $ \x f -> App Nothing f [x]
   , inlineNonClassFunction (isModFnWithDict (C.dataArray, C.unsafeIndex)) $ flip (Indexer Nothing)
   ] ++
   [ fn | i <- [0..10], fn <- [ mkFn i, runFn i ] ] ++
@@ -247,11 +245,6 @@ inlineCommonOperators = everywhereTopDown $ applyAll $
     convert :: AST -> AST
     convert (App _ (App _ op' [x]) [y]) | p op' = f x y
     convert other = other
-
-  isModFn :: (Text, PSString) -> AST -> Bool
-  isModFn (m, op) (Indexer _ (StringLiteral _ op') (Var _ m')) =
-    m == m' && op == op'
-  isModFn _ _ = False
 
   isModFnWithDict :: (Text, PSString) -> AST -> Bool
   isModFnWithDict (m, op) (App _ (Indexer _ (StringLiteral _ op') (Var _ m')) [Var _ _]) =

--- a/tests/TestCompiler.hs
+++ b/tests/TestCompiler.hs
@@ -28,6 +28,7 @@ import Prelude.Compat
 import qualified Language.PureScript as P
 
 import Control.Arrow ((>>>))
+import qualified Data.ByteString as BS
 import Data.Function (on)
 import Data.List (sort, stripPrefix, minimumBy)
 import Data.Maybe (mapMaybe)
@@ -54,6 +55,7 @@ spec = do
   passingTests
   warningTests
   failingTests
+  optimizeTests
 
 passingTests :: SpecWith SupportModules
 passingTests = do
@@ -86,6 +88,15 @@ failingTests = do
       it ("'" <> takeFileName mainPath <> "' should fail to compile") $ \support -> do
         expectedFailures <- getShouldFailWith mainPath
         assertDoesNotCompile support testPurs expectedFailures
+
+optimizeTests :: SpecWith SupportModules
+optimizeTests = do
+  optimizeTestCases <- runIO $ getTestFiles "optimize"
+
+  describe "Optimization examples" $
+    forM_ optimizeTestCases $ \testPurs ->
+      it ("'" <> takeFileName (getTestMain testPurs) <> "' should compile to expected output") $ \support ->
+        assertCompilesToExpectedOutput support testPurs
 
 checkShouldReport :: [String] -> (P.MultipleErrors -> String) -> P.MultipleErrors -> Expectation
 checkShouldReport expected prettyPrintDiagnostics errs =
@@ -177,6 +188,19 @@ assertDoesNotCompile support inputFiles shouldFailWith = do
         (return . T.encodeUtf8 . T.pack $ printDiagnosticsForGoldenTest result)
     Right _ ->
       expectationFailure "Should not have compiled"
+
+assertCompilesToExpectedOutput
+  :: SupportModules
+  -> [FilePath]
+  -> Expectation
+assertCompilesToExpectedOutput support inputFiles = do
+  (result, _) <- compile support inputFiles
+  case result of
+    Left errs -> expectationFailure . P.prettyPrintMultipleErrors P.defaultPPEOptions $ errs
+    Right _ ->
+      goldenVsString
+        (replaceExtension (getTestMain inputFiles) ".out.js")
+        (BS.readFile $ modulesDir </> "Main/index.js")
 
 -- Prints a set of diagnostics (i.e. errors or warnings) as a string, in order
 -- to compare it to the contents of a golden test file.

--- a/tests/purs/.gitattributes
+++ b/tests/purs/.gitattributes
@@ -1,0 +1,1 @@
+*.out.js -text

--- a/tests/purs/optimize/2866.out.js
+++ b/tests/purs/optimize/2866.out.js
@@ -6,8 +6,10 @@
 var Area = function (x) {
     return x;
 };
+var areaFlipped = 42;
 var area = 42;
 module.exports = {
     Area: Area,
-    area: area
+    area: area,
+    areaFlipped: areaFlipped
 };

--- a/tests/purs/optimize/2866.out.js
+++ b/tests/purs/optimize/2866.out.js
@@ -1,0 +1,13 @@
+
+// Canonical test for #2866. This doesn't need to test whether `apply`s
+// defined from modules other than `Data.Function` are incorrectly
+// optimized since the rest of the test suite seemingly catches it.
+"use strict";
+var Area = function (x) {
+    return x;
+};
+var area = 42;
+module.exports = {
+    Area: Area,
+    area: area
+};

--- a/tests/purs/optimize/2866.purs
+++ b/tests/purs/optimize/2866.purs
@@ -8,3 +8,5 @@ import Prelude
 newtype Area = Area Int
 
 area = Area $ 42
+
+areaFlipped = 42 # Area

--- a/tests/purs/optimize/2866.purs
+++ b/tests/purs/optimize/2866.purs
@@ -1,0 +1,10 @@
+-- Canonical test for #2866. This doesn't need to test whether `apply`s
+-- defined from modules other than `Data.Function` are incorrectly
+-- optimized since the rest of the test suite seemingly catches it.
+module Main where
+
+import Prelude
+
+newtype Area = Area Int
+
+area = Area $ 42


### PR DESCRIPTION
**Description of the change**
This change makes it so that newtype application using the `($)` operator is inlined, which fixes #2866.

I'm not entirely sure how to add tests for this though, or for codegen code in general.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
~~[ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)~~
- [x] Linked any existing issues or proposals that this pull request should close
~~[ ] Updated or added relevant documentation~~
- [x] Added a test for the contribution (if applicable)
