### PR TITLE
Restore names when generalizing unknowns

### DIFF
--- a/CHANGELOG.d/feature_restore_names.md
+++ b/CHANGELOG.d/feature_restore_names.md
@@ -1,25 +1,25 @@
-# Restore names of quantified variables during generalization
+* Restore names of quantified variables during generalization
 
-This makes the compiler aware of the names of quantified variables
-instantiated into unification variables, such that when the latter
-is generalized, semantic information is restored. For example:
+  This makes the compiler aware of the names of quantified variables
+  instantiated into unification variables, such that when the latter
+  is generalized, semantic information is restored. For example:
 
-```hs
-addNumberSuffix :: forall a b c d. a -> b -> c -> d -> a
-addNumberSuffix a _ _ _ = a
+  ```purs
+  addNumberSuffix :: forall a b c d. a -> b -> c -> d -> a
+  addNumberSuffix a _ _ _ = a
+  
+  addNumberSuffix' = addNumberSuffix 0
+  ```
 
-addNumberSuffix' = addNumberSuffix 0
-```
+  Previously, inferring top-level declarations without type signatures
+  would use `t` suffixed with an integer for type variables.
 
-Previously, inferring top-level declarations without type signatures
-would use `t` suffixed with an integer for type variables.
+  ```purs
+  forall t6 t7 t8. t6 -> t7 -> t8 -> Int
+  ```
 
-```hs
-forall t6 t7 t8. t6 -> t7 -> t8 -> Int
-```
+  Now, the inferred type would refer back to their original names.
 
-Now, the inferred type would refer back to their original names.
-
-```hs
-forall b6 c7 d8. b6 -> c7 -> d8 -> Int
-```
+  ```purs
+  forall b6 c7 d8. b6 -> c7 -> d8 -> Int
+  ```

--- a/CHANGELOG.d/feature_restore_names.md
+++ b/CHANGELOG.d/feature_restore_names.md
@@ -1,0 +1,33 @@
+# Restore names of quantified variables during generalization
+
+This makes the compiler aware of the names of quantified variables
+instantiated into unification variables, such that when the latter
+is generalized, semantic information is restored. For example:
+
+```hs
+addNumberSuffix :: forall a b c d. a -> b -> c -> d -> a
+addNumberSuffix a _ _ _ = a
+
+addNumberSuffix' = addNumberSuffix 0
+```
+
+This now generalizes with the original names suffixed with a number
+instead of just being replaced by a `t`.
+
+```hs
+Warning found:
+in module Main
+at Main.purs:6:1 - 6:37 (line 6, column 1 - line 6, column 37)
+
+  No type declaration was provided for the top-level declaration of addNumberSuffix'.
+  It is good practice to provide type declarations as a form of documentation.
+  The inferred type of addNumberSuffix' was:
+
+    forall b6 c7 d8. b6 -> c7 -> d8 -> Int
+
+
+in value declaration addNumberSuffix'
+
+See https://github.com/purescript/documentation/blob/master/errors/MissingTypeDeclaration.md for more information,
+or to contribute content related to this warning.
+```

--- a/CHANGELOG.d/feature_restore_names.md
+++ b/CHANGELOG.d/feature_restore_names.md
@@ -11,23 +11,15 @@ addNumberSuffix a _ _ _ = a
 addNumberSuffix' = addNumberSuffix 0
 ```
 
-This now generalizes with the original names suffixed with a number
-instead of just being replaced by a `t`.
+Previously, inferring top-level declarations without type signatures
+would use `t` suffixed with an integer for type variables.
 
 ```hs
-Warning found:
-in module Main
-at Main.purs:6:1 - 6:37 (line 6, column 1 - line 6, column 37)
+forall t6 t7 t8. t6 -> t7 -> t8 -> Int
+```
 
-  No type declaration was provided for the top-level declaration of addNumberSuffix'.
-  It is good practice to provide type declarations as a form of documentation.
-  The inferred type of addNumberSuffix' was:
+Now, the inferred type would refer back to their original names.
 
-    forall b6 c7 d8. b6 -> c7 -> d8 -> Int
-
-
-in value declaration addNumberSuffix'
-
-See https://github.com/purescript/documentation/blob/master/errors/MissingTypeDeclaration.md for more information,
-or to contribute content related to this warning.
+```hs
+forall b6 c7 d8. b6 -> c7 -> d8 -> Int
 ```

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -391,7 +391,8 @@ typeCheckAll moduleName _ = traverse go
       env <- getEnv
       (elabTy, kind) <- withFreshSubstitution $ do
         ((unks, ty'), kind) <- kindOfWithUnknowns ty
-        pure (varIfUnknown unks ty', kind)
+        ty'' <- varIfUnknown unks ty'
+        pure (ty'', kind)
       checkTypeKind elabTy kind
       case M.lookup (Qualified (Just moduleName) name) (names env) of
         Just _ -> throwError . errorMessage $ RedefinedIdent name

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -163,11 +163,15 @@ typesOf bindingGroupType moduleName vals = withFreshSubstitution $ do
         let constraintTypeVars = fold (conData >>= snd)
         let solved = solveFrom determinedFromType
         let unsolvedVars = S.difference constraintTypeVars solved
+        let lookupUnkName' i = do
+              mn <- lookupUnkName i
+              pure $ (fromMaybe "t" mn, i)
+        unsolvedVarNames <- traverse lookupUnkName' (S.toList unsolvedVars)
         unless (S.null unsolvedVars) .
           throwError
             . onErrorMessages (replaceTypes currentSubst)
             . errorMessage' ss
-            $ AmbiguousTypeVariables generalized (S.toList unsolvedVars)
+            $ AmbiguousTypeVariables generalized unsolvedVarNames
 
       -- Check skolem variables did not escape their scope
       skolemEscapeCheck val'

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -165,7 +165,7 @@ typesOf bindingGroupType moduleName vals = withFreshSubstitution $ do
         let unsolvedVars = S.difference constraintTypeVars solved
         let lookupUnkName' i = do
               mn <- lookupUnkName i
-              pure $ (fromMaybe "t" mn, i)
+              pure (fromMaybe "t" mn, i)
         unsolvedVarNames <- traverse lookupUnkName' (S.toList unsolvedVars)
         unless (S.null unsolvedVars) .
           throwError

--- a/tests/purs/failing/ConstraintInference.out
+++ b/tests/purs/failing/ConstraintInference.out
@@ -8,7 +8,7 @@ at tests/purs/failing/ConstraintInference.purs:10:1 - 10:21 (line 10, column 1 -
   [33m                                         [0m
   has type variables which are not determined by those mentioned in the body of the type:
 
-    [33mt8[0m could not be determined
+    [33mc8[0m could not be determined
 
   Consider adding a type annotation.
 

--- a/tests/purs/failing/ConstraintInference.out
+++ b/tests/purs/failing/ConstraintInference.out
@@ -4,7 +4,7 @@ at tests/purs/failing/ConstraintInference.purs:10:1 - 10:21 (line 10, column 1 -
 
   The inferred type
   [33m                                         [0m
-  [33m  forall t8 t11. Show t8 => t11 -> String[0m
+  [33m  forall c8 t11. Show c8 => t11 -> String[0m
   [33m                                         [0m
   has type variables which are not determined by those mentioned in the body of the type:
 

--- a/tests/purs/failing/Generalization2.out
+++ b/tests/purs/failing/Generalization2.out
@@ -5,7 +5,7 @@ at tests/purs/failing/Generalization2.purs:6:1 - 7:45 (line 6, column 1 - line 7
   Unable to generalize the type of the recursive function [33mtest[0m.
   The inferred type of [33mtest[0m was:
   [33m                                            [0m
-  [33m  forall t7. Semigroup t7 => Int -> t7 -> t7[0m
+  [33m  forall a7. Semigroup a7 => Int -> a7 -> a7[0m
   [33m                                            [0m
   Try adding a type signature.
 

--- a/tests/purs/warning/4256.out
+++ b/tests/purs/warning/4256.out
@@ -1,16 +1,34 @@
-Warning found:
-in module [33mMain[0m
-at tests/purs/warning/4256.purs:7:1 - 7:37 (line 7, column 1 - line 7, column 37)
+Warning 1 of 2:
 
-  No type declaration was provided for the top-level declaration of [33maddNumberSuffix'[0m.
-  It is good practice to provide type declarations as a form of documentation.
-  The inferred type of [33maddNumberSuffix'[0m was:
-  [33m                                        [0m
-  [33m  forall b6 c7 d8. b6 -> c7 -> d8 -> Int[0m
-  [33m                                        [0m
+  in module [33mMain[0m
+  at tests/purs/warning/4256.purs:16:1 - 16:58 (line 16, column 1 - line 16, column 58)
 
-in value declaration [33maddNumberSuffix'[0m
+    No type declaration was provided for the top-level declaration of [33mbaz[0m.
+    It is good practice to provide type declarations as a form of documentation.
+    The inferred type of [33mbaz[0m was:
+    [33m                                                         [0m
+    [33m  forall c14 d15 b25 d27. d27 -> c14 -> b25 -> d15 -> d27[0m
+    [33m                                                         [0m
 
-See https://github.com/purescript/documentation/blob/master/errors/MissingTypeDeclaration.md for more information,
-or to contribute content related to this warning.
+  in value declaration [33mbaz[0m
+
+  See https://github.com/purescript/documentation/blob/master/errors/MissingTypeDeclaration.md for more information,
+  or to contribute content related to this warning.
+
+Warning 2 of 2:
+
+  in module [33mMain[0m
+  at tests/purs/warning/4256.purs:8:1 - 8:37 (line 8, column 1 - line 8, column 37)
+
+    No type declaration was provided for the top-level declaration of [33maddNumberSuffix'[0m.
+    It is good practice to provide type declarations as a form of documentation.
+    The inferred type of [33maddNumberSuffix'[0m was:
+    [33m                                              [0m
+    [33m  forall b34 c35 d36. b34 -> c35 -> d36 -> Int[0m
+    [33m                                              [0m
+
+  in value declaration [33maddNumberSuffix'[0m
+
+  See https://github.com/purescript/documentation/blob/master/errors/MissingTypeDeclaration.md for more information,
+  or to contribute content related to this warning.
 

--- a/tests/purs/warning/4256.out
+++ b/tests/purs/warning/4256.out
@@ -1,0 +1,16 @@
+Warning found:
+in module [33mMain[0m
+at tests/purs/warning/4256.purs:7:1 - 7:37 (line 7, column 1 - line 7, column 37)
+
+  No type declaration was provided for the top-level declaration of [33maddNumberSuffix'[0m.
+  It is good practice to provide type declarations as a form of documentation.
+  The inferred type of [33maddNumberSuffix'[0m was:
+  [33m                                        [0m
+  [33m  forall b6 c7 d8. b6 -> c7 -> d8 -> Int[0m
+  [33m                                        [0m
+
+in value declaration [33maddNumberSuffix'[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/MissingTypeDeclaration.md for more information,
+or to contribute content related to this warning.
+

--- a/tests/purs/warning/4256.purs
+++ b/tests/purs/warning/4256.purs
@@ -1,0 +1,7 @@
+-- @shouldWarnWith MissingTypeDeclaration
+module Main where
+
+addNumberSuffix :: forall a b c d. a -> b -> c -> d -> a
+addNumberSuffix a _ _ _ = a
+
+addNumberSuffix' = addNumberSuffix 0

--- a/tests/purs/warning/4256.purs
+++ b/tests/purs/warning/4256.purs
@@ -1,7 +1,16 @@
 -- @shouldWarnWith MissingTypeDeclaration
+-- @shouldWarnWith MissingTypeDeclaration
 module Main where
 
 addNumberSuffix :: forall a b c d. a -> b -> c -> d -> a
 addNumberSuffix a _ _ _ = a
 
 addNumberSuffix' = addNumberSuffix 0
+
+foo :: forall a b c d. a -> b -> c -> d -> a
+foo a _ _ _ = a
+
+bar :: forall a b c d. a -> b -> c -> d -> a
+bar a _ _ _ = a
+
+baz a x y = bar (foo a 2 3 4) (foo a 2 3 4) (foo x y a a)


### PR DESCRIPTION
Closes #4256. This change makes it so the type checker tracks which quantified type variables are replaced with unknowns such that they can then be restored in the future.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
[ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
[ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)