### PR TITLE
Fix broken link to 0.15 migration documentation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -86,6 +86,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@mrhania](https://github.com/mrhania) | Łukasz Hanuszczak | [MIT license](http://opensource.org/licenses/MIT) |
 | [@natefaubion](https://github.com/natefaubion) | Nathan Faubion | [MIT license](http://opensource.org/licenses/MIT) |
 | [@ncaq](https://github.com/ncaq) | ncaq | [MIT license](http://opensource.org/licenses/MIT) |
+| [@NickMolloy](https://github.com/NickMolloy) | Nick Molloy | [MIT license](http://opensource.org/licenses/MIT) |
 | [@nicodelpiano](https://github.com/nicodelpiano) | Nicolas Del Piano | [MIT license](http://opensource.org/licenses/MIT) |
 | [@noraesae](https://github.com/noraesae) | Hyunje Jun | [MIT license](http://opensource.org/licenses/MIT) |
 | [@nullobject](https://github.com/nullobject) | Josh Bassett | [MIT license](http://opensource.org/licenses/MIT) |

--- a/app/Command/Bundle.hs
+++ b/app/Command/Bundle.hs
@@ -11,7 +11,7 @@ app :: IO ()
 app = do
   hPutStrLn stderr $ unlines
     [ "'purs bundle' was removed in the v0.15.0 release."
-    , "See https://www.github.com/purescript/documentation/migration-guides/0.15-Migration-Guide.md "
+    , "See https://github.com/purescript/documentation/blob/master/migration-guides/0.15-Migration-Guide.md"
     , "for more information and bundler alternatives."
     ]
   exitFailure


### PR DESCRIPTION
**Description of the change**
The output of `purs bundle` contains a link to the 0.15 migration guide, but it gives a `404` response. Updated the link to refer to the actual location.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
