### PR TITLE
Fix ownership of the CI working directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,11 @@ jobs:
           stack-version: "${{ env.STACK_VERSION }}"
           stack-no-global: true
 
-      - name: "(Linux only) Check Stack version"
+      - name: "(Linux only) Check Stack version and fix working directory ownership"
         if: "${{ runner.os == 'Linux' }}"
         run: |
           [ "$(stack --numeric-version)" = "$STACK_VERSION" ]
+          chown root:root .
 
       - uses: "actions/cache@v2"
         with:
@@ -133,6 +134,10 @@ jobs:
           echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
           apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
       - uses: "actions/checkout@v2"
+
+      - name: "Fix working directory ownership"
+        run: |
+          chown root:root .
 
       - uses: "actions/cache@v2"
         with:


### PR DESCRIPTION
**Description of the change**

Fix current CI build errors that happen after merging https://github.com/purescript/purescript/pull/4228.

Required working directory ownership will be configured as below:
```
chown root:root .
```

Previous CI builds in the PR were successful only because the previous configuration file `/root/.stack/config.yaml` with the option `allow-different-user: true` was a cached path.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
