### PR TITLE
Fix purescript-installer call for prereleases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
       - uses: "actions/download-artifact@v3"
       - uses: "ncipollo/release-action@v1.10.0"
         with:
-          tag: "${{ needs.build.outputs.version }}"
+          tag: "v${{ needs.build.outputs.version }}"
           artifacts: "*-bundle/*"
           prerelease: true
           body: "This is an automated preview release. Get the latest stable release [here](https://github.com/purescript/purescript/releases/latest)."

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -107,7 +107,7 @@ else # (current version does not contain a prerelease suffix)
   fi
 fi
 
-echo "::set-output name=version::v$build_version"
+echo "::set-output name=version::$build_version"
 
 if [ "$build_version" != "$package_version" ]
 then


### PR DESCRIPTION
**Description of the change**

The `install-purescript --purs-ver=` command expects a raw version number without the ‘v’ prefix. The action that creates a release tag does want a ‘v’ prefix. So I moved the ‘v’ from the output of the build to the release tag, which shouldn't have any other consequences (`npm version` doesn't care if its called with a ‘v’ or without).

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
