### PR TITLE
Properly deserialize unused identifiers in the CoreFn

### DIFF
--- a/CHANGELOG.d/fix_unused_ident.md
+++ b/CHANGELOG.d/fix_unused_ident.md
@@ -1,0 +1,7 @@
+# Properly deserialize unused identifiers in the CoreFn
+
+  This mostly affects downstream consumers of the CoreFn as discussed in
+  #4201. This makes it so CoreFn deserialization properly reads `$__unused`
+  into `UnusedIdent` instead of an `Ident`. This is particularly useful for
+  downstream consumers of the CoreFn such as alternative backends that don't
+  allow arguments to be omitted from functions.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -148,7 +148,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@woody88](https://github.com/woody88) | Woodson Delhia | [MIT license](http://opensource.org/licenses/MIT) |
 | [@mhmdanas](https://github.com/mhmdanas) | Mohammed Anas | [MIT license](http://opensource.org/licenses/MIT) |
 | [@kl0tl](https://github.com/kl0tl) | Cyril Sobierajewicz | [MIT license](http://opensource.org/licenses/MIT) |
-| [@PureFunctor](https://github.com/PureFunctor) | Justin Garcia | [MIT license](http://opensource.org/licenses/MIT) |
+| [@PureFunctor](https://github.com/PureFunctor), [@sjpgarcia](https://github.com/sjpgarcia) | Justin Garcia | [MIT license](http://opensource.org/licenses/MIT) |
 | [@xgrommx](https://github.com/xgrommx) | Denis Stoyanov | [MIT license](http://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms

--- a/lib/purescript-cst/src/Language/PureScript/Names.hs
+++ b/lib/purescript-cst/src/Language/PureScript/Names.hs
@@ -78,11 +78,14 @@ data Ident
 instance NFData Ident
 instance Serialise Ident
 
+unusedIdent :: Text
+unusedIdent = "$__unused"
+
 runIdent :: Ident -> Text
 runIdent (Ident i) = i
 runIdent (GenIdent Nothing n) = "$" <> T.pack (show n)
 runIdent (GenIdent (Just name) n) = "$" <> name <> T.pack (show n)
-runIdent UnusedIdent = "$__unused"
+runIdent UnusedIdent = unusedIdent
 
 showIdent :: Ident -> Text
 showIdent = runIdent

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -23,7 +23,7 @@ moduleNameToJs (ModuleName mn) =
 identToJs :: Ident -> Text
 identToJs (Ident name) = anyNameToJs name
 identToJs (GenIdent _ _) = internalError "GenIdent in identToJs"
-identToJs UnusedIdent = "$__unused"
+identToJs UnusedIdent = unusedIdent
 
 -- | Convert a 'ProperName' into a valid JavaScript identifier:
 --

--- a/src/Language/PureScript/CoreFn/Binders.hs
+++ b/src/Language/PureScript/CoreFn/Binders.hs
@@ -31,7 +31,7 @@ data Binder a
   -- |
   -- A binder which binds its input to an identifier
   --
-  | NamedBinder a Ident (Binder a) deriving (Show, Functor)
+  | NamedBinder a Ident (Binder a) deriving (Eq, Show, Functor)
 
 
 extractBinderAnn :: Binder a -> a

--- a/src/Language/PureScript/CoreFn/Expr.hs
+++ b/src/Language/PureScript/CoreFn/Expr.hs
@@ -52,7 +52,7 @@ data Expr a
   -- A let binding
   --
   | Let a [Bind a] (Expr a)
-  deriving (Show, Functor)
+  deriving (Eq, Show, Functor)
 
 -- |
 -- A let or module binding.
@@ -65,7 +65,7 @@ data Bind a
   -- |
   -- Mutually recursive binding group for several values
   --
-  | Rec [((a, Ident), Expr a)] deriving (Show, Functor)
+  | Rec [((a, Ident), Expr a)] deriving (Eq, Show, Functor)
 
 -- |
 -- A guard is just a boolean-valued expression that appears alongside a set of binders
@@ -84,7 +84,7 @@ data CaseAlternative a = CaseAlternative
     -- The result expression or a collect of guarded expressions
     --
   , caseAlternativeResult :: Either [(Guard a, Expr a)] (Expr a)
-  } deriving (Show)
+  } deriving (Eq, Show)
 
 instance Functor CaseAlternative where
 

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -99,7 +99,9 @@ literalFromJSON t = withObject "Literal" literalFromObj
     ObjectLiteral <$> recordFromJSON t val
 
 identFromJSON :: Value -> Parser Ident
-identFromJSON = withText "Ident" (return . Ident)
+identFromJSON = withText "Ident" $ \case
+  ident | ident == unusedIdent -> pure UnusedIdent 
+        | otherwise -> pure $ Ident ident 
 
 properNameFromJSON :: Value -> Parser (ProperName a)
 properNameFromJSON = fmap ProperName . parseJSON

--- a/tests/TestCoreFn.hs
+++ b/tests/TestCoreFn.hs
@@ -149,6 +149,15 @@ spec = context "CoreFnFromJson" $ do
                 ]
       parseMod m `shouldSatisfy` isSuccess
 
+    specify "should parse UnusedIdent in Abs" $ do
+      let i = NonRec ann (Ident "f") (Abs ann UnusedIdent (Var ann (Qualified Nothing (Ident "x"))))
+      let r = parseMod $ Module ss [] mn mp [] [] M.empty [] [i]
+      r `shouldSatisfy` isSuccess
+      case r of
+        Error _ -> pure ()
+        Aeson.Success Module{..} ->
+          moduleDecls `shouldBe` [i]
+
     specify "should parse Case" $ do
       let m = Module ss [] mn mp [] [] M.empty []
                 [ NonRec ann (Ident "case") $


### PR DESCRIPTION
Addresses #4201. This makes it so CoreFn deserialization properly reads `$__unused` into `UnusedIdent` instead of an `Ident`. This is particularly useful for downstream consumers of the CoreFn such as alternative backends that don't allow arguments to be omitted from functions.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md
- [x] Linked any existing issues or proposals that this pull request should close