### PR TITLE
Add GNU Guix installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,6 +24,7 @@ There are several other distributions of the PureScript compiler available, whic
 * NPM: `npm install -g purescript`
 * Homebrew (for macOS): `brew install purescript`
 * FreeBSD binary packages: `pkg install hs-purescript`
+* GNU Guix: `guix install purescript`
 
 ## Compiling from source
 


### PR DESCRIPTION
This PR adds installation instructions with [Guix](https://guix.gnu.org/en/packages/purescript-0.14.5/).