### PR TITLE
Rewrite `Partial` optimization to be cleaner

### DIFF
--- a/CHANGELOG.d/feature_rewrite-partial-optimization.md
+++ b/CHANGELOG.d/feature_rewrite-partial-optimization.md
@@ -1,0 +1,5 @@
+* Rewrite `Partial` optimization to be cleaner
+
+  This feature shrinks the generated JS code for declarations that use
+  empty type classes, such as `Partial`, but is otherwise not expected to
+  have user-visible consequences.

--- a/src/Language/PureScript/CoreFn/Optimizer.hs
+++ b/src/Language/PureScript/CoreFn/Optimizer.hs
@@ -27,8 +27,7 @@ optimizeModuleDecls = map transformBinds
   where
   (transformBinds, _, _) = everywhereOnValues identity transformExprs identity
   transformExprs
-    = optimizeUnusedPartialFn
-    . optimizeClosedRecordUpdate
+    = optimizeClosedRecordUpdate
     . optimizeDataFunctionApply
 
 optimizeClosedRecordUpdate :: Expr Ann -> Expr Ann
@@ -51,14 +50,6 @@ closedRecordFields (TypeApp _ (TypeConstructor _ C.Record) row) =
     collect (RCons _ l _ r) = (l :) <$> collect r
     collect _ = Nothing
 closedRecordFields _ = Nothing
-
--- | See https://github.com/purescript/purescript/issues/3157
-optimizeUnusedPartialFn :: Expr a -> Expr a
-optimizeUnusedPartialFn (Let _
-  [NonRec _ UnusedIdent _]
-  (App _ (App _ (Var _ (Qualified _ UnusedIdent)) _) originalCoreFn)) =
-  originalCoreFn
-optimizeUnusedPartialFn e = e
 
 optimizeDataFunctionApply :: Expr a -> Expr a
 optimizeDataFunctionApply e = case e of

--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -9,7 +9,6 @@ import Control.Monad.State (State, evalState, get, modify)
 import Data.Functor (($>), (<&>))
 import qualified Data.Set as S
 import Data.Text (Text, pack)
-import qualified Language.PureScript.Constants.Prim as C
 import Language.PureScript.CoreImp.AST
 import Language.PureScript.AST.SourcePos (SourceSpan)
 import Safe (headDef, tailSafe)
@@ -175,9 +174,6 @@ tco = flip evalState 0 . everywhereTopDownM convert where
     rootSS = Nothing
 
     collectArgs :: [[AST]] -> AST -> [[AST]]
-    collectArgs acc (App _ fn []) =
-      -- count 0-argument applications as single-argument so we get the correct number of args
-      collectArgs ([Var Nothing C.undefined] : acc) fn
     collectArgs acc (App _ fn args') = collectArgs (args' : acc) fn
     collectArgs acc _ = acc
 

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -75,6 +75,12 @@ data TypedValue' = TypedValue' Bool Expr SourceType
 tvToExpr :: TypedValue' -> Expr
 tvToExpr (TypedValue' c e t) = TypedValue c e t
 
+-- | Lookup data about a type class in the @Environment@
+lookupTypeClass :: MonadState CheckState m => Qualified (ProperName 'ClassName) -> m TypeClassData
+lookupTypeClass name =
+  let findClass = fromMaybe (internalError "entails: type class not found in environment") . M.lookup name
+   in gets (findClass . typeClasses . checkEnv)
+
 -- | Infer the types of multiple mutually-recursive values, and return elaborated values including
 -- type class dictionaries and type annotations.
 typesOf
@@ -116,8 +122,7 @@ typesOf bindingGroupType moduleName vals = withFreshSubstitution $ do
         -- ambiguous types to be inferred if they can be solved by some functional
         -- dependency.
         conData <- forM unsolved $ \(_, _, con) -> do
-          let findClass = fromMaybe (internalError "entails: type class not found in environment") . M.lookup (constraintClass con)
-          TypeClassData{ typeClassDependencies } <- gets (findClass . typeClasses . checkEnv)
+          TypeClassData{ typeClassDependencies } <- lookupTypeClass $ constraintClass con
           let
             -- The set of unknowns mentioned in each argument.
             unknownsForArg :: [S.Set Int]
@@ -670,8 +675,11 @@ check' val (ForAll ann ident mbK ty _) = do
         | otherwise = val
   val' <- tvToExpr <$> check skVal sk
   return $ TypedValue' True val' (ForAll ann ident mbK ty (Just scope))
-check' val t@(ConstrainedType _ con@(Constraint _ (Qualified _ (ProperName className)) _ _ _) ty) = do
-  dictName <- freshIdent ("dict" <> className)
+check' val t@(ConstrainedType _ con@(Constraint _ cls@(Qualified _ (ProperName className)) _ _ _) ty) = do
+  TypeClassData{ typeClassIsEmpty } <- lookupTypeClass cls
+  -- An empty class dictionary is never used; see code in `TypeChecker.Entailment`
+  -- that wraps empty dictionary solutions in `Unused`.
+  dictName <- if typeClassIsEmpty then pure UnusedIdent else freshIdent ("dict" <> className)
   dicts <- newDictionaries [] (Qualified Nothing dictName) con
   val' <- withBindingGroupVisible $ withTypeClassDictionaries dicts $ check val ty
   return $ TypedValue' True (Abs (VarBinder nullSourceSpan dictName) (tvToExpr val')) t

--- a/tests/purs/failing/2806.out
+++ b/tests/purs/failing/2806.out
@@ -9,13 +9,10 @@ at tests/purs/failing/2806.purs:6:1 - 6:29 (line 6, column 1 - line 6, column 29
 
   Alternatively, add a Partial constraint to the type of the enclosing value.
 
-while applying a function [33m$__unused[0m
-  of type [33mPartial => t1 -> t1[0m
-  to argument [33mcase e of          [0m
-              [33m  e | L x <- e -> x[0m
-while checking that expression [33m$__unused (case e of          [0m
-                               [33m             e | L x <- e -> x[0m
-                               [33m          )                   [0m
+while checking that type [33mPartial => t1[0m
+  is at least as general as type [33ma0[0m
+while checking that expression [33mcase e of          [0m
+                               [33m  e | L x <- e -> x[0m
   has type [33ma0[0m
 in value declaration [33mg[0m
 

--- a/tests/purs/failing/NonExhaustivePatGuard.out
+++ b/tests/purs/failing/NonExhaustivePatGuard.out
@@ -9,13 +9,10 @@ at tests/purs/failing/NonExhaustivePatGuard.purs:4:1 - 4:16 (line 4, column 1 - 
 
   Alternatively, add a Partial constraint to the type of the enclosing value.
 
-while applying a function [33m$__unused[0m
-  of type [33mPartial => t0 -> t0[0m
-  to argument [33mcase x of        [0m
-              [33m  x | 1 <- x -> x[0m
-while checking that expression [33m$__unused (case x of        [0m
-                               [33m             x | 1 <- x -> x[0m
-                               [33m          )                 [0m
+while checking that type [33mPartial => t0[0m
+  is at least as general as type [33mInt[0m
+while checking that expression [33mcase x of        [0m
+                               [33m  x | 1 <- x -> x[0m
   has type [33mInt[0m
 in value declaration [33mf[0m
 

--- a/tests/purs/failing/Superclasses5.out
+++ b/tests/purs/failing/Superclasses5.out
@@ -9,15 +9,10 @@ at tests/purs/failing/Superclasses5.purs:17:1 - 18:18 (line 17, column 1 - line 
 
   Alternatively, add a Partial constraint to the type of the enclosing value.
 
-while applying a function [33m$__unused[0m
-  of type [33mPartial => t0 -> t0[0m
-  to argument [33mcase $0 of       [0m
-              [33m  [ x ] -> [ su x[0m
-              [33m           ]     [0m
-while inferring the type of [33m$__unused (case $0 of      [0m
-                            [33m             [ x ] -> [ ...[0m
-                            [33m                      ]    [0m
-                            [33m          )                [0m
+while checking that expression [33mcase $0 of       [0m
+                               [33m  [ x ] -> [ su x[0m
+                               [33m           ]     [0m
+  has type [33mt0[0m
 in value declaration [33msuArray[0m
 
 where [33mt0[0m is an unknown type


### PR DESCRIPTION
This feature shrinks the generated JS code for declarations that use
empty type classes, such as `Partial`, but is otherwise not expected to
have user-visible consequences.

A previous issue involving `Partial` resulted in an ad-hoc optimization
pass added to the CoreFn phase. This pass consumed code generated by the
exhaustiveness checker, which used `UnusedIdent` in a questionable
manner, and ran a rewrite on it that assumed that the only part of the
compile that would use `UnusedIdent` in such a questionable manner was
necessarily the exhaustiveness checker.

This commit:

* simplifies the code generated by the exhaustiveness checker for
  partial matches, in particular removing any use of `UnusedIdent`s;

* removes the offending CoreFn optimization pass;

* solves the problem originally motivating said optimization pass by
  using an `UnusedIdent` for the generated parameter when type-checking
  a value constrained by an empty type class (such parameters,
  importantly for our sanity, are actually unused);

* and backs out a related hack in TCO that worked around such generated
  parameters being present but called without an argument.

The intended result is simpler compiler code; happy side effects include
simpler error messages involving partial pattern matches (seen here in a
few golden test output changes) and simpler generated code (fewer unused
function parameters, fewer local variables in some TCO-triggering
functions).

---

This backs out #3218 (except for the test) and a small part of #3416.

For the two test files added in those PRs, here are diffs of the generated code before and after this PR:

```diff
@@ -30,7 +30,7 @@
     }
 };
 var whenAccessingSuperDict = (function () {
-    var bar = function (dictWithArgEmpty) {
+    var bar = function () {
         return function (x) {
             return x;
         };
@@ -80,8 +80,8 @@
 };
 var whenAliasEmptyClass = Check.value;
 var main = (function () {
-    var $13 = Data_Eq.eq(eqCheck)(Check.value)(whenEmpty) && (Data_Eq.eq(eqCheck)(Check.value)(whenHasEmptySuper) && (Data_Eq.eq(eqCheck)(Check.value)(whenHasNonEmptySuper) && (Data_Eq.eq(eqCheck)(Check.value)(whenAliasEmptyClass) && Data_Eq.eq(eqCheck)(Check.value)(whenAccessingSuperDict))));
-    if ($13) {
+    var $10 = Data_Eq.eq(eqCheck)(Check.value)(whenEmpty) && (Data_Eq.eq(eqCheck)(Check.value)(whenHasEmptySuper) && (Data_Eq.eq(eqCheck)(Check.value)(whenHasNonEmptySuper) && (Data_Eq.eq(eqCheck)(Check.value)(whenAliasEmptyClass) && Data_Eq.eq(eqCheck)(Check.value)(whenAccessingSuperDict))));
+    if ($10) {
         return Effect_Console.log("Done");
     };
     return Control_Applicative.pure(Effect.applicativeEffect)(Data_Unit.unit);
```
```diff
@@ -1,19 +1,17 @@
 "use strict";
 var Effect_Console = require("../Effect.Console/index.js");
-var partialTCO = function ($copy_dictPartial) {
+var partialTCO = function () {
     return function ($copy_v) {
         return function ($copy_v1) {
-            var $tco_var_dictPartial = $copy_dictPartial;
             var $tco_var_v = $copy_v;
             var $tco_done = false;
             var $tco_result;
-            function $tco_loop(dictPartial, v, v1) {
+            function $tco_loop(v, v1) {
                 if (v && v1 === 0) {
                     $tco_done = true;
                     return 0;
                 };
                 if (v) {
-                    $tco_var_dictPartial = undefined;
                     $tco_var_v = true;
                     $copy_v1 = v1 - 1 | 0;
                     return;
@@ -21,7 +19,7 @@
                 throw new Error("Failed pattern match at Main (line 11, column 1 - line 11, column 47): " + [ v.constructor.name, v1.constructor.name ]);
             };
             while (!$tco_done) {
-                $tco_result = $tco_loop($tco_var_dictPartial, $tco_var_v, $copy_v1);
+                $tco_result = $tco_loop($tco_var_v, $copy_v1);
             };
             return $tco_result;
         };
```

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- <s>Added myself to CONTRIBUTORS.md (if this is my first contribution)</s>
- <s>Linked any existing issues or proposals that this pull request should close</s>
- <s>Updated or added relevant documentation</s>
- <s>Added a test for the contribution (if applicable)</s>
