### PR TITLE
Fix type operators in declaration param kinds

### DIFF
--- a/CHANGELOG.d/fix_4218.md
+++ b/CHANGELOG.d/fix_4218.md
@@ -1,0 +1,5 @@
+* Fix type operators in declaration param kinds
+
+  This fixes an internal error triggered by using a type operator in the
+  kind of a type parameter of a data declaration, type synonym
+  declaration, or class declaration.

--- a/tests/purs/passing/TypeOperators.purs
+++ b/tests/purs/passing/TypeOperators.purs
@@ -25,4 +25,10 @@ foreign import data NatData ∷ ∀ f g. (f ~> g) -> f Type -> g Type
 type NatKind ∷ ∀ f g. (f ~> g) -> f Type -> g Type
 type NatKind k a = k a
 
+data UseOperatorInDataParamKind (a :: Type /\ Type) = UseOperatorInDataParamKind
+
+type UseOperatorInTypeParamKind (a :: Type /\ Type) = Int
+
+class UseOperatorInClassParamKind (a :: Type /\ Type)
+
 main = log "Done"


### PR DESCRIPTION
This fixes an internal error triggered by using a type operator in the
kind of a type parameter of a data declaration, type synonym
declaration, or class declaration.

**Description of the change**

Fixes #4218.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- <s> Added myself to CONTRIBUTORS.md (if this is my first contribution) </s>
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
