### PR TITLE
Containerized Linux build (Glibc 2.24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,22 @@ defaults:
 
 env:
   CI_RELEASE: "${{ github.event_name == 'release' }}"
+  STACK_VERSION: "2.7.3"
 
 jobs:
   build:
     strategy:
       fail-fast: false # do not cancel builds for other OSes if one fails
       matrix:
-        # If upgrading Ubuntu, also upgrade it in the lint job below
-        os: [ "ubuntu-18.04", "macOS-10.15", "windows-2019" ]
+        include:
+          - # If upgrading the Haskell image, also upgrade it in the lint job below
+            os: "ubuntu-latest"
+            image: "haskell:8.10.7-stretch@sha256:100f8fb7d7d8d64adb5e106fe8136b8d4cbdc03aeb2cbd145a7597d74b69bafb"
+          - os: "macOS-10.15"
+          - os: "windows-2019"
 
     runs-on: "${{ matrix.os }}"
+    container: "${{ matrix.image }}"
 
     steps:
       - uses: "actions/checkout@v2"
@@ -33,18 +39,28 @@ jobs:
           node-version: "12"
 
       - id: "haskell"
+        name: "(Non-Linux only) Install Haskell"
+        if: "${{ runner.os != 'Linux' }}"
         uses: "haskell/actions/setup@v1"
         with:
           enable-stack: true
           # If upgrading Stack, also upgrade it in the lint job below
-          stack-version: "2.7.1"
+          stack-version: "${{ env.STACK_VERSION }}"
           stack-no-global: true
+
+      - name: "(Linux only) Check Stack version and ensure a (dummy) accessible local repository"
+        if: "${{ runner.os == 'Linux' }}"
+        run: |
+          [ "$(stack --numeric-version)" = "$STACK_VERSION" ]
+          echo 'allow-different-user: true' >>/root/.stack/config.yaml
+          git -C .. init
 
       - uses: "actions/cache@v2"
         with:
           path: |
+            /root/.stack
             ${{ steps.haskell.outputs.stack-root }}
-          key: "${{ runner.os }}-${{ hashFiles('stack.yaml') }}"
+          key: "${{ runner.os }}-MdyPsf-${{ hashFiles('stack.yaml') }}"
 
       - name: "(Windows only) Configure Stack to store its programs in STACK_ROOT"
         # This ensures that the local GHC and MSYS binaries that Stack installs
@@ -55,7 +71,7 @@ jobs:
           mkdir -p "$STACK_ROOT"
           echo "local-programs-path: $STACK_ROOT/programs" > $STACK_ROOT/config.yaml
 
-      - run: "ci/build.sh"
+      - run: "ci/fix-home ci/build.sh"
 
       - name: "(Linux only) Build the entire package set"
         if: "${{ runner.os == 'Linux' }}"
@@ -67,7 +83,7 @@ jobs:
         # into which stack places all build artifacts. Since we use --haddock
         # in our CI builds, in order to actually get stack to find the purs
         # binary it created, we need to use the flag here as well.
-        run: "stack --haddock exec ../ci/build-package-set.sh"
+        run: "../ci/fix-home stack --haddock exec ../ci/build-package-set.sh"
 
       - name: "(Release only) Create bundle"
         if: "${{ env.CI_RELEASE == 'true' }}"
@@ -85,7 +101,7 @@ jobs:
               exit 1;;
           esac
           cd sdist-test
-          bundle/build.sh "$bundle_os"
+          ci/fix-home bundle/build.sh "$bundle_os"
 
       - name: "(Release only) Publish bundle"
         if: "${{ env.CI_RELEASE == 'true' }}"
@@ -100,25 +116,24 @@ jobs:
           files: "sdist-test/bundle/*.{tar.gz,sha}"
 
   lint:
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-latest"
+    container: "haskell:8.10.7-stretch@sha256:100f8fb7d7d8d64adb5e106fe8136b8d4cbdc03aeb2cbd145a7597d74b69bafb"
 
     steps:
       - uses: "actions/checkout@v2"
 
-      - id: "haskell"
-        uses: "haskell/actions/setup@v1"
-        with:
-          enable-stack: true
-          stack-version: "2.7.1"
-          stack-no-global: true
+      - name: "Ensure a (dummy) accessible local repository"
+        run: |
+          echo 'allow-different-user: true' >>/root/.stack/config.yaml
+          git -C .. init
 
       - uses: "actions/cache@v2"
         with:
           path: |
-            ${{ steps.haskell.outputs.stack-root }}
-          key: "${{ runner.os }}-lint-${{ hashFiles('stack.yaml') }}"
+            /root/.stack
+          key: "${{ runner.os }}-UnWw0N-lint-${{ hashFiles('stack.yaml') }}"
 
-      - run: "ci/run-hlint.sh --git"
+      - run: "ci/fix-home ci/run-hlint.sh --git"
         env:
           VERSION: "2.2.11"
 
@@ -139,16 +154,16 @@ jobs:
           # `allow-newer: true` is needed so that weeder-2.2.0 can be
           # installed with the dependencies present in LTS-18.
           echo 'allow-newer: true' >> stack-weeder.yaml
-          stack --no-terminal --jobs=2 build --copy-compiler-tool --stack-yaml ./stack-weeder.yaml weeder-2.2.0
+          ci/fix-home stack --no-terminal --jobs=2 build --copy-compiler-tool --stack-yaml ./stack-weeder.yaml weeder-2.2.0
 
-      - run: "stack --no-terminal --jobs=2 build --fast --ghc-options -fwrite-ide-info"
+      - run: "ci/fix-home stack --no-terminal --jobs=2 build --fast --ghc-options -fwrite-ide-info"
 
-      - run: "stack exec weeder"
+      - run: "ci/fix-home stack exec weeder"
 
       # Now do it again, with the test suite included. We don't want a
       # reference from our test suite to count in the above check; the fact
       # that a function is tested is not evidence that it's needed. But we also
       # don't want to leave weeds lying around in our test suite either.
-      - run: "stack --no-terminal --jobs=2 build --fast --test --no-run-tests --ghc-options -fwrite-ide-info"
+      - run: "ci/fix-home stack --no-terminal --jobs=2 build --fast --test --no-run-tests --ghc-options -fwrite-ide-info"
 
-      - run: "stack exec weeder"
+      - run: "ci/fix-home stack exec weeder"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
         uses: "haskell/actions/setup@v1"
         with:
           enable-stack: true
-          # If upgrading Stack, also upgrade it in the lint job below
           stack-version: "${{ env.STACK_VERSION }}"
           stack-no-global: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
     container: "${{ matrix.image }}"
 
     steps:
+      - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone
+        # if the Git version is less than 2.18.
+        name: "(Linux only) Install a newer version of Git"
+        if: "${{ runner.os == 'Linux' }}"
+        run: |
+          . /etc/os-release
+          echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
+          apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
       - uses: "actions/checkout@v2"
 
       - uses: "actions/setup-node@v1"
@@ -48,12 +56,10 @@ jobs:
           stack-version: "${{ env.STACK_VERSION }}"
           stack-no-global: true
 
-      - name: "(Linux only) Check Stack version and ensure a (dummy) accessible local repository"
+      - name: "(Linux only) Check Stack version"
         if: "${{ runner.os == 'Linux' }}"
         run: |
           [ "$(stack --numeric-version)" = "$STACK_VERSION" ]
-          echo 'allow-different-user: true' >>/root/.stack/config.yaml
-          git -C .. init
 
       - uses: "actions/cache@v2"
         with:
@@ -120,12 +126,14 @@ jobs:
     container: "haskell:8.10.7-stretch@sha256:100f8fb7d7d8d64adb5e106fe8136b8d4cbdc03aeb2cbd145a7597d74b69bafb"
 
     steps:
-      - uses: "actions/checkout@v2"
-
-      - name: "Ensure a (dummy) accessible local repository"
+      - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone
+        # if the Git version is less than 2.18.
+        name: "Install a newer version of Git"
         run: |
-          echo 'allow-different-user: true' >>/root/.stack/config.yaml
-          git -C .. init
+          . /etc/os-release
+          echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
+          apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
+      - uses: "actions/checkout@v2"
 
       - uses: "actions/cache@v2"
         with:

--- a/CHANGELOG.d/feature_support_older_glibc.md
+++ b/CHANGELOG.d/feature_support_older_glibc.md
@@ -1,4 +1,4 @@
-* Support Glibc version >= `2.24`
+* Support Glibc versions >= `2.24`
 
   Previously, `purs` required a Glibc version greater than or equal to `2.27`.
   This requirement is relaxed to support a Glibc version down to `2.24`.

--- a/CHANGELOG.d/feature_support_older_glibc.md
+++ b/CHANGELOG.d/feature_support_older_glibc.md
@@ -1,0 +1,4 @@
+* Support Glibc version >= `2.24`
+
+  Previously, `purs` required a Glibc version greater than or equal to `2.27`.
+  This requirement is relaxed to support a Glibc version down to `2.24`.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -154,6 +154,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@thomashoneyman](https://github.com/thomashoneyman) | Thomas Honeyman | [MIT license](http://opensource.org/licenses/MIT) |
 | [@sigma-andex](https://github.com/sigma-andex) | Jan Schulte | [MIT license](http://opensource.org/licenses/MIT) |
 | [@i-am-the-slime](https://github.com/i-am-the-slime) | Mark Eibes | [MIT license](http://opensource.org/licenses/MIT) |
+| [@sd-yip](https://github.com/sd-yip) | Nicholas Yip | [MIT license](http://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms
 

--- a/ci/build-package-set.sh
+++ b/ci/build-package-set.sh
@@ -16,7 +16,7 @@ export PATH="$tmpdir/node_modules/.bin:$PATH"
 cd "$tmpdir"
 
 echo ::group::Ensure Spago is available
-which spago || npm install spago
+which spago || npm install spago@0.20.3
 echo ::endgroup::
 
 echo ::group::Create dummy project

--- a/ci/fix-home
+++ b/ci/fix-home
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+# CI Steps are known to mess with container environment variables like USER or HOME
+if [ "$(whoami)" = root ]; then
+  HOME=/root "$@"
+else
+  "$@"
+fi

--- a/ci/fix-home
+++ b/ci/fix-home
@@ -1,6 +1,10 @@
 #!/usr/bin/env sh
 
-# CI Steps are known to mess with container environment variables like USER or HOME
+# CI Steps on Linux (in the container) are run as root, while on macOS and Windows, they are not.
+# And on GitHub Actions, environment variables from the host machine has a higher priority than those from a container,
+# including user-specific variables like `USER`, `HOME`, etc.
+#
+# The following fixes the `HOME` value for CLI tools (primarily Stack) that expects a properly configured `HOME` value.
 if [ "$(whoami)" = root ]; then
   HOME=/root "$@"
 else

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,5 @@
+# Please update Haskell image versions under .github/workflows/ci.yml together to use the same GHC version
+# (or the CI build will fail)
 resolver: lts-18.15
 pvp-bounds: both
 packages:


### PR DESCRIPTION
**Description of the change**

I am utilising a modified CI workflow of this repository to build `purs` with an older Glibc version for personal usage:
https://github.com/sd-yip/purescript/releases/tag/0.14.5-c9

I think it might be a good idea to share the modification here, so is this PR. Please let me know if you like this idea. After that, I can go through the checklist and any suggestions.

The `haskell:8.10.7-stretch` Haskell image, which uses Glibc ~2.23~ 2.24, is used here for the build to save a little bit of the setup time for GHC. In case the provided GHC version does not match the Stackage LTS, the build will fail like this:
```
No compiler found, expected minor version match with ghc-8.10.7 (x86_64) (based on resolver setting in /__w/purescript/purescript/stack.yaml). 
427 To install the correct GHC into /root/.stack/programs/x86_64-linux/, try running "stack setup" or use the "--install-ghc" flag. To use your system GHC installation, run "stack config set system-ghc --global true", or use the "--system-ghc" flag.
```

Related issue: https://github.com/purescript/purescript/issues/4191#issuecomment-952820382

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
