### PR TITLE
Deploy builds continuously to GitHub and npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,19 @@ defaults:
     shell: "bash"
 
 env:
+  CI_PRERELEASE: "${{ github.event_name == 'push' }}"
   CI_RELEASE: "${{ github.event_name == 'release' }}"
   STACK_VERSION: "2.7.3"
+
+concurrency:
+  # We never want two releases or prereleases building at the same time, since
+  # they would likely both claim the same version number. Pull request builds
+  # can happen in parallel with anything else, since they don't mutate global
+  # state with a release. (GitHub Actions is either too cheap to give us `if`
+  # expressions or too lazy to document them, but we have untyped boolean
+  # operators to fall back on.)
+  group: "${{ github.event_name == 'pull_request' && github.run_id || 'continuous-deployment' }}"
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -30,6 +41,10 @@ jobs:
 
     runs-on: "${{ matrix.os }}"
     container: "${{ matrix.image }}"
+
+    outputs:
+      do-not-prerelease: "${{ steps.build.outputs.do-not-prerelease }}"
+      version: "${{ steps.build.outputs.version }}"
 
     steps:
       - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone
@@ -77,7 +92,8 @@ jobs:
           mkdir -p "$STACK_ROOT"
           echo "local-programs-path: $STACK_ROOT/programs" > $STACK_ROOT/config.yaml
 
-      - run: "ci/fix-home ci/build.sh"
+      - id: "build"
+        run: "ci/fix-home ci/build.sh"
 
       - name: "(Linux only) Build the entire package set"
         if: "${{ runner.os == 'Linux' }}"
@@ -106,8 +122,8 @@ jobs:
             exit 1
           fi
 
-      - name: "(Release only) Create bundle"
-        if: "${{ env.CI_RELEASE == 'true' }}"
+      - name: "(Release/prerelease only) Create bundle"
+        if: "${{ env.CI_RELEASE == 'true' || env.CI_PRERELEASE == 'true' && steps.build.outputs.do-not-prerelease != 'true' }}"
         run: |
           os_name="${{ runner.os }}"
           case "$os_name" in
@@ -123,6 +139,15 @@ jobs:
           esac
           cd sdist-test
           ../ci/fix-home bundle/build.sh "$bundle_os"
+
+      - name: "(Prerelease only) Upload bundle"
+        if: "${{ env.CI_PRERELEASE == 'true' && steps.build.outputs.do-not-prerelease != 'true' }}"
+        uses: "actions/upload-artifact@v3"
+        with:
+          name: "${{ runner.os }}-bundle"
+          path: |
+            sdist-test/bundle/*.sha
+            sdist-test/bundle/*.tar.gz
 
       - name: "(Release only) Publish bundle"
         if: "${{ env.CI_RELEASE == 'true' }}"
@@ -194,3 +219,32 @@ jobs:
       - run: "ci/fix-home stack --no-terminal --jobs=2 build --fast --test --no-run-tests --ghc-options -fwrite-ide-info"
 
       - run: "ci/fix-home stack exec weeder"
+
+  make-prerelease:
+    runs-on: "ubuntu-latest"
+    needs:
+      - "build"
+      - "lint"
+    if: "${{ github.event_name == 'push' && needs.build.outputs.do-not-prerelease != 'true' }}"
+    steps:
+      - uses: "actions/download-artifact@v3"
+      - uses: "ncipollo/release-action@v1.10.0"
+        with:
+          tag: "${{ needs.build.outputs.version }}"
+          artifacts: "*-bundle/*"
+          prerelease: true
+          body: "This is an automated preview release. Get the latest stable release [here](https://github.com/purescript/purescript/releases/latest)."
+      - uses: "actions/checkout@v3"
+      - uses: "actions/setup-node@v3"
+        with:
+          node-version: "16.x"
+      - name: "Publish npm package"
+        working-directory: "npm-package"
+        env:
+          BUILD_VERSION: "${{ needs.build.outputs.version }}"
+          NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}"
+        run: |
+          src_version=$(node -pe 'require("./package.json").version')
+          npm version --allow-same-version "$BUILD_VERSION"
+          sed -i -e "s/--purs-ver=${src_version//./\\.}/--purs-ver=$BUILD_VERSION/" package.json
+          npm publish --tag next

--- a/CHANGELOG.d/internal_cd.md
+++ b/CHANGELOG.d/internal_cd.md
@@ -1,0 +1,1 @@
+* Deploy builds continuously to GitHub and npm

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -72,14 +72,38 @@ considering what effects this may have:
 - JSON produced by `purs publish`
   - this might affect Pursuit
 
+## Making a release candidate
+
+- Make a commit bumping versions. The following should be updated:
+
+  - The `version` field in `purescript.cabal` should be set to the expected
+    final release version.
+
+  - The `prerelease` field in `app/Version.hs` should be set to `-rc.0`.
+
+  - The `version` field in `npm-package/package.json` should be set to the
+    concatenation of the above two items.
+
+  - The version to install in the `postinstall` script in `package.json` should
+    match the `version` field.
+
+- Upon merging the PR, the release candidate will be published to GitHub and
+  npm. There is no need to make a manual release for the RC. Subsequent builds
+  will be deployed to successive `-rc.*` numbers until a final release is made.
+
+- Verify that the release candidate can be installed via `npm i purescript@next`
+
 ## Making a release
+
+- Test that the last build published to `purescript@next` works in downstream
+  projects before starting the manual release process.
 
 - Make a commit bumping versions. The following should be updated:
 
   - The `version` field in `purescript.cabal`
 
-  - The `prerelease` field in `app/Version.hs`, if updating the prerelease
-    field
+  - The `prerelease` field in `app/Version.hs` should be cleared, if a
+    release candidate was previously published
 
   - The `version` field in `npm-package/package.json`
 
@@ -103,14 +127,10 @@ considering what effects this may have:
 
 - After all of the prebuilt binaries are present on the GitHub releases page,
   publish to npm: change to the `npm-package` directory and do the following:
-    - if making a pre-release (e.g. `v0.15.0-alpha-05`)
-        - run `npm publish --tag next`
-        - verify that the prerelease can be installed via `npm i purescript@next`
-    - if making a normal release (e.g. `v0.15.0`)
-        - run `npm publish`
-        - run `npm dist-tag add purescript@VERSION next` where `VERSION` is `v0.15.0`.
-        - verify that the release can be installed via `npm i purescript@next`
-        - verify that the release can be installed via `npm i purescript`
+    - run `npm publish`
+    - run `npm dist-tag add purescript@VERSION next` where `VERSION` is `v0.15.0`.
+    - verify that the release can be installed via `npm i purescript@next`
+    - verify that the release can be installed via `npm i purescript`
 
 Note: if a release does not go as planned (e.g. [`v0.14.3`](https://github.com/purescript/purescript/pull/4139)), we should not delete the broken GitHub release or its Git tag. Rather, we should make a new release and update the GitHub release notes and the corresponding section in the CHANGELOG.md file for the broken release to
 1. say that it's not a real release, and

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -28,12 +28,99 @@ set -ex
 STACK="stack --no-terminal --haddock --jobs=2"
 
 STACK_OPTS="--test"
-if [ "$CI_RELEASE" = "true" ]
+if [ "$CI_RELEASE" = "true" -o "$CI_PRERELEASE" = "true" ]
 then
   STACK_OPTS="$STACK_OPTS --flag=purescript:RELEASE"
 else
   STACK_OPTS="$STACK_OPTS --fast"
 fi
+
+(echo "::endgroup::"; echo "::group::Set version number for build") 2>/dev/null
+
+pushd npm-package
+
+package_version=$(node -pe 'require("./package.json").version')
+package_release_version=${package_version%%-*}
+package_prerelease_suffix=${package_version#$package_release_version}
+
+if ! grep -q "\"install-purescript --purs-ver=${package_version//./\\.}\"" package.json
+then
+  echo "Version in npm-package/package.json doesn't match version in install-purescript call"
+  exit 1
+fi
+
+if ! grep -q "^version:\\s*${package_release_version//./\\.}$" ../purescript.cabal
+then
+  echo "Version in npm-package/package.json doesn't match version in purescript.cabal"
+  exit 1
+fi
+
+if ! grep -q "^prerelease = \"${package_prerelease_suffix//./\\.}\"$" ../app/Version.hs
+then
+  echo "Version in npm-package/package.json doesn't match prerelease in app/Version.hs"
+  exit 1
+fi
+
+function largest-matching-git-tag {
+  grep -E "^${1//./\\.}(\\.|$)" "$git_tags" | head -n 1
+}
+
+git_tags=$(mktemp)
+trap 'rm "$git_tags"' EXIT
+git ls-remote --tags -q --sort=-version:refname | sed 's_^.*refs/tags/__' > $git_tags
+if [ "$package_prerelease_suffix" ]
+then
+  tag=$(largest-matching-git-tag "v$package_release_version${package_prerelease_suffix%%.*}")
+  if [ "$tag" ]
+  then
+    npm version --allow-same-version "$tag"
+    build_version=$(npm version --no-git-tag-version prerelease)
+    build_version=${build_version#v}
+  else
+    build_version=$package_version
+  fi
+else # (current version does not contain a prerelease suffix)
+  if grep -Fqx "v$package_release_version" "$git_tags"
+  then # (the current version has been published)
+    bump=patch
+    if [ "$(find ../CHANGELOG.d -maxdepth 1 -name 'breaking_*' -print -quit)" ]
+    then
+      # If we ever reach 1.0, change this to major and uncomment the below
+      bump=minor
+    #elif [ "$(find ../CHANGELOG.d -maxdepth 1 -name 'feature_*' -print -quit)" ]
+    #then
+    #  bump=minor
+    fi
+    next_tag=$(npm version --no-git-tag-version "$bump")
+    tag=$(largest-matching-git-tag "$next_tag-[0-9]+")
+    if [ "$tag" ]
+    then
+      npm version --allow-same-version "$tag"
+      build_version=$(npm version --no-git-tag-version prerelease)
+    else
+      build_version=$(npm version --allow-same-version "$next_tag-0")
+    fi
+    build_version=${build_version#v}
+  else # (current version has not been published)
+    build_version=$package_version
+    echo "::set-output name=do-not-prerelease::true"
+  fi
+fi
+
+echo "::set-output name=version::v$build_version"
+
+if [ "$build_version" != "$package_version" ]
+then
+  build_release_version=${build_version%%-*}
+  build_prerelease_suffix=${build_version#$build_release_version}
+  # We don't need to update the install-purescript command before we build;
+  # we'll do that when we publish. All we need to update here are the files
+  # that affect the purs binary.
+  sed -i -e "s/^\\(version:\\s*\\)${package_release_version//./\\.}/\1$build_release_version/" ../purescript.cabal
+  sed -i -e "s/^prerelease = \"${package_prerelease_suffix//./\\.}\"$/prerelease = \"${build_prerelease_suffix}\"/" ../app/Version.hs
+fi
+
+popd
 
 (echo "::endgroup::"; echo "::group::Install snapshot dependencies") 2>/dev/null
 

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -1,7 +1,7 @@
 cabal-version:  2.4
 
 name:           purescript
--- note: When updating the prerelease identifier, update it in app/Version.hs too!
+-- Note: don't add prerelease identifiers here! Add them in app/Version.hs and npm-package/package.json instead.
 version:        0.15.0
 synopsis:       PureScript Programming Language Compiler
 description:    A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.


### PR DESCRIPTION
**Description of the change**

Closes #4303. However, before this PR is merged, someone with more access than me needs to do the following:
- [x] Create a new npm account for automated deployment
  * what email address should we use?
  * how should the password to this account be managed?
- [x] Add that account as an owner of `purescript` in the npm registry
  * one of the existing owners will need to do this
- [x] Generate an automation token with that account
- [x] Add that token to a secret variable named `NPM_TOKEN`
  * requires someone with admin access ([possibly](https://github.com/github/docs/issues/1087) lower access levels could do this but not through the web interface)

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- <s>Added myself to CONTRIBUTORS.md (if this is my first contribution)</s>
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- <s>Added a test for the contribution (if applicable)</s>
