### PR TITLE
Document our evolving changelog principles

### DIFF
--- a/CHANGELOG.d/README.md
+++ b/CHANGELOG.d/README.md
@@ -6,13 +6,32 @@ Maintainers: see update-changelog.hs for details of this process.
 
 Contributors: read on!
 
-When you are preparing a new PR, add a new file to this directory. The file
-should be named `{PREFIX}_{SLUG}.md`, where `{PREFIX}` is one of the following:
-* `breaking`: for breaking changes
-* `feature`: for new features
-* `fix`: for bug fixes
-* `internal`: for work that will not directly affect users of PureScript
-* `misc`: for anything else that needs to be logged
+Our guiding principle is that the changelog is a tool for users—people who
+depend on PureScript as a compiler or as a library—who are considering
+upgrading, or have recently upgraded, their PureScript compiler version. We ask
+that when making changes that such users might need to know about, you help
+them out by adding to our changelog.
+
+Work that doesn't change the compiler (such as updates to README.md) doesn't
+need a changelog entry. But keep in mind that even parts of the project like
+our CI workflow can introduce changes to the compiler we release.
+
+When you are preparing a new PR that does change the compiler, add a new file
+to this directory. The file should be named `{PREFIX}_{SLUG}.md`, where
+`{PREFIX}` is one of the following:
+* `breaking`: for breaking changes to the compiler, for which a user may need to do
+  work to their project before or immediately upon upgrading
+* `feature`: for new features, which might prevent a user from downgrading to an
+  earlier version
+* `fix`: for bug fixes, which might motivate a user to upgrade
+* `internal`: for work that is not expected to directly affect users; these
+  entries should usually be brief, but may serve as useful starting points for
+  investigations if a change ends up having unintended consequences
+
+(There is also a fifth prefix, `misc`. This is an escape hatch in case we have
+something that somehow doesn't fit in the above categories but that we want to
+include in the changelog, which frankly seems unlikely given how much of a
+catch-all `internal` is. We'll tell you if you should use this one.)
 
 `{SLUG}` should be a short description of the work you've done. The name has no
 impact on the final CHANGELOG.md.
@@ -20,7 +39,7 @@ impact on the final CHANGELOG.md.
 Some example names:
 * `fix_issue-9876.md`
 * `breaking_deprecate-classes.md`
-* `misc_add-forum-to-readme.md`
+* `internal_use-ubuntu-38.04-in-ci.md`
 
 The contents of the file can be as brief as:
 


### PR DESCRIPTION
**Description of the change**

Motivated by the conversation in #4286, this is an opinionated attempt to add more clarity to our CHANGELOG.d/README.md documentation. Please let me know if these opinions match yours.

One opposing position I want to highlight is the use of the changelog as a way to give credit to people who contributed to a given release. The set ‘changes to the compiler’ is not exactly the same as the set ‘contributions to the project’, and in this formulation, the changelog focuses entirely on the former. Someone who comes in and massively improves some aspect of our test suite, for example, would deserve a shout-out, but this wouldn't qualify as a change to the compiler that users would need to know about when considering an upgrade. Perhaps this is what the ‘Other improvements’ (`misc`) section should be for? Or maybe I have ‘Internal’ and ‘Other improvements’ swapped?

In accordance with the revised documentation here, this PR doesn't include a changelog entry. 😄

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
