### PR TITLE
Scope type vars when type checking typed values

### DIFF
--- a/CHANGELOG.d/fix_scope-type-vars-when-type-checking-typed-values.md
+++ b/CHANGELOG.d/fix_scope-type-vars-when-type-checking-typed-values.md
@@ -1,0 +1,10 @@
+* Scope type vars when type checking typed values
+
+  When the compiler is checking an expression that is annotated with a
+  type against another expected type, and the annotation introduces a type
+  variable, the compiler needs to introduce that type variable to the
+  scope of any types used inside the expression.
+
+  One noteworthy case of this pattern is member signatures inside
+  instances. This fix allows type variables introduced in member
+  signatures to be used in the member declaration itself.

--- a/tests/purs/passing/2941.purs
+++ b/tests/purs/passing/2941.purs
@@ -1,0 +1,18 @@
+module Main where
+
+import Effect.Console (log)
+
+test0 = ((((\_ -> 0) :: b -> Int) :: forall b. b -> Int) :: forall a. a -> Int)
+
+test1 :: {attr :: forall a. a -> Int}
+test1 = {attr: ((\_ -> 0) :: b -> Int) :: forall b. b -> Int}
+
+class Test2 where
+  f :: forall a. a -> a
+
+instance test2 :: Test2 where
+  f :: forall a. a -> a
+  f x = (x :: a)
+
+
+main = log "Done"


### PR DESCRIPTION
When the compiler is checking an expression that is annotated with a
type against another expected type, and the annotation introduces a type
variable, the compiler needs to introduce that type variable to the
scope of any types used inside the expression.

One noteworthy case of this pattern is member signatures inside
instances. This fix allows type variables introduced in member
signatures to be used in the member declaration itself.

**Description of the change**

Fixes #2941.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- <s> Added myself to CONTRIBUTORS.md (if this is my first contribution) </s>
- [x] Linked any existing issues or proposals that this pull request should close
- <s> Updated or added relevant documentation </s>
- [x] Added a test for the contribution (if applicable)
