### PR TITLE
Qualify locally-bound names with source spans

### DIFF
--- a/CHANGELOG.d/feature_local_qualification.md
+++ b/CHANGELOG.d/feature_local_qualification.md
@@ -1,0 +1,9 @@
+* Add qualification for locally-bound names
+
+  This change makes it so that `Qualified` names can now be qualified by either
+  a `ModuleName` for module-level declarations or a `SourceSpan` for bindings
+  introduced locally. This makes disambiguation between references to local
+  bindings much easier in AST-driven analysis.
+
+  A new desugaring step, `desugarLocals`, has also been added to insert
+  `SourceSpan`s into references of local bindings in the AST.

--- a/lib/purescript-cst/src/Language/PureScript/AST/Traversals.hs
+++ b/lib/purescript-cst/src/Language/PureScript/AST/Traversals.hs
@@ -124,48 +124,63 @@ everywhereOnValuesTopDownM
      , Expr -> m Expr
      , Binder -> m Binder
      )
-everywhereOnValuesTopDownM f g h = (f' <=< f, g' <=< g, h' <=< h)
+everywhereOnValuesTopDownM f g h = everywhereOnValuesTopDownThenM f g h pure pure pure
+
+everywhereOnValuesTopDownThenM
+  :: forall m
+   . (Monad m)
+  => (Declaration -> m Declaration)
+  -> (Expr -> m Expr)
+  -> (Binder -> m Binder)
+  -> (Declaration -> m Declaration)
+  -> (Expr -> m Expr)
+  -> (Binder -> m Binder)
+  -> ( Declaration -> m Declaration
+     , Expr -> m Expr
+     , Binder -> m Binder
+     )
+everywhereOnValuesTopDownThenM f g h f'' g'' h'' = (f' <=< f, g' <=< g, h' <=< h)
   where
 
   f' :: Declaration -> m Declaration
-  f' (DataBindingGroupDeclaration ds) = DataBindingGroupDeclaration <$> traverse (f' <=< f) ds
+  f' (DataBindingGroupDeclaration ds) = DataBindingGroupDeclaration <$> traverse (f' <=< f) ds >>= f''
   f' (ValueDecl sa name nameKind bs val) =
-     ValueDecl sa name nameKind <$> traverse (h' <=< h) bs <*> traverse (guardedExprM handleGuard (g' <=< g)) val
-  f' (BindingGroupDeclaration ds) = BindingGroupDeclaration <$> traverse (\(name, nameKind, val) -> (name, nameKind, ) <$> (g val >>= g')) ds
-  f' (TypeClassDeclaration sa name args implies deps ds) = TypeClassDeclaration sa name args implies deps <$> traverse (f' <=< f) ds
-  f' (TypeInstanceDeclaration sa ch idx name cs className args ds) = TypeInstanceDeclaration sa ch idx name cs className args <$> traverseTypeInstanceBody (traverse (f' <=< f)) ds
-  f' (BoundValueDeclaration sa b expr) = BoundValueDeclaration sa <$> (h' <=< h) b <*> (g' <=< g) expr
-  f' other = f other
+     ValueDecl sa name nameKind <$> traverse (h' <=< h) bs <*> traverse (guardedExprM handleGuard (g' <=< g)) val >>= f''
+  f' (BindingGroupDeclaration ds) = BindingGroupDeclaration <$> traverse (\(name, nameKind, val) -> (name, nameKind, ) <$> (g val >>= g')) ds >>= f''
+  f' (TypeClassDeclaration sa name args implies deps ds) = TypeClassDeclaration sa name args implies deps <$> traverse (f' <=< f) ds >>= f''
+  f' (TypeInstanceDeclaration sa ch idx name cs className args ds) = TypeInstanceDeclaration sa ch idx name cs className args <$> traverseTypeInstanceBody (traverse (f' <=< f)) ds >>= f''
+  f' (BoundValueDeclaration sa b expr) = BoundValueDeclaration sa <$> (h' <=< h) b <*> (g' <=< g) expr >>= f''
+  f' other = f other >>= f''
 
   g' :: Expr -> m Expr
-  g' (Literal ss l) = Literal ss <$> litM (g >=> g') l
-  g' (UnaryMinus ss v) = UnaryMinus ss <$> (g v >>= g')
-  g' (BinaryNoParens op v1 v2) = BinaryNoParens <$> (g op >>= g') <*> (g v1 >>= g') <*> (g v2 >>= g')
-  g' (Parens v) = Parens <$> (g v >>= g')
-  g' (Accessor prop v) = Accessor prop <$> (g v >>= g')
-  g' (ObjectUpdate obj vs) = ObjectUpdate <$> (g obj >>= g') <*> traverse (sndM (g' <=< g)) vs
-  g' (ObjectUpdateNested obj vs) = ObjectUpdateNested <$> (g obj >>= g') <*> traverse (g' <=< g) vs
-  g' (Abs binder v) = Abs <$> (h binder >>= h') <*> (g v >>= g')
-  g' (App v1 v2) = App <$> (g v1 >>= g') <*> (g v2 >>= g')
-  g' (Unused v) = Unused <$> (g v >>= g')
-  g' (IfThenElse v1 v2 v3) = IfThenElse <$> (g v1 >>= g') <*> (g v2 >>= g') <*> (g v3 >>= g')
-  g' (Case vs alts) = Case <$> traverse (g' <=< g) vs <*> traverse handleCaseAlternative alts
-  g' (TypedValue check v ty) = TypedValue check <$> (g v >>= g') <*> pure ty
-  g' (Let w ds v) = Let w <$> traverse (f' <=< f) ds <*> (g v >>= g')
-  g' (Do m es) = Do m <$> traverse handleDoNotationElement es
-  g' (Ado m es v) = Ado m <$> traverse handleDoNotationElement es <*> (g v >>= g')
-  g' (PositionedValue pos com v) = PositionedValue pos com <$> (g v >>= g')
-  g' other = g other
+  g' (Literal ss l) = Literal ss <$> litM (g >=> g') l >>= g''
+  g' (UnaryMinus ss v) = UnaryMinus ss <$> (g v >>= g') >>= g''
+  g' (BinaryNoParens op v1 v2) = BinaryNoParens <$> (g op >>= g') <*> (g v1 >>= g') <*> (g v2 >>= g') >>= g''
+  g' (Parens v) = Parens <$> (g v >>= g') >>= g''
+  g' (Accessor prop v) = Accessor prop <$> (g v >>= g') >>= g''
+  g' (ObjectUpdate obj vs) = ObjectUpdate <$> (g obj >>= g') <*> traverse (sndM (g' <=< g)) vs >>= g''
+  g' (ObjectUpdateNested obj vs) = ObjectUpdateNested <$> (g obj >>= g') <*> traverse (g' <=< g) vs >>= g''
+  g' (Abs binder v) = Abs <$> (h binder >>= h') <*> (g v >>= g') >>= g''
+  g' (App v1 v2) = App <$> (g v1 >>= g') <*> (g v2 >>= g') >>= g''
+  g' (Unused v) = Unused <$> (g v >>= g') >>= g''
+  g' (IfThenElse v1 v2 v3) = IfThenElse <$> (g v1 >>= g') <*> (g v2 >>= g') <*> (g v3 >>= g') >>= g''
+  g' (Case vs alts) = Case <$> traverse (g' <=< g) vs <*> traverse handleCaseAlternative alts >>= g''
+  g' (TypedValue check v ty) = TypedValue check <$> (g v >>= g') <*> pure ty >>= g''
+  g' (Let w ds v) = Let w <$> traverse (f' <=< f) ds <*> (g v >>= g') >>= g''
+  g' (Do m es) = Do m <$> traverse handleDoNotationElement es >>= g''
+  g' (Ado m es v) = Ado m <$> traverse handleDoNotationElement es <*> (g v >>= g') >>= g''
+  g' (PositionedValue pos com v) = PositionedValue pos com <$> (g v >>= g') >>= g''
+  g' other = g other >>= g''
 
   h' :: Binder -> m Binder
-  h' (LiteralBinder ss l) = LiteralBinder ss <$> litM (h >=> h') l
-  h' (ConstructorBinder ss ctor bs) = ConstructorBinder ss ctor <$> traverse (h' <=< h) bs
-  h' (BinaryNoParensBinder b1 b2 b3) = BinaryNoParensBinder <$> (h b1 >>= h') <*> (h b2 >>= h') <*> (h b3 >>= h')
-  h' (ParensInBinder b) = ParensInBinder <$> (h b >>= h')
-  h' (NamedBinder ss name b) = NamedBinder ss name <$> (h b >>= h')
-  h' (PositionedBinder pos com b) = PositionedBinder pos com <$> (h b >>= h')
-  h' (TypedBinder t b) = TypedBinder t <$> (h b >>= h')
-  h' other = h other
+  h' (LiteralBinder ss l) = LiteralBinder ss <$> litM (h >=> h') l >>= h''
+  h' (ConstructorBinder ss ctor bs) = ConstructorBinder ss ctor <$> traverse (h' <=< h) bs >>= h''
+  h' (BinaryNoParensBinder b1 b2 b3) = BinaryNoParensBinder <$> (h b1 >>= h') <*> (h b2 >>= h') <*> (h b3 >>= h') >>= h''
+  h' (ParensInBinder b) = ParensInBinder <$> (h b >>= h') >>= h''
+  h' (NamedBinder ss name b) = NamedBinder ss name <$> (h b >>= h') >>= h''
+  h' (PositionedBinder pos com b) = PositionedBinder pos com <$> (h b >>= h') >>= h''
+  h' (TypedBinder t b) = TypedBinder t <$> (h b >>= h') >>= h''
+  h' other = h other >>= h''
 
   handleCaseAlternative :: CaseAlternative -> m CaseAlternative
   handleCaseAlternative (CaseAlternative bs val) =

--- a/lib/purescript-cst/src/Language/PureScript/CST/Convert.hs
+++ b/lib/purescript-cst/src/Language/PureScript/CST/Convert.hs
@@ -90,7 +90,11 @@ moduleName = \case
   go ns = Just $ N.ModuleName $ Text.intercalate "." ns
 
 qualified :: QualifiedName a -> N.Qualified a
-qualified q = N.Qualified (qualModule q) (qualName q)
+qualified q = N.Qualified qb (qualName q)
+  where
+  qb = case qualModule q of
+    Just mn -> N.ByModuleName mn
+    Nothing -> N.ByNullSourceSpan
 
 ident :: Ident -> N.Ident
 ident = N.Ident . getIdent

--- a/lib/purescript-cst/src/Language/PureScript/Constants/Prim.hs
+++ b/lib/purescript-cst/src/Language/PureScript/Constants/Prim.hs
@@ -1,8 +1,6 @@
 -- | Various constants which refer to things in Prim
 module Language.PureScript.Constants.Prim where
 
-import Prelude.Compat
-
 import Data.String (IsString)
 import Language.PureScript.Names
 
@@ -17,25 +15,25 @@ pattern Prim :: ModuleName
 pattern Prim = ModuleName "Prim"
 
 pattern Partial :: Qualified (ProperName 'ClassName)
-pattern Partial = Qualified (Just Prim) (ProperName "Partial")
+pattern Partial = Qualified (ByModuleName Prim) (ProperName "Partial")
 
 pattern Record :: Qualified (ProperName 'TypeName)
-pattern Record = Qualified (Just Prim) (ProperName "Record")
+pattern Record = Qualified (ByModuleName Prim) (ProperName "Record")
 
 pattern Type :: Qualified (ProperName 'TypeName)
-pattern Type = Qualified (Just Prim) (ProperName "Type")
+pattern Type = Qualified (ByModuleName Prim) (ProperName "Type")
 
 pattern Constraint :: Qualified (ProperName 'TypeName)
-pattern Constraint = Qualified (Just Prim) (ProperName "Constraint")
+pattern Constraint = Qualified (ByModuleName Prim) (ProperName "Constraint")
 
 pattern Function :: Qualified (ProperName 'TypeName)
-pattern Function = Qualified (Just Prim) (ProperName "Function")
+pattern Function = Qualified (ByModuleName Prim) (ProperName "Function")
 
 pattern Array :: Qualified (ProperName 'TypeName)
-pattern Array = Qualified (Just Prim) (ProperName "Array")
+pattern Array = Qualified (ByModuleName Prim) (ProperName "Array")
 
 pattern Row :: Qualified (ProperName 'TypeName)
-pattern Row = Qualified (Just Prim) (ProperName "Row")
+pattern Row = Qualified (ByModuleName Prim) (ProperName "Row")
 
 -- Prim.Boolean
 
@@ -43,10 +41,10 @@ pattern PrimBoolean :: ModuleName
 pattern PrimBoolean = ModuleName "Prim.Boolean"
 
 booleanTrue :: Qualified (ProperName 'TypeName)
-booleanTrue = Qualified (Just PrimBoolean) (ProperName "True")
+booleanTrue = Qualified (ByModuleName PrimBoolean) (ProperName "True")
 
 booleanFalse :: Qualified (ProperName 'TypeName)
-booleanFalse = Qualified (Just PrimBoolean) (ProperName "False")
+booleanFalse = Qualified (ByModuleName PrimBoolean) (ProperName "False")
 
 -- Prim.Coerce
 
@@ -54,7 +52,7 @@ pattern PrimCoerce :: ModuleName
 pattern PrimCoerce = ModuleName "Prim.Coerce"
 
 pattern Coercible :: Qualified (ProperName 'ClassName)
-pattern Coercible = Qualified (Just PrimCoerce) (ProperName "Coercible")
+pattern Coercible = Qualified (ByModuleName PrimCoerce) (ProperName "Coercible")
 
 -- Prim.Ordering
 
@@ -62,13 +60,13 @@ pattern PrimOrdering :: ModuleName
 pattern PrimOrdering = ModuleName "Prim.Ordering"
 
 orderingLT :: Qualified (ProperName 'TypeName)
-orderingLT = Qualified (Just PrimOrdering) (ProperName "LT")
+orderingLT = Qualified (ByModuleName PrimOrdering) (ProperName "LT")
 
 orderingEQ :: Qualified (ProperName 'TypeName)
-orderingEQ = Qualified (Just PrimOrdering) (ProperName "EQ")
+orderingEQ = Qualified (ByModuleName PrimOrdering) (ProperName "EQ")
 
 orderingGT :: Qualified (ProperName 'TypeName)
-orderingGT = Qualified (Just PrimOrdering) (ProperName "GT")
+orderingGT = Qualified (ByModuleName PrimOrdering) (ProperName "GT")
 
 -- Prim.Row
 
@@ -76,16 +74,16 @@ pattern PrimRow :: ModuleName
 pattern PrimRow = ModuleName "Prim.Row"
 
 pattern RowUnion :: Qualified (ProperName 'ClassName)
-pattern RowUnion = Qualified (Just PrimRow) (ProperName "Union")
+pattern RowUnion = Qualified (ByModuleName PrimRow) (ProperName "Union")
 
 pattern RowNub :: Qualified (ProperName 'ClassName)
-pattern RowNub = Qualified (Just PrimRow) (ProperName "Nub")
+pattern RowNub = Qualified (ByModuleName PrimRow) (ProperName "Nub")
 
 pattern RowCons :: Qualified (ProperName 'ClassName)
-pattern RowCons = Qualified (Just PrimRow) (ProperName "Cons")
+pattern RowCons = Qualified (ByModuleName PrimRow) (ProperName "Cons")
 
 pattern RowLacks :: Qualified (ProperName 'ClassName)
-pattern RowLacks = Qualified (Just PrimRow) (ProperName "Lacks")
+pattern RowLacks = Qualified (ByModuleName PrimRow) (ProperName "Lacks")
 
 -- Prim.RowList
 
@@ -93,13 +91,13 @@ pattern PrimRowList :: ModuleName
 pattern PrimRowList = ModuleName "Prim.RowList"
 
 pattern RowToList :: Qualified (ProperName 'ClassName)
-pattern RowToList = Qualified (Just PrimRowList) (ProperName "RowToList")
+pattern RowToList = Qualified (ByModuleName PrimRowList) (ProperName "RowToList")
 
 pattern RowListNil :: Qualified (ProperName 'TypeName)
-pattern RowListNil = Qualified (Just PrimRowList) (ProperName "Nil")
+pattern RowListNil = Qualified (ByModuleName PrimRowList) (ProperName "Nil")
 
 pattern RowListCons :: Qualified (ProperName 'TypeName)
-pattern RowListCons = Qualified (Just PrimRowList) (ProperName "Cons")
+pattern RowListCons = Qualified (ByModuleName PrimRowList) (ProperName "Cons")
 
 -- Prim.Int
 
@@ -107,13 +105,13 @@ pattern PrimInt :: ModuleName
 pattern PrimInt = ModuleName "Prim.Int"
 
 pattern IntAdd :: Qualified (ProperName 'ClassName)
-pattern IntAdd = Qualified (Just PrimInt) (ProperName "Add")
+pattern IntAdd = Qualified (ByModuleName PrimInt) (ProperName "Add")
 
 pattern IntCompare :: Qualified (ProperName 'ClassName)
-pattern IntCompare = Qualified (Just PrimInt) (ProperName "Compare")
+pattern IntCompare = Qualified (ByModuleName PrimInt) (ProperName "Compare")
 
 pattern IntMul :: Qualified (ProperName 'ClassName)
-pattern IntMul = Qualified (Just PrimInt) (ProperName "Mul")
+pattern IntMul = Qualified (ByModuleName PrimInt) (ProperName "Mul")
 
 -- Prim.Symbol
 
@@ -121,13 +119,13 @@ pattern PrimSymbol :: ModuleName
 pattern PrimSymbol = ModuleName "Prim.Symbol"
 
 pattern SymbolCompare :: Qualified (ProperName 'ClassName)
-pattern SymbolCompare = Qualified (Just PrimSymbol) (ProperName "Compare")
+pattern SymbolCompare = Qualified (ByModuleName PrimSymbol) (ProperName "Compare")
 
 pattern SymbolAppend :: Qualified (ProperName 'ClassName)
-pattern SymbolAppend = Qualified (Just PrimSymbol) (ProperName "Append")
+pattern SymbolAppend = Qualified (ByModuleName PrimSymbol) (ProperName "Append")
 
 pattern SymbolCons :: Qualified (ProperName 'ClassName)
-pattern SymbolCons = Qualified (Just PrimSymbol) (ProperName "Cons")
+pattern SymbolCons = Qualified (ByModuleName PrimSymbol) (ProperName "Cons")
 
 -- Prim.TypeError
 
@@ -135,10 +133,10 @@ pattern PrimTypeError :: ModuleName
 pattern PrimTypeError = ModuleName "Prim.TypeError"
 
 pattern Fail :: Qualified (ProperName 'ClassName)
-pattern Fail = Qualified (Just PrimTypeError) (ProperName "Fail")
+pattern Fail = Qualified (ByModuleName PrimTypeError) (ProperName "Fail")
 
 pattern Warn :: Qualified (ProperName 'ClassName)
-pattern Warn = Qualified (Just PrimTypeError) (ProperName "Warn")
+pattern Warn = Qualified (ByModuleName PrimTypeError) (ProperName "Warn")
 
 primModules :: [ModuleName]
 primModules = [Prim, PrimBoolean, PrimCoerce, PrimOrdering, PrimRow, PrimRowList, PrimSymbol, PrimInt, PrimTypeError]

--- a/lib/purescript-cst/src/Language/PureScript/Environment.hs
+++ b/lib/purescript-cst/src/Language/PureScript/Environment.hs
@@ -242,12 +242,12 @@ instance A.FromJSON DataDeclType where
 
 -- | Construct a ProperName in the Prim module
 primName :: Text -> Qualified (ProperName a)
-primName = Qualified (Just C.Prim) . ProperName
+primName = Qualified (ByModuleName C.Prim) . ProperName
 
 -- | Construct a 'ProperName' in the @Prim.NAME@ module.
 primSubName :: Text -> Text -> Qualified (ProperName a)
 primSubName sub =
-  Qualified (Just $ ModuleName $ C.prim <> "." <> sub) . ProperName
+  Qualified (ByModuleName $ ModuleName $ C.prim <> "." <> sub) . ProperName
 
 primKind :: Text -> SourceType
 primKind = primTy

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -195,9 +195,9 @@ moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreignInclude =
     goBinder (ConstructorBinder ann q1 q2 bs) = ConstructorBinder ann (renameQual q1) (renameQual q2) bs
     goBinder b = b
     renameQual :: Qualified a -> Qualified a
-    renameQual (Qualified (Just mn') a) =
+    renameQual (Qualified (ByModuleName mn') a) =
       let (_,mnSafe) = fromMaybe (internalError "Missing value in mnLookup") $ M.lookup mn' mnLookup
-      in Qualified (Just mnSafe) a
+      in Qualified (ByModuleName mnSafe) a
     renameQual q = q
 
   -- |
@@ -349,7 +349,7 @@ moduleBindToJs mn = bindToJs
     unApp :: Expr Ann -> [Expr Ann] -> (Expr Ann, [Expr Ann])
     unApp (App _ val arg) args = unApp val (arg : args)
     unApp other args = (other, args)
-  valueToJs' (Var (_, _, _, Just IsForeign) qi@(Qualified (Just mn') ident)) =
+  valueToJs' (Var (_, _, _, Just IsForeign) qi@(Qualified (ByModuleName mn') ident)) =
     return $ if mn' == mn
              then foreignIdent ident
              else varToJs qi
@@ -418,14 +418,14 @@ moduleBindToJs mn = bindToJs
   -- | Generate code in the simplified JavaScript intermediate representation for a reference to a
   -- variable.
   varToJs :: Qualified Ident -> AST
-  varToJs (Qualified Nothing ident) = var ident
+  varToJs (Qualified (BySourceSpan _) ident) = var ident
   varToJs qual = qualifiedToJS id qual
 
   -- | Generate code in the simplified JavaScript intermediate representation for a reference to a
   -- variable that may have a qualified name.
   qualifiedToJS :: (a -> Ident) -> Qualified a -> AST
-  qualifiedToJS f (Qualified (Just C.Prim) a) = AST.Var Nothing . runIdent $ f a
-  qualifiedToJS f (Qualified (Just mn') a) | mn /= mn' = moduleAccessor (f a) (AST.Var Nothing (moduleNameToJs mn'))
+  qualifiedToJS f (Qualified (ByModuleName C.Prim) a) = AST.Var Nothing . runIdent $ f a
+  qualifiedToJS f (Qualified (ByModuleName mn') a) | mn /= mn' = moduleAccessor (f a) (AST.Var Nothing (moduleNameToJs mn'))
   qualifiedToJS f (Qualified _ a) = AST.Var Nothing $ identToJs (f a)
 
   foreignIdent :: Ident -> AST

--- a/src/Language/PureScript/Constants/Data/Generic/Rep.hs
+++ b/src/Language/PureScript/Constants/Data/Generic/Rep.hs
@@ -1,40 +1,39 @@
 module Language.PureScript.Constants.Data.Generic.Rep where
 
-import Prelude.Compat
 import Language.PureScript.Names
 
 pattern DataGenericRep :: ModuleName
 pattern DataGenericRep = ModuleName "Data.Generic.Rep"
 
 pattern Generic :: Qualified (ProperName 'ClassName)
-pattern Generic = Qualified (Just DataGenericRep) (ProperName "Generic")
+pattern Generic = Qualified (ByModuleName DataGenericRep) (ProperName "Generic")
 
 to :: Qualified Ident
-to = Qualified (Just DataGenericRep) (Ident "to")
+to = Qualified (ByModuleName DataGenericRep) (Ident "to")
 
 from :: Qualified Ident
-from = Qualified (Just DataGenericRep) (Ident "from")
+from = Qualified (ByModuleName DataGenericRep) (Ident "from")
 
 pattern NoConstructors :: Qualified (ProperName a)
-pattern NoConstructors = Qualified (Just DataGenericRep) (ProperName "NoConstructors")
+pattern NoConstructors = Qualified (ByModuleName DataGenericRep) (ProperName "NoConstructors")
 
 pattern NoArguments :: Qualified (ProperName a)
-pattern NoArguments = Qualified (Just DataGenericRep) (ProperName "NoArguments")
+pattern NoArguments = Qualified (ByModuleName DataGenericRep) (ProperName "NoArguments")
 
 pattern Sum :: Qualified (ProperName a)
-pattern Sum = Qualified (Just DataGenericRep) (ProperName "Sum")
+pattern Sum = Qualified (ByModuleName DataGenericRep) (ProperName "Sum")
 
 pattern Inl :: Qualified (ProperName a)
-pattern Inl = Qualified (Just DataGenericRep) (ProperName "Inl")
+pattern Inl = Qualified (ByModuleName DataGenericRep) (ProperName "Inl")
 
 pattern Inr :: Qualified (ProperName a)
-pattern Inr = Qualified (Just DataGenericRep) (ProperName "Inr")
+pattern Inr = Qualified (ByModuleName DataGenericRep) (ProperName "Inr")
 
 pattern Product :: Qualified (ProperName a)
-pattern Product = Qualified (Just DataGenericRep) (ProperName "Product")
+pattern Product = Qualified (ByModuleName DataGenericRep) (ProperName "Product")
 
 pattern Constructor :: Qualified (ProperName a)
-pattern Constructor = Qualified (Just DataGenericRep) (ProperName "Constructor")
+pattern Constructor = Qualified (ByModuleName DataGenericRep) (ProperName "Constructor")
 
 pattern Argument :: Qualified (ProperName a)
-pattern Argument = Qualified (Just DataGenericRep) (ProperName "Argument")
+pattern Argument = Qualified (ByModuleName DataGenericRep) (ProperName "Argument")

--- a/src/Language/PureScript/Constants/Data/Newtype.hs
+++ b/src/Language/PureScript/Constants/Data/Newtype.hs
@@ -1,7 +1,6 @@
 module Language.PureScript.Constants.Data.Newtype where
 
-import Prelude.Compat
 import Language.PureScript.Names
 
 pattern Newtype :: Qualified (ProperName 'ClassName)
-pattern Newtype = Qualified (Just (ModuleName "Data.Newtype")) (ProperName "Newtype")
+pattern Newtype = Qualified (ByModuleName (ModuleName "Data.Newtype")) (ProperName "Newtype")

--- a/src/Language/PureScript/Constants/Prelude.hs
+++ b/src/Language/PureScript/Constants/Prelude.hs
@@ -1,8 +1,6 @@
 -- | Various constants which refer to things in the Prelude
 module Language.PureScript.Constants.Prelude where
 
-import Prelude.Compat
-
 import Data.String (IsString)
 import Language.PureScript.PSString (PSString)
 import Language.PureScript.Names
@@ -25,7 +23,7 @@ discard :: forall a. (IsString a) => a
 discard = "discard"
 
 pattern Discard :: Qualified (ProperName 'ClassName)
-pattern Discard = Qualified (Just ControlBind) (ProperName "Discard")
+pattern Discard = Qualified (ByModuleName ControlBind) (ProperName "Discard")
 
 add :: forall a. (IsString a) => a
 add = "add"
@@ -271,13 +269,13 @@ pattern DataSymbol :: ModuleName
 pattern DataSymbol = ModuleName "Data.Symbol"
 
 pattern IsSymbol :: Qualified (ProperName 'ClassName)
-pattern IsSymbol = Qualified (Just DataSymbol) (ProperName "IsSymbol")
+pattern IsSymbol = Qualified (ByModuleName DataSymbol) (ProperName "IsSymbol")
 
 pattern DataReflectable :: ModuleName
 pattern DataReflectable = ModuleName "Data.Reflectable"
 
 pattern Reflectable :: Qualified (ProperName 'ClassName)
-pattern Reflectable = Qualified (Just DataReflectable) (ProperName "Reflectable")
+pattern Reflectable = Qualified (ByModuleName DataReflectable) (ProperName "Reflectable")
 
 pattern DataOrdering :: ModuleName
 pattern DataOrdering = ModuleName "Data.Ordering"
@@ -289,16 +287,16 @@ pattern PartialUnsafe :: ModuleName
 pattern PartialUnsafe = ModuleName "Partial.Unsafe"
 
 pattern Ordering :: Qualified (ProperName 'TypeName)
-pattern Ordering = Qualified (Just DataOrdering) (ProperName "Ordering")
+pattern Ordering = Qualified (ByModuleName DataOrdering) (ProperName "Ordering")
 
 pattern LT :: Qualified (ProperName 'ConstructorName)
-pattern LT = Qualified (Just DataOrdering) (ProperName "LT")
+pattern LT = Qualified (ByModuleName DataOrdering) (ProperName "LT")
 
 pattern EQ :: Qualified (ProperName 'ConstructorName)
-pattern EQ = Qualified (Just DataOrdering) (ProperName "EQ")
+pattern EQ = Qualified (ByModuleName DataOrdering) (ProperName "EQ")
 
 pattern GT :: Qualified (ProperName 'ConstructorName)
-pattern GT = Qualified (Just DataOrdering) (ProperName "GT")
+pattern GT = Qualified (ByModuleName DataOrdering) (ProperName "GT")
 
 dataArray :: forall a. (IsString a) => a
 dataArray = "Data_Array"

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -63,7 +63,7 @@ moduleToCoreFn env (A.Module modSS coms mn decls (Just exps)) =
   declToCoreFn :: A.Declaration -> [Bind Ann]
   declToCoreFn (A.DataDeclaration (ss, com) Newtype _ _ [ctor]) =
     [NonRec (ss, [], Nothing, declMeta) (properToIdent $ A.dataCtorName ctor) $
-      Abs (ss, com, Nothing, Just IsNewtype) (Ident "x") (Var (ssAnn ss) $ Qualified Nothing (Ident "x"))]
+      Abs (ss, com, Nothing, Just IsNewtype) (Ident "x") (Var (ssAnn ss) $ Qualified ByNullSourceSpan (Ident "x"))]
     where
     declMeta = isDictTypeName (A.dataCtorName ctor) `orEmpty` IsTypeClassConstructor
   declToCoreFn d@(A.DataDeclaration _ Newtype _ _ _) =
@@ -72,7 +72,7 @@ moduleToCoreFn env (A.Module modSS coms mn decls (Just exps)) =
     flip fmap ctors $ \ctorDecl ->
       let
         ctor = A.dataCtorName ctorDecl
-        (_, _, _, fields) = lookupConstructor env (Qualified (Just mn) ctor)
+        (_, _, _, fields) = lookupConstructor env (Qualified (ByModuleName mn) ctor)
       in NonRec (ssA ss) (properToIdent ctor) $ Constructor (ss, com, Nothing, Nothing) tyName ctor fields
   declToCoreFn (A.DataBindingGroupDeclaration ds) =
     concatMap declToCoreFn ds
@@ -97,7 +97,7 @@ moduleToCoreFn env (A.Module modSS coms mn decls (Just exps)) =
   exprToCoreFn ss com ty (A.App v1 v2) =
     App (ss, com, ty, Nothing) (exprToCoreFn ss [] Nothing v1) (exprToCoreFn ss [] Nothing v2)
   exprToCoreFn ss com ty (A.Unused _) =
-    Var (ss, com, ty, Nothing) (Qualified (Just C.Prim) (Ident C.undefined))
+    Var (ss, com, ty, Nothing) (Qualified (ByModuleName C.Prim) (Ident C.undefined))
   exprToCoreFn _ com ty (A.Var ss ident) =
     Var (ss, com, ty, getValueMeta ident) ident
   exprToCoreFn ss com ty (A.IfThenElse v1 v2 v3) =
@@ -189,7 +189,7 @@ moduleToCoreFn env (A.Module modSS coms mn decls (Just exps)) =
     typeConstructor
       :: (Qualified (ProperName 'ConstructorName), (DataDeclType, ProperName 'TypeName, SourceType, [Ident]))
       -> (ModuleName, ProperName 'TypeName)
-    typeConstructor (Qualified (Just mn') _, (_, tyCtor, _, _)) = (mn', tyCtor)
+    typeConstructor (Qualified (ByModuleName mn') _, (_, tyCtor, _, _)) = (mn', tyCtor)
     typeConstructor _ = internalError "Invalid argument to typeConstructor"
 
 -- | Find module names from qualified references to values. This is used to

--- a/src/Language/PureScript/CoreFn/Laziness.hs
+++ b/src/Language/PureScript/CoreFn/Laziness.hs
@@ -128,7 +128,7 @@ onVarsWithDelayAndForce f = snd . go 0 $ Just 0
       Var a i -> f delay force a i
       Abs a i e -> Abs a i <$> snd (if force == Just 0 then go (succ delay) force else go delay $ fmap pred force) e
       -- A clumsy hack to preserve TCO in a particular idiom of unsafePartial once seen in Data.Map.Internal, possibly still used elsewhere.
-      App a1 e1@(Var _ (Qualified (Just C.PartialUnsafe) (Ident up))) (Abs a2 i e2) | up == C.unsafePartial
+      App a1 e1@(Var _ (Qualified (ByModuleName C.PartialUnsafe) (Ident up))) (Abs a2 i e2) | up == C.unsafePartial
         -> App a1 e1 . Abs a2 i <$> handleExpr' e2
       App a e1 e2 ->
         -- `handleApp` is just to handle the constructor application exception
@@ -433,7 +433,7 @@ applyLazinessTransform mn rawItems = let
   --                A           B (keys)           C (keys)           D
   findReferences :: Expr Ann -> IM.MonoidalIntMap (IM.MonoidalIntMap (Ap Maybe (Max Int)))
   findReferences = (getConst .) . onVarsWithDelayAndForce $ \delay force _ -> \case
-    Qualified mn' ident | all (== mn) mn', Just i <- ident `S.lookupIndex` names
+    Qualified qb ident | all (== mn) (toMaybeModuleName qb), Just i <- ident `S.lookupIndex` names
       -> Const . IM.singleton delay . IM.singleton i $ coerceForce force
     _ -> Const IM.empty
 
@@ -517,7 +517,7 @@ applyLazinessTransform mn rawItems = let
     Nothing -> pair
     Just m -> let
       rewriteExpr = (runIdentity .) . onVarsWithDelayAndForce $ \delay _ ann -> pure . \case
-        Qualified mn' ident' | all (== mn) mn', any (all (>= Max delay) . getAp) $ ident' `M.lookup` m
+        Qualified qb ident' | all (== mn) (toMaybeModuleName qb), any (all (>= Max delay) . getAp) $ ident' `M.lookup` m
           -> makeForceCall ann ident'
         q -> Var ann q
       in (ident, rewriteExpr <$> item)
@@ -532,8 +532,8 @@ applyLazinessTransform mn rawItems = let
   where
 
   nullAnn = ssAnn nullSourceSpan
-  runtimeLazy = Var nullAnn . Qualified Nothing $ InternalIdent RuntimeLazyFactory
-  runFn3 = Var nullAnn . Qualified (Just C.DataFunctionUncurried) . Ident $ C.runFn <> "3"
+  runtimeLazy = Var nullAnn . Qualified ByNullSourceSpan $ InternalIdent RuntimeLazyFactory
+  runFn3 = Var nullAnn . Qualified (ByModuleName C.DataFunctionUncurried) . Ident $ C.runFn <> "3"
   strLit = Literal nullAnn . StringLiteral . mkString
 
   lazifyIdent = \case
@@ -546,7 +546,7 @@ applyLazinessTransform mn rawItems = let
     -- argument: the line number on which this reference is made. The runtime
     -- code uses this number to generate a message that identifies where the
     -- evaluation looped.
-    = App nullAnn (Var nullAnn . Qualified Nothing $ lazifyIdent ident)
+    = App nullAnn (Var nullAnn . Qualified ByNullSourceSpan $ lazifyIdent ident)
     . Literal nullAnn . NumericLiteral . Left . toInteger . sourcePosLine
     $ spanStart ss
 

--- a/src/Language/PureScript/CoreFn/Optimizer.hs
+++ b/src/Language/PureScript/CoreFn/Optimizer.hs
@@ -10,7 +10,7 @@ import Language.PureScript.CoreFn.Ann
 import Language.PureScript.CoreFn.Expr
 import Language.PureScript.CoreFn.Module
 import Language.PureScript.CoreFn.Traversals
-import Language.PureScript.Names (Ident(..), ModuleName(..), Qualified(..))
+import Language.PureScript.Names (Ident(..), ModuleName(..), QualifiedBy(..), Qualified(..))
 import Language.PureScript.Label
 import Language.PureScript.Types
 import qualified Language.PureScript.Constants.Prelude as C
@@ -53,7 +53,7 @@ closedRecordFields _ = Nothing
 
 optimizeDataFunctionApply :: Expr a -> Expr a
 optimizeDataFunctionApply e = case e of
-  (App a (App _ (Var _ (Qualified (Just (ModuleName mn)) (Ident fn))) x) y)
+  (App a (App _ (Var _ (Qualified (ByModuleName (ModuleName mn)) (Ident fn))) x) y)
     | mn == dataFunction && fn == C.apply -> App a x y
     | mn == dataFunction && fn == C.applyFlipped -> App a y x
   _ -> e

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -18,7 +18,7 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           Language.PureScript.AST.Literals
-import           Language.PureScript.AST.SourcePos (SourceSpan(SourceSpan))
+import           Language.PureScript.AST.SourcePos (SourceSpan(..))
 import           Language.PureScript.CoreFn
 import           Language.PureScript.Names
 import           Language.PureScript.PSString (PSString)
@@ -94,10 +94,18 @@ properNameToJSON :: ProperName a -> Value
 properNameToJSON = toJSON . runProperName
 
 qualifiedToJSON :: (a -> Text) -> Qualified a -> Value
-qualifiedToJSON f (Qualified mn a) = object
-  [ T.pack "moduleName"   .= maybe Null moduleNameToJSON mn
-  , T.pack "identifier"   .= toJSON (f a)
-  ]
+qualifiedToJSON f (Qualified qb a) =
+  case qb of
+    ByModuleName mn -> object
+      [ T.pack "moduleName" .= moduleNameToJSON mn
+      , T.pack "identifier" .= toJSON (f a)
+      ]
+    BySourceSpan ss -> object
+      -- TODO: Should `sourceSpanXJSON` encode this information as well?
+      [ T.pack "spanName"   .= toJSON (spanName ss)
+      , T.pack "sourceSpan" .= sourceSpanToJSON ss
+      , T.pack "identifier" .= toJSON (f a)
+      ]
 
 moduleNameToJSON :: ModuleName -> Value
 moduleNameToJSON (ModuleName name) = toJSON (T.splitOn (T.pack ".") name)

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -84,7 +84,7 @@ insertValueTypesAndAdjustKinds env m =
     where
     inferredRoles :: [P.Role]
     inferredRoles = do
-      let key = P.Qualified (Just (modName m)) (P.ProperName (declTitle d))
+      let key = P.Qualified (P.ByModuleName (modName m)) (P.ProperName (declTitle d))
       case Map.lookup key (P.types env) of
         Just (_, tyKind) -> case tyKind of
           P.DataType _ tySourceTyRole _ ->
@@ -164,7 +164,7 @@ insertValueTypesAndAdjustKinds env m =
     either (err . ("failed to parse Ident: " ++)) identity . runParser CST.parseIdent
 
   lookupName name =
-    let key = P.Qualified (Just (modName m)) name
+    let key = P.Qualified (P.ByModuleName (modName m)) name
     in case Map.lookup key (P.names env) of
       Just (ty, _, _) ->
         ty
@@ -217,7 +217,7 @@ insertValueTypesAndAdjustKinds env m =
   insertInferredKind :: Declaration -> Text -> P.KindSignatureFor -> Declaration
   insertInferredKind d name keyword =
     let
-      key = P.Qualified (Just (modName m)) (P.ProperName name)
+      key = P.Qualified (P.ByModuleName (modName m)) (P.ProperName name)
     in case Map.lookup key (P.types env) of
       Just (inferredKind, _) ->
         if isUninteresting keyword inferredKind'

--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -512,7 +512,7 @@ typeClassConstraintFor :: Declaration -> Maybe Constraint'
 typeClassConstraintFor Declaration{..} =
   case declInfo of
     TypeClassDeclaration tyArgs _ _ ->
-      Just (P.Constraint () (P.Qualified Nothing (P.ProperName declTitle)) [] (mkConstraint tyArgs) Nothing)
+      Just (P.Constraint () (P.Qualified P.ByNullSourceSpan (P.ProperName declTitle)) [] (mkConstraint tyArgs) Nothing)
     _ ->
       Nothing
   where

--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -123,10 +123,10 @@ renderConstraints constraints
                  (map renderConstraint constraints)
 
 notQualified :: Text -> P.Qualified (P.ProperName a)
-notQualified = P.Qualified Nothing . P.ProperName
+notQualified = P.Qualified P.ByNullSourceSpan . P.ProperName
 
 ident' :: Text -> RenderedCode
-ident' = ident . P.Qualified Nothing . P.Ident
+ident' = ident . P.Qualified P.ByNullSourceSpan . P.Ident
 
 dataCtor' :: Text -> RenderedCode
 dataCtor' = dataCtor . notQualified

--- a/src/Language/PureScript/Docs/RenderedCode/Types.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Types.hs
@@ -117,8 +117,8 @@ maybeToContainingModule Nothing = ThisModule
 maybeToContainingModule (Just mn) = OtherModule mn
 
 fromQualified :: Qualified a -> (ContainingModule, a)
-fromQualified (Qualified mn x) =
-  (maybeToContainingModule mn, x)
+fromQualified (Qualified (ByModuleName mn) x) = (OtherModule mn, x)
+fromQualified (Qualified _ x) = (ThisModule, x)
 
 data Link
   = NoLink
@@ -296,9 +296,9 @@ aliasName for name' =
   in
     case ns of
       ValueLevel ->
-        ident (Qualified Nothing (Ident name))
+        ident (Qualified ByNullSourceSpan (Ident name))
       TypeLevel ->
-        typeCtor (Qualified Nothing (ProperName name))
+        typeCtor (Qualified ByNullSourceSpan (ProperName name))
 
 -- | Converts a FixityAlias into a different representation which is more
 -- useful to other functions in this module.

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -750,35 +750,35 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       line $ "The role declaration for " <> markCode (runProperName nm) <> " should follow its definition."
     renderSimpleErrorMessage (RedefinedIdent name) =
       line $ "The value " <> markCode (showIdent name) <> " has been defined multiple times"
-    renderSimpleErrorMessage (UnknownName name@(Qualified Nothing (IdentName (Ident i)))) | i `elem` [ C.bind, C.discard ] =
+    renderSimpleErrorMessage (UnknownName name@(Qualified (BySourceSpan _) (IdentName (Ident i)))) | i `elem` [ C.bind, C.discard ] =
       line $ "Unknown " <> printName name <> ". You're probably using do-notation, which the compiler replaces with calls to the " <> markCode "bind" <> " and " <> markCode "discard" <> " functions. Please import " <> markCode i <> " from module " <> markCode "Prelude"
-    renderSimpleErrorMessage (UnknownName name@(Qualified Nothing (IdentName (Ident i)))) | i == C.negate =
+    renderSimpleErrorMessage (UnknownName name@(Qualified (BySourceSpan _) (IdentName (Ident i)))) | i == C.negate =
       line $ "Unknown " <> printName name <> ". You're probably using numeric negation (the unary " <> markCode "-" <> " operator), which the compiler replaces with calls to the " <> markCode i <> " function. Please import " <> markCode i <> " from module " <> markCode "Prelude"
     renderSimpleErrorMessage (UnknownName name) =
       line $ "Unknown " <> printName name
     renderSimpleErrorMessage (UnknownImport mn name) =
-      paras [ line $ "Cannot import " <> printName (Qualified Nothing name) <> " from module " <> markCode (runModuleName mn)
+      paras [ line $ "Cannot import " <> printName (Qualified ByNullSourceSpan name) <> " from module " <> markCode (runModuleName mn)
             , line "It either does not exist or the module does not export it."
             ]
     renderSimpleErrorMessage (UnknownImportDataConstructor mn tcon dcon) =
       line $ "Module " <> runModuleName mn <> " does not export data constructor " <> markCode (runProperName dcon) <> " for type " <> markCode (runProperName tcon)
     renderSimpleErrorMessage (UnknownExport name) =
-      line $ "Cannot export unknown " <> printName (Qualified Nothing name)
+      line $ "Cannot export unknown " <> printName (Qualified ByNullSourceSpan name)
     renderSimpleErrorMessage (UnknownExportDataConstructor tcon dcon) =
       line $ "Cannot export data constructor " <> markCode (runProperName dcon) <> " for type " <> markCode (runProperName tcon) <> ", as it has not been declared."
     renderSimpleErrorMessage (ScopeConflict nm ms) =
-      paras [ line $ "Conflicting definitions are in scope for " <> printName (Qualified Nothing nm) <> " from the following modules:"
+      paras [ line $ "Conflicting definitions are in scope for " <> printName (Qualified ByNullSourceSpan nm) <> " from the following modules:"
             , indent $ paras $ map (line . markCode . runModuleName) ms
             ]
     renderSimpleErrorMessage (ScopeShadowing nm exmn ms) =
-      paras [ line $ "Shadowed definitions are in scope for " <> printName (Qualified Nothing nm) <> " from the following open imports:"
+      paras [ line $ "Shadowed definitions are in scope for " <> printName (Qualified ByNullSourceSpan nm) <> " from the following open imports:"
             , indent $ paras $ map (line . markCode . ("import " <>) . runModuleName) ms
             , line $ "These will be ignored and the " <> case exmn of
                 Just exmn' -> "declaration from " <> markCode (runModuleName exmn') <> " will be used."
                 Nothing -> "local declaration will be used."
             ]
     renderSimpleErrorMessage (DeclConflict new existing) =
-      line $ "Declaration for " <> printName (Qualified Nothing new) <> " conflicts with an existing " <> nameType existing <> " of the same name."
+      line $ "Declaration for " <> printName (Qualified ByNullSourceSpan new) <> " conflicts with an existing " <> nameType existing <> " of the same name."
     renderSimpleErrorMessage (ExportConflict new existing) =
       line $ "Export for " <> printName new <> " conflicts with " <> printName existing
     renderSimpleErrorMessage (DuplicateModule mn) =
@@ -1163,7 +1163,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
 
     renderSimpleErrorMessage msg@(UnusedExplicitImport mn names _ _) =
       paras [ line $ "The import of module " <> markCode (runModuleName mn) <> " contains the following unused references:"
-            , indent $ paras $ map (line . markCode . runName . Qualified Nothing) names
+            , indent $ paras $ map (line . markCode . runName . Qualified ByNullSourceSpan) names
             , line "It could be replaced with:"
             , indent $ line $ markCode $ showSuggestion msg ]
 
@@ -1187,10 +1187,10 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       line $ "Duplicate import of " <> markCode (prettyPrintImport name imp qual)
 
     renderSimpleErrorMessage (DuplicateImportRef name) =
-      line $ "Import list contains multiple references to " <> printName (Qualified Nothing name)
+      line $ "Import list contains multiple references to " <> printName (Qualified ByNullSourceSpan name)
 
     renderSimpleErrorMessage (DuplicateExportRef name) =
-      line $ "Export list contains multiple references to " <> printName (Qualified Nothing name)
+      line $ "Export list contains multiple references to " <> printName (Qualified ByNullSourceSpan name)
 
     renderSimpleErrorMessage (IntOutOfRange value backend lo hi) =
       paras [ line $ "Integer value " <> markCode (T.pack (show value)) <> " is out of range for the " <> backend <> " backend."
@@ -1607,19 +1607,19 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
     nameType (ModName _) = "module"
 
     runName :: Qualified Name -> Text
-    runName (Qualified mn (IdentName name)) =
-      showQualified showIdent (Qualified mn name)
-    runName (Qualified mn (ValOpName op)) =
-      showQualified showOp (Qualified mn op)
-    runName (Qualified mn (TyName name)) =
-      showQualified runProperName (Qualified mn name)
-    runName (Qualified mn (TyOpName op)) =
-      showQualified showOp (Qualified mn op)
-    runName (Qualified mn (DctorName name)) =
-      showQualified runProperName (Qualified mn name)
-    runName (Qualified mn (TyClassName name)) =
-      showQualified runProperName (Qualified mn name)
-    runName (Qualified Nothing (ModName name)) =
+    runName (Qualified qb (IdentName name)) =
+      showQualified showIdent (Qualified qb name)
+    runName (Qualified qb (ValOpName op)) =
+      showQualified showOp (Qualified qb op)
+    runName (Qualified qb (TyName name)) =
+      showQualified runProperName (Qualified qb name)
+    runName (Qualified qb (TyOpName op)) =
+      showQualified showOp (Qualified qb op)
+    runName (Qualified qb (DctorName name)) =
+      showQualified runProperName (Qualified qb name)
+    runName (Qualified qb (TyClassName name)) =
+      showQualified runProperName (Qualified qb name)
+    runName (Qualified (BySourceSpan _) (ModName name)) =
       runModuleName name
     runName (Qualified _ ModName{}) =
       internalError "qualified ModName in runName"
@@ -1724,13 +1724,13 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
 
   prettyInstanceName :: Qualified (Either SourceType Ident) -> Box.Box
   prettyInstanceName = \case
-    Qualified maybeMn (Left ty) ->
+    Qualified qb (Left ty) ->
       "instance "
-        Box.<> (case maybeMn of
-                  Just mn -> "in module "
+        Box.<> (case qb of
+                  ByModuleName mn -> "in module "
                     Box.<> line (markCode $ runModuleName mn)
                     Box.<> " "
-                  Nothing -> Box.nullBox)
+                  _ -> Box.nullBox)
         Box.<> "with type "
         Box.<> markCodeBox (prettyType ty)
         Box.<> " "

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -173,7 +173,7 @@ applyExternsFileToEnvironment ExternsFile{..} = flip (foldl' applyDecl) efDeclar
   applyDecl env (EDType pn kind tyKind) = env { types = M.insert (qual pn) (kind, tyKind) (types env) }
   applyDecl env (EDTypeSynonym pn args ty) = env { typeSynonyms = M.insert (qual pn) (args, ty) (typeSynonyms env) }
   applyDecl env (EDDataConstructor pn dTy tNm ty nms) = env { dataConstructors = M.insert (qual pn) (dTy, tNm, ty, nms) (dataConstructors env) }
-  applyDecl env (EDValue ident ty) = env { names = M.insert (Qualified (Just efModuleName) ident) (ty, External, Defined) (names env) }
+  applyDecl env (EDValue ident ty) = env { names = M.insert (Qualified (ByModuleName efModuleName) ident) (ty, External, Defined) (names env) }
   applyDecl env (EDClass pn args members cs deps tcIsEmpty) = env { typeClasses = M.insert (qual pn) (makeTypeClassData args members cs deps tcIsEmpty) (typeClasses env) }
   applyDecl env (EDInstance className ident vars kinds tys cs ch idx ns ss) =
     env { typeClassDictionaries =
@@ -193,7 +193,7 @@ applyExternsFileToEnvironment ExternsFile{..} = flip (foldl' applyDecl) efDeclar
       UserNamed -> Nothing
 
   qual :: a -> Qualified a
-  qual = Qualified (Just efModuleName)
+  qual = Qualified (ByModuleName efModuleName)
 
 -- | Generate an externs file for all declarations in a module.
 --
@@ -231,26 +231,26 @@ moduleToExternsFile (Module ss _ mn ds (Just exps)) env renamedIdents = ExternsF
 
   toExternsDeclaration :: DeclarationRef -> [ExternsDeclaration]
   toExternsDeclaration (TypeRef _ pn dctors) =
-    case Qualified (Just mn) pn `M.lookup` types env of
+    case Qualified (ByModuleName mn) pn `M.lookup` types env of
       Nothing -> internalError "toExternsDeclaration: no kind in toExternsDeclaration"
       Just (kind, TypeSynonym)
-        | Just (args, synTy) <- Qualified (Just mn) pn `M.lookup` typeSynonyms env -> [ EDType pn kind TypeSynonym, EDTypeSynonym pn args synTy ]
+        | Just (args, synTy) <- Qualified (ByModuleName mn) pn `M.lookup` typeSynonyms env -> [ EDType pn kind TypeSynonym, EDTypeSynonym pn args synTy ]
       Just (kind, ExternData rs) -> [ EDType pn kind (ExternData rs) ]
       Just (kind, tk@(DataType _ _ tys)) ->
         EDType pn kind tk : [ EDDataConstructor dctor dty pn ty args
                             | dctor <- fromMaybe (map fst tys) dctors
-                            , (dty, _, ty, args) <- maybeToList (Qualified (Just mn) dctor `M.lookup` dataConstructors env)
+                            , (dty, _, ty, args) <- maybeToList (Qualified (ByModuleName mn) dctor `M.lookup` dataConstructors env)
                             ]
       _ -> internalError "toExternsDeclaration: Invalid input"
   toExternsDeclaration (ValueRef _ ident)
-    | Just (ty, _, _) <- Qualified (Just mn) ident `M.lookup` names env
+    | Just (ty, _, _) <- Qualified (ByModuleName mn) ident `M.lookup` names env
     = [ EDValue (lookupRenamedIdent ident) ty ]
   toExternsDeclaration (TypeClassRef _ className)
     | let dictName = dictTypeName . coerceProperName $ className
-    , Just TypeClassData{..} <- Qualified (Just mn) className `M.lookup` typeClasses env
-    , Just (kind, tk) <- Qualified (Just mn) (coerceProperName className) `M.lookup` types env
-    , Just (dictKind, dictData@(DataType _ _ [(dctor, _)])) <- Qualified (Just mn) dictName `M.lookup` types env
-    , Just (dty, _, ty, args) <- Qualified (Just mn) dctor `M.lookup` dataConstructors env
+    , Just TypeClassData{..} <- Qualified (ByModuleName mn) className `M.lookup` typeClasses env
+    , Just (kind, tk) <- Qualified (ByModuleName mn) (coerceProperName className) `M.lookup` types env
+    , Just (dictKind, dictData@(DataType _ _ [(dctor, _)])) <- Qualified (ByModuleName mn) dictName `M.lookup` types env
+    , Just (dty, _, ty, args) <- Qualified (ByModuleName mn) dctor `M.lookup` dataConstructors env
     = [ EDType (coerceProperName className) kind tk
       , EDType dictName dictKind dictData
       , EDDataConstructor dctor dty dictName ty args
@@ -260,7 +260,7 @@ moduleToExternsFile (Module ss _ mn ds (Just exps)) env renamedIdents = ExternsF
     = [ EDInstance tcdClassName (lookupRenamedIdent ident) tcdForAll tcdInstanceKinds tcdInstanceTypes tcdDependencies tcdChain tcdIndex ns ss'
       | m1 <- maybeToList (M.lookup (Just mn) (typeClassDictionaries env))
       , m2 <- M.elems m1
-      , nel <- maybeToList (M.lookup (Qualified (Just mn) ident) m2)
+      , nel <- maybeToList (M.lookup (Qualified (ByModuleName mn) ident) m2)
       , TypeClassDictionaryInScope{..} <- NEL.toList nel
       ]
   toExternsDeclaration _ = []

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -67,13 +67,13 @@ encodeRebuildErrors = toJSON . map encodeRebuildError . P.runMultipleErrors
 
     identCompletion (P.Qualified mn i, ty) =
       Completion     
-        { complModule = maybe "" P.runModuleName mn
+        { complModule = maybe "" P.runModuleName $ P.toMaybeModuleName mn
         , complIdentifier = i
         , complType = prettyPrintTypeSingleLine ty
         , complExpandedType = prettyPrintTypeSingleLine ty
         , complLocation = Nothing
         , complDocumentation = Nothing
-        , complExportedFrom = toList mn
+        , complExportedFrom = toList $ P.toMaybeModuleName mn
         , complDeclarationType = Nothing
         }
     fieldCompletion (label, ty) =

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -360,7 +360,7 @@ resolveInstances externs declarations =
   where
     extractInstances mn P.EDInstance{..} =
       case edInstanceClassName of
-          P.Qualified (Just classModule) className ->
+          P.Qualified (P.ByModuleName classModule) className ->
             Just (IdeInstance mn
                   edInstanceName
                   edInstanceTypes
@@ -405,14 +405,14 @@ resolveOperatorsForModule modules = map (idaDeclaration %~ resolveOperator)
       & map discardAnn
 
     resolveOperator (IdeDeclValueOperator op)
-      | (P.Qualified (Just mn) (Left ident)) <- op ^. ideValueOpAlias =
+      | (P.Qualified (P.ByModuleName mn) (Left ident)) <- op ^. ideValueOpAlias =
           let t = getDeclarations mn
                   & mapMaybe (preview _IdeDeclValue)
                   & filter (anyOf ideValueIdent (== ident))
                   & map (view ideValueType)
                   & listToMaybe
           in IdeDeclValueOperator (op & ideValueOpType .~ t)
-      | (P.Qualified (Just mn) (Right dtor)) <- op ^. ideValueOpAlias =
+      | (P.Qualified (P.ByModuleName mn) (Right dtor)) <- op ^. ideValueOpAlias =
           let t = getDeclarations mn
                   & mapMaybe (preview _IdeDeclDataConstructor)
                   & filter (anyOf ideDtorName (== dtor))
@@ -420,7 +420,7 @@ resolveOperatorsForModule modules = map (idaDeclaration %~ resolveOperator)
                   & listToMaybe
           in IdeDeclValueOperator (op & ideValueOpType .~ t)
     resolveOperator (IdeDeclTypeOperator op)
-      | P.Qualified (Just mn) properName <- op ^. ideTypeOpAlias =
+      | P.Qualified (P.ByModuleName mn) properName <- op ^. ideTypeOpAlias =
           let k = getDeclarations mn
                   & mapMaybe (preview _IdeDeclType)
                   & filter (anyOf ideTypeName (== properName))

--- a/src/Language/PureScript/Ide/Usage.hs
+++ b/src/Language/PureScript/Ide/Usage.hs
@@ -67,7 +67,7 @@ directDependants declaration modules mn = Map.mapMaybe (nonEmpty . go) modules
     go = foldMap isImporting . P.getModuleDeclarations
 
     isImporting d = case d of
-      P.ImportDeclaration _ mn' it qual | mn == mn' -> P.Qualified qual <$> case it of
+      P.ImportDeclaration _ mn' it qual | mn == mn' -> P.Qualified (P.byMaybeModuleName qual) <$> case it of
         P.Implicit -> pure declaration
         P.Explicit refs
           | any (declaration `matchesRef`) refs -> pure declaration
@@ -120,7 +120,7 @@ eligibleModules
   -> ModuleMap (NonEmpty Search)
 eligibleModules query@(moduleName, declaration) decls modules =
   let
-    searchDefiningModule = P.Qualified Nothing declaration :| []
+    searchDefiningModule = P.Qualified P.ByNullSourceSpan declaration :| []
   in
     Map.insert moduleName searchDefiningModule $
       foldMap (directDependants declaration modules) (moduleName :| findReexportingModules query decls)

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -292,7 +292,7 @@ handleKindOf print' typ = do
   case e of
     Left errs -> printErrors errs
     Right (_, env') ->
-      case M.lookup (P.Qualified (Just mName) $ P.ProperName "IT") (P.typeSynonyms env') of
+      case M.lookup (P.Qualified (P.ByModuleName mName) $ P.ProperName "IT") (P.typeSynonyms env') of
         Just (_, typ') -> do
           let chk = (P.emptyCheckState env') { P.checkCurrentModule = Just mName }
               k   = check (snd <$> P.kindOf typ') chk

--- a/src/Language/PureScript/Interactive/Module.hs
+++ b/src/Language/PureScript/Interactive/Module.hs
@@ -40,14 +40,14 @@ createTemporaryModule exec st val =
     effModuleName = P.ModuleName "Effect"
     effImport     = (effModuleName, P.Implicit, Just (P.ModuleName "$Effect"))
     supportImport = (fst (psciInteractivePrint st), P.Implicit, Just (P.ModuleName "$Support"))
-    eval          = P.Var internalSpan (P.Qualified (Just (P.ModuleName "$Support")) (snd (psciInteractivePrint st)))
-    mainValue     = P.App eval (P.Var internalSpan (P.Qualified Nothing (P.Ident "it")))
+    eval          = P.Var internalSpan (P.Qualified (P.ByModuleName (P.ModuleName "$Support")) (snd (psciInteractivePrint st)))
+    mainValue     = P.App eval (P.Var internalSpan (P.Qualified P.ByNullSourceSpan (P.Ident "it")))
     itDecl        = P.ValueDecl (internalSpan, []) (P.Ident "it") P.Public [] [P.MkUnguarded val]
     typeDecl      = P.TypeDeclaration
                       (P.TypeDeclarationData (internalSpan, []) (P.Ident "$main")
                         (P.srcTypeApp
                           (P.srcTypeConstructor
-                            (P.Qualified (Just (P.ModuleName "$Effect")) (P.ProperName "Effect")))
+                            (P.Qualified (P.ByModuleName (P.ModuleName "$Effect")) (P.ProperName "Effect")))
                                   P.srcTypeWildcard))
     mainDecl      = P.ValueDecl (internalSpan, []) (P.Ident "$main") P.Public [] [P.MkUnguarded mainValue]
     decls         = if exec then [itDecl, typeDecl, mainDecl] else [itDecl]

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -187,7 +187,7 @@ lintUnused (Module modSS _ mn modDecls exports) =
     goDecl _ = mempty
 
     go :: Expr -> (S.Set Ident, MultipleErrors)
-    go (Var _ (Qualified Nothing v)) = (S.singleton v, mempty)
+    go (Var _ (Qualified (BySourceSpan _) v)) = (S.singleton v, mempty)
     go (Var _ _) = (S.empty, mempty)
 
     go (Let _ ds e) = onDecls ds (go e)

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -50,7 +50,7 @@ qualifyName
   -> ModuleName
   -> Qualified (ProperName b)
   -> Qualified (ProperName a)
-qualifyName n defmn qn = Qualified (Just mn) n
+qualifyName n defmn qn = Qualified (ByModuleName mn) n
   where
   (mn, _) = qualify defmn qn
 

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -196,7 +196,7 @@ lintImports (Module _ _ mn mdecls (Just mexports)) env usedImps = do
             _ -> Nothing
       | isQualifiedWith k q =
           case importName (head is) of
-            Qualified (Just mn') name -> Just (mn', Qualified mnq (toName name))
+            Qualified (ByModuleName mn') name -> Just (mn', Qualified mnq (toName name))
             _ -> internalError "unqualified name in extractByQual"
     go _ = Nothing
 

--- a/src/Language/PureScript/Renamer.hs
+++ b/src/Language/PureScript/Renamer.hs
@@ -9,7 +9,7 @@ import Control.Monad.State
 
 import Data.Functor ((<&>))
 import Data.List (find)
-import Data.Maybe (fromJust, fromMaybe, isNothing)
+import Data.Maybe (fromJust, fromMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -172,12 +172,12 @@ renameInValue (Abs ann name v) =
   newScope $ Abs ann <$> updateScope name <*> renameInValue v
 renameInValue (App ann v1 v2) =
   App ann <$> renameInValue v1 <*> renameInValue v2
-renameInValue (Var ann (Qualified mn name)) | isNothing mn || not (isPlainIdent name) =
+renameInValue (Var ann (Qualified qb name)) | isBySourceSpan qb || not (isPlainIdent name) =
   -- This should only rename identifiers local to the current module: either
   -- they aren't qualified, or they are but they have a name that should not
   -- have appeared in a module's externs, so they must be from this module's
   -- top-level scope.
-  Var ann . Qualified mn <$> lookupIdent name
+  Var ann . Qualified qb <$> lookupIdent name
 renameInValue v@Var{} = return v
 renameInValue (Case ann vs alts) =
   newScope $ Case ann <$> traverse renameInValue vs <*> traverse renameInCaseAlternative alts

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -93,9 +93,9 @@ findTypeSynonyms externs mn decls =
     M.fromList $ (externs >>= \ExternsFile{..} -> mapMaybe (fromExternsDecl efModuleName) efDeclarations)
               ++ mapMaybe fromLocalDecl decls
   where
-    fromExternsDecl mn' (EDTypeSynonym name args ty) = Just (Qualified (Just mn') name, (args, ty))
+    fromExternsDecl mn' (EDTypeSynonym name args ty) = Just (Qualified (ByModuleName mn') name, (args, ty))
     fromExternsDecl _ _ = Nothing
 
     fromLocalDecl (TypeSynonymDeclaration _ name args ty) =
-      Just (Qualified (Just mn) name, (args, ty))
+      Just (Qualified (ByModuleName mn) name, (args, ty))
     fromLocalDecl _ = Nothing

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -87,6 +87,7 @@ desugar externs =
        in deriveInstances externs syns kinds m)
     >=> desugarTypeClasses externs
     >=> createBindingGroupsModule
+    >=> desugarLocals
 
 findTypeSynonyms :: [ExternsFile] -> ModuleName -> [Declaration] -> SynonymMap
 findTypeSynonyms externs mn decls =

--- a/src/Language/PureScript/Sugar/AdoNotation.hs
+++ b/src/Language/PureScript/Sugar/AdoNotation.hs
@@ -28,13 +28,13 @@ desugarAdo d =
   in rethrowWithPosition ss $ f d
   where
   pure' :: SourceSpan -> Maybe ModuleName -> Expr
-  pure' ss m = Var ss (Qualified m (Ident C.pure'))
+  pure' ss m = Var ss (Qualified (byMaybeModuleName m) (Ident C.pure'))
 
   map' :: SourceSpan -> Maybe ModuleName -> Expr
-  map' ss m = Var ss (Qualified m (Ident C.map))
+  map' ss m = Var ss (Qualified (byMaybeModuleName m) (Ident C.map))
 
   apply :: SourceSpan -> Maybe ModuleName -> Expr
-  apply ss m = Var ss (Qualified m (Ident C.apply))
+  apply ss m = Var ss (Qualified (byMaybeModuleName m) (Ident C.apply))
 
   replace :: SourceSpan -> Expr -> m Expr
   replace pos (Ado m els yield) = do
@@ -53,7 +53,7 @@ desugarAdo d =
   go ss (yield, args) (DoNotationBind binder val) = do
     ident <- freshIdent'
     let abs = Abs (VarBinder ss ident)
-                  (Case [Var ss (Qualified Nothing ident)]
+                  (Case [Var ss (Qualified ByNullSourceSpan ident)]
                         [CaseAlternative [binder] [MkUnguarded yield]])
     return (abs, val : args)
   go _ (yield, args) (DoNotationLet ds) = do

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -145,9 +145,9 @@ usedIdents moduleName = ordNub . usedIdents' S.empty . valdeclExpression
   (_, usedIdents', _, _, _) = everythingWithScope def usedNamesE def def def
 
   usedNamesE :: S.Set ScopedIdent -> Expr -> [Ident]
-  usedNamesE scope (Var _ (Qualified Nothing name))
+  usedNamesE scope (Var _ (Qualified (BySourceSpan _) name))
     | LocalIdent name `S.notMember` scope = [name]
-  usedNamesE scope (Var _ (Qualified (Just moduleName') name))
+  usedNamesE scope (Var _ (Qualified (ByModuleName moduleName') name))
     | moduleName == moduleName' && ToplevelIdent name `S.notMember` scope = [name]
   usedNamesE _ _ = []
 
@@ -159,8 +159,8 @@ usedImmediateIdents moduleName =
   def s _ = (s, [])
 
   usedNamesE :: Bool -> Expr -> (Bool, [Ident])
-  usedNamesE True (Var _ (Qualified Nothing name)) = (True, [name])
-  usedNamesE True (Var _ (Qualified (Just moduleName') name))
+  usedNamesE True (Var _ (Qualified (BySourceSpan _) name)) = (True, [name])
+  usedNamesE True (Var _ (Qualified (ByModuleName moduleName') name))
     | moduleName == moduleName' = (True, [name])
   usedNamesE True (Abs _ _) = (False, [])
   usedNamesE scope _ = (scope, [])
@@ -175,12 +175,12 @@ usedTypeNames moduleName = go
 
   usedNames :: SourceType -> [ProperName 'TypeName]
   usedNames (ConstrainedType _ con _) = usedConstraint con
-  usedNames (TypeConstructor _ (Qualified (Just moduleName') name))
+  usedNames (TypeConstructor _ (Qualified (ByModuleName moduleName') name))
     | moduleName == moduleName' = [name]
   usedNames _ = []
 
   usedConstraint :: SourceConstraint -> [ProperName 'TypeName]
-  usedConstraint (Constraint _ (Qualified (Just moduleName') name) _ _ _)
+  usedConstraint (Constraint _ (Qualified (ByModuleName moduleName') name) _ _ _)
     | moduleName == moduleName' = [coerceProperName name]
   usedConstraint _ = []
 
@@ -248,8 +248,8 @@ toDataBindingGroup (CyclicSCC ds')
         $ typeSynonymCycles
   | otherwise = return . DataBindingGroupDeclaration . NEL.fromList $ getDecl <$> ds'
   where
-  kindDecl (KindDeclaration sa _ pn _) = [(fst sa, Qualified Nothing pn)]
-  kindDecl (ExternDataDeclaration sa pn _) = [(fst sa, Qualified Nothing pn)]
+  kindDecl (KindDeclaration sa _ pn _) = [(fst sa, Qualified ByNullSourceSpan pn)]
+  kindDecl (ExternDataDeclaration sa pn _) = [(fst sa, Qualified ByNullSourceSpan pn)]
   kindDecl _ = []
 
   getDecl (decl, _, _) = decl

--- a/src/Language/PureScript/Sugar/CaseDeclarations.hs
+++ b/src/Language/PureScript/Sugar/CaseDeclarations.hs
@@ -64,7 +64,7 @@ desugarGuardedExprs ss (Case scrut alternatives)
     -- We bind the scrutinee to Vars here to mitigate this case.
     (scrut', scrut_decls) <- unzip <$> forM scrut (\e -> do
       scrut_id <- freshIdent'
-      pure ( Var ss (Qualified Nothing scrut_id)
+      pure ( Var ss (Qualified ByNullSourceSpan scrut_id)
            , ValueDecl (ss, []) scrut_id Private [] [MkUnguarded e]
            )
       )
@@ -226,7 +226,7 @@ desugarGuardedExprs ss (Case scrut alternatives) =
 
         let
           goto_rem_case :: Expr
-          goto_rem_case = Var ss (Qualified Nothing rem_case_id)
+          goto_rem_case = Var ss (Qualified ByNullSourceSpan rem_case_id)
             `App` Literal ss (BooleanLiteral True)
           alt_fail :: Int -> [CaseAlternative]
           alt_fail n = [CaseAlternative (replicate n NullBinder) [MkUnguarded goto_rem_case]]
@@ -313,7 +313,7 @@ desugarAbs = flip parU f
     pure (Abs (VarBinder ss i) val)
   replace (Abs binder val) = do
     ident <- freshIdent'
-    return $ Abs (VarBinder nullSourceSpan ident) $ Case [Var nullSourceSpan (Qualified Nothing ident)] [CaseAlternative [binder] [MkUnguarded val]]
+    return $ Abs (VarBinder nullSourceSpan ident) $ Case [Var nullSourceSpan (Qualified ByNullSourceSpan ident)] [CaseAlternative [binder] [MkUnguarded val]]
   replace other = return other
 
 stripPositioned :: Binder -> Binder
@@ -381,7 +381,7 @@ makeCaseDeclaration ss ident alternatives = do
   args <- if allUnique (catMaybes argNames)
             then mapM argName argNames
             else replicateM (length argNames) freshIdent'
-  let vars = map (Var ss . Qualified Nothing) args
+  let vars = map (Var ss . Qualified ByNullSourceSpan) args
       binders = [ CaseAlternative bs result | (bs, result) <- alternatives ]
   let value = foldr (Abs . VarBinder ss) (Case vars binders) args
 

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -30,10 +30,10 @@ desugarDo d =
   in rethrowWithPosition ss $ f d
   where
   bind :: SourceSpan -> Maybe ModuleName -> Expr
-  bind ss m = Var ss (Qualified m (Ident C.bind))
+  bind ss m = Var ss (Qualified (byMaybeModuleName m) (Ident C.bind))
 
   discard :: SourceSpan -> Maybe ModuleName -> Expr
-  discard ss m = Var ss (Qualified m (Ident C.discard))
+  discard ss m = Var ss (Qualified (byMaybeModuleName m) (Ident C.discard))
 
   replace :: SourceSpan -> Expr -> m Expr
   replace pos (Do m els) = go pos m els
@@ -70,7 +70,7 @@ desugarDo d =
         return $ App (App (bind pos m) val) (Abs (VarBinder ss ident) rest')
       _ -> do
         ident <- freshIdent'
-        return $ App (App (bind pos m) val) (Abs (VarBinder pos ident) (Case [Var pos (Qualified Nothing ident)] [CaseAlternative [binder] [MkUnguarded rest']]))
+        return $ App (App (bind pos m) val) (Abs (VarBinder pos ident) (Case [Var pos (Qualified ByNullSourceSpan ident)] [CaseAlternative [binder] [MkUnguarded rest']]))
   go _ _ [DoNotationLet _] = throwError . errorMessage $ InvalidDoLet
   go pos m (DoNotationLet ds : rest) = do
     let checkBind :: Declaration -> m ()

--- a/src/Language/PureScript/Sugar/Names/Env.hs
+++ b/src/Language/PureScript/Sugar/Names/Env.hs
@@ -27,13 +27,14 @@ import Control.Monad.Writer.Class (MonadWriter(..))
 import Data.Function (on)
 import Data.Foldable (find)
 import Data.List (groupBy, sortOn, delete)
-import Data.Maybe (fromJust, mapMaybe)
+import Data.Maybe (mapMaybe)
 import Safe (headMay)
 import qualified Data.Map as M
 import qualified Data.Set as S
 
 import qualified Language.PureScript.Constants.Prim as C
 import Language.PureScript.AST
+import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Errors
 import Language.PureScript.Names
@@ -228,13 +229,16 @@ mkPrimExports ts cs =
     , exportedTypeClasses = M.fromList $ mkClassEntry `map` M.keys cs
     }
   where
-  mkTypeEntry (Qualified mn name) = (name, ([], primExportSource mn))
-  mkClassEntry (Qualified mn name) = (name, primExportSource mn)
+  mkTypeEntry (Qualified (ByModuleName mn) name) = (name, ([], primExportSource mn))
+  mkTypeEntry _ = internalError "mkPrimExports.mkTypEntry: invalid argument"
+
+  mkClassEntry (Qualified (ByModuleName mn) name) = (name, primExportSource mn)
+  mkClassEntry _ = internalError "mkPrimExports.mkClassEntry: invalid argument"
 
   primExportSource mn =
     ExportSource
       { exportSourceImportedFrom = Nothing
-      , exportSourceDefinedIn = fromJust mn
+      , exportSourceDefinedIn = mn
       }
 
 -- | Environment which only contains the Prim modules.
@@ -457,7 +461,7 @@ throwExportConflict'
   -> m a
 throwExportConflict' ss new existing newName existingName =
   throwError . errorMessage' ss $
-    ExportConflict (Qualified (Just new) newName) (Qualified (Just existing) existingName)
+    ExportConflict (Qualified (ByModuleName new) newName) (Qualified (ByModuleName existing) existingName)
 
 -- |
 -- When reading a value from the imports, check that there are no conflicts in
@@ -481,12 +485,12 @@ checkImportConflicts ss currentModule toName xs =
   in
     if length groups > 1
     then case nonImplicit of
-      [ImportRecord (Qualified (Just mnNew) _) mnOrig _ _] -> do
+      [ImportRecord (Qualified (ByModuleName mnNew) _) mnOrig _ _] -> do
         let warningModule = if mnNew == currentModule then Nothing else Just mnNew
             ss' = maybe nullSourceSpan importSourceSpan . headMay . filter ((== FromImplicit) . importProvenance) $ xs
         tell . errorMessage' ss' $ ScopeShadowing name warningModule $ delete mnNew conflictModules
         return (mnNew, mnOrig)
       _ -> throwError . errorMessage' ss $ ScopeConflict name conflictModules
     else
-      let ImportRecord (Qualified (Just mnNew) _) mnOrig _ _ = head byOrig
+      let ImportRecord (Qualified (ByModuleName mnNew) _) mnOrig _ _ = head byOrig
       in return (mnNew, mnOrig)

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -170,7 +170,7 @@ resolveExports env ss mn imps exps refs =
     go
       :: Qualified (ProperName 'TypeName)
       -> ((ProperName 'TypeName, [ProperName 'ConstructorName]), ExportSource)
-    go (Qualified (Just mn'') name) =
+    go (Qualified (ByModuleName mn'') name) =
       fromMaybe (internalError "Missing value in resolveTypeExports") $ do
         exps' <- envModuleExports <$> mn'' `M.lookup` env
         (dctors', src) <- name `M.lookup` exportedTypes exps'
@@ -179,7 +179,7 @@ resolveExports env ss mn imps exps refs =
           ( (name, relevantDctors `intersect` dctors')
           , src { exportSourceImportedFrom = Just mn'' }
           )
-    go (Qualified Nothing _) = internalError "Unqualified value in resolveTypeExports"
+    go (Qualified _ _) = internalError "Unqualified value in resolveTypeExports"
 
   -- Looks up an imported type operator and re-qualifies it with the original
   -- module it came from.
@@ -214,7 +214,7 @@ resolveExports env ss mn imps exps refs =
     => (Exports -> M.Map a ExportSource)
     -> Qualified a
     -> Maybe (a, ExportSource)
-  resolve f (Qualified (Just mn'') a) = do
+  resolve f (Qualified (ByModuleName mn'') a) = do
     exps' <- envModuleExports <$> mn'' `M.lookup` env
     src <- a `M.lookup` f exps'
     return (a, src { exportSourceImportedFrom = Just mn'' })

--- a/src/Language/PureScript/Sugar/Names/Imports.hs
+++ b/src/Language/PureScript/Sugar/Names/Imports.hs
@@ -69,7 +69,7 @@ resolveModuleImport env ie (mn, imps) = foldM go ie imps
   go ie' (ss, typ, impQual) = do
     modExports <-
       maybe
-        (throwError . errorMessage' ss . UnknownName . Qualified Nothing $ ModName mn)
+        (throwError . errorMessage' ss . UnknownName . Qualified ByNullSourceSpan $ ModName mn)
         (return . envModuleExports)
         (mn `M.lookup` env)
     let impModules = importedModules ie'
@@ -221,9 +221,9 @@ resolveImport importModule exps imps impQual = resolveByType
   updateImports imps' exps' expName name ss prov =
     let
       src = maybe (internalError "Invalid state in updateImports") expName (name `M.lookup` exps')
-      rec = ImportRecord (Qualified (Just importModule) name) (exportSourceDefinedIn src) ss prov
+      rec = ImportRecord (Qualified (ByModuleName importModule) name) (exportSourceDefinedIn src) ss prov
     in
       M.alter
         (\currNames -> Just $ rec : fromMaybe [] currNames)
-        (Qualified impQual name)
+        (Qualified (byMaybeModuleName impQual) name)
         imps'

--- a/src/Language/PureScript/Sugar/ObjectWildcards.hs
+++ b/src/Language/PureScript/Sugar/ObjectWildcards.hs
@@ -98,4 +98,4 @@ desugarDecl d = rethrowWithPosition (declSourceSpan d) $ fn d
     | otherwise = return Nothing
 
   argToExpr :: Ident -> Expr
-  argToExpr = Var nullSourceSpan . Qualified Nothing
+  argToExpr = Var nullSourceSpan . Qualified ByNullSourceSpan

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -100,7 +100,7 @@ desugarModule (Module ss coms name decls (Just exps)) = do
   constraintName (Constraint _ cName _ _ _) = cName
 
   classDeclName :: Declaration -> Qualified (ProperName 'ClassName)
-  classDeclName (TypeClassDeclaration _ pn _ _ _ _) = Qualified (Just name) pn
+  classDeclName (TypeClassDeclaration _ pn _ _ _ _) = Qualified (ByModuleName name) pn
   classDeclName _ = internalError "Expected TypeClassDeclaration"
 
 desugarModule _ = internalError "Exports should have been elaborated in name desugaring"
@@ -245,7 +245,7 @@ desugarDecl mn exps = go
     :: (ProperName a -> [DeclarationRef] -> Bool)
     -> Qualified (ProperName a)
     -> Bool
-  isExported test (Qualified (Just mn') pn) = mn /= mn' || test pn exps
+  isExported test (Qualified (ByModuleName mn') pn) = mn /= mn' || test pn exps
   isExported _ _ = internalError "Names should have been qualified in name desugaring"
 
   matchesTypeRef :: ProperName 'TypeName -> DeclarationRef -> Bool
@@ -291,14 +291,14 @@ typeClassMemberToDictionaryAccessor
   -> Declaration
   -> Declaration
 typeClassMemberToDictionaryAccessor mn name args (TypeDeclaration (TypeDeclarationData sa@(ss, _) ident ty)) =
-  let className = Qualified (Just mn) name
+  let className = Qualified (ByModuleName mn) name
       dictIdent = Ident "dict"
       dictObjIdent = Ident "v"
       ctor = ConstructorBinder ss (coerceProperName . dictTypeName <$> className) [VarBinder ss dictObjIdent]
-      acsr = Accessor (mkString $ runIdent ident) (Var ss (Qualified Nothing dictObjIdent))
+      acsr = Accessor (mkString $ runIdent ident) (Var ss (Qualified ByNullSourceSpan dictObjIdent))
   in ValueDecl sa ident Private []
     [MkUnguarded (
-     TypedValue False (Abs (VarBinder ss dictIdent) (Case [Var ss $ Qualified Nothing dictIdent] [CaseAlternative [ctor] [MkUnguarded acsr]])) $
+     TypedValue False (Abs (VarBinder ss dictIdent) (Case [Var ss $ Qualified ByNullSourceSpan dictIdent] [CaseAlternative [ctor] [MkUnguarded acsr]])) $
        moveQuantifiersToFront (quantify (srcConstrainedType (srcConstraint className [] (map (srcTypeVar . fst) args) Nothing) ty))
     )]
 typeClassMemberToDictionaryAccessor _ _ _ _ = internalError "Invalid declaration in type class definition"

--- a/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
@@ -686,11 +686,11 @@ lookupNewtypeConstructorInScope env currentModuleName currentModuleImports quali
   let fromModule = find isNewtypeCtorImported currentModuleImports
       fromModuleName = (\(_, n, _, _, _) -> n) <$> fromModule
       asModuleName = (\(_, _, _, n, _) -> n) =<< fromModule
-      isDefinedInCurrentModule = newtypeModuleName == currentModuleName
+      isDefinedInCurrentModule = toMaybeModuleName newtypeModuleName == currentModuleName
       isImported = isJust fromModule
       inScope = isDefinedInCurrentModule || isImported
   (tvs, ctorName, wrappedTy) <- lookupNewtypeConstructor env qualifiedNewtypeName ks
-  pure (inScope, fromModuleName, tvs, Qualified asModuleName ctorName, wrappedTy)
+  pure (inScope, fromModuleName, tvs, Qualified (byMaybeModuleName asModuleName) ctorName, wrappedTy)
   where
   isNewtypeCtorImported (_, _, importDeclType, _, exportedTypes) =
     case M.lookup newtypeName exportedTypes of

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -189,7 +189,7 @@ inferKind = \tyToInfer ->
       pure (ty, E.tyInt $> ann)
     ty@(TypeVar ann v) -> do
       moduleName <- unsafeCheckCurrentModule
-      kind <- apply =<< lookupTypeVariable moduleName (Qualified Nothing $ ProperName v)
+      kind <- apply =<< lookupTypeVariable moduleName (Qualified ByNullSourceSpan $ ProperName v)
       pure (ty, kind $> ann)
     ty@(Skolem ann _ mbK _ _) -> do
       kind <- apply $ fromMaybe (internalError "Skolem has no kind") mbK
@@ -499,7 +499,7 @@ elaborateKind = \case
         ($> ann) <$> apply kind
   TypeVar ann a -> do
     moduleName <- unsafeCheckCurrentModule
-    kind <- apply =<< lookupTypeVariable moduleName (Qualified Nothing $ ProperName a)
+    kind <- apply =<< lookupTypeVariable moduleName (Qualified ByNullSourceSpan $ ProperName a)
     pure (kind $> ann)
   (Skolem ann _ mbK _ _) -> do
     kind <- apply $ fromMaybe (internalError "Skolem has no kind") mbK
@@ -611,7 +611,7 @@ inferDataDeclaration
   -> DataDeclarationArgs
   -> m [(DataConstructorDeclaration, SourceType)]
 inferDataDeclaration moduleName (ann, tyName, tyArgs, ctors) = do
-  tyKind <- apply =<< lookupTypeVariable moduleName (Qualified Nothing tyName)
+  tyKind <- apply =<< lookupTypeVariable moduleName (Qualified ByNullSourceSpan tyName)
   let (sigBinders, tyKind') = fromJust . completeBinderList $ tyKind
   bindLocalTypeVariables moduleName (first ProperName . snd <$> sigBinders) $ do
     tyArgs' <- for tyArgs . traverse . maybe (freshKind (fst ann)) $ replaceAllTypeSynonyms <=< apply <=< flip checkKind E.kindType
@@ -662,7 +662,7 @@ inferTypeSynonym
   -> TypeDeclarationArgs
   -> m SourceType
 inferTypeSynonym moduleName (ann, tyName, tyArgs, tyBody) = do
-  tyKind <- apply =<< lookupTypeVariable moduleName (Qualified Nothing tyName)
+  tyKind <- apply =<< lookupTypeVariable moduleName (Qualified ByNullSourceSpan tyName)
   let (sigBinders, tyKind') = fromJust . completeBinderList $ tyKind
   bindLocalTypeVariables moduleName (first ProperName . snd <$> sigBinders) $ do
     kindRes <- freshKind (fst ann)
@@ -779,7 +779,7 @@ inferClassDeclaration
   -> ClassDeclarationArgs
   -> m ([(Text, SourceType)], [SourceConstraint], [Declaration])
 inferClassDeclaration moduleName (ann, clsName, clsArgs, superClasses, decls) = do
-  clsKind <- apply =<< lookupTypeVariable moduleName (Qualified Nothing $ coerceProperName clsName)
+  clsKind <- apply =<< lookupTypeVariable moduleName (Qualified ByNullSourceSpan $ coerceProperName clsName)
   let (sigBinders, clsKind') = fromJust . completeBinderList $ clsKind
   bindLocalTypeVariables moduleName (first ProperName . snd <$> sigBinders) $ do
     clsArgs' <- for clsArgs . traverse . maybe (freshKind (fst ann)) $ replaceAllTypeSynonyms <=< apply <=< flip checkKind E.kindType
@@ -910,7 +910,7 @@ existingSignatureOrFreshKind
   -> m SourceType
 existingSignatureOrFreshKind moduleName ss name = do
   env <- getEnv
-  case M.lookup (Qualified (Just moduleName) name) (E.types env) of
+  case M.lookup (Qualified (ByModuleName moduleName) name) (E.types env) of
     Nothing -> freshKind ss
     Just (kind, _) -> pure kind
 

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -230,11 +230,11 @@ lookupTypeClassDictionariesForClass mn cn = fromMaybe M.empty . M.lookup cn <$> 
 -- | Temporarily bind a collection of names to local variables
 bindLocalVariables
   :: (MonadState CheckState m)
-  => [(Ident, SourceType, NameVisibility)]
+  => [(SourceSpan, Ident, SourceType, NameVisibility)]
   -> m a
   -> m a
 bindLocalVariables bindings =
-  bindNames (M.fromList $ flip map bindings $ \(name, ty, visibility) -> (Qualified ByNullSourceSpan name, (ty, Private, visibility)))
+  bindNames (M.fromList $ flip map bindings $ \(ss, name, ty, visibility) -> (Qualified (BySourceSpan ss) name, (ty, Private, visibility)))
 
 -- | Temporarily bind a collection of names to local type variables
 bindLocalTypeVariables

--- a/src/Language/PureScript/TypeChecker/Roles.hs
+++ b/src/Language/PureScript/TypeChecker/Roles.hs
@@ -140,12 +140,12 @@ inferDataBindingGroupRoles
   -> [(Text, Maybe SourceType)]
   -> [Role]
 inferDataBindingGroupRoles env moduleName roleDeclarations group =
-  let declaredRoleEnv = M.fromList $ map (Qualified (Just moduleName) . rdeclIdent &&& rdeclRoles) roleDeclarations
+  let declaredRoleEnv = M.fromList $ map (Qualified (ByModuleName moduleName) . rdeclIdent &&& rdeclRoles) roleDeclarations
       inferredRoleEnv = getRoleEnv env
       initialRoleEnv = declaredRoleEnv `M.union` inferredRoleEnv
       inferredRoleEnv' = inferDataBindingGroupRoles' moduleName group initialRoleEnv
   in \tyName tyArgs ->
-        let qualTyName = Qualified (Just moduleName) tyName
+        let qualTyName = Qualified (ByModuleName moduleName) tyName
             inferredRoles = M.lookup qualTyName inferredRoleEnv'
         in fromMaybe (Phantom <$ tyArgs) inferredRoles
 
@@ -177,7 +177,7 @@ inferDataDeclarationRoles
   -> RoleEnv
   -> (Any, RoleEnv)
 inferDataDeclarationRoles moduleName (tyName, tyArgs, ctors) roleEnv =
-  let qualTyName = Qualified (Just moduleName) tyName
+  let qualTyName = Qualified (ByModuleName moduleName) tyName
       ctorRoles = getRoleMap . foldMap (walk mempty . snd) $ ctors >>= dataCtorFields
       inferredRoles = map (\(arg, _) -> fromMaybe Phantom (M.lookup arg ctorRoles)) tyArgs
   in updateRoleEnv qualTyName inferredRoles roleEnv

--- a/src/Language/PureScript/TypeChecker/TypeSearch.hs
+++ b/src/Language/PureScript/TypeChecker/TypeSearch.hs
@@ -59,7 +59,7 @@ checkSubsume unsolved env st userT envT = checkInEnvironment env st $ do
   userT' <- initializeSkolems userT
   envT' <- initializeSkolems envT
 
-  let dummyExpression = P.Var nullSourceSpan (P.Qualified Nothing (P.Ident "x"))
+  let dummyExpression = P.Var nullSourceSpan (P.Qualified P.ByNullSourceSpan (P.Ident "x"))
 
   elab <- subsumes envT' userT'
   subst <- gets TC.checkSubstitution
@@ -127,7 +127,7 @@ typeSearch unsolved env st type' =
     runPlainIdent (Qualified m (Ident k), v) = Just (Qualified m k, v)
     runPlainIdent _ = Nothing
   in
-    ( (first (P.Qualified Nothing . ("_." <>) . P.prettyPrintLabel) <$> matchingLabels)
+    ( (first (P.Qualified P.ByNullSourceSpan . ("_." <>) . P.prettyPrintLabel) <$> matchingLabels)
       <> mapMaybe runPlainIdent (Map.toList matchingNames)
       <> (first (map P.runProperName) <$> Map.toList matchingConstructors)
     , if null allLabels then Nothing else Just allLabels)

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -265,7 +265,7 @@ typeDictionaryForBindingGroup moduleName vals = do
       return ((sai, ty), (sai, (expr, ty)))
     -- Create the dictionary of all name/type pairs, which will be added to the
     -- environment during type checking
-    let dict = M.fromList [ (Qualified moduleName ident, (ty, Private, Undefined))
+    let dict = M.fromList [ (Qualified (byMaybeModuleName moduleName) ident, (ty, Private, Undefined))
                           | ((_, ident), ty) <- typedDict <> untypedDict
                           ]
     return (SplitBindingGroup untyped' typed' dict)
@@ -486,20 +486,20 @@ inferLetBinding seen (ValueDecl sa@(ss, _) ident nameKind [] [MkUnguarded (Typed
   TypedValue' _ val' ty'' <- warnAndRethrowWithPositionTC ss $ do
     ((args, elabTy), kind) <- kindOfWithScopedVars ty
     checkTypeKind ty kind
-    let dict = M.singleton (Qualified Nothing ident) (elabTy, nameKind, Undefined)
+    let dict = M.singleton (Qualified ByNullSourceSpan ident) (elabTy, nameKind, Undefined)
     ty' <- introduceSkolemScope <=< replaceAllTypeSynonyms <=< replaceTypeWildcards $ elabTy
     if checkType
       then withScopedTypeVars moduleName args (bindNames dict (check val ty'))
       else return (TypedValue' checkType val elabTy)
-  bindNames (M.singleton (Qualified Nothing ident) (ty'', nameKind, Defined))
+  bindNames (M.singleton (Qualified ByNullSourceSpan ident) (ty'', nameKind, Defined))
     $ inferLetBinding (seen ++ [ValueDecl sa ident nameKind [] [MkUnguarded (TypedValue checkType val' ty'')]]) rest ret j
 inferLetBinding seen (ValueDecl sa@(ss, _) ident nameKind [] [MkUnguarded val] : rest) ret j = do
   valTy <- freshTypeWithKind kindType
   TypedValue' _ val' valTy' <- warnAndRethrowWithPositionTC ss $ do
-    let dict = M.singleton (Qualified Nothing ident) (valTy, nameKind, Undefined)
+    let dict = M.singleton (Qualified ByNullSourceSpan ident) (valTy, nameKind, Undefined)
     bindNames dict $ infer val
   warnAndRethrowWithPositionTC ss $ unifyTypes valTy valTy'
-  bindNames (M.singleton (Qualified Nothing ident) (valTy', nameKind, Defined))
+  bindNames (M.singleton (Qualified ByNullSourceSpan ident) (valTy', nameKind, Defined))
     $ inferLetBinding (seen ++ [ValueDecl sa ident nameKind [] [MkUnguarded val']]) rest ret j
 inferLetBinding seen (BindingGroupDeclaration ds : rest) ret j = do
   moduleName <- unsafeCheckCurrentModule
@@ -681,7 +681,7 @@ check' val (ForAll ann ident mbK ty _) = do
       -- an undefined type variable that happens to clash with the variable we
       -- want to skolemize. This can happen due to synonym expansion (see 2542).
       skVal
-        | Just _ <- M.lookup (Qualified mn (ProperName ident)) $ types env =
+        | Just _ <- M.lookup (Qualified (byMaybeModuleName mn) (ProperName ident)) $ types env =
             skolemizeTypesInValue ss ident mbK sko scope val
         | otherwise = val
   val' <- tvToExpr <$> check skVal sk
@@ -691,7 +691,7 @@ check' val t@(ConstrainedType _ con@(Constraint _ cls@(Qualified _ (ProperName c
   -- An empty class dictionary is never used; see code in `TypeChecker.Entailment`
   -- that wraps empty dictionary solutions in `Unused`.
   dictName <- if typeClassIsEmpty then pure UnusedIdent else freshIdent ("dict" <> className)
-  dicts <- newDictionaries [] (Qualified Nothing dictName) con
+  dicts <- newDictionaries [] (Qualified ByNullSourceSpan dictName) con
   val' <- withBindingGroupVisible $ withTypeClassDictionaries dicts $ check val ty
   return $ TypedValue' True (Abs (VarBinder nullSourceSpan dictName) (tvToExpr val')) t
 check' val u@(TUnknown _ _) = do

--- a/tests/Language/PureScript/Ide/FilterSpec.hs
+++ b/tests/Language/PureScript/Ide/FilterSpec.hs
@@ -20,8 +20,8 @@ moduleD = (P.moduleNameFromString "Module.D", [T.ideType "kind1" Nothing []])
 moduleE = (P.moduleNameFromString "Module.E", [T.ideSynonym "SFType" Nothing Nothing `annLoc` synonymSS])
 moduleF = (P.moduleNameFromString "Module.F", [T.ideDtor "DtorA" "TypeA" Nothing])
 moduleG = (P.moduleNameFromString "Module.G", [T.ideTypeClass "MyClass" P.kindType []])
-moduleH = (P.moduleNameFromString "Module.H", [T.ideValueOp "<$>" (P.Qualified Nothing (Left "")) 0 Nothing Nothing])
-moduleI = (P.moduleNameFromString "Module.I", [T.ideTypeOp "~>" (P.Qualified Nothing "") 0 Nothing Nothing])
+moduleH = (P.moduleNameFromString "Module.H", [T.ideValueOp "<$>" (P.Qualified P.ByNullSourceSpan (Left "")) 0 Nothing Nothing])
+moduleI = (P.moduleNameFromString "Module.I", [T.ideTypeOp "~>" (P.Qualified P.ByNullSourceSpan "") 0 Nothing Nothing])
 
 modules :: ModuleMap [IdeDeclarationAnn]
 modules = Map.fromList [moduleA, moduleB]

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -113,7 +113,7 @@ spec = do
         addValueImport i mn q is =
           prettyPrintImportSection (addExplicitImport' (_idaDeclaration (Test.ideValue i Nothing)) mn q is)
         addOpImport op mn q is =
-          prettyPrintImportSection (addExplicitImport' (_idaDeclaration (Test.ideValueOp op (P.Qualified q (Left "")) 2 Nothing Nothing)) mn q is)
+          prettyPrintImportSection (addExplicitImport' (_idaDeclaration (Test.ideValueOp op (P.Qualified (P.byMaybeModuleName q) (Left "")) 2 Nothing Nothing)) mn q is)
         addDtorImport i t mn q is =
           prettyPrintImportSection (addExplicitImport' (_idaDeclaration (Test.ideDtor i t Nothing)) mn q is)
         addTypeImport i mn q is =

--- a/tests/Language/PureScript/Ide/SourceFileSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFileSpec.hs
@@ -29,13 +29,13 @@ valueFixity =
   P.ValueFixityDeclaration
     ann1
     (P.Fixity P.Infix 0)
-    (P.Qualified Nothing (Left (P.Ident "")))
+    (P.Qualified P.ByNullSourceSpan (Left (P.Ident "")))
     (P.OpName "<$>")
 typeFixity =
   P.TypeFixityDeclaration
     ann1
     (P.Fixity P.Infix 0)
-    (P.Qualified Nothing (P.ProperName ""))
+    (P.Qualified P.ByNullSourceSpan (P.ProperName ""))
     (P.OpName "~>")
 foreign1 = P.ExternDeclaration ann1 (P.Ident "foreign1") P.srcREmpty
 foreign2 = P.ExternDataDeclaration ann1 (P.ProperName "Foreign2") P.kindType
@@ -106,9 +106,9 @@ getLocation s = do
          , ideDtor "SFTwo" "SFData" Nothing `annLoc` typeSS
          , ideDtor "SFThree" "SFData" Nothing `annLoc` typeSS
          , ideTypeClass "SFClass" P.kindType [] `annLoc` classSS
-         , ideValueOp "<$>" (P.Qualified Nothing (Left "")) 0 Nothing Nothing
+         , ideValueOp "<$>" (P.Qualified P.ByNullSourceSpan (Left "")) 0 Nothing Nothing
            `annLoc` valueOpSS
-         , ideTypeOp "~>" (P.Qualified Nothing "") 0 Nothing Nothing
+         , ideTypeOp "~>" (P.Qualified P.ByNullSourceSpan "") 0 Nothing Nothing
            `annLoc` typeOpSS
          ])
       ]

--- a/tests/Language/PureScript/Ide/StateSpec.hs
+++ b/tests/Language/PureScript/Ide/StateSpec.hs
@@ -11,15 +11,15 @@ import qualified Data.Map as Map
 
 valueOperator :: Maybe P.SourceType -> IdeDeclarationAnn
 valueOperator =
-  ideValueOp "<$>" (P.Qualified (Just (mn "Test")) (Left "function")) 2 Nothing
+  ideValueOp "<$>" (P.Qualified (P.ByModuleName (mn "Test")) (Left "function")) 2 Nothing
 
 ctorOperator :: Maybe P.SourceType -> IdeDeclarationAnn
 ctorOperator =
-  ideValueOp ":" (P.Qualified (Just (mn "Test")) (Right "Cons")) 2 Nothing
+  ideValueOp ":" (P.Qualified (P.ByModuleName (mn "Test")) (Right "Cons")) 2 Nothing
 
 typeOperator :: Maybe P.SourceType -> IdeDeclarationAnn
 typeOperator =
-  ideTypeOp ":" (P.Qualified (Just (mn "Test")) "List") 2 Nothing
+  ideTypeOp ":" (P.Qualified (P.ByModuleName (mn "Test")) "List") 2 Nothing
 
 testModule :: (P.ModuleName, [IdeDeclarationAnn])
 testModule =
@@ -53,7 +53,7 @@ ef = P.ExternsFile
   --, efDeclarations =
     [ P.EDInstance
       -- { edInstanceClassName =
-      (P.Qualified (Just (mn "ClassModule")) (P.ProperName "MyClass"))
+      (P.Qualified (P.ByModuleName (mn "ClassModule")) (P.ProperName "MyClass"))
       -- , edInstanceName =
       (P.Ident "myClassInstance")
       -- . edInstanceForAll =

--- a/tests/TestCoreFn.hs
+++ b/tests/TestCoreFn.hs
@@ -136,7 +136,7 @@ spec = context "CoreFnFromJson" $ do
     specify "should parse Abs" $ do
       let m = Module ss [] mn mp [] [] M.empty []
                 [ NonRec ann (Ident "abs")
-                    $ Abs ann (Ident "x") (Var ann (Qualified (Just mn) (Ident "x")))
+                    $ Abs ann (Ident "x") (Var ann (Qualified (ByModuleName mn) (Ident "x")))
                 ]
       parseMod m `shouldSatisfy` isSuccess
 
@@ -144,13 +144,13 @@ spec = context "CoreFnFromJson" $ do
       let m = Module ss [] mn mp [] [] M.empty []
                 [ NonRec ann (Ident "app")
                     $ App ann
-                        (Abs ann (Ident "x") (Var ann (Qualified Nothing (Ident "x"))))
+                        (Abs ann (Ident "x") (Var ann (Qualified ByNullSourceSpan (Ident "x"))))
                         (Literal ann (CharLiteral 'c'))
                 ]
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse UnusedIdent in Abs" $ do
-      let i = NonRec ann (Ident "f") (Abs ann UnusedIdent (Var ann (Qualified Nothing (Ident "x"))))
+      let i = NonRec ann (Ident "f") (Abs ann UnusedIdent (Var ann (Qualified (BySourceSpan nullSourceSpan { spanName = mp }) (Ident "x"))))
       let r = parseMod $ Module ss [] mn mp [] [] M.empty [] [i]
       r `shouldSatisfy` isSuccess
       case r of
@@ -161,7 +161,7 @@ spec = context "CoreFnFromJson" $ do
     specify "should parse Case" $ do
       let m = Module ss [] mn mp [] [] M.empty []
                 [ NonRec ann (Ident "case") $
-                    Case ann [Var ann (Qualified Nothing (Ident "x"))]
+                    Case ann [Var ann (Qualified ByNullSourceSpan (Ident "x"))]
                       [ CaseAlternative
                         [ NullBinder ann ]
                         (Right (Literal ann (CharLiteral 'a')))
@@ -172,7 +172,7 @@ spec = context "CoreFnFromJson" $ do
     specify "should parse Case with guards" $ do
       let m = Module ss [] mn mp [] [] M.empty []
                 [ NonRec ann (Ident "case") $
-                    Case ann [Var ann (Qualified Nothing (Ident "x"))]
+                    Case ann [Var ann (Qualified ByNullSourceSpan (Ident "x"))]
                       [ CaseAlternative
                         [ NullBinder ann ]
                         (Left [(Literal ann (BooleanLiteral True), Literal ann (CharLiteral 'a'))])
@@ -184,7 +184,7 @@ spec = context "CoreFnFromJson" $ do
       let m = Module ss [] mn mp [] [] M.empty []
                 [ NonRec ann (Ident "case") $
                     Let ann
-                      [ Rec [((ann, Ident "a"), Var ann (Qualified Nothing (Ident "x")))] ]
+                      [ Rec [((ann, Ident "a"), Var ann (Qualified ByNullSourceSpan (Ident "x")))] ]
                       (Literal ann (BooleanLiteral True))
                 ]
       parseMod m `shouldSatisfy` isSuccess
@@ -222,7 +222,7 @@ spec = context "CoreFnFromJson" $ do
     specify "should parse LiteralBinder" $ do
       let m = Module ss [] mn mp [] [] M.empty []
                 [ NonRec ann (Ident "case") $
-                    Case ann [Var ann (Qualified Nothing (Ident "x"))]
+                    Case ann [Var ann (Qualified ByNullSourceSpan (Ident "x"))]
                       [ CaseAlternative
                         [ LiteralBinder ann (BooleanLiteral True) ]
                         (Right (Literal ann (CharLiteral 'a')))
@@ -233,12 +233,12 @@ spec = context "CoreFnFromJson" $ do
     specify "should parse VarBinder" $ do
       let m = Module ss [] mn mp [] [] M.empty []
                 [ NonRec ann (Ident "case") $
-                    Case ann [Var ann (Qualified Nothing (Ident "x"))]
+                    Case ann [Var ann (Qualified ByNullSourceSpan (Ident "x"))]
                       [ CaseAlternative
                         [ ConstructorBinder
                             ann
-                            (Qualified (Just (ModuleName "Data.Either")) (ProperName "Either"))
-                            (Qualified Nothing (ProperName "Left"))
+                            (Qualified (ByModuleName (ModuleName "Data.Either")) (ProperName "Either"))
+                            (Qualified ByNullSourceSpan (ProperName "Left"))
                             [VarBinder ann (Ident "z")]
                         ]
                         (Right (Literal ann (CharLiteral 'a')))
@@ -249,7 +249,7 @@ spec = context "CoreFnFromJson" $ do
     specify "should parse NamedBinder" $ do
       let m = Module ss [] mn mp [] [] M.empty []
                 [ NonRec ann (Ident "case") $
-                    Case ann [Var ann (Qualified Nothing (Ident "x"))]
+                    Case ann [Var ann (Qualified ByNullSourceSpan (Ident "x"))]
                       [ CaseAlternative
                         [ NamedBinder ann (Ident "w") (NamedBinder ann (Ident "w'") (VarBinder ann (Ident "w''"))) ]
                         (Right (Literal ann (CharLiteral 'a')))

--- a/tests/TestCoreFn.hs
+++ b/tests/TestCoreFn.hs
@@ -150,7 +150,7 @@ spec = context "CoreFnFromJson" $ do
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse UnusedIdent in Abs" $ do
-      let i = NonRec ann (Ident "f") (Abs ann UnusedIdent (Var ann (Qualified (BySourceSpan nullSourceSpan { spanName = mp }) (Ident "x"))))
+      let i = NonRec ann (Ident "f") (Abs ann UnusedIdent (Var ann (Qualified ByNullSourceSpan (Ident "x"))))
       let r = parseMod $ Module ss [] mn mp [] [] M.empty [] [i]
       r `shouldSatisfy` isSuccess
       case r of

--- a/tests/TestHierarchy.hs
+++ b/tests/TestHierarchy.hs
@@ -51,7 +51,7 @@ spec = describe "hierarchy" $ do
                  (P.internalModuleSourceSpan "<B>", [])
                  (P.ProperName "B")
                  []
-                 [P.srcConstraint (P.Qualified Nothing $ P.ProperName "A") [] [] Nothing]
+                 [P.srcConstraint (P.Qualified P.ByNullSourceSpan $ P.ProperName "A") [] [] Nothing]
                  []
                  []
               ]


### PR DESCRIPTION
**Description of the change**

Closes #4287. This adds a new desugaring step, `desugarLocals`, which turns references to local bindings be qualified by the source spans of the said bindings they're referring back to. Note that this had to be a separate step from `desugarImports` as it also needs to take into account binding groups. This also doesn't introduce new tests as an incorrect implementation breaks all other compiler tests quite heavily.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
[ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
[ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
