### PR TITLE
Enable more warnings in purescript.cabal

### DIFF
--- a/CHANGELOG.d/internal_enable-more-ghc-warnings.md
+++ b/CHANGELOG.d/internal_enable-more-ghc-warnings.md
@@ -1,0 +1,3 @@
+* Update purescript.cabal so that the PureScript compiler is built with the
+  flags -Wincomplete-uni-patterns and -Wincomplete-record-updates enabled by
+  default.

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -51,7 +51,12 @@ flag release
   default: False
 
 common defaults
-  ghc-options: -Wall
+  -- Note: -Wall-incomplete-uni-patterns and -Wincomplete-record-updates can be
+  -- removed once we upgrade to GHC 9.2.1 since they are now included in -Wall.
+  ghc-options:
+    -Wall
+    -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
   default-language: Haskell2010
   default-extensions:
     BangPatterns
@@ -403,6 +408,8 @@ test-suite tests
   type: exitcode-stdio-1.0
   hs-source-dirs: tests
   main-is: Main.hs
+  -- Not a problem for this warning to arise in tests
+  ghc-options: -Wno-incomplete-uni-patterns
   build-depends:
       purescript
     , generic-random

--- a/src/Language/PureScript/CoreImp/Optimizer/Unused.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Unused.hs
@@ -20,8 +20,11 @@ removeCodeAfterReturnStatements :: AST -> AST
 removeCodeAfterReturnStatements = everywhere (removeFromBlock go)
   where
   go :: [AST] -> [AST]
-  go jss | not (any isReturn jss) = jss
-         | otherwise = let (body, ret : _) = break isReturn jss in body ++ [ret]
+  go jss =
+    case break isReturn jss of
+      (_, []) -> jss
+      (body, ret : _ ) -> body ++ [ret]
+
   isReturn (Return _ _) = True
   isReturn (ReturnNoResult _) = True
   isReturn _ = False

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -33,7 +33,7 @@ module Language.PureScript.Ide.Imports
 import           Protolude hiding (moduleName)
 
 import           Control.Lens                       ((^.), (%~), ix, has)
-import           Data.List                          (findIndex, nubBy, partition)
+import           Data.List                          (nubBy, partition)
 import qualified Data.List.NonEmpty                 as NE
 import qualified Data.Map                           as Map
 import qualified Data.Text                          as T
@@ -256,13 +256,14 @@ addExplicitImport' decl moduleName qualifier imports =
 ideSpan :: P.SourceSpan
 ideSpan = P.internalModuleSourceSpan "<psc-ide>"
 
+-- | If none of the elements of the list satisfy the given predicate 'predicate', then prepend the default value 'def'
+-- to the given list. Otherwise, update the first element of the list that satisfies 'predicate' with the updating
+-- function 'update'.
 updateAtFirstOrPrepend :: (a -> Bool) -> (a -> a) -> a -> [a] -> [a]
-updateAtFirstOrPrepend p t d l =
-  case findIndex p l of
-    Nothing -> d : l
-    Just i ->
-      let (x, a : y) = splitAt i l
-      in x ++ [t a] ++ y
+updateAtFirstOrPrepend predicate update def xs =
+  case break predicate xs of
+    (before, []) -> def : before
+    (before, x : after) -> before ++ [update x] ++ after
 
 -- | Looks up the given identifier in the currently loaded modules.
 --

--- a/src/Language/PureScript/Sugar/Names/Env.hs
+++ b/src/Language/PureScript/Sugar/Names/Env.hs
@@ -34,6 +34,7 @@ import qualified Data.Set as S
 
 import qualified Language.PureScript.Constants.Prim as C
 import Language.PureScript.AST
+import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Errors
 import Language.PureScript.Names
@@ -488,5 +489,8 @@ checkImportConflicts ss currentModule toName xs =
         return (mnNew, mnOrig)
       _ -> throwError . errorMessage' ss $ ScopeConflict name conflictModules
     else
-      let ImportRecord (Qualified (Just mnNew) _) mnOrig _ _ = head byOrig
-      in return (mnNew, mnOrig)
+      case head byOrig of
+        ImportRecord (Qualified (Just mnNew) _) mnOrig _ _ ->
+          return (mnNew, mnOrig)
+        _ ->
+          internalError "checkImportConflicts: ImportRecord should be qualified"

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -190,8 +190,7 @@ deriveNewtype tyCon tyConArgs =
     DataDeclaration (ss', _) Data name _ _ ->
       throwError . errorMessage' ss' $ CannotDeriveNewtypeForData name
     DataDeclaration _ Newtype name args dctors -> do
-      checkNewtype name dctors
-      let (DataConstructorDeclaration _ _ [(_, ty)]) = head dctors
+      (_, (_, ty)) <- checkNewtype name dctors
       let subst = zipWith ((,) . fst) args tyConArgs
       return ([], replaceAllTypeVars subst ty)
     _ -> internalError "deriveNewtype: expected DataDeclaration"

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -282,7 +282,7 @@ typeCheckAll moduleName = traverse go
   go :: Declaration -> m Declaration
   go (DataDeclaration sa@(ss, _) dtype name args dctors) = do
     warnAndRethrow (addHint (ErrorInTypeConstructor name) . addHint (positionedError ss)) $ do
-      when (dtype == Newtype) $ checkNewtype name dctors
+      when (dtype == Newtype) $ void $ checkNewtype name dctors
       checkDuplicateTypeArguments $ map fst args
       (dataCtors, ctorKind) <- kindOfData moduleName (sa, name, args, dctors)
       let args' = args `withKinds` ctorKind
@@ -312,7 +312,7 @@ typeCheckAll moduleName = traverse go
         forM dataDeclsWithKinds $ \(_, name, args, dataCtors, _) ->
           (name, args,) <$> traverse (replaceTypeSynonymsInDataConstructor . fst) dataCtors
       for_ dataDeclsWithKinds $ \(dtype, name, args', dataCtors, ctorKind) -> do
-        when (dtype == Newtype) $ checkNewtype name (map fst dataCtors)
+        when (dtype == Newtype) $ void $ checkNewtype name (map fst dataCtors)
         checkDuplicateTypeArguments $ map fst args'
         let args'' = args' `withRoles` inferRoles' name args'
         addDataType moduleName dtype name args'' dataCtors ctorKind
@@ -584,13 +584,17 @@ typeCheckAll moduleName = traverse go
       , ..
       }
 
+-- | Check that a newtype has just one data constructor with just one field, or
+-- throw an error. If the newtype is valid, this function returns the single
+-- data constructor declaration and the single field, as a 'proof' that the
+-- newtype was indeed a valid newtype.
 checkNewtype
   :: forall m
    . MonadError MultipleErrors m
   => ProperName 'TypeName
   -> [DataConstructorDeclaration]
-  -> m ()
-checkNewtype _ [DataConstructorDeclaration _ _ [_]] = return ()
+  -> m (DataConstructorDeclaration, (Ident, SourceType))
+checkNewtype _ [decl@(DataConstructorDeclaration _ _ [field])] = return (decl, field)
 checkNewtype name _ = throwError . errorMessage $ InvalidNewtype name
 
 -- |

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -22,13 +22,14 @@ import Data.Either (lefts, partitionEithers)
 import Data.Foldable (for_, fold, toList)
 import Data.Function (on)
 import Data.Functor (($>))
-import Data.List (delete, findIndices, groupBy, minimumBy, nubBy, sortOn, tails)
+import Data.List (delete, findIndices, minimumBy, nubBy, sortOn, tails)
 import Data.Maybe (catMaybes, fromMaybe, listToMaybe, mapMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Traversable (for)
 import Data.Text (Text, stripPrefix, stripSuffix)
 import qualified Data.Text as T
+import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NEL
 
 import Language.PureScript.AST
@@ -91,7 +92,7 @@ type TypeClassDict = TypeClassDictionaryInScope Evidence
 -- | The 'InstanceContext' tracks those constraints which can be satisfied.
 type InstanceContext = M.Map (Maybe ModuleName)
                          (M.Map (Qualified (ProperName 'ClassName))
-                           (M.Map (Qualified Ident) (NEL.NonEmpty NamedDict)))
+                           (M.Map (Qualified Ident) (NonEmpty NamedDict)))
 
 -- | A type substitution which makes an instance head match a list of types.
 --
@@ -258,11 +259,12 @@ entails SolverOptions{..} constraint context hints =
             dicts <- lift . lift $ forClassNameM env (combineContexts context inferred) className' kinds'' tys''
 
             let (catMaybes -> ambiguous, instances) = partitionEithers $ do
-                  chain <- groupBy ((==) `on` tcdChain) $
+                  chain :: NonEmpty TypeClassDict <-
+                           NEL.groupBy ((==) `on` tcdChain) $
                            sortOn (tcdChain &&& tcdIndex)
                            dicts
                   -- process instances in a chain in index order
-                  let found = for (init $ tails chain) $ \(tcd:tl) ->
+                  let found = for (tails1 chain) $ \(tcd :| tl) ->
                                 -- Make sure the type unifies with the type in the type instance definition
                                 case matches typeClassDependencies tcd tys'' of
                                   Apart        -> Right ()                   -- keep searching
@@ -863,3 +865,19 @@ pairwiseM :: Applicative m => (a -> a -> m ()) -> [a] -> m ()
 pairwiseM _ [] = pure ()
 pairwiseM _ [_] = pure ()
 pairwiseM p (x : xs) = traverse (p x) xs *> pairwiseM p xs
+
+-- | Return all nonempty tails of a nonempty list. For example:
+--
+-- tails1 (fromList [1]) == fromList [fromList [1]]
+-- tails1 (fromList [1,2]) == fromList [fromList [1,2], fromList [2]]
+-- tails1 (fromList [1,2,3]) == fromList [fromList [1,2,3], fromList [2,3], fromList [3]]
+tails1 :: NonEmpty a -> NonEmpty (NonEmpty a)
+tails1 =
+  -- NEL.fromList is an unsafe function, but this usage should be safe, since:
+  -- * `tails xs = [xs, tail xs, tail (tail xs), ..., []]`
+  -- * If `xs` is nonempty, it follows that `tails xs` contains at least one nonempty
+  --   list, since `head (tails xs) = xs`.
+  -- * The only empty element of `tails xs` is the last one (by the definition of `tails`)
+  -- * Therefore, if we take all but the last element of `tails xs` i.e.
+  --   `init (tails xs)`, we have a nonempty list of nonempty lists
+  NEL.fromList . map NEL.fromList . init . tails . NEL.toList

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -866,7 +866,7 @@ pairwiseM _ [] = pure ()
 pairwiseM _ [_] = pure ()
 pairwiseM p (x : xs) = traverse (p x) xs *> pairwiseM p xs
 
--- | Return all nonempty tails of a nonempty list. For example:
+-- | Return all nonempty suffixes of a nonempty list. For example:
 --
 -- tails1 (fromList [1]) == fromList [fromList [1]]
 -- tails1 (fromList [1,2]) == fromList [fromList [1,2], fromList [2]]
@@ -874,10 +874,14 @@ pairwiseM p (x : xs) = traverse (p x) xs *> pairwiseM p xs
 tails1 :: NonEmpty a -> NonEmpty (NonEmpty a)
 tails1 =
   -- NEL.fromList is an unsafe function, but this usage should be safe, since:
-  -- * `tails xs = [xs, tail xs, tail (tail xs), ..., []]`
-  -- * If `xs` is nonempty, it follows that `tails xs` contains at least one nonempty
-  --   list, since `head (tails xs) = xs`.
-  -- * The only empty element of `tails xs` is the last one (by the definition of `tails`)
-  -- * Therefore, if we take all but the last element of `tails xs` i.e.
-  --   `init (tails xs)`, we have a nonempty list of nonempty lists
+  --
+  --     * `tails xs = [xs, tail xs, tail (tail xs), ..., []]`
+  --
+  --     * If `xs` is nonempty, it follows that `tails xs` contains at least one nonempty
+  --       list, since `head (tails xs) = xs`.
+  --
+  --     * The only empty element of `tails xs` is the last one (by the definition of `tails`)
+  --
+  --     * Therefore, if we take all but the last element of `tails xs` i.e.
+  --       `init (tails xs)`, we have a nonempty list of nonempty lists
   NEL.fromList . map NEL.fromList . init . tails . NEL.toList


### PR DESCRIPTION
This enables -Wincomplete-uni-patterns and -Wincomplete-record-updates
by default. They are both good warnings to have on, as they help
identify situations where code is likely to result in an error at
runtime.

-Wincomplete-uni-patterns causes a warning to be emitted for things like
this:

    head = \(x:_) -> x

which would blow up at runtime if given an empty list.

-Wincomplete-record-updates causes a warning to be emitted for code like
this:

    data Foo = Foo { x :: Int }
             | Bar

    f :: Foo -> Foo
    f foo = foo { x = 6 }

which will blow up if you try to call `f Bar`, since only the `Foo`
constructor has the `x` field. (This one isn't triggered by any of our
code at the moment, thankfully).

The reason I'm sending this now is that as of version 9.2.1, GHC
includes these two warnings as part of -Wall by default, which means
that in order to upgrade, we'd need to either rework our code to stop
emitting them, or explicitly turn them off. The former seems more
appealing to me.

Another nice consequence of this is that some functions become more
efficient, as we remove unnecessary extra traversals of lists in a
couple of cases.

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
