### PR TITLE
Fix bad interaction between module renaming and inliner

### DIFF
--- a/CHANGELOG.d/fix_4229.md
+++ b/CHANGELOG.d/fix_4229.md
@@ -1,0 +1,9 @@
+* Fix bad interaction between module renaming and inliner
+
+  This bug was triggered when modules that the compiler handles specially
+  are shadowed by local constructors. For example, a constructor named
+  `Prim` could have caused references to `Prim_1["undefined"]` to be
+  produced in the compiled code, leading to a reference error at run time.
+  Less severely, a constructor named `Control_Bind` would have caused the
+  compiler not to inline known monadic functions, leading to slower and
+  less readable compiled code.

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -59,23 +59,20 @@ moduleToJs
 moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreignInclude =
   rethrow (addHint (ErrorInModule mn)) $ do
     let usedNames = concatMap getNames decls
-    let mnLookup = renameImports usedNames imps
-    let decls' = renameModules mnLookup decls
-    (jsDecls, Any needRuntimeLazy) <- runWriterT $ mapM (moduleBindToJs mn) decls'
-    let mnReverseLookup = M.fromList $ map (\(origName, (_, safeName)) -> (moduleNameToJs safeName, origName)) $ M.toList mnLookup
-    let moduleObjectNames = "$foreign" `S.insert` M.keysSet mnReverseLookup
-    optimized <- traverse (traverse (fmap (annotatePure moduleObjectNames) . optimize)) (if needRuntimeLazy then [runtimeLazy] : jsDecls else jsDecls)
-    let usedModuleNames = foldMap (foldMap (findModules mnReverseLookup)) optimized
-          `S.union` M.keysSet reExps
-    let jsImports
-          = map (importToJs mnLookup)
-          . filter (flip S.member usedModuleNames)
-          . (\\ (mn : C.primModules)) $ ordNub $ map snd imps
+    let imps' = ordNub $ map snd imps
+    let mnLookup = renameImports usedNames imps'
+    (jsDecls, Any needRuntimeLazy) <- runWriterT $ mapM (moduleBindToJs mn) decls
+    optimized <- traverse (traverse (fmap annotatePure . optimize)) (if needRuntimeLazy then [runtimeLazy] : jsDecls else jsDecls)
     F.traverse_ (F.traverse_ checkIntegers) optimized
     comments <- not <$> asks optionsNoComments
     let header = if comments then coms else []
-    let foreign' = maybe [] (pure . AST.Import "$foreign") $ if null foreigns then Nothing else foreignInclude
+    let foreign' = maybe [] (pure . AST.Import FFINamespace) $ if null foreigns then Nothing else foreignInclude
     let moduleBody = concat optimized
+    let (S.union (M.keysSet reExps) -> usedModuleNames, renamedModuleBody) = traverse (replaceModuleAccessors mnLookup) moduleBody
+    let jsImports
+          = map (importToJs mnLookup)
+          . filter (flip S.member usedModuleNames)
+          $ (\\ (mn : C.primModules)) imps'
     let foreignExps = exps `intersect` foreigns
     let standardExps = exps \\ foreignExps
     let reExps' = M.toList (M.withoutKeys reExps (S.fromList C.primModules))
@@ -83,15 +80,15 @@ moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreignInclude =
           =  (maybeToList . exportsToJs foreignInclude $ foreignExps)
           ++ (maybeToList . exportsToJs Nothing $ standardExps)
           ++  mapMaybe reExportsToJs reExps'
-    return $ AST.Module header (foreign' ++ jsImports) moduleBody jsExports
+    return $ AST.Module header (foreign' ++ jsImports) renamedModuleBody jsExports
 
   where
   -- | Adds purity annotations to top-level values for bundlers.
   -- The semantics here derive from treating top-level module evaluation as pure, which lets
   -- us remove any unreferenced top-level declarations. To achieve this, we wrap any non-trivial
   -- top-level values in an IIFE marked with a pure annotation.
-  annotatePure :: S.Set Text -> AST -> AST
-  annotatePure moduleObjectNames = annotateOrWrap
+  annotatePure :: AST -> AST
+  annotatePure = annotateOrWrap
     where
     annotateOrWrap = liftA2 fromMaybe pureIife maybePure
 
@@ -113,19 +110,18 @@ moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreignInclude =
     maybePureGen alreadyAnnotated = \case
       AST.VariableIntroduction ss name j -> Just (AST.VariableIntroduction ss name (annotateOrWrap <$> j))
       AST.App ss f args -> (if alreadyAnnotated then AST.App else pureApp) ss <$> maybePure' f <*> traverse maybePure args
-      -- In general, indexers can be effectful, but not when indexing into an
-      -- ES module object.
-      AST.Indexer ss idx v@(AST.Var _ name)
-        | name `S.member` moduleObjectNames -> (\idx' -> AST.Indexer ss idx' v) <$> maybePure idx
       AST.ArrayLiteral ss jss -> AST.ArrayLiteral ss <$> traverse maybePure jss
       AST.ObjectLiteral ss props -> AST.ObjectLiteral ss <$> traverse (traverse maybePure) props
       AST.Comment c js -> AST.Comment c <$> maybePure js
+
+      js@(AST.Indexer _ _ (AST.Var _ FFINamespace)) -> Just js
 
       js@AST.NumericLiteral{} -> Just js
       js@AST.StringLiteral{}  -> Just js
       js@AST.BooleanLiteral{} -> Just js
       js@AST.Function{}       -> Just js
       js@AST.Var{}            -> Just js
+      js@AST.ModuleAccessor{} -> Just js
 
       _ -> Nothing
 
@@ -142,31 +138,31 @@ moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreignInclude =
 
   -- | Creates alternative names for each module to ensure they don't collide
   -- with declaration names.
-  renameImports :: [Ident] -> [(Ann, ModuleName)] -> M.Map ModuleName (Ann, ModuleName)
+  renameImports :: [Ident] -> [ModuleName] -> M.Map ModuleName Text
   renameImports = go M.empty
     where
-    go :: M.Map ModuleName (Ann, ModuleName) -> [Ident] -> [(Ann, ModuleName)] -> M.Map ModuleName (Ann, ModuleName)
-    go acc used ((ann, mn') : mns') =
-      let mni = Ident $ moduleNameToJs mn'
-      in if mn' /= mn && mni `elem` used
-         then let newName = freshModuleName 1 mn' used
-              in go (M.insert mn' (ann, newName) acc) (Ident (runModuleName newName) : used) mns'
-         else go (M.insert mn' (ann, mn') acc) used mns'
+    go :: M.Map ModuleName Text -> [Ident] -> [ModuleName] -> M.Map ModuleName Text
+    go acc used (mn' : mns') =
+      let mnj = moduleNameToJs mn'
+      in if mn' /= mn && Ident mnj `elem` used
+         then let newName = freshModuleName 1 mnj used
+              in go (M.insert mn' newName acc) (Ident newName : used) mns'
+         else go (M.insert mn' mnj acc) used mns'
     go acc _ [] = acc
 
-    freshModuleName :: Integer -> ModuleName -> [Ident] -> ModuleName
-    freshModuleName i mn'@(ModuleName name) used =
-      let newName = ModuleName $ name <> "_" <> T.pack (show i)
-      in if Ident (runModuleName newName) `elem` used
+    freshModuleName :: Integer -> Text -> [Ident] -> Text
+    freshModuleName i mn' used =
+      let newName = mn' <> "_" <> T.pack (show i)
+      in if Ident newName `elem` used
          then freshModuleName (i + 1) mn' used
          else newName
 
   -- | Generates JavaScript code for a module import, binding the required module
   -- to the alternative
-  importToJs :: M.Map ModuleName (Ann, ModuleName) -> ModuleName -> AST.Import
+  importToJs :: M.Map ModuleName Text -> ModuleName -> AST.Import
   importToJs mnLookup mn' =
-    let (_, mnSafe) = fromMaybe (internalError "Missing value in mnLookup") $ M.lookup mn' mnLookup
-    in AST.Import (moduleNameToJs mnSafe) (moduleImportPath mn')
+    let mnSafe = fromMaybe (internalError "Missing value in mnLookup") $ M.lookup mn' mnLookup
+    in AST.Import mnSafe (moduleImportPath mn')
 
   -- | Generates JavaScript code for exporting at least one identifier,
   -- eventually from another module.
@@ -181,33 +177,15 @@ moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreignInclude =
   moduleImportPath :: ModuleName -> PSString
   moduleImportPath mn' = fromString (".." </> T.unpack (runModuleName mn') </> "index.js")
 
-  -- | Replaces the `ModuleName`s in the AST so that the generated code refers to
-  -- the collision-avoiding renamed module imports.
-  renameModules :: M.Map ModuleName (Ann, ModuleName) -> [Bind Ann] -> [Bind Ann]
-  renameModules mnLookup binds =
-    let (f, _, _) = everywhereOnValues id goExpr goBinder
-    in map f binds
-    where
-    goExpr :: Expr a -> Expr a
-    goExpr (Var ann q) = Var ann (renameQual q)
-    goExpr e = e
-    goBinder :: Binder a -> Binder a
-    goBinder (ConstructorBinder ann q1 q2 bs) = ConstructorBinder ann (renameQual q1) (renameQual q2) bs
-    goBinder b = b
-    renameQual :: Qualified a -> Qualified a
-    renameQual (Qualified (Just mn') a) =
-      let (_,mnSafe) = fromMaybe (internalError "Missing value in mnLookup") $ M.lookup mn' mnLookup
-      in Qualified (Just mnSafe) a
-    renameQual q = q
-
-  -- |
-  -- Find the set of ModuleNames referenced by an AST.
-  --
-  findModules :: M.Map Text ModuleName -> AST -> S.Set ModuleName
-  findModules mnReverseLookup = AST.everything mappend go
-    where
-    go (AST.Var _ name) = foldMap S.singleton $ M.lookup name mnReverseLookup
-    go _ = mempty
+  -- | Replaces the `ModuleAccessor`s in the AST with `Indexer`s, ensuring that
+  -- the generated code refers to the collision-avoiding renamed module
+  -- imports. Also returns set of used module names.
+  replaceModuleAccessors :: M.Map ModuleName Text -> AST -> (S.Set ModuleName, AST)
+  replaceModuleAccessors mnLookup = everywhereTopDownM $ \case
+    AST.ModuleAccessor _ mn' name ->
+      let mnSafe = fromMaybe (internalError "Missing value in mnLookup") $ M.lookup mn' mnLookup
+      in (S.singleton mn', accessorString name $ AST.Var Nothing mnSafe)
+    other -> pure other
 
   -- Check that all integers fall within the valid int range for JavaScript.
   checkIntegers :: AST -> m ()
@@ -296,21 +274,6 @@ moduleBindToJs mn = bindToJs
   -- PureScript identifier.
   var :: Ident -> AST
   var = AST.Var Nothing . identToJs
-
-  -- | Generate code in the simplified JavaScript intermediate representation for an accessor based on
-  -- a PureScript identifier. If the name is not valid in JavaScript (symbol based, reserved name) an
-  -- indexer is returned.
-  moduleAccessor :: Ident -> AST -> AST
-  moduleAccessor (Ident prop) = moduleAccessorString prop
-  moduleAccessor (GenIdent _ _) = internalError "GenIdent in moduleAccessor"
-  moduleAccessor UnusedIdent = internalError "UnusedIdent in moduleAccessor"
-  moduleAccessor InternalIdent{} = internalError "InternalIdent in moduleAccessor"
-
-  moduleAccessorString :: Text -> AST -> AST
-  moduleAccessorString = accessorString . mkString . T.concatMap identCharToText
-
-  accessorString :: PSString -> AST -> AST
-  accessorString prop = AST.Indexer Nothing (AST.StringLiteral Nothing prop)
 
   -- | Generate code in the simplified JavaScript intermediate representation for a value or expression.
   valueToJs :: Expr Ann -> m AST
@@ -425,11 +388,11 @@ moduleBindToJs mn = bindToJs
   -- variable that may have a qualified name.
   qualifiedToJS :: (a -> Ident) -> Qualified a -> AST
   qualifiedToJS f (Qualified (Just C.Prim) a) = AST.Var Nothing . runIdent $ f a
-  qualifiedToJS f (Qualified (Just mn') a) | mn /= mn' = moduleAccessor (f a) (AST.Var Nothing (moduleNameToJs mn'))
+  qualifiedToJS f (Qualified (Just mn') a) | mn /= mn' = AST.ModuleAccessor Nothing mn' . mkString . T.concatMap identCharToText . runIdent $ f a
   qualifiedToJS f (Qualified _ a) = AST.Var Nothing $ identToJs (f a)
 
   foreignIdent :: Ident -> AST
-  foreignIdent ident = accessorString (mkString $ runIdent ident) (AST.Var Nothing "$foreign")
+  foreignIdent ident = accessorString (mkString $ runIdent ident) (AST.Var Nothing FFINamespace)
 
   -- | Generate code in the simplified JavaScript intermediate representation for pattern match binders
   -- and guards.
@@ -541,3 +504,9 @@ moduleBindToJs mn = bindToJs
       done'' <- go done' (index + 1) bs'
       js <- binderToJs elVar done'' binder
       return (AST.VariableIntroduction Nothing elVar (Just (AST.Indexer Nothing (AST.NumericLiteral Nothing (Left index)) (AST.Var Nothing varName))) : js)
+
+accessorString :: PSString -> AST -> AST
+accessorString prop = AST.Indexer Nothing (AST.StringLiteral Nothing prop)
+
+pattern FFINamespace :: Text
+pattern FFINamespace = "$foreign"

--- a/src/Language/PureScript/Constants/Prelude.hs
+++ b/src/Language/PureScript/Constants/Prelude.hs
@@ -300,77 +300,68 @@ pattern EQ = Qualified (Just DataOrdering) (ProperName "EQ")
 pattern GT :: Qualified (ProperName 'ConstructorName)
 pattern GT = Qualified (Just DataOrdering) (ProperName "GT")
 
-dataArray :: forall a. (IsString a) => a
-dataArray = "Data_Array"
+pattern DataArray :: ModuleName
+pattern DataArray = ModuleName "Data.Array"
 
-eff :: forall a. (IsString a) => a
-eff = "Control_Monad_Eff"
+pattern Eff :: ModuleName
+pattern Eff = ModuleName "Control.Monad.Eff"
 
-effect :: forall a. (IsString a) => a
-effect = "Effect"
+pattern Effect :: ModuleName
+pattern Effect = ModuleName "Effect"
 
-st :: forall a. (IsString a) => a
-st = "Control_Monad_ST_Internal"
+pattern ST :: ModuleName
+pattern ST = ModuleName "Control.Monad.ST.Internal"
 
-controlApplicative :: forall a. (IsString a) => a
-controlApplicative = "Control_Applicative"
+pattern ControlApplicative :: ModuleName
+pattern ControlApplicative = ModuleName "Control.Applicative"
 
-controlSemigroupoid :: forall a. (IsString a) => a
-controlSemigroupoid = "Control_Semigroupoid"
+pattern ControlSemigroupoid :: ModuleName
+pattern ControlSemigroupoid = ModuleName "Control.Semigroupoid"
 
 pattern ControlBind :: ModuleName
 pattern ControlBind = ModuleName "Control.Bind"
 
-controlBind :: forall a. (IsString a) => a
-controlBind = "Control_Bind"
+pattern ControlMonadEffUncurried :: ModuleName
+pattern ControlMonadEffUncurried = ModuleName "Control.Monad.Eff.Uncurried"
 
-controlMonadEffUncurried :: forall a. (IsString a) => a
-controlMonadEffUncurried = "Control_Monad_Eff_Uncurried"
+pattern EffectUncurried :: ModuleName
+pattern EffectUncurried = ModuleName "Effect.Uncurried"
 
-effectUncurried :: forall a. (IsString a) => a
-effectUncurried = "Effect_Uncurried"
+pattern DataBounded :: ModuleName
+pattern DataBounded = ModuleName "Data.Bounded"
 
-dataBounded :: forall a. (IsString a) => a
-dataBounded = "Data_Bounded"
+pattern DataSemigroup :: ModuleName
+pattern DataSemigroup = ModuleName "Data.Semigroup"
 
-dataSemigroup :: forall a. (IsString a) => a
-dataSemigroup = "Data_Semigroup"
+pattern DataHeytingAlgebra :: ModuleName
+pattern DataHeytingAlgebra = ModuleName "Data.HeytingAlgebra"
 
-dataHeytingAlgebra :: forall a. (IsString a) => a
-dataHeytingAlgebra = "Data_HeytingAlgebra"
+pattern DataEq :: ModuleName
+pattern DataEq = ModuleName "Data.Eq"
 
-dataEq :: forall a. (IsString a) => a
-dataEq = "Data_Eq"
+pattern DataOrd :: ModuleName
+pattern DataOrd = ModuleName "Data.Ord"
 
-dataOrd :: forall a. (IsString a) => a
-dataOrd = "Data_Ord"
+pattern DataSemiring :: ModuleName
+pattern DataSemiring = ModuleName "Data.Semiring"
 
-dataSemiring :: forall a. (IsString a) => a
-dataSemiring = "Data_Semiring"
+pattern DataRing :: ModuleName
+pattern DataRing = ModuleName "Data.Ring"
 
-dataRing :: forall a. (IsString a) => a
-dataRing = "Data_Ring"
+pattern DataEuclideanRing :: ModuleName
+pattern DataEuclideanRing = ModuleName "Data.EuclideanRing"
 
-dataEuclideanRing :: forall a. (IsString a) => a
-dataEuclideanRing = "Data_EuclideanRing"
+pattern DataFunction :: ModuleName
+pattern DataFunction = ModuleName "Data.Function"
 
-dataFunction :: forall a. (IsString a) => a
-dataFunction = "Data_Function"
-
-dataFunctionUncurried :: forall a. (IsString a) => a
-dataFunctionUncurried = "Data_Function_Uncurried"
-
-dataIntBits :: forall a. (IsString a) => a
-dataIntBits = "Data_Int_Bits"
-
-partialUnsafe :: forall a. (IsString a) => a
-partialUnsafe = "Partial_Unsafe"
+pattern DataIntBits :: ModuleName
+pattern DataIntBits = ModuleName "Data.Int.Bits"
 
 unsafePartial :: forall a. (IsString a) => a
 unsafePartial = "unsafePartial"
 
-unsafeCoerce :: forall a. (IsString a) => a
-unsafeCoerce = "Unsafe_Coerce"
+pattern UnsafeCoerce :: ModuleName
+pattern UnsafeCoerce = ModuleName "Unsafe.Coerce"
 
 unsafeCoerceFn :: forall a. (IsString a) => a
 unsafeCoerceFn = "unsafeCoerce"

--- a/src/Language/PureScript/CoreFn/Optimizer.hs
+++ b/src/Language/PureScript/CoreFn/Optimizer.hs
@@ -3,14 +3,13 @@ module Language.PureScript.CoreFn.Optimizer (optimizeCoreFn) where
 import Protolude hiding (Type)
 
 import Data.List (lookup)
-import qualified Data.Text as T
 import Language.PureScript.AST.Literals
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.CoreFn.Ann
 import Language.PureScript.CoreFn.Expr
 import Language.PureScript.CoreFn.Module
 import Language.PureScript.CoreFn.Traversals
-import Language.PureScript.Names (Ident(..), ModuleName(..), Qualified(..))
+import Language.PureScript.Names (Ident(..), Qualified(..))
 import Language.PureScript.Label
 import Language.PureScript.Types
 import qualified Language.PureScript.Constants.Prelude as C
@@ -53,10 +52,7 @@ closedRecordFields _ = Nothing
 
 optimizeDataFunctionApply :: Expr a -> Expr a
 optimizeDataFunctionApply e = case e of
-  (App a (App _ (Var _ (Qualified (Just (ModuleName mn)) (Ident fn))) x) y)
-    | mn == dataFunction && fn == C.apply -> App a x y
-    | mn == dataFunction && fn == C.applyFlipped -> App a y x
+  (App a (App _ (Var _ (Qualified (Just C.DataFunction) (Ident fn))) x) y)
+    | fn == C.apply -> App a x y
+    | fn == C.applyFlipped -> App a y x
   _ -> e
-  where
-  dataFunction :: Text
-  dataFunction = T.replace "_" "." C.dataFunction

--- a/src/Language/PureScript/CoreImp/AST.hs
+++ b/src/Language/PureScript/CoreImp/AST.hs
@@ -9,6 +9,7 @@ import Data.Text (Text)
 
 import Language.PureScript.AST (SourceSpan(..))
 import Language.PureScript.Comments
+import Language.PureScript.Names (ModuleName)
 import Language.PureScript.PSString (PSString)
 import Language.PureScript.Traversals
 
@@ -75,6 +76,8 @@ data AST
   -- ^ Function application
   | Var (Maybe SourceSpan) Text
   -- ^ Variable
+  | ModuleAccessor (Maybe SourceSpan) ModuleName PSString
+  -- ^ Value from another module
   | Block (Maybe SourceSpan) [AST]
   -- ^ A block of expressions in braces
   | VariableIntroduction (Maybe SourceSpan) Text (Maybe AST)
@@ -118,6 +121,7 @@ withSourceSpan withSpan = go where
   go (Function _ name args j) = Function ss name args j
   go (App _ j js) = App ss j js
   go (Var _ s) = Var ss s
+  go (ModuleAccessor _ s1 s2) = ModuleAccessor ss s1 s2
   go (Block _ js) = Block ss js
   go (VariableIntroduction _ name j) = VariableIntroduction ss name j
   go (Assignment _ j1 j2) = Assignment ss j1 j2
@@ -145,6 +149,7 @@ getSourceSpan = go where
   go (Function ss _ _ _) = ss
   go (App ss _ _) = ss
   go (Var ss _) = ss
+  go (ModuleAccessor ss _ _) = ss
   go (Block ss _) = ss
   go (VariableIntroduction ss _ _) = ss
   go (Assignment ss _ _) = ss

--- a/src/Language/PureScript/CoreImp/Optimizer/Common.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Common.hs
@@ -9,6 +9,7 @@ import Data.Maybe (fromMaybe)
 
 import Language.PureScript.Crash
 import Language.PureScript.CoreImp.AST
+import Language.PureScript.Names (ModuleName)
 import Language.PureScript.PSString (PSString)
 
 applyAll :: [a -> a] -> a -> a
@@ -59,10 +60,10 @@ removeFromBlock :: ([AST] -> [AST]) -> AST -> AST
 removeFromBlock go (Block ss sts) = Block ss (go sts)
 removeFromBlock _  js = js
 
-isDict :: (Text, PSString) -> AST -> Bool
-isDict (moduleName, dictName) (Indexer _ (StringLiteral _ x) (Var _ y)) =
-  x == dictName && y == moduleName
+isDict :: (ModuleName, PSString) -> AST -> Bool
+isDict (moduleName, dictName) (ModuleAccessor _ x y) =
+  x == moduleName && y == dictName
 isDict _ _ = False
 
-isDict' :: [(Text, PSString)] -> AST -> Bool
+isDict' :: [(ModuleName, PSString)] -> AST -> Bool
 isDict' xs js = any (`isDict` js) xs

--- a/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
@@ -21,6 +21,7 @@ import Data.String (IsString, fromString)
 import Data.Text (Text)
 import qualified Data.Text as T
 
+import Language.PureScript.Names (ModuleName)
 import Language.PureScript.PSString (PSString)
 import Language.PureScript.CoreImp.AST
 import Language.PureScript.CoreImp.Optimizer.Common
@@ -34,6 +35,7 @@ import qualified Language.PureScript.Constants.Prim as C
 -- Probably needs to be fixed in pretty-printer instead.
 shouldInline :: AST -> Bool
 shouldInline (Var _ _) = True
+shouldInline (ModuleAccessor _ _ _) = True
 shouldInline (NumericLiteral _ _) = True
 shouldInline (StringLiteral _ _) = True
 shouldInline (BooleanLiteral _ _) = True
@@ -98,14 +100,14 @@ inlineCommonValues = everywhere convert
     | isDict semiringInt dict && isDict fnMultiply fn = intOp ss Multiply x y
     | isDict ringInt dict && isDict fnSubtract fn = intOp ss Subtract x y
   convert other = other
-  fnZero = (C.dataSemiring, C.zero)
-  fnOne = (C.dataSemiring, C.one)
-  fnBottom = (C.dataBounded, C.bottom)
-  fnTop = (C.dataBounded, C.top)
-  fnAdd = (C.dataSemiring, C.add)
-  fnMultiply = (C.dataSemiring, C.mul)
-  fnSubtract = (C.dataRing, C.sub)
-  fnNegate = (C.dataRing, C.negate)
+  fnZero = (C.DataSemiring, C.zero)
+  fnOne = (C.DataSemiring, C.one)
+  fnBottom = (C.DataBounded, C.bottom)
+  fnTop = (C.DataBounded, C.top)
+  fnAdd = (C.DataSemiring, C.add)
+  fnMultiply = (C.DataSemiring, C.mul)
+  fnSubtract = (C.DataRing, C.sub)
+  fnNegate = (C.DataRing, C.negate)
   intOp ss op x y = Binary ss BitwiseOr (Binary ss op x y) (NumericLiteral ss (Left 0))
 
 inlineCommonOperators :: AST -> AST
@@ -156,50 +158,50 @@ inlineCommonOperators = everywhereTopDown $ applyAll $
   , binary heytingAlgebraBoolean opDisj Or
   , unary  heytingAlgebraBoolean opNot Not
 
-  , binary' C.dataIntBits C.or BitwiseOr
-  , binary' C.dataIntBits C.and BitwiseAnd
-  , binary' C.dataIntBits C.xor BitwiseXor
-  , binary' C.dataIntBits C.shl ShiftLeft
-  , binary' C.dataIntBits C.shr ShiftRight
-  , binary' C.dataIntBits C.zshr ZeroFillShiftRight
-  , unary'  C.dataIntBits C.complement BitwiseNot
+  , binary' C.DataIntBits C.or BitwiseOr
+  , binary' C.DataIntBits C.and BitwiseAnd
+  , binary' C.DataIntBits C.xor BitwiseXor
+  , binary' C.DataIntBits C.shl ShiftLeft
+  , binary' C.DataIntBits C.shr ShiftRight
+  , binary' C.DataIntBits C.zshr ZeroFillShiftRight
+  , unary'  C.DataIntBits C.complement BitwiseNot
 
-  , inlineNonClassFunction (isModFnWithDict (C.dataArray, C.unsafeIndex)) $ flip (Indexer Nothing)
+  , inlineNonClassFunction (isModFnWithDict (C.DataArray, C.unsafeIndex)) $ flip (Indexer Nothing)
   ] ++
   [ fn | i <- [0..10], fn <- [ mkFn i, runFn i ] ] ++
-  [ fn | i <- [0..10], fn <- [ mkEffFn C.controlMonadEffUncurried C.mkEffFn i, runEffFn C.controlMonadEffUncurried C.runEffFn i ] ] ++
-  [ fn | i <- [0..10], fn <- [ mkEffFn C.effectUncurried C.mkEffectFn i, runEffFn C.effectUncurried C.runEffectFn i ] ]
+  [ fn | i <- [0..10], fn <- [ mkEffFn C.ControlMonadEffUncurried C.mkEffFn i, runEffFn C.ControlMonadEffUncurried C.runEffFn i ] ] ++
+  [ fn | i <- [0..10], fn <- [ mkEffFn C.EffectUncurried C.mkEffectFn i, runEffFn C.EffectUncurried C.runEffectFn i ] ]
   where
-  binary :: (Text, PSString) -> (Text, PSString) -> BinaryOperator -> AST -> AST
+  binary :: (ModuleName, PSString) -> (ModuleName, PSString) -> BinaryOperator -> AST -> AST
   binary dict fns op = convert where
     convert :: AST -> AST
     convert (App ss (App _ (App _ fn [dict']) [x]) [y]) | isDict dict dict' && isDict fns fn = Binary ss op x y
     convert other = other
-  binary' :: Text -> PSString -> BinaryOperator -> AST -> AST
+  binary' :: ModuleName -> PSString -> BinaryOperator -> AST -> AST
   binary' moduleName opString op = convert where
     convert :: AST -> AST
     convert (App ss (App _ fn [x]) [y]) | isDict (moduleName, opString) fn = Binary ss op x y
     convert other = other
-  unary :: (Text, PSString) -> (Text, PSString) -> UnaryOperator -> AST -> AST
+  unary :: (ModuleName, PSString) -> (ModuleName, PSString) -> UnaryOperator -> AST -> AST
   unary dicts fns op = convert where
     convert :: AST -> AST
     convert (App ss (App _ fn [dict']) [x]) | isDict dicts dict' && isDict fns fn = Unary ss op x
     convert other = other
-  unary' :: Text -> PSString -> UnaryOperator -> AST -> AST
+  unary' :: ModuleName -> PSString -> UnaryOperator -> AST -> AST
   unary' moduleName fnName op = convert where
     convert :: AST -> AST
     convert (App ss fn [x]) | isDict (moduleName, fnName) fn = Unary ss op x
     convert other = other
 
   mkFn :: Int -> AST -> AST
-  mkFn = mkFn' C.dataFunctionUncurried C.mkFn $ \ss1 ss2 ss3 args js ->
+  mkFn = mkFn' C.DataFunctionUncurried C.mkFn $ \ss1 ss2 ss3 args js ->
     Function ss1 Nothing args (Block ss2 [Return ss3 js])
 
-  mkEffFn :: Text -> Text -> Int -> AST -> AST
+  mkEffFn :: ModuleName -> Text -> Int -> AST -> AST
   mkEffFn modName fnName = mkFn' modName fnName $ \ss1 ss2 ss3 args js ->
     Function ss1 Nothing args (Block ss2 [Return ss3 (App ss3 js [])])
 
-  mkFn' :: Text -> Text -> (Maybe SourceSpan -> Maybe SourceSpan -> Maybe SourceSpan -> [Text] -> AST -> AST) -> Int -> AST -> AST
+  mkFn' :: ModuleName -> Text -> (Maybe SourceSpan -> Maybe SourceSpan -> Maybe SourceSpan -> [Text] -> AST -> AST) -> Int -> AST -> AST
   mkFn' modName fnName res 0 = convert where
     convert :: AST -> AST
     convert (App _ mkFnN [Function s1 Nothing [_] (Block s2 [Return s3 js])]) | isNFn modName fnName 0 mkFnN =
@@ -217,19 +219,19 @@ inlineCommonOperators = everywhereTopDown $ applyAll $
     collectArgs m acc (Function _ Nothing [oneArg] (Block _ [Return _ ret])) = collectArgs (m - 1) (oneArg : acc) ret
     collectArgs _ _   _ = Nothing
 
-  isNFn :: Text -> Text -> Int -> AST -> Bool
-  isNFn expectMod prefix n (Indexer _ (StringLiteral _ name) (Var _ modName)) | modName == expectMod =
+  isNFn :: ModuleName -> Text -> Int -> AST -> Bool
+  isNFn expectMod prefix n (ModuleAccessor _ modName name) | modName == expectMod =
     name == fromString (T.unpack prefix <> show n)
   isNFn _ _ _ _ = False
 
   runFn :: Int -> AST -> AST
-  runFn = runFn' C.dataFunctionUncurried C.runFn App
+  runFn = runFn' C.DataFunctionUncurried C.runFn App
 
-  runEffFn :: Text -> Text -> Int -> AST -> AST
+  runEffFn :: ModuleName -> Text -> Int -> AST -> AST
   runEffFn modName fnName = runFn' modName fnName $ \ss fn acc ->
     Function ss Nothing [] (Block ss [Return ss (App ss fn acc)])
 
-  runFn' :: Text -> Text -> (Maybe SourceSpan -> AST -> [AST] -> AST) -> Int -> AST -> AST
+  runFn' :: ModuleName -> Text -> (Maybe SourceSpan -> AST -> [AST] -> AST) -> Int -> AST -> AST
   runFn' modName runFnName res n = convert where
     convert :: AST -> AST
     convert js = fromMaybe js $ go n [] js
@@ -246,8 +248,8 @@ inlineCommonOperators = everywhereTopDown $ applyAll $
     convert (App _ (App _ op' [x]) [y]) | p op' = f x y
     convert other = other
 
-  isModFnWithDict :: (Text, PSString) -> AST -> Bool
-  isModFnWithDict (m, op) (App _ (Indexer _ (StringLiteral _ op') (Var _ m')) [Var _ _]) =
+  isModFnWithDict :: (ModuleName, PSString) -> AST -> Bool
+  isModFnWithDict (m, op) (App _ (ModuleAccessor _ m' op') [Var _ _]) =
     m == m' && op == op'
   isModFnWithDict _ _ = False
 
@@ -286,126 +288,126 @@ inlineFnComposition = everywhereTopDownM convert where
   isFnComposeFlipped :: AST -> AST -> Bool
   isFnComposeFlipped dict' fn = isDict semigroupoidFn dict' && isDict fnComposeFlipped fn
 
-  fnCompose :: forall a b. (IsString a, IsString b) => (a, b)
-  fnCompose = (C.controlSemigroupoid, C.compose)
+  fnCompose :: forall a. IsString a => (ModuleName, a)
+  fnCompose = (C.ControlSemigroupoid, C.compose)
 
-  fnComposeFlipped :: forall a b. (IsString a, IsString b) => (a, b)
-  fnComposeFlipped = (C.controlSemigroupoid, C.composeFlipped)
+  fnComposeFlipped :: forall a. IsString a => (ModuleName, a)
+  fnComposeFlipped = (C.ControlSemigroupoid, C.composeFlipped)
 
 inlineUnsafeCoerce :: AST -> AST
 inlineUnsafeCoerce = everywhereTopDown convert where
-  convert (App _ (Indexer _ (StringLiteral _ unsafeCoerceFn) (Var _ unsafeCoerce)) [ comp ])
-    | unsafeCoerceFn == C.unsafeCoerceFn && unsafeCoerce == C.unsafeCoerce
+  convert (App _ (ModuleAccessor _ C.UnsafeCoerce unsafeCoerceFn) [ comp ])
+    | unsafeCoerceFn == C.unsafeCoerceFn
     = comp
   convert other = other
 
 inlineUnsafePartial :: AST -> AST
 inlineUnsafePartial = everywhereTopDown convert where
-  convert (App ss (Indexer _ (StringLiteral _ unsafePartial) (Var _ partialUnsafe)) [ comp ])
-    | unsafePartial == C.unsafePartial && partialUnsafe == C.partialUnsafe
+  convert (App ss (ModuleAccessor _ C.PartialUnsafe unsafePartial) [ comp ])
+    | unsafePartial == C.unsafePartial
     -- Apply to undefined here, the application should be optimized away
     -- if it is safe to do so
     = App ss comp [ Var ss C.undefined ]
   convert other = other
 
-semiringNumber :: forall a b. (IsString a, IsString b) => (a, b)
-semiringNumber = (C.dataSemiring, C.semiringNumber)
+semiringNumber :: forall a. IsString a => (ModuleName, a)
+semiringNumber = (C.DataSemiring, C.semiringNumber)
 
-semiringInt :: forall a b. (IsString a, IsString b) => (a, b)
-semiringInt = (C.dataSemiring, C.semiringInt)
+semiringInt :: forall a. IsString a => (ModuleName, a)
+semiringInt = (C.DataSemiring, C.semiringInt)
 
-ringNumber :: forall a b. (IsString a, IsString b) => (a, b)
-ringNumber = (C.dataRing, C.ringNumber)
+ringNumber :: forall a. IsString a => (ModuleName, a)
+ringNumber = (C.DataRing, C.ringNumber)
 
-ringInt :: forall a b. (IsString a, IsString b) => (a, b)
-ringInt = (C.dataRing, C.ringInt)
+ringInt :: forall a. IsString a => (ModuleName, a)
+ringInt = (C.DataRing, C.ringInt)
 
-euclideanRingNumber :: forall a b. (IsString a, IsString b) => (a, b)
-euclideanRingNumber = (C.dataEuclideanRing, C.euclideanRingNumber)
+euclideanRingNumber :: forall a. IsString a => (ModuleName, a)
+euclideanRingNumber = (C.DataEuclideanRing, C.euclideanRingNumber)
 
-eqNumber :: forall a b. (IsString a, IsString b) => (a, b)
-eqNumber = (C.dataEq, C.eqNumber)
+eqNumber :: forall a. IsString a => (ModuleName, a)
+eqNumber = (C.DataEq, C.eqNumber)
 
-eqInt :: forall a b. (IsString a, IsString b) => (a, b)
-eqInt = (C.dataEq, C.eqInt)
+eqInt :: forall a. IsString a => (ModuleName, a)
+eqInt = (C.DataEq, C.eqInt)
 
-eqString :: forall a b. (IsString a, IsString b) => (a, b)
-eqString = (C.dataEq, C.eqString)
+eqString :: forall a. IsString a => (ModuleName, a)
+eqString = (C.DataEq, C.eqString)
 
-eqChar :: forall a b. (IsString a, IsString b) => (a, b)
-eqChar = (C.dataEq, C.eqChar)
+eqChar :: forall a. IsString a => (ModuleName, a)
+eqChar = (C.DataEq, C.eqChar)
 
-eqBoolean :: forall a b. (IsString a, IsString b) => (a, b)
-eqBoolean = (C.dataEq, C.eqBoolean)
+eqBoolean :: forall a. IsString a => (ModuleName, a)
+eqBoolean = (C.DataEq, C.eqBoolean)
 
-ordBoolean :: forall a b. (IsString a, IsString b) => (a, b)
-ordBoolean = (C.dataOrd, C.ordBoolean)
+ordBoolean :: forall a. IsString a => (ModuleName, a)
+ordBoolean = (C.DataOrd, C.ordBoolean)
 
-ordNumber :: forall a b. (IsString a, IsString b) => (a, b)
-ordNumber = (C.dataOrd, C.ordNumber)
+ordNumber :: forall a. IsString a => (ModuleName, a)
+ordNumber = (C.DataOrd, C.ordNumber)
 
-ordInt :: forall a b. (IsString a, IsString b) => (a, b)
-ordInt = (C.dataOrd, C.ordInt)
+ordInt :: forall a. IsString a => (ModuleName, a)
+ordInt = (C.DataOrd, C.ordInt)
 
-ordString :: forall a b. (IsString a, IsString b) => (a, b)
-ordString = (C.dataOrd, C.ordString)
+ordString :: forall a. IsString a => (ModuleName, a)
+ordString = (C.DataOrd, C.ordString)
 
-ordChar :: forall a b. (IsString a, IsString b) => (a, b)
-ordChar = (C.dataOrd, C.ordChar)
+ordChar :: forall a. IsString a => (ModuleName, a)
+ordChar = (C.DataOrd, C.ordChar)
 
-semigroupString :: forall a b. (IsString a, IsString b) => (a, b)
-semigroupString = (C.dataSemigroup, C.semigroupString)
+semigroupString :: forall a. IsString a => (ModuleName, a)
+semigroupString = (C.DataSemigroup, C.semigroupString)
 
-boundedBoolean :: forall a b. (IsString a, IsString b) => (a, b)
-boundedBoolean = (C.dataBounded, C.boundedBoolean)
+boundedBoolean :: forall a. IsString a => (ModuleName, a)
+boundedBoolean = (C.DataBounded, C.boundedBoolean)
 
-heytingAlgebraBoolean :: forall a b. (IsString a, IsString b) => (a, b)
-heytingAlgebraBoolean = (C.dataHeytingAlgebra, C.heytingAlgebraBoolean)
+heytingAlgebraBoolean :: forall a. IsString a => (ModuleName, a)
+heytingAlgebraBoolean = (C.DataHeytingAlgebra, C.heytingAlgebraBoolean)
 
-semigroupoidFn :: forall a b. (IsString a, IsString b) => (a, b)
-semigroupoidFn = (C.controlSemigroupoid, C.semigroupoidFn)
+semigroupoidFn :: forall a. IsString a => (ModuleName, a)
+semigroupoidFn = (C.ControlSemigroupoid, C.semigroupoidFn)
 
-opAdd :: forall a b. (IsString a, IsString b) => (a, b)
-opAdd = (C.dataSemiring, C.add)
+opAdd :: forall a. IsString a => (ModuleName, a)
+opAdd = (C.DataSemiring, C.add)
 
-opMul :: forall a b. (IsString a, IsString b) => (a, b)
-opMul = (C.dataSemiring, C.mul)
+opMul :: forall a. IsString a => (ModuleName, a)
+opMul = (C.DataSemiring, C.mul)
 
-opEq :: forall a b. (IsString a, IsString b) => (a, b)
-opEq = (C.dataEq, C.eq)
+opEq :: forall a. IsString a => (ModuleName, a)
+opEq = (C.DataEq, C.eq)
 
-opNotEq :: forall a b. (IsString a, IsString b) => (a, b)
-opNotEq = (C.dataEq, C.notEq)
+opNotEq :: forall a. IsString a => (ModuleName, a)
+opNotEq = (C.DataEq, C.notEq)
 
-opLessThan :: forall a b. (IsString a, IsString b) => (a, b)
-opLessThan = (C.dataOrd, C.lessThan)
+opLessThan :: forall a. IsString a => (ModuleName, a)
+opLessThan = (C.DataOrd, C.lessThan)
 
-opLessThanOrEq :: forall a b. (IsString a, IsString b) => (a, b)
-opLessThanOrEq = (C.dataOrd, C.lessThanOrEq)
+opLessThanOrEq :: forall a. IsString a => (ModuleName, a)
+opLessThanOrEq = (C.DataOrd, C.lessThanOrEq)
 
-opGreaterThan :: forall a b. (IsString a, IsString b) => (a, b)
-opGreaterThan = (C.dataOrd, C.greaterThan)
+opGreaterThan :: forall a. IsString a => (ModuleName, a)
+opGreaterThan = (C.DataOrd, C.greaterThan)
 
-opGreaterThanOrEq :: forall a b. (IsString a, IsString b) => (a, b)
-opGreaterThanOrEq = (C.dataOrd, C.greaterThanOrEq)
+opGreaterThanOrEq :: forall a. IsString a => (ModuleName, a)
+opGreaterThanOrEq = (C.DataOrd, C.greaterThanOrEq)
 
-opAppend :: forall a b. (IsString a, IsString b) => (a, b)
-opAppend = (C.dataSemigroup, C.append)
+opAppend :: forall a. IsString a => (ModuleName, a)
+opAppend = (C.DataSemigroup, C.append)
 
-opSub :: forall a b. (IsString a, IsString b) => (a, b)
-opSub = (C.dataRing, C.sub)
+opSub :: forall a. IsString a => (ModuleName, a)
+opSub = (C.DataRing, C.sub)
 
-opNegate :: forall a b. (IsString a, IsString b) => (a, b)
-opNegate = (C.dataRing, C.negate)
+opNegate :: forall a. IsString a => (ModuleName, a)
+opNegate = (C.DataRing, C.negate)
 
-opDiv :: forall a b. (IsString a, IsString b) => (a, b)
-opDiv = (C.dataEuclideanRing, C.div)
+opDiv :: forall a. IsString a => (ModuleName, a)
+opDiv = (C.DataEuclideanRing, C.div)
 
-opConj :: forall a b. (IsString a, IsString b) => (a, b)
-opConj = (C.dataHeytingAlgebra, C.conj)
+opConj :: forall a. IsString a => (ModuleName, a)
+opConj = (C.DataHeytingAlgebra, C.conj)
 
-opDisj :: forall a b. (IsString a, IsString b) => (a, b)
-opDisj = (C.dataHeytingAlgebra, C.disj)
+opDisj :: forall a. IsString a => (ModuleName, a)
+opDisj = (C.DataHeytingAlgebra, C.disj)
 
-opNot :: forall a b. (IsString a, IsString b) => (a, b)
-opNot = (C.dataHeytingAlgebra, C.not)
+opNot :: forall a. IsString a => (ModuleName, a)
+opNot = (C.DataHeytingAlgebra, C.not)

--- a/tests/purs/optimize/4229.out.js
+++ b/tests/purs/optimize/4229.out.js
@@ -1,0 +1,17 @@
+import * as Data_Unit from "../Data.Unit/index.js";
+import * as Effect_Console from "../Effect.Console/index.js";
+var Control_Bind = /* #__PURE__ */ (function () {
+    function Control_Bind() {
+
+    };
+    Control_Bind.value = new Control_Bind();
+    return Control_Bind;
+})();
+var main = function __do() {
+    Data_Unit.unit;
+    return Effect_Console.log("Done")();
+};
+export {
+    Control_Bind,
+    main
+};

--- a/tests/purs/optimize/4229.purs
+++ b/tests/purs/optimize/4229.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Console (log)
+
+data X = Control_Bind
+
+main :: Effect Unit
+main = do
+  pure unit
+  log "Done"

--- a/tests/purs/optimize/Foreign.js
+++ b/tests/purs/optimize/Foreign.js
@@ -1,0 +1,1 @@
+export const foo = 42;

--- a/tests/purs/optimize/Foreign.out.js
+++ b/tests/purs/optimize/Foreign.out.js
@@ -1,0 +1,5 @@
+import * as $foreign from "./foreign.js";
+var bar = $foreign.foo;
+export {
+    bar
+};

--- a/tests/purs/optimize/Foreign.purs
+++ b/tests/purs/optimize/Foreign.purs
@@ -1,0 +1,5 @@
+module Main (bar) where
+
+foreign import foo :: Int
+
+bar = foo

--- a/tests/purs/passing/4229.purs
+++ b/tests/purs/passing/4229.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Effect.Console (log)
+import Partial.Unsafe (unsafePartial)
+
+data X = Prim
+
+f :: Partial => Int -> Int
+f 0 = 0
+
+f' = unsafePartial f
+
+main = log "Done"


### PR DESCRIPTION
This bug was triggered when modules that the compiler handles specially
are shadowed by local constructors. For example, a constructor named
`Prim` could have caused references to `Prim_1["undefined"]` to be
produced in the compiled code, leading to a reference error at run time.
Less severely, a constructor named `Control_Bind` would have caused the
compiler not to inline known monadic functions, leading to slower and
less readable compiled code.

**Description of the change**

Fixes #4229 by moving module names into the CoreImp AST and performing module renaming after inlining and optimization. This also allowed me to clean up the bifurcation of `Underscore_Module_Names` and `Dotted.Module.Names` in our Prelude constants, as a bonus.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
