### PR TITLE
Adds option to ignore foreign declaration check

### DIFF
--- a/CHANGELOG.d/feature_disable-ffi-check.md
+++ b/CHANGELOG.d/feature_disable-ffi-check.md
@@ -1,0 +1,1 @@
+* Adds a `no-foreign-decl-check` flag to `purs compile` to skip foreign declaration checks.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -79,6 +79,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@mrkgnao](https://github.com/mrkgnao) | Soham Chowdhury | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mgmeier](https://github.com/mgmeier) | Michael Gilliland | [MIT license](http://opensource.org/licenses/MIT) |
 | [@michaelficarra](https://github.com/michaelficarra) | Michael Ficarra | [MIT license](http://opensource.org/licenses/MIT) |
+| [@mikesol](https://github.com/mikesol) | Mike Solomon | MIT license |
 | [@MichaelXavier](https://github.com/MichaelXavier) | Michael Xavier | MIT license |
 | [@milesfrain](https://github.com/milesfrain) | Miles Frain | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mjgpy3](https://github.com/mjgpy3) | Michael Gilliland | [MIT license](http://opensource.org/licenses/MIT) |

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -106,6 +106,13 @@ verboseErrors = Opts.switch $
   <> Opts.long "verbose-errors"
   <> Opts.help "Display verbose error messages"
 
+noForeignDeclCheck :: Opts.Parser Bool
+noForeignDeclCheck = Opts.switch $
+     Opts.short 'n'
+  <> Opts.long "no-foreign-decl-check"
+  <> Opts.help "Do not check foreign declaration files"
+
+
 noPrefix :: Opts.Parser Bool
 noPrefix = Opts.switch $
      Opts.short 'p'
@@ -145,6 +152,7 @@ options =
   P.Options
     <$> verboseErrors
     <*> (not <$> comments)
+    <*> noForeignDeclCheck
     <*> (handleTargets <$> codegenTargets)
   where
     -- Ensure that the JS target is included if sourcemaps are

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -260,8 +260,10 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
         Just path
           | not $ requiresForeign m ->
               tell $ errorMessage' (CF.moduleSourceSpan m) $ UnnecessaryFFIModule mn path
-          | otherwise ->
-              checkForeignDecls m path
+          | otherwise -> do
+              noForeignDeclCheck <- asks optionsNoForeignDeclCheck
+              unless noForeignDeclCheck $ do
+                checkForeignDecls m path
         Nothing | requiresForeign m -> throwError . errorMessage' (CF.moduleSourceSpan m) $ MissingFFIModule mn
                 | otherwise -> return ()
       for_ (mn `M.lookup` foreigns) $ \path ->

--- a/src/Language/PureScript/Options.hs
+++ b/src/Language/PureScript/Options.hs
@@ -11,6 +11,8 @@ data Options = Options
   { optionsVerboseErrors :: Bool
   -- ^ Verbose error message
   , optionsNoComments :: Bool
+  -- ^ Do not check foreign declarations
+  , optionsNoForeignDeclCheck :: Bool
   -- ^ Remove the comments from the generated js
   , optionsCodegenTargets :: S.Set CodegenTarget
   -- ^ Codegen targets (JS, CoreFn, etc.)
@@ -18,7 +20,7 @@ data Options = Options
 
 -- Default make options
 defaultOptions :: Options
-defaultOptions = Options False False (S.singleton JS)
+defaultOptions = Options False False False (S.singleton JS)
 
 data CodegenTarget = JS | JSSourceMap | CoreFn | Docs
   deriving (Eq, Ord, Show)


### PR DESCRIPTION
**Description of the change**

As ES module support may not make it for some time, this PR is intended to provide an escape hatch where checks for FFI validity can be dispensed with altogether. For those that use industrial bundlers like webpack, builds should still fail when FFIs are wanky, as the imports will not align.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
