### PR TITLE
Show compilation progress

### DIFF
--- a/CHANGELOG.d/feature_compilation_progress.md
+++ b/CHANGELOG.d/feature_compilation_progress.md
@@ -1,0 +1,12 @@
+* Print compilation progress on the command line
+
+  This feature makes it so `purs compile` and `purs docs` now show
+  compilation progress on the command line. Example output:
+
+  ```purs
+  [ 1 of 59] Compiling Type.Proxy
+  [ 2 of 59] Compiling Type.Data.RowList
+  ...
+  [58 of 59] Compiling Effect.Class.Console
+  [59 of 59] Compiling Test.Main
+  ```

--- a/src/Language/PureScript/Docs/Collect.hs
+++ b/src/Language/PureScript/Docs/Collect.hs
@@ -103,8 +103,18 @@ compileForDocs outputDir inputFiles = do
 
   where
   renderProgressMessage :: P.ProgressMessage -> String
-  renderProgressMessage (P.CompilingModule mn _) =
-    "Compiling documentation for " ++ T.unpack (P.runModuleName mn)
+  renderProgressMessage (P.CompilingModule mn mi) =
+    concat
+      [ renderProgressIndex mi
+      , "Compiling documentation for "
+      , T.unpack (P.runModuleName mn)
+      ]
+    where
+    renderProgressIndex = maybe "" $ \(start, end) ->
+      let start' = show start
+          end' = show end
+          preSpace = replicate (length end' - length start') ' '
+      in "[" <> preSpace <> start' <> " of " <> end' <> "] "
 
   testOptions :: P.Options
   testOptions = P.defaultOptions { P.optionsCodegenTargets = Set.singleton P.Docs }

--- a/src/Language/PureScript/Docs/Collect.hs
+++ b/src/Language/PureScript/Docs/Collect.hs
@@ -9,9 +9,9 @@ import Control.Arrow ((&&&))
 import qualified Data.Aeson.BetterErrors as ABE
 import qualified Data.ByteString as BS
 import qualified Data.Map as Map
-import Data.String (String)
 import qualified Data.Set as Set
 import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
 import System.FilePath ((</>))
 import System.IO.UTF8 (readUTF8FileT, readUTF8FilesT)
 
@@ -96,26 +96,12 @@ compileForDocs outputDir inputFiles = do
       foreigns <- P.inferForeignModules filePathMap
       let makeActions =
             (P.buildMakeActions outputDir filePathMap foreigns False)
-              { P.progress = liftIO . putStrLn . renderProgressMessage
+              { P.progress = liftIO . TIO.hPutStr stdout . (<> "\n") . P.renderProgressMessage "Compiling documentation for "
               }
       P.make makeActions (map snd ms)
   either throwError return result
 
   where
-  renderProgressMessage :: P.ProgressMessage -> String
-  renderProgressMessage (P.CompilingModule mn mi) =
-    concat
-      [ renderProgressIndex mi
-      , "Compiling documentation for "
-      , T.unpack (P.runModuleName mn)
-      ]
-    where
-    renderProgressIndex = maybe "" $ \(start, end) ->
-      let start' = show start
-          end' = show end
-          preSpace = replicate (length end' - length start') ' '
-      in "[" <> preSpace <> start' <> " of " <> end' <> "] "
-
   testOptions :: P.Options
   testOptions = P.defaultOptions { P.optionsCodegenTargets = Set.singleton P.Docs }
 

--- a/src/Language/PureScript/Docs/Collect.hs
+++ b/src/Language/PureScript/Docs/Collect.hs
@@ -103,7 +103,7 @@ compileForDocs outputDir inputFiles = do
 
   where
   renderProgressMessage :: P.ProgressMessage -> String
-  renderProgressMessage (P.CompilingModule mn) =
+  renderProgressMessage (P.CompilingModule mn _) =
     "Compiling documentation for " ++ T.unpack (P.runModuleName mn)
 
   testOptions :: P.Options

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -251,8 +251,8 @@ make ma@MakeActions{..} ms = do
             foldM go env deps
           env <- C.readMVar (bpEnv buildPlan)
           idx <- C.takeMVar (bpIndex buildPlan)
-          (exts, warnings) <- listen $ rebuildModuleWithIndex ma env externs m (Just (idx, cnt))
           C.putMVar (bpIndex buildPlan) (idx + 1)
+          (exts, warnings) <- listen $ rebuildModuleWithIndex ma env externs m (Just (idx, cnt))
           return $ BuildJobSucceeded (pwarnings' <> warnings) exts
         Nothing -> return BuildJobSkipped
 

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -72,7 +72,18 @@ data ProgressMessage
 
 -- | Render a progress message
 renderProgressMessage :: ProgressMessage -> T.Text
-renderProgressMessage (CompilingModule mn _) = T.append "Compiling " (runModuleName mn)
+renderProgressMessage (CompilingModule mn mi) =
+  T.concat
+    [ renderProgressIndex mi
+    , "Compiling "
+    , runModuleName mn
+    ]
+  where
+  renderProgressIndex = maybe "" $ \(start, end) ->
+    let start' = T.pack (show start)
+        end' = T.pack (show end)
+        preSpace = T.replicate (T.length end' - T.length start') " "
+    in "[" <> preSpace <> start' <> " of " <> end' <> "] "
 
 -- | Actions that require implementations when running in "make" mode.
 --

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -2,6 +2,7 @@ module Language.PureScript.Make.Actions
   ( MakeActions(..)
   , RebuildPolicy(..)
   , ProgressMessage(..)
+  , renderProgressMessage
   , buildMakeActions
   , checkForeignDecls
   , cacheDbFile
@@ -71,14 +72,15 @@ data ProgressMessage
   deriving (Show, Eq, Ord)
 
 -- | Render a progress message
-renderProgressMessage :: ProgressMessage -> T.Text
-renderProgressMessage (CompilingModule mn mi) =
+renderProgressMessage :: T.Text -> ProgressMessage -> T.Text
+renderProgressMessage infx (CompilingModule mn mi) =
   T.concat
     [ renderProgressIndex mi
-    , "Compiling "
+    , infx
     , runModuleName mn
     ]
   where
+  renderProgressIndex :: Maybe (Int, Int) -> T.Text
   renderProgressIndex = maybe "" $ \(start, end) ->
     let start' = T.pack (show start)
         end' = T.pack (show end)
@@ -323,7 +325,7 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
   requiresForeign = not . null . CF.moduleForeign
 
   progress :: ProgressMessage -> Make ()
-  progress = liftIO . TIO.hPutStr stderr . (<> "\n") . renderProgressMessage
+  progress = liftIO . TIO.hPutStr stderr . (<> "\n") . renderProgressMessage "Compiling "
 
   readCacheDb :: Make CacheDb
   readCacheDb = readCacheDb' outputDir

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -66,13 +66,13 @@ data RebuildPolicy
 
 -- | Progress messages from the make process
 data ProgressMessage
-  = CompilingModule ModuleName
+  = CompilingModule ModuleName (Maybe (Int, Int))
   -- ^ Compilation started for the specified module
   deriving (Show, Eq, Ord)
 
 -- | Render a progress message
 renderProgressMessage :: ProgressMessage -> T.Text
-renderProgressMessage (CompilingModule mn) = T.append "Compiling " (runModuleName mn)
+renderProgressMessage (CompilingModule mn _) = T.append "Compiling " (runModuleName mn)
 
 -- | Actions that require implementations when running in "make" mode.
 --

--- a/tests/TestMake.hs
+++ b/tests/TestMake.hs
@@ -233,7 +233,7 @@ compileWithOptions opts input = do
     foreigns <- P.inferForeignModules filePathMap
     let makeActions =
           (P.buildMakeActions modulesDir filePathMap foreigns True)
-            { P.progress = \(P.CompilingModule mn) ->
+            { P.progress = \(P.CompilingModule mn _) ->
                 liftIO $ modifyMVar_ recompiled (return . Set.insert mn)
             }
     P.make makeActions (map snd ms)


### PR DESCRIPTION
Closes #2961. This adds compilation progress to the `stderr` output that the compiler emits. I've also made this change backwards-compatible as much as possible because of existing consumers of `rebuildModule` and `rebuildModule'`. If needed, they can make use of `rebuildModuleWithIndex`.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
[ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
[ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
