### PR TITLE
Add CI test to ensure libtinfo isn't in binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,16 @@ jobs:
         # binary it created, we need to use the flag here as well.
         run: "stack --haddock exec ../ci/build-package-set.sh"
 
+      - name: Verify that 'libtinfo' isn't in binary
+        if: runner.os == 'Linux'
+        working-directory: "sdist-test"
+        run: |
+          if [ $(ldd $(stack path --local-doc-root)/../bin/purs | grep 'libtinfo' | wc -l) -ge 1 ]; then
+            echo "libtinfo detected"
+            $(ldd $(stack path --local-doc-root)/../bin/purs | grep 'libtinfo'
+            exit 1
+          fi
+
       - name: "(Release only) Create bundle"
         if: "${{ env.CI_RELEASE == 'true' }}"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           if [ $(ldd $(stack path --local-doc-root)/../bin/purs | grep 'libtinfo' | wc -l) -ge 1 ]; then
             echo "libtinfo detected"
-            $(ldd $(stack path --local-doc-root)/../bin/purs | grep 'libtinfo'
+            ldd $(stack path --local-doc-root)/../bin/purs | grep 'libtinfo'
             exit 1
           fi
 

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -157,7 +157,7 @@ common defaults
     parallel >=3.2.2.0 && <3.3,
     parsec >=3.1.14.0 && <3.2,
     pattern-arrows >=0.0.2 && <0.1,
-    process >=1.6.13.2 && <1.7,
+    process ==1.6.13.1,
     protolude >=0.3.0 && <0.4,
     purescript-cst ==0.5.0.0,
     regex-tdfa >=1.3.1.1 && <1.4,

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,6 +17,10 @@ extra-deps:
 - hspec-2.8.3
 - hspec-core-2.8.3
 - hspec-discover-2.8.3
+# Fix issue with libtinfo.
+# See https://github.com/purescript/purescript/issues/4253
+- process-1.6.13.1
+- Cabal-3.2.1.0
 nix:
   packages:
   - zlib


### PR DESCRIPTION
**Description of the change**

Fixes #4253. WIP.

I've only added a CI test based on Harry's comment. Also, when I ran `stack build --haddock --fast`, a `lib/purescript-ast.cabal` file was generated. Any idea why that happened? Running `stack purge` and then the same command doesn't generate the file again.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
