### PR TITLE
Accommodate internal initial-digit identifiers

### DIFF
--- a/CHANGELOG.d/internal_accommodate-initial-digit-idents.md
+++ b/CHANGELOG.d/internal_accommodate-initial-digit-idents.md
@@ -1,0 +1,1 @@
+* Accommodate internally-generated identifiers that start with digits

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -19,9 +19,12 @@ moduleNameToJs (ModuleName mn) =
 --
 --  * Alphanumeric characters are kept unmodified.
 --
---  * Reserved javascript identifiers are prefixed with '$$'.
+--  * Reserved javascript identifiers and identifiers starting with digits are
+--    prefixed with '$$'.
 identToJs :: Ident -> Text
-identToJs (Ident name) = anyNameToJs name
+identToJs (Ident name)
+  | not (T.null name) && isDigit (T.head name) = "$$" <> T.concatMap identCharToText name
+  | otherwise = anyNameToJs name
 identToJs (GenIdent _ _) = internalError "GenIdent in identToJs"
 identToJs UnusedIdent = unusedIdent
 identToJs (InternalIdent RuntimeLazyFactory) = "$runtime_lazy"

--- a/tests/purs/passing/CSEInitialDigitSymbols.purs
+++ b/tests/purs/passing/CSEInitialDigitSymbols.purs
@@ -1,0 +1,16 @@
+module Main where
+
+import Data.Symbol (class IsSymbol, reflectSymbol)
+import Effect.Console (log)
+import Type.Proxy (Proxy(..))
+
+reflectSymbol' :: forall s. IsSymbol s => Proxy s -> String
+reflectSymbol' = reflectSymbol
+
+two = reflectSymbol (Proxy :: _ "2")
+two2 = reflectSymbol' (Proxy :: _ "2")
+
+twoThirty = reflectSymbol (Proxy :: _ "2:30")
+twoThirty2 = reflectSymbol' (Proxy :: _ "2:30")
+
+main = log "Done"


### PR DESCRIPTION
The motivating example is the `xyzIsSymbol` style of variable name that
can be created by `CoreFn.CSE`.

**Description of the change**

Fixes issue reported [here](https://discourse.purescript.org/t/looking-for-beta-testers/3018/4). This is a fix for an issue triggered by an unreleased feature, so I didn't create a `fix` changelog entry for it, just an `internal` entry (because the fix could potentially have consequences on things other than the new feature).

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
