### PR TITLE
Ignore type wildcards in binders when under a fully-typed declaration

### DIFF
--- a/CHANGELOG.d/fix_issue-4308-type-wildcards-in-binders.md
+++ b/CHANGELOG.d/fix_issue-4308-type-wildcards-in-binders.md
@@ -1,0 +1,13 @@
+* Do not emit warnings about type wildcards used in binders (patterns).
+
+  Type wildcards in the following examples no longer trigger a warning:
+
+  ```
+  f :: Int
+  f = 42 # \(x :: _) -> x
+
+  g :: Maybe Int
+  g = do
+    x :: _ <- getX
+    pure $ x + 5
+  ```

--- a/src/Language/PureScript/Linter/Wildcards.hs
+++ b/src/Language/PureScript/Linter/Wildcards.hs
@@ -22,11 +22,18 @@ import Language.PureScript.Types
 ignoreWildcardsUnderCompleteTypeSignatures :: Declaration -> Declaration
 ignoreWildcardsUnderCompleteTypeSignatures = onDecl
   where
-  (onDecl, _, _, _, _) = everywhereWithContextOnValues False (,) handleExpr (,) (,) (,)
+  (onDecl, _, _, _, _) = everywhereWithContextOnValues False (,) handleExpr handleBinder (,) (,)
+
   handleExpr isCovered = \case
     tv@(TypedValue chk v ty)
       | isCovered -> (True, TypedValue chk v $ ignoreWildcards ty)
       | otherwise -> (isComplete ty, tv)
+    other -> (isCovered, other)
+
+  handleBinder isCovered = \case
+    tb@(TypedBinder ty b)
+      | isCovered -> (True, TypedBinder (ignoreWildcards ty) b)
+      | otherwise -> (isComplete ty, tb)
     other -> (isCovered, other)
 
 ignoreWildcards :: Type a -> Type a

--- a/tests/purs/warning/4308.out
+++ b/tests/purs/warning/4308.out
@@ -1,0 +1,49 @@
+Warning 1 of 3:
+
+  in module [33mMain[0m
+  at tests/purs/warning/4308.purs:13:6 - 13:7 (line 13, column 6 - line 13, column 7)
+
+    Wildcard type definition has the inferred type
+    [33m     [0m
+    [33m  Int[0m
+    [33m     [0m
+
+  in value declaration [33mg[0m
+
+  See https://github.com/purescript/documentation/blob/master/errors/WildcardInferredType.md for more information,
+  or to contribute content related to this warning.
+
+Warning 2 of 3:
+
+  in module [33mMain[0m
+  at tests/purs/warning/4308.purs:14:13 - 14:14 (line 14, column 13 - line 14, column 14)
+
+    Wildcard type definition has the inferred type
+    [33m     [0m
+    [33m  Int[0m
+    [33m     [0m
+
+  in value declaration [33mg[0m
+
+  See https://github.com/purescript/documentation/blob/master/errors/WildcardInferredType.md for more information,
+  or to contribute content related to this warning.
+
+Warning 3 of 3:
+
+  in module [33mMain[0m
+  at tests/purs/warning/4308.purs:14:25 - 14:26 (line 14, column 25 - line 14, column 26)
+
+    Wildcard type definition has the inferred type
+    [33m     [0m
+    [33m  Int[0m
+    [33m     [0m
+    in the following context:
+
+      y :: [33mInt[0m
+
+
+  in value declaration [33mg[0m
+
+  See https://github.com/purescript/documentation/blob/master/errors/WildcardInferredType.md for more information,
+  or to contribute content related to this warning.
+

--- a/tests/purs/warning/4308.purs
+++ b/tests/purs/warning/4308.purs
@@ -7,8 +7,8 @@ module Main where
 f :: Int
 f = (\(y :: _) -> (y :: _)) 42
 
--- All three warnings expected here because `g` has a wildcard in it: one
--- warning for the top-level signature wildcard, one in the lambda parameter
--- pattern, and one in the lambda body.
+-- All three warnings expected here because the type signature of `g` has a
+-- wildcard in it. One warning for the top-level signature wildcard, one in the
+-- lambda parameter pattern, and one in the lambda body.
 g :: _
 g = (\(y :: _) -> (y :: _)) 42

--- a/tests/purs/warning/4308.purs
+++ b/tests/purs/warning/4308.purs
@@ -1,0 +1,14 @@
+-- @shouldWarnWith WildcardInferredType
+-- @shouldWarnWith WildcardInferredType
+-- @shouldWarnWith WildcardInferredType
+module Main where
+
+-- No warnings expected here because `f` has full type signature
+f :: Int
+f = (\(y :: _) -> (y :: _)) 42
+
+-- All three warnings expected here because `g` has a wildcard in it: one
+-- warning for the top-level signature wildcard, one in the lambda parameter
+-- pattern, and one in the lambda body.
+g :: _
+g = (\(y :: _) -> (y :: _)) 42

--- a/tests/purs/warning/4308.purs
+++ b/tests/purs/warning/4308.purs
@@ -8,7 +8,7 @@ f :: Int
 f = (\(y :: _) -> (y :: _)) 42
 
 -- All three warnings expected here because the type signature of `g` has a
--- wildcard in it. One warning for the top-level signature wildcard, one in the
--- lambda parameter pattern, and one in the lambda body.
+-- wildcard in it. One warning for the top-level signature wildcard, one for the
+-- wildcard in the lambda parameter pattern, and one in the lambda body.
 g :: _
 g = (\(y :: _) -> (y :: _)) 42


### PR DESCRIPTION
**Description of the change**

Fixes #4308 

The type-wildcard-ignoring logic added in #4269 was explicitly ignoring type wildcards in values, but not in binders.
The PR adds similar ignoring logic for binders as well.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] ~Updated or added relevant documentation~
- [x] Added a test for the contribution (if applicable)
