### PR TITLE
Turn on ghc option -split-sections

### DIFF
--- a/CHANGELOG.d/internal_split-sections.md
+++ b/CHANGELOG.d/internal_split-sections.md
@@ -1,0 +1,5 @@
+* Pass -split-sections to GHC for potentially smaller binaries
+
+  Size before ~48MB vs after ~24MB.
+
+  See description of `-split-sections` [here](https://downloads.haskell.org/~ghc/9.0.1/docs/html/users_guide/phases.html#ghc-flag--split-sections).

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ packages:
 ghc-options:
   # Build with advanced optimizations enabled by default
   "$locals": -O2 -Werror
+  "$everything": -split-sections
 extra-deps:
 # As of 2021-11-08, the latest release of `language-javascript` is 0.7.1.0,
 # but it has a problem with parsing the `async` keyword.  It doesn't allow


### PR DESCRIPTION
**Description of the change**

There was talk on Discord about using the GHC option [`-split-sections`](https://downloads.haskell.org/~ghc/9.0.1/docs/html/users_guide/phases.html#ghc-flag--split-sections) to reduce binary size.

> #### -split-section
> Place each generated function or data item into its own section in the output file if the target supports arbitrary sections. The name of the function or the name of the data item determines the section’s name in the output file.
>
> When linking, the linker can automatically remove all unreferenced sections and thus produce smaller executables.


This pull-request attempts to apply this suggestion.

Roughly, size before 48MB vs size after 24MB.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
