### PR TITLE
Make alpha-06 release

### DIFF
--- a/app/Version.hs
+++ b/app/Version.hs
@@ -17,7 +17,7 @@ import qualified Development.GitRev as GitRev
 -- prerelease identifier here (if any). When releasing a proper version, simply
 -- set this to an empty string.
 prerelease :: String
-prerelease = "-alpha-05"
+prerelease = "-alpha-06"
 
 versionString :: String
 versionString = showVersion Paths.version ++ prerelease ++ extra

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript",
-  "version": "0.14.7",
+  "version": "0.15.0-alpha-06",
   "license": "ISC",
   "description": "PureScript wrapper that makes it available as a local dependency",
   "author": {
@@ -43,7 +43,7 @@
   ],
   "scripts": {
     "prepublishOnly": "node -e \"require('fs').copyFileSync('purs.bin.placeholder', 'purs.bin');\"",
-    "postinstall": "install-purescript --purs-ver=0.14.7",
+    "postinstall": "install-purescript --purs-ver=0.15.0-alpha-06",
     "test": "echo 'Error: no test specified' && exit 1"
   }
 }

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -2,7 +2,7 @@ cabal-version:  2.4
 
 name:           purescript
 -- note: When updating the prerelease identifier, update it in app/Version.hs too!
-version:        0.15.0-alpha-05
+version:        0.15.0-alpha-06
 synopsis:       PureScript Programming Language Compiler
 description:    A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
 category:       Language


### PR DESCRIPTION
**Description of the change**

Updates the version in `package.json`, so that (once this PR is merged and `alpha-06` is released as the `next` tag) `npm i purescript@next` will install `v0.15.0-alpha-06`.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
