### PR TITLE
Clarify what do-notation compiles to in error

### DIFF
--- a/CHANGELOG.d/misc_clarify-point-in-do-notation-error.md
+++ b/CHANGELOG.d/misc_clarify-point-in-do-notation-error.md
@@ -1,0 +1,7 @@
+* Improve "Unknown value bind" and "Unknown value discard" errors
+
+  The previous error implies that do-notation compiles down to only `bind` or to
+  only `discard` (depending on whether the symbol not found was `bind` or
+  `discard` respectively), which is somewhat misleading, especially in the
+  latter case. Now, the error states correctly that do-notation compiles down to
+  both functions.

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -751,7 +751,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     renderSimpleErrorMessage (RedefinedIdent name) =
       line $ "The value " <> markCode (showIdent name) <> " has been defined multiple times"
     renderSimpleErrorMessage (UnknownName name@(Qualified Nothing (IdentName (Ident i)))) | i `elem` [ C.bind, C.discard ] =
-      line $ "Unknown " <> printName name <> ". You're probably using do-notation, which the compiler replaces with calls to the " <> markCode i <> " function. Please import " <> markCode i <> " from module " <> markCode "Prelude"
+      line $ "Unknown " <> printName name <> ". You're probably using do-notation, which the compiler replaces with calls to the " <> markCode "bind" <> " and " <> markCode "discard" <> " functions. Please import " <> markCode i <> " from module " <> markCode "Prelude"
     renderSimpleErrorMessage (UnknownName name@(Qualified Nothing (IdentName (Ident i)))) | i == C.negate =
       line $ "Unknown " <> printName name <> ". You're probably using numeric negation (the unary " <> markCode "-" <> " operator), which the compiler replaces with calls to the " <> markCode i <> " function. Please import " <> markCode i <> " from module " <> markCode "Prelude"
     renderSimpleErrorMessage (UnknownName name) =

--- a/tests/purs/failing/2109-bind.out
+++ b/tests/purs/failing/2109-bind.out
@@ -2,7 +2,7 @@ Error found:
 in module [33mMain[0m
 at tests/purs/failing/2109-bind.purs:8:3 - 8:14 (line 8, column 3 - line 8, column 14)
 
-  Unknown value [33mbind[0m. You're probably using do-notation, which the compiler replaces with calls to the [33mbind[0m function. Please import [33mbind[0m from module [33mPrelude[0m
+  Unknown value [33mbind[0m. You're probably using do-notation, which the compiler replaces with calls to the [33mbind[0m and [33mdiscard[0m functions. Please import [33mbind[0m from module [33mPrelude[0m
 
 
 See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,

--- a/tests/purs/failing/2109-discard.out
+++ b/tests/purs/failing/2109-discard.out
@@ -2,7 +2,7 @@ Error found:
 in module [33mMain[0m
 at tests/purs/failing/2109-discard.purs:7:3 - 7:12 (line 7, column 3 - line 7, column 12)
 
-  Unknown value [33mdiscard[0m. You're probably using do-notation, which the compiler replaces with calls to the [33mdiscard[0m function. Please import [33mdiscard[0m from module [33mPrelude[0m
+  Unknown value [33mdiscard[0m. You're probably using do-notation, which the compiler replaces with calls to the [33mbind[0m and [33mdiscard[0m functions. Please import [33mdiscard[0m from module [33mPrelude[0m
 
 
 See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,


### PR DESCRIPTION
**Description of the change**

The previous error implies that do-notation compiles down to only `bind` or to only `discard` (depending on whether the symbol not found was `bind` or `discard` respectively), which is somewhat misleading, especially in the latter case. Now, the error states correctly that do-notation compiles down to both functions.

Relevant: https://github.com/purescript/purescript/pull/3952#discussion_r512509867

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] (contributed previously) Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] (none) Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] (updated golden tests) Added a test for the contribution (if applicable)
