### PR TITLE
Doc HSPEC_ACCEPT; verify `Main` module exists in PS tests

### DIFF
--- a/CHANGELOG.d/internal_document-hspec-accept.md
+++ b/CHANGELOG.d/internal_document-hspec-accept.md
@@ -1,0 +1,1 @@
+* Document the `HSPEC_ACCEPT` flag for generating golden files

--- a/CHANGELOG.d/internal_error-on-non-Main-modules.md
+++ b/CHANGELOG.d/internal_error-on-non-Main-modules.md
@@ -1,0 +1,1 @@
+* Fail test if PureScript file(s) don't have a `Main` module

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ stack test --fast --test-arguments="--match 1110.purs"
 
 This will run whatever test uses the example file `1110.purs`.
 
+The golden files (e.g. `*.out` files) are generated automatically when missing, and can be updated by setting the "HSPEC_ACCEPT" environment variable, e.g. by running `HSPEC_ACCEPT=true stack test`.
+
 ### Adding Dependencies
 
 Because the PureScript compiler is distributed in binary form, we include the licenses of all dependencies, including transitive ones, in the LICENSE file. Therefore, whenever the dependencies change, the LICENSE file should be updated.

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -5,6 +5,8 @@ import Prelude.Compat
 
 import qualified Language.PureScript as P
 import qualified Language.PureScript.CST as CST
+import qualified Language.PureScript.AST as AST
+import qualified Language.PureScript.Names as N
 
 import Control.Arrow ((***), (>>>))
 import Control.Monad
@@ -209,10 +211,23 @@ compile SupportModules{..} inputFiles = runTest $ do
   tell $ foldMap (\(fp, (ws, _)) -> CST.toMultipleWarnings fp ws) msWithWarnings
   let ms = fmap snd <$> msWithWarnings
   foreigns <- inferForeignModules ms
-  let actions = makeActions supportModules (foreigns `M.union` supportForeigns)
+  let
+    actions = makeActions supportModules (foreigns `M.union` supportForeigns)
+    hasMainModule = (==) 1 $ length $ filter (== T.pack "Main") $ fmap getPsModuleName ms
   case ms of
-    [singleModule] -> pure <$> P.rebuildModule actions supportExterns (snd singleModule)
-    _ -> P.make actions (CST.pureResult <$> supportModules ++ map snd ms)
+    [singleModule] -> do
+      unless hasMainModule $ do
+        error $ "When testing a single PureScript file, the file's module's name must be 'Main' but got '"
+          <> T.unpack (getPsModuleName singleModule) <> "'."
+      pure <$> P.rebuildModule actions supportExterns (snd singleModule)
+    _ -> do
+      unless hasMainModule $ do
+        error "When testing a multiple PureScript files, the main file's module's name must be 'Main'."
+      P.make actions (CST.pureResult <$> supportModules ++ map snd ms)
+
+getPsModuleName :: (a, AST.Module) -> T.Text
+getPsModuleName psModule = case snd psModule of
+  AST.Module _ _ (N.ModuleName t) _ _ -> t
 
 makeActions :: [P.Module] -> M.Map P.ModuleName FilePath -> P.MakeActions P.Make
 makeActions modules foreigns = (P.buildMakeActions modulesDir (P.internalError "makeActions: input file map was read.") foreigns False)


### PR DESCRIPTION
**Description of the change**

Related to #4192, but documents the `HSPEC_ACCEPT` flag, which is stated in a non-obvious place [here](https://github.com/purescript/purescript/blob/master/tests/TestCompiler.hs#L20-L23)

Fixes the issue discovered in https://github.com/purescript/purescript/pull/4240#discussion_r813424911. To verify this fix works, I'll push a commit not doing that and get a failure in CI before pushing a commit that reverts that.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
