### PR TITLE
Erase kind applications when loading type synonyms from externs for instance deriving

### DIFF
--- a/CHANGELOG.d/fix_4200.md
+++ b/CHANGELOG.d/fix_4200.md
@@ -1,0 +1,27 @@
+* Erase kind applications when loading type synonyms from externs for instance deriving
+
+  This fixes a bug where polykinded type synonyms defined in other
+  modules cannot be used when deriving a `Newtype` instance.
+
+  Previously, given the `Test.B` module:
+  ```purs
+  module Test.B where
+
+  data T :: forall m. m -> Type
+  data T msg = E
+
+  type TAlias :: forall k. k -> Type
+  type TAlias msg = T msg
+  ```
+
+  `Test.A` would fail with `KindsDoNotUnify`:
+  ```purs
+  module Test.A where
+
+  import Test.B (T, TAlias)
+  import Data.Newtype (class Newtype)
+
+  newtype NewA a = NewA (TAlias Int)
+
+  derive instance Newtype (NewA a) _
+  ```

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -31,6 +31,7 @@ import Language.PureScript.Sugar.Operators as S
 import Language.PureScript.Sugar.TypeClasses as S
 import Language.PureScript.Sugar.TypeClasses.Deriving as S
 import Language.PureScript.Sugar.TypeDeclarations as S
+import Language.PureScript.Types (eraseKindApps)
 import Language.PureScript.TypeChecker.Synonyms (SynonymMap)
 
 -- |
@@ -93,7 +94,8 @@ findTypeSynonyms externs mn decls =
     M.fromList $ (externs >>= \ExternsFile{..} -> mapMaybe (fromExternsDecl efModuleName) efDeclarations)
               ++ mapMaybe fromLocalDecl decls
   where
-    fromExternsDecl mn' (EDTypeSynonym name args ty) = Just (Qualified (Just mn') name, (args, ty))
+    fromExternsDecl mn' (EDTypeSynonym name args ty) = do
+      Just (Qualified (Just mn') name, (args, eraseKindApps ty))
     fromExternsDecl _ _ = Nothing
 
     fromLocalDecl (TypeSynonymDeclaration _ name args ty) =

--- a/tests/purs/passing/4200.purs
+++ b/tests/purs/passing/4200.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Data.Newtype (class Newtype)
+import Effect.Console (log)
+import Lib (T, TAlias)
+
+newtype NewA a = NewA (TAlias Int)
+
+derive instance Newtype (NewA a) _
+
+main = log "Done"

--- a/tests/purs/passing/4200/Lib.purs
+++ b/tests/purs/passing/4200/Lib.purs
@@ -1,0 +1,7 @@
+module Lib where
+
+data T :: forall m. m -> Type
+data T msg = E
+
+type TAlias :: forall k. k -> Type
+type TAlias msg = T msg


### PR DESCRIPTION
Closes #4200. This makes it so that type synonyms loaded for the `deriveInstances` have their kind applications removed. This achieves the same effect as having the type synonym exist as a local declaration e.g. `fromLocalDecl`. 

Likewise, since an empty `kinds` is passed to `deriveInstance`, and in effect, to `replaceAllTypeSynonyms`, kind applications aren't actually replaced; this leads to the eventual `KindsDoNotUnify` error.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
[ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
[ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
