### PR TITLE
Lazy initialization for recursive bindings

### DIFF
--- a/CHANGELOG.d/breaking_fix-4179.md
+++ b/CHANGELOG.d/breaking_fix-4179.md
@@ -1,0 +1,67 @@
+* Lazy initialization for recursive bindings
+
+  This is unlikely to break a working program, but the upshot for users is
+  that it's now possible to get a run-time error when dereferencing an
+  identifier in a recursive binding group before it has been initialized,
+  instead of silently getting an `undefined` value and having that maybe
+  or maybe not lead to an error somewhere else.
+
+  This change can cause code that relies on tail-call optimization to no
+  longer compile with that optimization. If you find that code that
+  previously compiled to a TCO loop no longer does but does include `$lazy`
+  initializers, please report the issue.
+
+  **Alternate backend maintainers:** for you, this change represents a
+  clarification of a responsibility shared by all backends. The identifiers
+  bound in a recursive binding group need to behave as if those identifiers
+  have call-by-need semantics during the initialization of the entire binding
+  group. (Initializing the binding group entails ensuring every initializer
+  has been executed, so after the binding group is initialized, these
+  identifiers can be considered call-by-value again.)
+
+  If an identifier is needed during its own call-by-need initialization, the
+  backend must ensure that an explicit run-time error is raised appropriate for
+  your target platform. This error may be raised at compile time instead if the
+  backend can determine that such a cycle is inevitable. Returning your
+  target language's equivalent of JavaScript's `undefined`, as `purs` did in
+  earlier releases in some cases, is not permitted.
+
+  If your target language natively has call-by-need semantics, you probably
+  don't have to do anything. If your target language is call-by-value and you
+  are using PureScript as a library, you can use the function
+  `Language.PureScript.CoreFn.Laziness.applyLazinessTransform` to your CoreFn
+  input to satisfy this responsibility; if you do, you will need to do the
+  following:
+
+    * Translate `InternalIdent RuntimeLazyFactory` and `InternalIdent (Lazy _)`
+      identifiers to appropriate strings for your backend
+    * Ensure that any output file that needs it has a reference to a function
+      named `InternalIdent RuntimeLazyFactory`, with type `forall a. Fn3 String
+      String (Unit -> a) (Int -> a)`, and with the same semantics as the
+      following JavaScript (though you should customize the error raised to be
+      appropriate for your target language):
+
+      ```js
+      function (name, moduleName, init) {
+          var state = 0;
+          var val;
+          return function (lineNumber) {
+              if (state === 2) return val;
+              if (state === 1) throw new ReferenceError(name + " was needed before it finished initializing (module " + moduleName + ", line " + lineNumber + ")", moduleName, lineNumber);
+              state = 1;
+              val = init();
+              state = 2;
+              return val;
+          };
+      };
+      ```
+  
+  If neither of the previous cases apply to you, you can meet this
+  responsibility most easily simply by ensuring that all recursive bindings are
+  lazy. You may instead choose to implement some light analysis to skip
+  generating lazy bindings in some cases, such as if every initializer in the
+  binding group is an `Abs`. You also may choose to reimplement
+  `applyLazinessTransform`, or even develop a more sophisticated laziness
+  transform for your backend. It is of course your responsibility to ensure
+  that the result of whatever analysis you do is equivalent to the expected
+  semantics.

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -151,6 +151,7 @@ common defaults
     microlens-platform >=0.4.2 && <0.5,
     monad-control >=1.0.3.1 && <1.1,
     monad-logger >=0.3.36 && <0.4,
+    monoidal-containers >=0.6.2.0 && <0.7,
     mtl >=2.2.2 && <2.3,
     parallel >=3.2.2.0 && <3.3,
     parsec >=3.1.14.0 && <3.2,
@@ -198,6 +199,7 @@ library
     Language.PureScript.CoreFn.Desugar
     Language.PureScript.CoreFn.Expr
     Language.PureScript.CoreFn.FromJSON
+    Language.PureScript.CoreFn.Laziness
     Language.PureScript.CoreFn.Meta
     Language.PureScript.CoreFn.Module
     Language.PureScript.CoreFn.Optimizer

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -24,6 +24,8 @@ identToJs :: Ident -> Text
 identToJs (Ident name) = anyNameToJs name
 identToJs (GenIdent _ _) = internalError "GenIdent in identToJs"
 identToJs UnusedIdent = unusedIdent
+identToJs (InternalIdent RuntimeLazyFactory) = "$runtime_lazy"
+identToJs (InternalIdent (Lazy name)) = "$lazy_" <> anyNameToJs name
 
 -- | Convert a 'ProperName' into a valid JavaScript identifier:
 --

--- a/src/Language/PureScript/Constants/Prelude.hs
+++ b/src/Language/PureScript/Constants/Prelude.hs
@@ -282,6 +282,12 @@ pattern Reflectable = Qualified (Just DataReflectable) (ProperName "Reflectable"
 pattern DataOrdering :: ModuleName
 pattern DataOrdering = ModuleName "Data.Ordering"
 
+pattern DataFunctionUncurried :: ModuleName
+pattern DataFunctionUncurried = ModuleName "Data.Function.Uncurried"
+
+pattern PartialUnsafe :: ModuleName
+pattern PartialUnsafe = ModuleName "Partial.Unsafe"
+
 pattern Ordering :: Qualified (ProperName 'TypeName)
 pattern Ordering = Qualified (Just DataOrdering) (ProperName "Ordering")
 

--- a/src/Language/PureScript/CoreFn/Laziness.hs
+++ b/src/Language/PureScript/CoreFn/Laziness.hs
@@ -1,0 +1,569 @@
+module Language.PureScript.CoreFn.Laziness
+  ( applyLazinessTransform
+  ) where
+
+import Protolude hiding (force)
+import Protolude.Unsafe (unsafeHead)
+
+import Control.Arrow ((&&&))
+import qualified Data.Array as A
+import Data.Coerce (coerce)
+import Data.Graph (SCC(..), stronglyConnComp)
+import Data.List (foldl1', (!!))
+import qualified Data.IntMap.Monoidal as IM
+import qualified Data.IntSet as IS
+import qualified Data.Map.Monoidal as M
+import Data.Semigroup (Max(..))
+import qualified Data.Set as S
+
+import Language.PureScript.AST.SourcePos
+import qualified Language.PureScript.Constants.Prelude as C
+import Language.PureScript.CoreFn
+import Language.PureScript.Crash
+import Language.PureScript.Names
+import Language.PureScript.PSString (mkString)
+
+-- This module is responsible for ensuring that the bindings in recursive
+-- binding groups are initialized in a valid order, introducing run-time
+-- laziness and initialization checks as necessary.
+--
+-- PureScript is a call-by-value language with strict data constructors, this
+-- transformation notwithstanding. The only laziness introduced here is in the
+-- initialization of a binding. PureScript is uninterested in the order in
+-- which bindings are written by the user. The compiler has always attempted to
+-- emit the bindings in an order that makes sense for the backend, but without
+-- this transformation, recursive bindings are emitted in an arbitrary order,
+-- which can cause unexpected behavior at run time if a binding is dereferenced
+-- before it has initialized.
+--
+-- To prevent unexpected errors, this transformation does a syntax-driven
+-- analysis of a single recursive binding group to attempt to statically order
+-- the bindings, and when that fails, falls back to lazy initializers that will
+-- succeed or fail deterministically with a clear error at run time.
+--
+-- Example:
+--
+--   x = f \_ ->
+--     x
+--
+-- becomes (with some details of the $runtime_lazy function elided):
+-- 
+--   -- the binding of x has been rewritten as a lazy initializer
+--   $lazy_x = $runtime_lazy \_ ->
+--     f \_ ->
+--       $lazy_x 2  -- the reference to x has been rewritten as a force call
+--   x = $lazy_x 1
+--
+-- Central to this analysis are the concepts of delay and force, which are
+-- attributes given to every subexpression in the binding group. Delay and
+-- force are defined by the following traversal. This traversal is used twice:
+-- once to collect all the references made by each binding in the group, and
+-- then again to rewrite some references to force calls. (The implications of
+-- delay and force on initialization order are specified later.)
+
+-- |
+-- Visits every `Var` in an expression with the provided function, including
+-- the amount of delay and force applied to that `Var`, and substitutes the
+-- result back into the tree (propagating an `Applicative` effect).
+--
+-- Delay is a non-negative integer that represents the number of lambdas that
+-- enclose an expression. Force is a non-negative integer that represents the
+-- number of values that are being applied to an expression. Delay is always
+-- statically determinable, but force can be *unknown*, so it's represented
+-- here with a Maybe. In a function application `f a b`, `f` has force 2, but
+-- `a` and `b` have unknown force--it depends on what `f` does with them.
+--
+-- The rules of assigning delay and force are simple:
+--   * The expressions that are assigned to bindings in this group have
+--     delay 0, force 0.
+--   * In a function application, the function expression has force 1 higher
+--     than the force of the application expression, and the argument
+--     expression has unknown force.
+--     * UNLESS this argument is being directly provided to a constructor (in
+--       other words, the function expression is either a constructor itself or
+--       a constructor that has already been partially applied), in which case
+--       the force of both subexpressions is unchanged. We can assume that
+--       constructors don't apply any additional force to their arguments.
+--   * If the force of a lambda is zero, the delay of the body of the lambda is
+--     incremented; otherwise, the force of the body of the lambda is
+--     decremented. (Applying one argument to a lambda cancels out one unit of
+--     delay.)
+--   * In the argument of a Case and the bindings of a Let, force is unknown.
+--   * Everywhere else, preserve the delay and force of the enclosing
+--     expression.
+--
+-- Here are some illustrative examples of the above rules. We will use a
+-- pseudocode syntax to annotate a subexpression with delay and force:
+-- `expr#d!f` means `expr` has delay d and force f. `!*` is used to denote
+-- unknown force.
+--
+--   x = y#0!0
+--   x = y#0!2 a#0!* b#0!*
+--   x = (\_ -> y#1!0)#0!0
+--   x = \_ _ -> y#2!1 a#2!*
+--   x = (\_ -> y#0!0)#0!1 z#0!*
+--   x = Just { a: a#0!0, b: b#0!0 }
+--   x = let foo = (y#1!* a b#1!*)#1!* in foo + 1
+--
+-- (Note that this analysis is quite ignorant of any actual control flow
+-- choices made at run time. It doesn't even track what happens to a reference
+-- after it has been locally bound by a Let or Case. Instead, it just assumes
+-- the worst--once locally bound to a new name, it imagines that absolutely
+-- anything could happen to that new name and thus to the underlying reference.
+-- But the value-to-weight ratio of this approach is perhaps surprisingly
+-- high.)
+--
+-- Every subexpression gets a delay and a force, but we are only interested
+-- in references to other bindings in the binding group, so the traversal only
+-- exposes `Var`s to the provided function.
+--
+onVarsWithDelayAndForce :: forall f. Applicative f => (Int -> Maybe Int -> Ann -> Qualified Ident -> f (Expr Ann)) -> Expr Ann -> f (Expr Ann)
+onVarsWithDelayAndForce f = snd . go 0 $ Just 0
+  where
+  go :: Int -> Maybe Int -> (Bind Ann -> f (Bind Ann), Expr Ann -> f (Expr Ann))
+  go delay force = (handleBind, handleExpr')
+    where
+    (handleBind, handleExpr, handleBinder, handleCaseAlternative) = traverseCoreFn handleBind handleExpr' handleBinder handleCaseAlternative
+    handleExpr' = \case
+      Var a i -> f delay force a i
+      Abs a i e -> Abs a i <$> snd (if force == Just 0 then go (succ delay) force else go delay $ fmap pred force) e
+      -- A clumsy hack to preserve TCO in a particular idiom of unsafePartial once seen in Data.Map.Internal, possibly still used elsewhere.
+      App a1 e1@(Var _ (Qualified (Just C.PartialUnsafe) (Ident up))) (Abs a2 i e2) | up == C.unsafePartial
+        -> App a1 e1 . Abs a2 i <$> handleExpr' e2
+      App a e1 e2 ->
+        -- `handleApp` is just to handle the constructor application exception
+        -- somewhat gracefully (i.e., without requiring a deep inspection of
+        -- the function expression at every step). If we didn't care about
+        -- constructors, this could have been simply:
+        --   App a <$> snd (go delay (fmap succ force)) e1 <*> snd (go delay Nothing) e2
+        handleApp 1 [(a, e2)] e1
+      Case a vs alts -> Case a <$> traverse (snd $ go delay Nothing) vs <*> traverse handleCaseAlternative alts
+      Let a ds e -> Let a <$> traverse (fst $ go delay Nothing) ds <*> handleExpr' e
+      other -> handleExpr other
+
+    handleApp len args = \case
+      App a e1 e2 -> handleApp (len + 1) ((a, e2) : args) e1
+      Var a@(_, _, _, Just meta) i | isConstructorLike meta
+        -> foldl (\e1 (a2, e2) -> App a2 <$> e1 <*> handleExpr' e2) (f delay force a i) args
+      e -> foldl (\e1 (a2, e2) -> App a2 <$> e1 <*> snd (go delay Nothing) e2) (snd (go delay (fmap (+ len) force)) e) args
+    isConstructorLike = \case
+      IsConstructor{} -> True
+      IsNewtype -> True
+      _ -> False
+
+-- Once we assign a delay and force value to every `Var` in the binding group,
+-- we can consider how to order the bindings to allow them all to successfully
+-- initialize. There is one principle here: each binding must be initialized
+-- before the identifier being bound is ready for use. If the preorder thus
+-- induced has cycles, those cycles need to be resolved with laziness. All of
+-- the details concern what "ready for use" means.
+--
+-- The definition of delay and force suggests that "ready for use" depends on
+-- those attributes. If a lambda is bound to the name x, then the references in
+-- the lambda don't need to be initialized before x is initialized. This is
+-- represented by the fact that those references have non-zero delay. But if
+-- the expression bound to x is instead the application of a function y that is
+-- also bound in this binding group, then not only does y need to be
+-- initialized before x, so do some of the non-zero delay references in y. This
+-- is represented by the fact that the occurrence of y in the expression bound
+-- to x has non-zero force.
+--
+-- An example, reusing the pseudocode annotations defined above:
+--
+--   x _ = y#1!0
+--   y = x#0!1 a
+--
+-- y doesn't need to be initialized before x is, because the reference to y in
+-- x's initializer has delay 1. But y does need to be initialized before x is
+-- ready for use with force 1, because force 1 is enough to overcome the delay
+-- of that reference. And since y has a delay-0 reference to x with force 1, y
+-- will need to be ready for use before it is initialized; thus, y needs to be
+-- made lazy.
+--
+-- So just as function applications "cancel out" lambdas, a known applied force
+-- cancels out an equal amount of delay, causing some references that may not
+-- have been needed earlier to enter play. (And to be safe, we must assume that
+-- unknown force cancels out *any* amount of delay.) There is another, subtler
+-- aspect of this: if there are not enough lambdas to absorb every argument
+-- applied to a function, those arguments will end up applied to the result of
+-- the function. Likewise, if there is excess force left over after some of it
+-- has been canceled by delay, that excess is carried to the references
+-- activated. (Again, an unknown amount of force must be assumed to lead to an
+-- unknown amount of excess force.)
+--
+-- Another example:
+--
+--   f = g#0!2 a b
+--   g x = h#1!2 c x
+--   h _ _ _ = f#3!0
+--
+-- Initializing f will lead to an infinite loop in this example. f invokes g
+-- with two arguments. g absorbs one argument, and the second ends up being
+-- applied to the result of h c x, resulting in h being invoked with three
+-- arguments. Invoking h with three arguments results in dereferencing f, which
+-- is not yet ready. To capture this loop in our analysis, we say that making
+-- f ready for use with force 0 requires making g ready for use with force 2,
+-- which requires making h ready for use with force 3 (two units of force from
+-- the lexical position of h, plus one unit of excess force carried forward),
+-- which cyclically requires f to be ready for use with force 0.
+--
+-- These preceding observations are captured and generalized by the following
+-- rules:
+--
+--   USE-INIT: Before a reference to x is ready for use with any force, x must
+--     be initialized.
+--
+--     We will make x lazy iff this rule induces a cycle--i.e., initializing x
+--     requires x to be ready for use first.
+--
+--   USE-USE: Before a reference to x is ready for use with force f:
+--     * if a reference in the initializer of x has delay d and force f',
+--     * and either d <= f or f is unknown,
+--     * then that reference must itself be ready for use with
+--       force f – d + f' (or with unknown force if f or f' is unknown).
+--
+--   USE-IMMEDIATE: Initializing a binding x is equivalent to requiring a
+--     reference to x to be ready for use with force 0, per USE-USE.
+--     
+--     Equivalently: before x is initialized, any reference in the initializer
+--     of x with delay 0 and force f must be ready for use with force f.
+--
+-- Examples:
+--
+--   Assume x is bound in a recursive binding group with the below bindings.
+--
+--   All of the following initializers require x to be ready for use with some
+--   amount of force, and therefore require x to be initialized first.
+--
+--   a = x#0!0
+--   b = (\_ -> x#0!0) 1
+--   c = foo x#0!*
+--   d = (\_ -> foo x#0!*) 1
+--
+--   In the following initializers, before p can be initialized, x must be
+--   ready for use with force f – d + f'. (And both x and q must be
+--   initialized, of course; but x being ready for use with that force may
+--   induce additional constraints.)
+--
+--   p = ... q#0!f ...
+--   q = ... x#d!f' ... (where d <= f)
+--
+--   Excess force stacks, of course: in the following initializers, before r
+--   can be initialized, x must be ready for use with force
+--   f — d + f' — d' + f'':
+--
+--   r = ... s#0!f ...
+--   s = ... t#d!f' ... (where d <= f)
+--   t = ... x#d'!f'' ... (where d' <= f – d + f')
+--
+--
+-- To satisfy these rules, we will construct a graph between (identifier,
+-- delay) pairs, with edges induced by the USE-USE rule, and effectively run a
+-- topsort to get the initialization preorder. For this part, it's simplest to
+-- think of delay as an element of the naturals extended with a positive
+-- infinity, corresponding to an unknown amount of force. (We'll do arithmetic
+-- on these extended naturals as you would naively expect; we won't do anything
+-- suspect like subtracting infinity from infinity.) With that in mind, we can
+-- construct the graph as follows: for each reference from i1 to i2 with delay
+-- d and force f, draw an infinite family of edges from (i1, d + n) to (i2, f +
+-- n) for all 0 <= n <= ∞, where n represents the excess force carried over
+-- from a previous edge. Unfortunately, as an infinite graph, we can't expect
+-- the tools in Data.Graph to help us traverse it; we will have to be a little
+-- bit clever.
+--
+-- The following data types and functions are for searching this infinite graph
+-- and carving from it a finite amount of data to work with. Specifically, we
+-- want to know for each identifier i, which other identifiers are
+-- irreflexively reachable from (i, 0) (and thus must be initialized before i
+-- is), and with what maximum force (in the event of a loop, not every
+-- reference to i in the reachable identifier needs to be rewritten to a force
+-- call; only the ones with delay up to the maximum force used during i's
+-- initialization). We also want the option of aborting a given reachability
+-- search, for one of two reasons.
+--
+--   * If we encounter a reference with unknown force, abort.
+--   * If we encounter a cycle where force on a single identifier is
+--     increasing, abort. (Because of USE-USE, as soon as an identifier is
+--     revisited with greater force than its first visit, the difference is
+--     carried forward as excess, so it is possible to retrace that path to get
+--     an arbitrarily high amount of force.)
+--
+-- Both reasons mean that it is theoretically possible for the identifier in
+-- question to need every other identifier in the binding group to be
+-- initialized before it is. (Every identifier in a recursive binding group is
+-- necessarily reachable from every other, ignoring delay and force, which is
+-- what arbitrarily high force lets you do.)
+--
+-- In order to reuse parts of this reachability computation across identifiers,
+-- we are going to represent it with a rose tree data structure interleaved with
+-- a monad capturing the abort semantics. (The monad is Maybe, but we don't
+-- need to know that here!)
+
+type MaxRoseTree m a = m (IM.MonoidalIntMap (MaxRoseNode m a))
+data MaxRoseNode m a = MaxRoseNode a (MaxRoseTree m a)
+
+-- Dissecting this data structure:
+--
+-- m (...)
+-- ^ represents whether to abort or continue the search
+--
+--   IM.MonoidalIntMap (...)
+--   ^ the keys of this map are other identifiers reachable from the current
+--     one (we'll map the identifiers in this binding group to Ints for ease of
+--     computation)
+--
+--     the values of this map are:
+--
+--     MaxRoseNode a (...)
+--     ^ this will store the force applied to the next identifier
+--       (MaxRoseTree m a)
+--       ^ and this, the tree of identifiers reachable from there
+--
+-- We're only interested in continuing down the search path that applies the
+-- most force to a given identifier! So when we combine two MaxRoseTrees,
+-- we want to resolve any key collisions in their MonoidalIntMaps with this
+-- semigroup:
+
+instance Ord a => Semigroup (MaxRoseNode m a) where
+  l@(MaxRoseNode l1 _) <> r@(MaxRoseNode r1 _) = if r1 > l1 then r else l
+
+-- And that's why this is called a MaxRoseTree.
+--
+-- Traversing this tree to get a single MonoidalIntMap with the entire closure
+-- plus force information is fairly straightforward:
+
+mrtFlatten :: (Monad m, Ord a) => MaxRoseTree m a -> m (IM.MonoidalIntMap (Max a))
+mrtFlatten = (getAp . IM.foldMapWithKey (\i (MaxRoseNode a inner) -> Ap $ (IM.singleton i (Max a) <>) <$> mrtFlatten inner) =<<)
+
+-- The use of the `Ap` monoid ensures that if any child of this tree aborts,
+-- the entire tree aborts.
+--
+-- One might ask, why interleave the abort monad with the tree at all if we're
+-- just going to flatten it out at the end? The point is to flatten it out at
+-- the end, but *not* during the generation of the tree. Attempting to flatten
+-- the tree as we generate it can result in an infinite loop, because a subtree
+-- needs to be exhaustively searched for abort conditions before it can be used
+-- in another tree. With this approach, we can use lazy trees as building
+-- blocks and, as long as they get rewritten to be finite or have aborts before
+-- they're flattened, the analysis still terminates.
+
+-- |
+-- Given a maximum index and a function that returns a map of edges to next
+-- indices, returns an array for each index up to maxIndex of maps from the
+-- indices reachable from the current index, to the maximum force applied to
+-- those indices.
+searchReachable
+  :: forall m force
+   . (Alternative m, Monad m, Enum force, Ord force)
+  => Int
+  -> ((Int, force) -> m (IM.MonoidalIntMap (Max force)))
+  -> A.Array Int (m (IM.MonoidalIntMap (Max force)))
+searchReachable maxIdx lookupEdges = mrtFlatten . unsafeHead <$> mem
+  where
+  -- This is a finite array of infinite lists, used to memoize all the search
+  -- trees. `unsafeHead` is used above to pull the first tree out of each list
+  -- in the array--the one corresponding to zero force, which is what's needed
+  -- to initialize the corresponding identifier. (`unsafeHead` is safe here, of
+  -- course: infinite lists.)
+  mem :: A.Array Int [MaxRoseTree m force]
+  mem = A.listArray (0, maxIdx)
+    [ [cutLoops <*> fmap (IM.mapWithKey memoizedNode) . lookupEdges $ (i, f) | f <- [toEnum 0..]]
+    | i <- [0..maxIdx]
+    ]
+
+  memoizedNode :: Int -> Max force -> MaxRoseNode m force
+  memoizedNode i (Max force) = MaxRoseNode force $ mem A.! i !! fromEnum force
+
+  -- And this is the function that prevents the search from actually being
+  -- infinite. It applies a filter to a `MaxRoseTree` at every level, looking for
+  -- indices anywhere in the tree that match the current vertex. If a match is
+  -- found with greater force than the current force, that part of the tree is
+  -- rewritten to abort; otherwise, that part of the tree is rewritten to be
+  -- empty (there's nothing new in that part of the search).
+  --
+  -- A new version of `cutLoops` is applied for each node in the search, so
+  -- each edge in a search path will add another filter on a new index. Since
+  -- there are a finite number of indices in our universe, this guarantees that
+  -- the analysis terminates, because no single search path can have length
+  -- greater than `maxIdx`.
+  cutLoops :: (Int, force) -> MaxRoseTree m force -> MaxRoseTree m force
+  cutLoops (i, force) = go
+    where
+    go = (=<<) . IM.traverseWithKey $ \i' (MaxRoseNode force' inner) ->
+      MaxRoseNode force' <$> if i == i' then guard (force >= force') $> pure IM.empty else pure $ go inner
+
+-- One last data structure to define and then it's on to the main event.
+--
+-- The laziness transform effectively takes a list of eager bindings (x = ...)
+-- and splits some of them into lazy definitions ($lazy_x = ...) and lazy
+-- bindings (x = $lazy_x ...). It's convenient to work with these three
+-- declarations as the following sum type:
+
+data RecursiveGroupItem e = EagerBinding Ann e | LazyDefinition e | LazyBinding Ann
+  deriving Functor
+
+-- |
+-- Transform a recursive binding group, reordering the bindings within when a
+-- correct initialization order can be statically determined, and rewriting
+-- bindings and references to be lazy otherwise.
+--
+applyLazinessTransform :: ModuleName -> [((Ann, Ident), Expr Ann)] -> ([((Ann, Ident), Expr Ann)], Any)
+applyLazinessTransform mn rawItems = let
+
+  -- Establish the mapping from names to ints.
+  rawItemsByName :: M.MonoidalMap Ident (Ann, Expr Ann)
+  rawItemsByName = M.fromList $ (snd . fst &&& first fst) <$> rawItems
+
+  maxIdx = M.size rawItemsByName - 1
+
+  rawItemsByIndex :: A.Array Int (Ann, Expr Ann)
+  rawItemsByIndex = A.listArray (0, maxIdx) $ M.elems rawItemsByName
+
+  names :: S.Set Ident
+  names = M.keysSet rawItemsByName
+
+  -- Now do the first delay/force traversal of all the bindings to find
+  -- references to other names in this binding group.
+  --
+  -- The parts of this type mean:
+  -- D is the maximum force (or Nothing if unknown) with which the identifier C
+  -- is referenced in any delay-B position inside the expression A.
+  --
+  -- where A, B, C, and D are as below:
+  --                A           B (keys)           C (keys)           D
+  findReferences :: Expr Ann -> IM.MonoidalIntMap (IM.MonoidalIntMap (Ap Maybe (Max Int)))
+  findReferences = (getConst .) . onVarsWithDelayAndForce $ \delay force _ -> \case
+    Qualified mn' ident | all (== mn) mn', Just i <- ident `S.lookupIndex` names
+      -> Const . IM.singleton delay . IM.singleton i $ coerceForce force
+    _ -> Const IM.empty
+
+  -- The parts of this type mean:
+  -- D is the maximum force (or Nothing if unknown) with which the identifier C
+  -- is referenced in any delay-B position inside the binding of identifier A.
+  --
+  -- where A, B, C, and D are as below:
+  --                     A    B (keys)           C (keys)           D
+  refsByIndex :: A.Array Int (IM.MonoidalIntMap (IM.MonoidalIntMap (Ap Maybe (Max Int))))
+  refsByIndex = findReferences . snd <$> rawItemsByIndex
+
+  -- Using the approach explained above, traverse the reference graph generated
+  -- by `refsByIndex` and find all reachable names.
+  --
+  -- The parts of this type mean:
+  -- D is the maximum force with which the identifier C is referenced,
+  -- directly or indirectly, during the initialization of identifier A. B is
+  -- Nothing if the analysis of A was inconclusive and A might need the entire
+  -- binding group.
+  -- 
+  -- where A, B, C, and D are as below:
+  --                           A    B      C (keys)           D
+  reachablesByIndex :: A.Array Int (Maybe (IM.MonoidalIntMap (Max Int)))
+  reachablesByIndex = searchReachable maxIdx $ \(i, force) ->
+    getAp . flip IM.foldMapWithKey (dropKeysAbove force $ refsByIndex A.! i) $ \delay ->
+      IM.foldMapWithKey $ \i' force' ->
+        Ap $ IM.singleton i' . Max . (force - delay +) <$> uncoerceForce force'
+
+  -- If `reachablesByIndex` is a sort of labeled relation, this function
+  -- produces part of the reverse relation, but only for the edges from the
+  -- given vertex.
+  --
+  -- The parts of this type mean:
+  -- The identifier A is reachable from the identifier B with maximum force C
+  -- (B is also the index provided to the function).
+  --
+  -- where A, B, and C are as below:
+  --                      (B)    A                  B (singleton key)  C
+  reverseReachablesFor :: Int -> IM.MonoidalIntMap (IM.MonoidalIntMap (Ap Maybe (Max Int)))
+  reverseReachablesFor i = case reachablesByIndex A.! i of
+    Nothing -> IM.fromAscList $ (, IM.singleton i $ Ap Nothing) <$> [0..maxIdx]
+    Just im -> IM.singleton i . Ap . Just <$> im
+
+  -- We can use `reachablesByIndex` to build a finite graph and topsort it;
+  -- in the process, we'll pack the nodes of the graph with data we'll want
+  -- next. Remember that if our reachability computation aborted, we have to
+  -- assume that every other identifier is reachable from that one--hence the
+  -- `maybe [0..maxIdx]`.
+  sccs = stronglyConnComp $ do
+    (i, mbReachable) <- A.assocs reachablesByIndex
+    pure ((reverseReachablesFor i, (S.elemAt i names, rawItemsByIndex A.! i)), i, maybe [0..maxIdx] (IS.toList . IM.keysSet) mbReachable)
+
+  (replacements, items) = flip foldMap sccs $ \case
+    -- The easy case: this binding doesn't need to be made lazy after all!
+    AcyclicSCC (_, (ident, (a, e))) -> pure [(ident, EagerBinding a e)]
+    -- The tough case: we have a loop.
+    -- We need to do two things here:
+    --   * Collect the reversed reachables relation for each vertex in this
+    --     loop; we'll use this to replace references with force calls
+    --   * Copy the vertex list into two lists: a list of lazy definitions and
+    --     a list of lazy bindings
+    -- Both of these results are monoidal, so the outer `foldMap` will
+    -- concatenate them pairwise.
+    CyclicSCC vertices -> (foldMap fst vertices, map (fmap (LazyDefinition . snd) . snd) vertices ++ map (fmap (LazyBinding . fst) . snd) vertices)
+
+  -- We have `replacements` expressed in terms of indices; we want to map it
+  -- back to names before traversing the bindings again.
+  replacementsByName :: M.MonoidalMap Ident (M.MonoidalMap Ident (Ap Maybe (Max Int)))
+  replacementsByName = M.fromAscList . map (bimap (flip S.elemAt names) (M.fromAscList . map (first (flip S.elemAt names)) . IM.toAscList)) . IM.toAscList $ replacements
+
+  -- And finally, this is the second delay/force traversal where we take
+  -- `replacementsByName` and use it to rewrite references with force calls,
+  -- but only if the delay of those references is at most the maximum amount
+  -- of force used by the initialization of the referenced binding to
+  -- reference the outer binding. A reference made with a higher delay than
+  -- that can safely continue to use the original reference, since it won't be
+  -- needed until after the referenced binding is done initializing.
+  replaceReferencesWithForceCall :: (Ident, RecursiveGroupItem (Expr Ann)) -> (Ident, RecursiveGroupItem (Expr Ann))
+  replaceReferencesWithForceCall pair@(ident, item) = case ident `M.lookup` replacementsByName of
+    Nothing -> pair
+    Just m -> let
+      rewriteExpr = (runIdentity .) . onVarsWithDelayAndForce $ \delay _ ann -> pure . \case
+        Qualified mn' ident' | all (== mn) mn', any (all (>= Max delay) . getAp) $ ident' `M.lookup` m
+          -> makeForceCall ann ident'
+        q -> Var ann q
+      in (ident, rewriteExpr <$> item)
+
+  -- All that's left to do is run the above replacement on every item,
+  -- translate items from our `RecursiveGroupItem` representation back into the
+  -- form CoreFn expects, and inform the caller whether we made any laziness
+  -- transformations after all. (That last bit of information is used to
+  -- determine if the runtime factory function needs to be injected.)
+  in (uncurry fromRGI . replaceReferencesWithForceCall <$> items, Any . not $ IM.null replacements)
+
+  where
+
+  nullAnn = ssAnn nullSourceSpan
+  runtimeLazy = Var nullAnn . Qualified Nothing $ InternalIdent RuntimeLazyFactory
+  runFn3 = Var nullAnn . Qualified (Just C.DataFunctionUncurried) . Ident $ C.runFn <> "3"
+  strLit = Literal nullAnn . StringLiteral . mkString
+
+  lazifyIdent = \case
+    Ident txt -> InternalIdent $ Lazy txt
+    _ -> internalError "Unexpected argument to lazifyIdent"
+
+  makeForceCall :: Ann -> Ident -> Expr Ann
+  makeForceCall (ss, _, _, _) ident
+    -- We expect the functions produced by `runtimeLazy` to accept one
+    -- argument: the line number on which this reference is made. The runtime
+    -- code uses this number to generate a message that identifies where the
+    -- evaluation looped.
+    = App nullAnn (Var nullAnn . Qualified Nothing $ lazifyIdent ident)
+    . Literal nullAnn . NumericLiteral . Left . toInteger . sourcePosLine
+    $ spanStart ss
+
+  fromRGI :: Ident -> RecursiveGroupItem (Expr Ann) -> ((Ann, Ident), Expr Ann)
+  fromRGI i = \case
+    EagerBinding a e -> ((a, i), e)
+    -- We expect the `runtimeLazy` factory to accept three arguments: the
+    -- identifier being initialized, the name of the module, and of course a
+    -- thunk that actually contains the initialization code.
+    LazyDefinition e -> ((nullAnn, lazifyIdent i), foldl1' (App nullAnn) [runFn3, runtimeLazy, strLit $ runIdent i, strLit $ runModuleName mn, Abs nullAnn UnusedIdent e])
+    LazyBinding a -> ((a, i), makeForceCall a i)
+
+  dropKeysAbove :: Int -> IM.MonoidalIntMap a -> IM.MonoidalIntMap a
+  dropKeysAbove n = fst . IM.split (n + 1)
+
+  coerceForce :: Maybe Int -> Ap Maybe (Max Int)
+  coerceForce = coerce
+
+  uncoerceForce :: Ap Maybe (Max Int) -> Maybe Int
+  uncoerceForce = coerce

--- a/stack.yaml
+++ b/stack.yaml
@@ -23,6 +23,8 @@ extra-deps:
 # See https://github.com/purescript/purescript/issues/4253
 - process-1.6.13.1
 - Cabal-3.2.1.0
+# Not included in Stackage until the lts-19 series
+- monoidal-containers-0.6.2.0
 nix:
   packages:
   - zlib

--- a/tests/purs/optimize/4179.out.js
+++ b/tests/purs/optimize/4179.out.js
@@ -1,0 +1,101 @@
+var $runtime_lazy = function (name, moduleName, init) {
+    var state = 0;
+    var val;
+    return function (lineNumber) {
+        if (state === 2) return val;
+        if (state === 1) throw new ReferenceError(name + " was needed before it finished initializing (module " + moduleName + ", line " + lineNumber + ")", moduleName, lineNumber);
+        state = 1;
+        val = init();
+        state = 2;
+        return val;
+    };
+};
+
+// This is a test that TCO isn't broken by unsafePartial.
+var tcoable = function ($copy_v) {
+    var $tco_done = false;
+    var $tco_result;
+    function $tco_loop(v) {
+        if (v === 0) {
+            $tco_done = true;
+            return "done";
+        };
+        if (v > 0) {
+            $copy_v = v - 1 | 0;
+            return;
+        };
+        throw new Error("Failed pattern match at Main (line 43, column 25 - line 45, column 31): " + [ v.constructor.name ]);
+    };
+    while (!$tco_done) {
+        $tco_result = $tco_loop($copy_v);
+    };
+    return $tco_result;
+};
+var isOdd = function (n) {
+    return n > 0 && !isEven(n - 1 | 0);
+};
+var isEven = function (n) {
+    return n === 0 || isOdd(n - 1 | 0);
+};
+
+// This is an example of four mutually recursive bindings with a complex
+// run-time dependency structure. The expected result is:
+//   alpha is defined without any laziness
+//   bravo and charlie are lazily initialized in a group
+//   and then delta is lazily initialized
+var alpha = function (v) {
+    if (v === 0) {
+        return $lazy_bravo(18);
+    };
+    if (v === 1) {
+        return $lazy_charlie(19);
+    };
+    if (v === 2) {
+        return function (y) {
+            var $7 = y > 0;
+            if ($7) {
+                return bravo(y);
+            };
+            return charlie(y);
+        };
+    };
+    return function (y) {
+        return $lazy_delta(21)(y)(v);
+    };
+};
+var $lazy_charlie = /* #__PURE__ */ $runtime_lazy("charlie", "Main", function () {
+    return (function (v) {
+        return alpha;
+    })({})(4);
+});
+var $lazy_bravo = /* #__PURE__ */ $runtime_lazy("bravo", "Main", function () {
+    return (function (v) {
+        return alpha;
+    })({})(3);
+});
+var charlie = /* #__PURE__ */ $lazy_charlie(31);
+var bravo = /* #__PURE__ */ $lazy_bravo(28);
+var $lazy_delta = /* #__PURE__ */ $runtime_lazy("delta", "Main", function () {
+    var b = (function (v) {
+        return bravo;
+    })({});
+    return function (x) {
+        return function (y) {
+            var $8 = x === y;
+            if ($8) {
+                return b(0);
+            };
+            return 1.0;
+        };
+    };
+});
+var delta = /* #__PURE__ */ $lazy_delta(34);
+export {
+    isEven,
+    isOdd,
+    alpha,
+    bravo,
+    charlie,
+    delta,
+    tcoable
+};

--- a/tests/purs/optimize/4179.purs
+++ b/tests/purs/optimize/4179.purs
@@ -1,0 +1,45 @@
+module Main where
+
+import Prelude
+
+import Partial.Unsafe (unsafePartial)
+
+isEven n = n == 0 || isOdd (n - 1)
+isOdd n = n > 0 && not (isEven (n - 1))
+
+-- This is an example of four mutually recursive bindings with a complex
+-- run-time dependency structure. The expected result is:
+--   alpha is defined without any laziness
+--   bravo and charlie are lazily initialized in a group
+--   and then delta is lazily initialized
+
+alpha :: Int -> Int -> Number
+alpha = case _ of
+  0 -> bravo
+  1 -> charlie
+  2 -> \y -> if y > 0 then bravo y else charlie y
+  x -> \y -> delta y x
+
+-- Me: `alpha`
+-- purs: The value of alpha is undefined here, so this reference is not allowed.
+-- Me: `(\_ -> alpha) {}`
+-- purs: LGTM!
+
+bravo :: Int -> Number
+bravo = (\_ -> alpha) {} 3
+
+charlie :: Int -> Number
+charlie = (\_ -> alpha) {} 4
+
+delta :: Int -> Int -> Number
+delta =
+  let b = (\_ -> bravo) {}
+  in \x y -> if x == y then b 0 else 1.0
+
+
+-- This is a test that TCO isn't broken by unsafePartial.
+
+tcoable :: Int -> String
+tcoable = unsafePartial case _ of
+  0 -> "done"
+  n | n > 0 -> tcoable (n - 1)

--- a/tests/purs/passing/4179.js
+++ b/tests/purs/passing/4179.js
@@ -1,0 +1,2 @@
+export const runtimeImportImpl = nothing => just => moduleName => body => () =>
+  import(`../${moduleName}/index.js`).then(() => body(nothing)(), err => body(just(err.toString()))());

--- a/tests/purs/passing/4179.purs
+++ b/tests/purs/passing/4179.purs
@@ -1,0 +1,73 @@
+module Main where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Effect (Effect)
+import Effect.Console (log)
+import Test.Assert (assertEqual)
+import CustomAssert (assertThrows)
+
+force :: forall a b. (Unit -> b) -> b
+force f = f unit
+
+alpha = { backref: \_ -> bravo, x: 1 }
+bravo = force \_ -> alpha.x
+
+
+complicatedIdentity :: forall a. a -> a
+complicatedIdentity = h
+  where
+  -- This highly contrived function tests that escalating force is caught and
+  -- doesn't cause an infinite loop during compilation. ("Escalating force"
+  -- means that invoking `f` with two argument leads to `f` being invoked with
+  -- three arguments, and so on.)
+
+  -- If the escalating loop in `f` isn't taken into account, `h` might be
+  -- initialized before `g`, which will lead to a run-time error. The intended
+  -- behavior is to lazily initialize `g` and `h` together, and let the fact
+  -- that at run time `g` never actually dereferences `h` resolve the
+  -- initialization ordering.
+
+  f :: forall a. Int -> { tick :: a -> a, tock :: a -> a }
+  f n = { tick: if n <= 0 then identity else (f (n - 1)).tock identity, tock: \a -> g n a }
+
+  g :: forall a. Int -> a -> a
+  g = (\bit -> if bit then \n -> (f n).tick else const h) true
+
+  h :: forall a. a -> a
+  h = (\n -> (f n).tick) 10
+
+
+foreign import runtimeImportImpl :: forall a. Maybe String -> (String -> Maybe String) -> String -> (Maybe String -> Effect a) -> Effect a
+
+runtimeImport :: forall a. String -> (Maybe String -> Effect a) -> Effect a
+runtimeImport = runtimeImportImpl Nothing Just
+
+type ID = forall a. a -> a
+
+main = do
+  err <- assertThrows \_ ->
+    let
+      selfOwn = { a: 1, b: force \_ -> selfOwn.a }
+    in selfOwn
+  assertEqual { actual: err, expected: "ReferenceError: selfOwn was needed before it finished initializing (module Main, line 52)" }
+
+  err2 <- assertThrows \_ ->
+    let
+      f = (\_ -> { left: g identity, right: h identity }) unit
+
+      g :: ID -> ID
+      g x = (j x x x).right
+
+      h :: ID -> ID -> { left :: ID, right :: ID }
+      h x = j x x
+
+      j x y z = { left: x y z, right: f.left }
+    in f
+  assertEqual { actual: err2, expected: "ReferenceError: f was needed before it finished initializing (module Main, line 66)" }
+
+  assertEqual { actual: bravo, expected: 1 }
+  runtimeImport "InitializationError" \err3 -> do
+    assertEqual { actual: err3, expected: Just "ReferenceError: alphaArray was needed before it finished initializing (module InitializationError, line 0)" } -- TODO: fix the 0
+    log "Done"

--- a/tests/purs/passing/4179/CustomAssert.js
+++ b/tests/purs/passing/4179/CustomAssert.js
@@ -1,0 +1,12 @@
+export var assertThrowsImpl = function (arg) {
+  return function (f) {
+    return function () {
+      try {
+        f(arg);
+      } catch (e) {
+        return e.toString();
+      }
+      throw new Error("Assertion failed: An error should have been thrown");
+    };
+  };
+};

--- a/tests/purs/passing/4179/CustomAssert.purs
+++ b/tests/purs/passing/4179/CustomAssert.purs
@@ -1,0 +1,10 @@
+module CustomAssert (assertThrows) where
+
+import Prelude
+
+import Effect (Effect)
+
+assertThrows :: forall a. (Unit -> a) -> Effect String
+assertThrows = assertThrowsImpl unit
+
+foreign import assertThrowsImpl :: forall a b. a -> (a -> b) -> Effect String

--- a/tests/purs/passing/4179/InitializationError.purs
+++ b/tests/purs/passing/4179/InitializationError.purs
@@ -1,0 +1,14 @@
+module InitializationError where
+
+class Alpha a where
+  alpha :: a Int -> a Int
+class Alpha a <= Bravo a
+class Bravo a <= Charlie a
+
+charlieAlpha :: forall a. Charlie a => a Int -> a Int
+charlieAlpha = alpha
+
+instance alphaArray :: Alpha Array where
+  alpha = charlieAlpha
+instance Bravo Array
+instance Charlie Array


### PR DESCRIPTION
I wrote a book in src/Language/PureScript/CoreFn/Laziness.hs; read that
for details.

This is unlikely to break a working program, but the upshot for users is
that it's now possible to get a run-time error when dereferencing an
identifier in a recursive binding group before it has been initialized,
instead of silently getting an `undefined` value and having that maybe
or maybe not lead to an error somewhere else.

**Description of the change**

Fixes #4179.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
