### PR TITLE
Eagerly apply substitutions when inferring object binders

### DIFF
--- a/CHANGELOG.d/fix_3938.md
+++ b/CHANGELOG.d/fix_3938.md
@@ -1,0 +1,3 @@
+* Eagerly apply substitutions when inferring object binders
+
+  Resolves #3938.

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -534,7 +534,8 @@ inferBinder val (LiteralBinder _ (ObjectLiteral props)) = do
   rest <- freshTypeWithKind (kindRow kindType)
   m1 <- inferRowProperties row rest props
   unifyTypes val (srcTypeApp tyRecord row)
-  return m1
+  sub <- gets checkSubstitution
+  pure $ M.map (substituteType sub) m1
   where
   inferRowProperties :: SourceType -> SourceType -> [(PSString, Binder)] -> m (M.Map Ident SourceType)
   inferRowProperties nrow row [] = unifyTypes nrow row >> return M.empty

--- a/tests/purs/passing/3938.purs
+++ b/tests/purs/passing/3938.purs
@@ -1,0 +1,31 @@
+module Main where
+
+import Prelude
+import Effect (Effect)
+import Effect.Console (log)
+
+type PolyR = { id :: forall a. a -> a }
+
+test :: PolyR
+test = { id: \a -> a }
+
+wat :: (forall b. b -> b) -> Unit
+wat _ =  unit
+  
+example :: Unit
+example = let { id } = test in wat id
+
+example1 :: PolyR -> Unit
+example1 { id } = wat id
+
+type Stuff =
+  { foo :: forall a. a -> a
+  , bar :: forall a. Eq a => a -> a
+  }
+
+broken :: Stuff -> Int
+broken { foo, bar } =
+  bar $ foo 1
+
+main :: Effect Unit
+main = log "Done"


### PR DESCRIPTION
Closes #3938. This makes it so that substitutions are eagerly applied when inferring object binders.

I'd figured out that the following failing example:
```purescript
type PolyR = { id :: forall a. a -> a }

test :: PolyR
test = { id: \a -> a }

wat :: (forall b. b -> b) -> Unit
wat _ =  unit
  
example :: Unit
example = let { id } = test in wat id
```
compiles when the `id` binder is annotated with a polytype.
```
example :: Unit
example = let { id: id :: forall a. a -> a } = test in wat id
```

This patch removes ambiguity in the compiler when inferring the row type of the record being destructured. Instead of having the following substitutions:
```purescript
[ (t7, (id :: t9 | t8))
, (t8, ())
, (t9, forall a. a -> a)
]
```
we force `t7` into
```purescript
[ (t7, (id :: forall a. a -> a | ()))
, (t8, ())
, (t9, forall a. a -> a)
]
```

This is a pretty simple fix, but there must be a better way that involves refactoring this particular `inferBinder` case entirely.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
* Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
* Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
