### PR TITLE
Fix npm publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
       - uses: "actions/setup-node@v3"
         with:
           node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
       - name: "Publish npm package"
         working-directory: "npm-package"
         env:


### PR DESCRIPTION
Without an explicit `registry-url` input, `setup-node` doesn't create
the `.npmrc` file that hooks `NODE_AUTH_TOKEN` into the publishing
workflow.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
