### PR TITLE
ci/build-package-set.sh: exclude metadata package

### DIFF
--- a/ci/build-package-set.sh
+++ b/ci/build-package-set.sh
@@ -26,7 +26,7 @@ spago upgrade-set
 # Override the `metadata` package's version to match `purs` version
 # so that `spago build` actually works
 sed -i'' "\$c in upstream with metadata.version = \"v$(purs --version | { read v z && echo $v; })\"" packages.dhall
-spago install $(spago ls packages | while read name z; do echo $name; done)
+spago install $(spago ls packages | while read name z; do if [[ $name != metadata ]]; then echo $name; fi; done)
 echo ::endgroup::
 
 echo ::group::Compile package set


### PR DESCRIPTION
`metadata` is a dummy package, not an actual part of the package set.
However, if asked, spago will try to install it anyway, and complain if
a matching version doesn't exist. When developing a new version of
PureScript, there might be a delay before the package set maintainers
get around to ensuring such a version exists. But there's no need to
wait for that if we simply don't install that package.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
