### PR TITLE
Make v0.14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to this project are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.14.6
+## 0.14.7
 
 New features:
 
@@ -132,6 +132,10 @@ Internal:
   This adds machinery for testing code generation for optimizations.
 
   Partially extracted from #3915 to add tests for #4205.
+
+## 0.14.6
+
+Do not use this release. `purescript-cst`'s version wasn't bumped when this release was made. So, tools like `trypurescript` cannot depend on it. See [0.14.7](#0147) for the same thing.
 
 ## 0.14.5
 
@@ -2602,14 +2606,14 @@ The way names are resolved has now been updated in a way that may result in some
 
 Some examples:
 
-| Import statement | Exposed members |
-| --- | --- |
-| `import X` | `A`, `f` |
-| `import X as Y` | `Y.A` `Y.f` |
-| `import X (A)` | `A` |
-| `import X (A) as Y` | `Y.A` |
-| `import X hiding (f)` | `A` |
-| `import Y hiding (f) as Y` | `Y.A` |
+| Import statement           | Exposed members |
+| -------------------------- | --------------- |
+| `import X`                 | `A`, `f`        |
+| `import X as Y`            | `Y.A` `Y.f`     |
+| `import X (A)`             | `A`             |
+| `import X (A) as Y`        | `Y.A`           |
+| `import X hiding (f)`      | `A`             |
+| `import Y hiding (f) as Y` | `Y.A`           |
 
 Qualified references like `Control.Monad.Eff.Console.log` will no longer resolve unless there is a corresponding `import Control.Monad.Eff.Console as Control.Monad.Eff.Console`. Importing a module unqualified does not allow you to reference it with qualification, so `import X` does not allow references to `X.A` unless there is also an `import X as X`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2606,14 +2606,14 @@ The way names are resolved has now been updated in a way that may result in some
 
 Some examples:
 
-| Import statement           | Exposed members |
-| -------------------------- | --------------- |
-| `import X`                 | `A`, `f`        |
-| `import X as Y`            | `Y.A` `Y.f`     |
-| `import X (A)`             | `A`             |
-| `import X (A) as Y`        | `Y.A`           |
-| `import X hiding (f)`      | `A`             |
-| `import Y hiding (f) as Y` | `Y.A`           |
+| Import statement | Exposed members |
+| --- | --- |
+| `import X` | `A`, `f` |
+| `import X as Y` | `Y.A` `Y.f` |
+| `import X (A)` | `A` |
+| `import X (A) as Y` | `Y.A` |
+| `import X hiding (f)` | `A` |
+| `import Y hiding (f) as Y` | `Y.A` |
 
 Qualified references like `Control.Monad.Eff.Console.log` will no longer resolve unless there is a corresponding `import Control.Monad.Eff.Console as Control.Monad.Eff.Console`. Importing a module unqualified does not allow you to reference it with qualification, so `import X` does not allow references to `X.A` unless there is also an `import X as X`.
 

--- a/lib/purescript-cst/README.md
+++ b/lib/purescript-cst/README.md
@@ -13,6 +13,7 @@ We provide a table to make it a bit easier to map between versions of `purescrip
 | 0.14.4 | 0.4.0.0 |
 | 0.14.5 | 0.4.0.0 |
 | 0.14.6 | 0.4.0.0 |
+| 0.14.7 | 0.5.0.0 |
 
 Before v0.14.2, there was a third package, `purescript-ast`. In v0.14.2, `purescript-ast` was merged into `purescript-cst`.
 

--- a/lib/purescript-cst/purescript-cst.cabal
+++ b/lib/purescript-cst/purescript-cst.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:           purescript-cst
-version:        0.4.0.0
+version:        0.5.0.0
 synopsis:       PureScript Programming Language Concrete Syntax Tree
 description:    The parser for the PureScript programming language.
 category:       Language

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "license": "ISC",
   "description": "PureScript wrapper that makes it available as a local dependency",
   "author": {
@@ -43,7 +43,7 @@
   ],
   "scripts": {
     "prepublishOnly": "node -e \"require('fs').copyFileSync('purs.bin.placeholder', 'purs.bin');\"",
-    "postinstall": "install-purescript --purs-ver=0.14.6",
+    "postinstall": "install-purescript --purs-ver=0.14.7",
     "test": "echo 'Error: no test specified' && exit 1"
   }
 }

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -2,7 +2,7 @@ cabal-version:  2.4
 
 name:           purescript
 -- note: When updating the prerelease identifier, update it in app/Version.hs too!
-version:        0.14.6
+version:        0.14.7
 synopsis:       PureScript Programming Language Compiler
 description:    A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
 category:       Language
@@ -159,7 +159,7 @@ common defaults
     pattern-arrows >=0.0.2 && <0.1,
     process >=1.6.13.2 && <1.7,
     protolude >=0.3.0 && <0.4,
-    purescript-cst ==0.4.0.0,
+    purescript-cst ==0.5.0.0,
     regex-tdfa >=1.3.1.1 && <1.4,
     safe >=0.3.19 && <0.4,
     scientific >=0.3.7.0 && <0.4,


### PR DESCRIPTION
**Description of the change**

`purescript-cst` wasn't bumped to a later version, so `trypurescript` can't use `v0.14.6` as a version. The `purs` binary published on npm should be fine since it depends on `purescript-cst` locally rather than via a version, but I need to make a new release due to `trypurescript`.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
