### PR TITLE
Make first alpha release for v0.15.0

### DIFF
--- a/app/Version.hs
+++ b/app/Version.hs
@@ -17,7 +17,7 @@ import qualified Development.GitRev as GitRev
 -- prerelease identifier here (if any). When releasing a proper version, simply
 -- set this to an empty string.
 prerelease :: String
-prerelease = "-rc1"
+prerelease = "-alpha1"
 
 versionString :: String
 versionString = showVersion Paths.version ++ prerelease ++ extra

--- a/app/Version.hs
+++ b/app/Version.hs
@@ -17,7 +17,7 @@ import qualified Development.GitRev as GitRev
 -- prerelease identifier here (if any). When releasing a proper version, simply
 -- set this to an empty string.
 prerelease :: String
-prerelease = "-alpha1"
+prerelease = "-alpha.1"
 
 versionString :: String
 versionString = showVersion Paths.version ++ prerelease ++ extra

--- a/app/Version.hs
+++ b/app/Version.hs
@@ -17,7 +17,7 @@ import qualified Development.GitRev as GitRev
 -- prerelease identifier here (if any). When releasing a proper version, simply
 -- set this to an empty string.
 prerelease :: String
-prerelease = ""
+prerelease = "-rc1"
 
 versionString :: String
 versionString = showVersion Paths.version ++ prerelease ++ extra

--- a/app/Version.hs
+++ b/app/Version.hs
@@ -17,7 +17,7 @@ import qualified Development.GitRev as GitRev
 -- prerelease identifier here (if any). When releasing a proper version, simply
 -- set this to an empty string.
 prerelease :: String
-prerelease = "-alpha.1"
+prerelease = "-alpha-01"
 
 versionString :: String
 versionString = showVersion Paths.version ++ prerelease ++ extra

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -2,7 +2,7 @@ cabal-version:  2.4
 
 name:           purescript
 -- note: When updating the prerelease identifier, update it in app/Version.hs too!
-version:        0.15.0-alpha1
+version:        0.15.0-alpha.1
 synopsis:       PureScript Programming Language Compiler
 description:    A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
 category:       Language

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -2,7 +2,7 @@ cabal-version:  2.4
 
 name:           purescript
 -- note: When updating the prerelease identifier, update it in app/Version.hs too!
-version:        0.15.0-rc1
+version:        0.15.0-alpha1
 synopsis:       PureScript Programming Language Compiler
 description:    A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
 category:       Language

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -2,7 +2,7 @@ cabal-version:  2.4
 
 name:           purescript
 -- note: When updating the prerelease identifier, update it in app/Version.hs too!
-version:        0.15.0
+version:        0.15.0-rc1
 synopsis:       PureScript Programming Language Compiler
 description:    A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
 category:       Language

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -2,7 +2,7 @@ cabal-version:  2.4
 
 name:           purescript
 -- note: When updating the prerelease identifier, update it in app/Version.hs too!
-version:        0.14.7
+version:        0.15.0-rc1
 synopsis:       PureScript Programming Language Compiler
 description:    A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
 category:       Language

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -2,7 +2,7 @@ cabal-version:  2.4
 
 name:           purescript
 -- note: When updating the prerelease identifier, update it in app/Version.hs too!
-version:        0.15.0-alpha.1
+version:        0.15.0-alpha-01
 synopsis:       PureScript Programming Language Compiler
 description:    A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
 category:       Language

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -2,7 +2,7 @@ cabal-version:  2.4
 
 name:           purescript
 -- note: When updating the prerelease identifier, update it in app/Version.hs too!
-version:        0.15.0-rc1
+version:        0.15.0
 synopsis:       PureScript Programming Language Compiler
 description:    A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
 category:       Language


### PR DESCRIPTION
**Description of the change**

This follows the approach done in #3976. In #3933, we dropped `package.yaml` file. Running `stack build` and then calling `purs --version` on the produced binary prints this output:
```
$ ./.stack-work/install/x86_64-linux-tinfo6/d400b0043ab29e05088ff3d6399c1c588ef336df281e2e819bcac83142913d36/8.10.7/bin/purs --version
0.15.0-rc1 [development build; commit: f01ba8f4d402dde0dad9feae4c48949318bf24be DIRTY]
```

I'm not sure when we want to make the first release candidate (as there may be additional work to do before such a release), but once this PR is merged, we'd make a new GH release by creating a tag for `v0.15.0-rc1` and checking the 'Is prelease' checkbox.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
