### PR TITLE
Update CI to use `windows-2019`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false # do not cancel builds for other OSes if one fails
       matrix:
         # If upgrading Ubuntu, also upgrade it in the lint job below
-        os: [ "ubuntu-18.04", "macOS-10.15", "windows-2016" ]
+        os: [ "ubuntu-18.04", "macOS-10.15", "windows-2019" ]
 
     runs-on: "${{ matrix.os }}"
 

--- a/CHANGELOG.d/internal_update-ci-windows-to-2019.md
+++ b/CHANGELOG.d/internal_update-ci-windows-to-2019.md
@@ -1,0 +1,1 @@
+* Update CI to use `windows-2019` since `windows-2016` is deprecated


### PR DESCRIPTION
**Description of the change**

Fixes #4242

I've listed the changelog entry as 'internal' as I'm not quite sure how this is a "breaking change" to end-users. CI does build our binaries, so perhaps that can affect things? 

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
