### PR TITLE
Build the entire latest package set in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
 
       - run: "ci/build.sh"
 
+      - name: "(Linux only) Build the entire package set"
+        if: "${{ runner.os == 'Linux' }}"
+        run: "ci/build-package-set.sh"
+
       - name: "(Release only) Create bundle"
         if: "${{ env.CI_RELEASE == 'true' }}"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,15 @@ jobs:
 
       - name: "(Linux only) Build the entire package set"
         if: "${{ runner.os == 'Linux' }}"
-        run: "ci/build-package-set.sh"
+        # We build in this directory in build.sh, so this is where we need to
+        # launch `stack exec`. The actual package-set building happens in a
+        # temporary directory.
+        working-directory: "sdist-test"
+        # The presence or absence of the --haddock flag changes the location
+        # into which stack places all build artifacts. Since we use --haddock
+        # in our CI builds, in order to actually get stack to find the purs
+        # binary it created, we need to use the flag here as well.
+        run: "stack --haddock exec ../ci/build-package-set.sh"
 
       - name: "(Release only) Create bundle"
         if: "${{ env.CI_RELEASE == 'true' }}"

--- a/CHANGELOG.d/internal_build-package-set-in-ci.md
+++ b/CHANGELOG.d/internal_build-package-set-in-ci.md
@@ -1,0 +1,3 @@
+* Build the entire latest package set in CI
+
+  See [#4128](https://github.com/purescript/purescript/pull/4128).

--- a/ci/build-package-set.sh
+++ b/ci/build-package-set.sh
@@ -5,29 +5,14 @@ shopt -s nullglob
 
 psroot=$(dirname "$(dirname "$(realpath "$0")")")
 
-if [[ "${CI:-}" ]]; then
-  if [[ "$(echo $psroot/CHANGELOG.d/breaking_*)" ]]; then
-    echo "Skipping package-set build due to unreleased breaking changes"
-    exit 0
-  fi
-
-  # Go to where we actually built PureScript in a previous step.
-  cd "$psroot/sdist-test"
-
-  # !!! `--local-doc-root`? Yes. Our ci/build.sh script, for some reason,
-  # doesn't put the purs binary in a location included in the PATH that
-  # `stack exec` uses, so `stack exec which purs` doesn't work. I don't have a
-  # good explanation for why that is, or why local-doc-root is the path that
-  # *does* contain the binary, but... well, here we are and I'm sorry.
-  pursdir=$(dirname "$(stack path --local-doc-root)")/bin
-else
-  # Outside of CI, we'll look for purs in the expected place.
-  pursdir=$(dirname "$(stack exec which purs)")
+if [[ "${CI:-}" && "$(echo $psroot/CHANGELOG.d/breaking_*)" ]]; then
+  echo "Skipping package-set build due to unreleased breaking changes"
+  exit 0
 fi
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
-export PATH="$pursdir:$tmpdir/node_modules/.bin:$PATH"
+export PATH="$tmpdir/node_modules/.bin:$PATH"
 cd "$tmpdir"
 
 echo ::group::Ensure Spago is available

--- a/ci/build-package-set.sh
+++ b/ci/build-package-set.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+shopt -s nullglob
+
+psroot=$(dirname "$(dirname "$(realpath "$0")")")
+
+if [[ "${CI:-}" ]]; then
+  if [[ "$(echo $psroot/CHANGELOG.d/breaking_*)" ]]; then
+    echo "Skipping package-set build due to unreleased breaking changes"
+    exit 0
+  fi
+
+  # Go to where we actually built PureScript in a previous step.
+  cd "$psroot/sdist-test"
+
+  # !!! `--local-doc-root`? Yes. Our ci/build.sh script, for some reason,
+  # doesn't put the purs binary in a location included in the PATH that
+  # `stack exec` uses, so `stack exec which purs` doesn't work. I don't have a
+  # good explanation for why that is, or why local-doc-root is the path that
+  # *does* contain the binary, but... well, here we are and I'm sorry.
+  pursdir=$(dirname "$(stack path --local-doc-root)")/bin
+else
+  # Outside of CI, we'll look for purs in the expected place.
+  pursdir=$(dirname "$(stack exec which purs)")
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+export PATH="$pursdir:$tmpdir/node_modules/.bin:$PATH"
+cd "$tmpdir"
+
+echo ::group::Ensure Spago is available
+which spago || npm install spago
+echo ::endgroup::
+
+echo ::group::Create dummy project
+echo 'let upstream = https://github.com/purescript/package-sets/releases/download/XXX/packages.dhall in upstream' > packages.dhall
+echo '{ name = "my-project", dependencies = [] : List Text, packages = ./packages.dhall, sources = [] : List Text }' > spago.dhall
+spago upgrade-set
+# Override the `metadata` package's version to match `purs` version
+# so that `spago build` actually works
+sed -i'' "\$c in upstream with metadata.version = \"v$(purs --version | { read v z && echo $v; })\"" packages.dhall
+spago install $(spago ls packages | while read name z; do echo $name; done)
+echo ::endgroup::
+
+echo ::group::Compile package set
+spago build
+echo ::endgroup::
+
+echo ::group::Document package set
+spago docs --no-search
+echo ::endgroup::


### PR DESCRIPTION
The package set is only built in Linux, as that tends to be the OS that
otherwise finishes first, and there's no need to run this test three
times. The package set is *not* built if there are any files in
CHANGELOG.d starting with `breaking_`, indicating that there are
unreleased breaking changes.

**Description of the change**

Building from the path @JordanMartinez blazed in #4165; the main differences in approach here are not worrying about splitting this step into its own job (it looked like that was going to make CI both take longer and be more complex), and using the presence of `CHANGELOG.d/breaking_*` files to bail out. Let's see if I have any more luck....

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- <s> Added myself to CONTRIBUTORS.md (if this is my first contribution) </s>
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- <s> Added a test for the contribution (if applicable) </s>
