### PR TITLE
Drop dependency on microlens libraries

### DIFF
--- a/CHANGELOG.d/internal_drop-microlens.md
+++ b/CHANGELOG.d/internal_drop-microlens.md
@@ -1,0 +1,1 @@
+* Drop dependency on microlens libraries

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -149,8 +149,6 @@ common defaults
     lifted-async >=0.10.2.2 && <0.11,
     lifted-base >=0.2.3.12 && <0.3,
     memory >=0.15.0 && <0.16,
-    microlens >=0.4.12.0 && <0.5,
-    microlens-platform >=0.4.2 && <0.5,
     monad-control >=1.0.3.1 && <1.1,
     monad-logger >=0.3.36 && <0.4,
     monoidal-containers >=0.6.2.0 && <0.7,

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -11,6 +11,7 @@ module Language.PureScript.Ide.Completion
 
 import           Protolude hiding ((<&>), moduleName)
 
+import           Control.Lens hiding (op, (&))
 import           Data.Aeson
 import qualified Data.Map as Map
 import qualified Data.Text as T
@@ -20,7 +21,6 @@ import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.Matcher
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
-import           Lens.Micro.Platform hiding ((&))
 
 -- | Applies the CompletionFilters and the Matcher to the given Modules
 --   and sorts the found Completions according to the Matching Score

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -8,6 +8,7 @@ module Language.PureScript.Ide.Externs
 import           Protolude hiding (to, from, (&))
 
 import           Codec.CBOR.Term as Term
+import           Control.Lens hiding (anyOf)
 import           "monad-logger" Control.Monad.Logger
 import           Data.Version (showVersion)
 import qualified Data.Text as Text
@@ -16,7 +17,6 @@ import qualified Language.PureScript.Make.Monad as Make
 import           Language.PureScript.Ide.Error (IdeError (..))
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util (properNameT)
-import           Lens.Micro.Platform
 
 readExternFile
   :: (MonadIO m, MonadError IdeError m, MonadLogger m)

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -32,6 +32,7 @@ module Language.PureScript.Ide.Imports
 
 import           Protolude hiding (moduleName)
 
+import           Control.Lens                       ((^.), (%~), ix, has)
 import           Data.List                          (findIndex, nubBy, partition)
 import qualified Data.List.NonEmpty                 as NE
 import qualified Data.Map                           as Map
@@ -46,7 +47,6 @@ import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Prim
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
-import           Lens.Micro.Platform                ((^.), (%~), ix, has)
 import           System.IO.UTF8                     (writeUTF8FileT)
 
 data Import = Import P.ModuleName P.ImportDeclarationType (Maybe P.ModuleName)

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -24,11 +24,11 @@ module Language.PureScript.Ide.Reexports
 
 import           Protolude hiding (moduleName)
 
+import           Control.Lens                  hiding (anyOf, (&))
 import qualified Data.Map                      as Map
 import qualified Language.PureScript           as P
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
-import           Lens.Micro.Platform           hiding ((&))
 
 -- | Contains the module with resolved reexports, and possible failures
 data ReexportResult a

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -41,6 +41,7 @@ import           Protolude hiding (moduleName)
 
 import           Control.Arrow
 import           Control.Concurrent.STM
+import           Control.Lens                       hiding (anyOf, op, (&))
 import           "monad-logger" Control.Monad.Logger
 import           Data.IORef
 import qualified Data.Map.Lazy                      as Map
@@ -54,7 +55,6 @@ import           Language.PureScript.Ide.Reexports
 import           Language.PureScript.Ide.SourceFile
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
-import           Lens.Micro.Platform                hiding ((&))
 import           System.Directory (getModificationTime)
 
 -- | Resets all State inside psc-ide

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -8,6 +8,7 @@ module Language.PureScript.Ide.Types where
 import           Protolude hiding (moduleName)
 
 import           Control.Concurrent.STM (TVar)
+import           Control.Lens hiding (op, (.=))
 import           Control.Monad.Fail (fail)
 import           Data.Aeson (ToJSON, FromJSON, (.=))
 import qualified Data.Aeson as Aeson
@@ -17,7 +18,6 @@ import qualified Data.Map.Lazy as M
 import qualified Language.PureScript as P
 import qualified Language.PureScript.Errors.JSON as P
 import           Language.PureScript.Ide.Filter.Declaration (DeclarationType(..))
-import           Lens.Micro.Platform hiding ((.=))
 
 type ModuleIdent = Text
 type ModuleMap a = Map P.ModuleName a

--- a/src/Language/PureScript/Ide/Usage.hs
+++ b/src/Language/PureScript/Ide/Usage.hs
@@ -8,13 +8,13 @@ module Language.PureScript.Ide.Usage
 
 import           Protolude hiding (moduleName)
 
+import           Control.Lens (preview)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Language.PureScript as P
 import           Language.PureScript.Ide.State (getAllModules, getFileState)
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
-import           Lens.Micro.Platform (preview)
 
 -- |
 -- How we find usages, given an IdeDeclaration and the module it was defined in:

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -32,6 +32,7 @@ module Language.PureScript.Ide.Util
 import           Protolude                           hiding (decodeUtf8,
                                                       encodeUtf8, to)
 
+import           Control.Lens                        hiding (op, (&))
 import           Data.Aeson
 import qualified Data.Text                           as T
 import qualified Data.Text.Lazy                      as TL
@@ -40,7 +41,6 @@ import qualified Language.PureScript                 as P
 import           Language.PureScript.Ide.Error       (IdeError(..))
 import           Language.PureScript.Ide.Logging
 import           Language.PureScript.Ide.Types
-import           Lens.Micro.Platform                 hiding ((&))
 import           System.IO.UTF8                      (readUTF8FileT)
 import           System.Directory                    (makeAbsolute)
 

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -10,6 +10,7 @@ module Language.PureScript.TypeChecker
 import Prelude.Compat
 import Protolude (headMay, maybeToLeft, ordNub)
 
+import Control.Lens ((^..), _2)
 import Control.Monad (when, unless, void, forM, zipWithM_)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Class (MonadState(..), modify, gets)
@@ -46,8 +47,6 @@ import Language.PureScript.TypeChecker.Types as T
 import Language.PureScript.TypeChecker.Unify (varIfUnknown)
 import Language.PureScript.TypeClassDictionaries
 import Language.PureScript.Types
-
-import Lens.Micro.Platform ((^..), _2)
 
 addDataType
   :: (MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -28,6 +28,7 @@ module Language.PureScript.TypeChecker.Kinds
 import Prelude.Compat
 
 import Control.Arrow ((***))
+import Control.Lens ((^.), _1, _2, _3)
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State
@@ -55,7 +56,6 @@ import Language.PureScript.TypeChecker.Skolems (newSkolemConstant, newSkolemScop
 import Language.PureScript.TypeChecker.Synonyms
 import Language.PureScript.Types
 import Language.PureScript.Pretty.Types
-import Lens.Micro.Platform ((^.), _1, _2, _3)
 
 generalizeUnknowns :: [(Unknown, SourceType)] -> SourceType -> SourceType
 generalizeUnknowns unks ty =

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -10,6 +10,7 @@ import Codec.Serialise (Serialise)
 import Control.Applicative ((<|>))
 import Control.Arrow (first, second)
 import Control.DeepSeq (NFData)
+import Control.Lens (Lens', (^.), set)
 import Control.Monad ((<=<), (>=>))
 import Data.Aeson ((.:), (.:?), (.!=), (.=))
 import qualified Data.Aeson as A
@@ -27,8 +28,6 @@ import qualified Language.PureScript.Constants.Prim as C
 import Language.PureScript.Names
 import Language.PureScript.Label (Label)
 import Language.PureScript.PSString (PSString)
-
-import Lens.Micro (Lens', (^.), set)
 
 type SourceType = Type SourceAnn
 type SourceConstraint = Constraint SourceAnn

--- a/tests/Language/PureScript/Ide/StateSpec.hs
+++ b/tests/Language/PureScript/Ide/StateSpec.hs
@@ -1,11 +1,11 @@
 module Language.PureScript.Ide.StateSpec where
 
 import           Protolude
+import           Control.Lens hiding (anyOf, (&))
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Test
 import qualified Language.PureScript as P
-import           Lens.Micro.Platform hiding ((&))
 import           Test.Hspec
 import qualified Data.Map as Map
 


### PR DESCRIPTION
**Description of the change**

Having acquired an explicit dependency on `lens` (in #4155, though it could have been #3915 if that had made it in first), as foretold in https://github.com/purescript/purescript/pull/3915#pullrequestreview-967042097, it's time to remove `microlens` and `microlens-platform`.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)