### PR TITLE
Qualify types as necessary in errors and warnings

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -331,6 +331,7 @@ library
     Language.PureScript.Sugar.Names.Env
     Language.PureScript.Sugar.Names.Exports
     Language.PureScript.Sugar.Names.Imports
+    Language.PureScript.Sugar.Names.Requalify
     Language.PureScript.Sugar.ObjectWildcards
     Language.PureScript.Sugar.Operators
     Language.PureScript.Sugar.Operators.Binders

--- a/src/Language/PureScript/Names.hs
+++ b/src/Language/PureScript/Names.hs
@@ -124,7 +124,7 @@ isPlainIdent _ = False
 -- Operator alias names.
 --
 newtype OpName (a :: OpNameType) = OpName { runOpName :: Text }
-  deriving (Show, Eq, Ord, Generic)
+  deriving (Show, Read, Eq, Ord, Generic)
 
 instance NFData (OpName a)
 instance Serialise (OpName a)
@@ -153,7 +153,7 @@ coerceOpName = OpName . runOpName
 -- Proper names, i.e. capitalized names for e.g. module names, type//data constructors.
 --
 newtype ProperName (a :: ProperNameType) = ProperName { runProperName :: Text }
-  deriving (Show, Eq, Ord, Generic)
+  deriving (Show, Read, Eq, Ord, Generic)
 
 instance NFData (ProperName a)
 instance Serialise (ProperName a)
@@ -185,7 +185,7 @@ coerceProperName = ProperName . runProperName
 -- Module names
 --
 newtype ModuleName = ModuleName Text
-  deriving (Show, Eq, Ord, Generic)
+  deriving (Show, Read, Eq, Ord, Generic)
   deriving newtype Serialise
 
 instance NFData ModuleName

--- a/src/Language/PureScript/Sugar/Names/Requalify.hs
+++ b/src/Language/PureScript/Sugar/Names/Requalify.hs
@@ -1,0 +1,127 @@
+-- | This module provides functions for "re-qualifying" names in a type given
+-- an Imports record, so that they can be displayed unambiguously in
+-- diagnostics and suggestions without unnecessary qualification. That is,
+-- given a fully qualified name like `Foo.Bar.X`, this module lets you go to
+-- simply `X` (no qualification) if the given Imports record includes an open
+-- import for `X` from `Foo.Bar`, or alternatively if `Foo.Bar` is imported
+-- like `import Foo.Bar as F` then it produces `F.X`.
+module Language.PureScript.Sugar.Names.Requalify
+  ( ReverseImports(..)
+  , buildReverseImports
+  , requalify
+  ) where
+
+import Debug.Trace
+import Prelude.Compat
+import Control.Monad
+import qualified Data.Map as M
+import Data.Maybe
+import Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import qualified Language.PureScript.Constants.Prim as Prim
+import Language.PureScript.Names
+import Language.PureScript.Types
+import Language.PureScript.Sugar.Names.Env
+
+type ReverseImportMap a = M.Map (ModuleName, a) (Maybe ModuleName)
+
+-- | Like an Imports record, except this only contains type and type operator
+-- names, and is reversed - while an Imports record maps local names to fully
+-- qualified names, this data type maps fully qualified names to local names.
+-- This enables 'requalifying' qualified names with their locally qualified
+-- names if any, or no qualification if they were imported open
+data ReverseImports = ReverseImports
+  { reverseImportsTypes :: ReverseImportMap (ProperName 'TypeName)
+  , reverseImportsTypeOps :: ReverseImportMap (OpName 'TypeOpName)
+  }
+  deriving (Show, Read)
+
+buildReverseImports :: Imports -> ReverseImports
+buildReverseImports Imports { importedTypes, importedTypeOps } =
+  trace (show revimps) revimps
+  where
+  revimps = ReverseImports
+    { reverseImportsTypes =
+        M.fromListWith preferShortest $
+          mapMaybe (toReverseAssoc typeExceptions) $
+            M.toList importedTypes
+    , reverseImportsTypeOps =
+        M.fromListWith preferShortest $
+          mapMaybe (toReverseAssoc typeOpExceptions) $
+            M.toList importedTypeOps
+    }
+
+  preferShortest :: Maybe ModuleName -> Maybe ModuleName -> Maybe ModuleName
+  preferShortest mx my = do
+    x <- mx
+    y <- my
+    Just $
+      if T.length (runModuleName x) > T.length (runModuleName y)
+        then x
+        else y
+
+  -- | Given an entry from an ImportMap from an Imports (see Sugar.Names.Env)
+  -- which maps a local name to a fully qualified name, produce an entry for
+  -- the corresponding ReverseImports.
+  --
+  -- TODO does this need to care about situations where this is ambiguous i.e.
+  -- there are two different declarations that a given name could refer to? I
+  -- think the answer is yes. Eg:
+  --
+  -- import Foo as X
+  -- import Bar as X
+  --
+  -- is fine, as long as you don't do X.whatever for anything that both modules
+  -- export
+  --
+  -- We make exceptions for anything that has special cases in the type
+  -- pretty-printer such as Record and Function
+  toReverseAssoc :: Ord a => Set (Qualified a) -> (Qualified a, [ImportRecord a]) -> Maybe ((ModuleName, a), Maybe ModuleName)
+  toReverseAssoc exceptions (Qualified localModName name, importRecords) =
+    case importRecords of
+      [] ->
+        -- Probably shouldn't happen
+        Nothing
+      (ImportRecord { importName = importName@(Qualified mFullModName _) } : _) -> do
+        guard (not (Set.member importName exceptions))
+        -- TODO need to check the whole list including provenance? eg in the
+        -- case of two open imports with overlap and we're warning but it still
+        -- compiles
+        fullModName <- mFullModName
+        pure ((fullModName, name), localModName)
+
+  typeExceptions :: Set (Qualified (ProperName 'TypeName))
+  typeExceptions = Set.fromList
+    [ Prim.Function
+    , Prim.Record
+    , fmap coerceProperName Prim.Fail
+    ]
+
+  typeOpExceptions :: Set (Qualified (OpName 'TypeOpName))
+  typeOpExceptions = Set.empty
+
+-- | This module provides functions for "re-qualifying" names in a type given
+-- an Imports record, so that they can be displayed unambiguously in
+-- diagnostics and suggestions without unnecessary qualification. That is,
+-- given a fully qualified name like `Foo.Bar.X`, this module lets you go to
+-- simply `X` (no qualification) if the given Imports record includes an open
+-- import for `X` from `Foo.Bar`, or alternatively if `Foo.Bar` is imported
+-- like `import Foo.Bar as F` then it produces `F.X`.
+requalify :: ReverseImports -> Type a -> Type a
+requalify ReverseImports { reverseImportsTypes, reverseImportsTypeOps } =
+  everywhereOnTypes $ \ty -> fromMaybe ty $ case ty of
+    TypeConstructor ann fullyQualifiedName ->
+      fmap (TypeConstructor ann) $
+        reverseLookup reverseImportsTypes fullyQualifiedName
+    TypeOp ann fullyQualifiedName -> do
+      fmap (TypeOp ann) $
+        reverseLookup reverseImportsTypeOps fullyQualifiedName
+    _ ->
+      Nothing
+  where
+  reverseLookup :: Ord a => ReverseImportMap a -> Qualified a -> Maybe (Qualified a)
+  reverseLookup revMap (Qualified mFullModName name) = do
+    fullModName <- mFullModName
+    mLocalModName <- M.lookup (fullModName, name) revMap
+    pure $ Qualified mLocalModName name

--- a/tests/purs/failing/1570.out
+++ b/tests/purs/failing/1570.out
@@ -8,9 +8,9 @@ at tests/purs/failing/1570.purs:6:10 - 6:16 (line 6, column 10 - line 6, column 
   [33m  F[0m
   [33m   [0m
   having the kind
-  [33m              [0m
-  [33m  Type -> Type[0m
-  [33m              [0m
+  [33m                        [0m
+  [33m  Prim.Type -> Prim.Type[0m
+  [33m                        [0m
   instead.
 
 while inferring the type of [33m\$0 ->      [0m

--- a/tests/purs/failing/2567.out
+++ b/tests/purs/failing/2567.out
@@ -2,10 +2,10 @@ Error found:
 in module [33mMain[0m
 at tests/purs/failing/2567.purs:7:8 - 7:67 (line 7, column 8 - line 7, column 67)
 
-  A custom type error occurred while solving type class constraints:
-
-    This constraint should be checked
-
+  No type class instance was found for
+  [33m                                                                [0m
+  [33m  Prim.TypeError.Fail (Text "This constraint should be checked")[0m
+  [33m                                                                [0m
 
 while checking that type [33mFail (Text "This constraint should be checked") => Int[0m
   is at least as general as type [33mInt[0m

--- a/tests/purs/failing/3275-BindingGroupErrorPos.out
+++ b/tests/purs/failing/3275-BindingGroupErrorPos.out
@@ -8,7 +8,7 @@ at tests/purs/failing/3275-BindingGroupErrorPos.purs:11:17 - 11:23 (line 11, col
   [33m      [0m
   with kind
   [33m            [0m
-  [33m  Type -> t3[0m
+  [33m  Type -> t0[0m
   [33m            [0m
 
 while checking that type [33mResult[0m

--- a/tests/purs/failing/3275-DataBindingGroupErrorPos.out
+++ b/tests/purs/failing/3275-DataBindingGroupErrorPos.out
@@ -7,9 +7,9 @@ at tests/purs/failing/3275-DataBindingGroupErrorPos.purs:7:19 - 7:22 (line 7, co
   [33m  Type[0m
   [33m      [0m
   with kind
-  [33m            [0m
-  [33m  t10 -> t11[0m
-  [33m            [0m
+  [33m          [0m
+  [33m  t0 -> t1[0m
+  [33m          [0m
 
 while checking that type [33mBar a[0m
   has kind [33mt0 -> t1[0m

--- a/tests/purs/failing/3531-5.out
+++ b/tests/purs/failing/3531-5.out
@@ -9,7 +9,7 @@ at tests/purs/failing/3531-5.purs:16:7 - 16:27 (line 16, column 7 - line 16, col
   [33m           [0m
   The following instance partially overlaps the above constraint, which means the rest of its instance chain will not be considered:
 
-    instance in module [33mMain[0m with type [33mforall a. C String (Array a)[0m (line 9, column 1 - line 10, column 15)
+    instance in module [33mMain[0m with type [33mforall a. Main.C Prim.String (Prim.Array a)[0m (line 9, column 1 - line 10, column 15)
 
 
 while applying a function [33mc[0m

--- a/tests/purs/failing/3531-6.out
+++ b/tests/purs/failing/3531-6.out
@@ -9,8 +9,8 @@ at tests/purs/failing/3531-6.purs:21:7 - 21:27 (line 21, column 7 - line 21, col
   [33m           [0m
   The following instances partially overlap the above constraint, which means the rest of their instance chains will not be considered:
 
-    instance in module [33mMain[0m with type [33mforall a. C String (Array a)[0m (line 9, column 1 - line 10, column 15)
-    instance in module [33mMain[0m with type [33mC Int Int[0m (line 14, column 1 - line 15, column 15)
+    instance in module [33mMain[0m with type [33mforall a. Main.C Prim.String (Prim.Array a)[0m (line 9, column 1 - line 10, column 15)
+    instance in module [33mMain[0m with type [33mMain.C Prim.Int Prim.Int[0m (line 14, column 1 - line 15, column 15)
 
 
 while applying a function [33mc[0m

--- a/tests/purs/failing/3765-kinds.out
+++ b/tests/purs/failing/3765-kinds.out
@@ -5,13 +5,13 @@ at tests/purs/failing/3765-kinds.purs:7:28 - 7:29 (line 7, column 28 - line 7, c
   Could not match kind
   [33m            [0m
   [33m  ( a :: Int[0m
-  [33m  | t11     [0m
+  [33m  | t0      [0m
   [33m  )         [0m
   [33m            [0m
   with kind
   [33m            [0m
   [33m  ( b :: Int[0m
-  [33m  | t11     [0m
+  [33m  | t0      [0m
   [33m  )         [0m
   [33m            [0m
 

--- a/tests/purs/failing/CoercibleKindMismatch.out
+++ b/tests/purs/failing/CoercibleKindMismatch.out
@@ -7,9 +7,9 @@ at tests/purs/failing/CoercibleKindMismatch.purs:15:17 - 15:23 (line 15, column 
   [33m  Type[0m
   [33m      [0m
   with kind
-  [33m             [0m
-  [33m  t29 -> Type[0m
-  [33m             [0m
+  [33m            [0m
+  [33m  t2 -> Type[0m
+  [33m            [0m
 
 while solving type class constraint
 [33m                                                                    [0m

--- a/tests/purs/failing/DiffKindsSameName.out
+++ b/tests/purs/failing/DiffKindsSameName.out
@@ -3,13 +3,13 @@ in module [33mDiffKindsSameName[0m
 at tests/purs/failing/DiffKindsSameName.purs:13:18 - 13:31 (line 13, column 18 - line 13, column 31)
 
   Could not match kind
-  [33m          [0m
-  [33m  DemoKind[0m
-  [33m          [0m
+  [33m               [0m
+  [33m  LibB.DemoKind[0m
+  [33m               [0m
   with kind
-  [33m          [0m
-  [33m  DemoKind[0m
-  [33m          [0m
+  [33m               [0m
+  [33m  LibA.DemoKind[0m
+  [33m               [0m
 
 while checking that type [33mDemoData[0m
   has kind [33mDemoKind[0m

--- a/tests/purs/failing/DoNotSuggestComposition2.out
+++ b/tests/purs/failing/DoNotSuggestComposition2.out
@@ -3,13 +3,13 @@ in module [33mDoNotSuggestComposition2[0m
 at tests/purs/failing/DoNotSuggestComposition2.purs:7:27 - 7:30 (line 7, column 27 - line 7, column 30)
 
   Could not match type
-  [33m        [0m
-  [33m  Record[0m
-  [33m        [0m
+  [33m             [0m
+  [33m  Prim.Record[0m
+  [33m             [0m
   with type
-  [33m              [0m
-  [33m  Function Int[0m
-  [33m              [0m
+  [33m                   [0m
+  [33m  Prim.Function Int[0m
+  [33m                   [0m
 
 while trying to match type [33m{ y :: Int[0m
                            [33m}         [0m

--- a/tests/purs/failing/InfiniteKind2.out
+++ b/tests/purs/failing/InfiniteKind2.out
@@ -3,9 +3,9 @@ in module [33mInfiniteKind2[0m
 at tests/purs/failing/InfiniteKind2.purs:5:23 - 5:27 (line 5, column 23 - line 5, column 27)
 
   An infinite kind was inferred for a type:
-  [33m                    [0m
-  [33m  (t5 -> t6) -> Type[0m
-  [33m                    [0m
+  [33m                         [0m
+  [33m  (t5 -> t6) -> Prim.Type[0m
+  [33m                         [0m
 
 while checking that type [33mTree[0m
   has kind [33mt0[0m

--- a/tests/purs/failing/InvalidCoercibleInstanceDeclaration.out
+++ b/tests/purs/failing/InvalidCoercibleInstanceDeclaration.out
@@ -2,10 +2,10 @@ Error found:
 at tests/purs/failing/InvalidCoercibleInstanceDeclaration.purs:8:1 - 8:36 (line 8, column 1 - line 8, column 36)
 
   Invalid type class instance declaration for
-  [33m                         [0m
-  [33m  Prim.Coerce.Coercible D[0m
-  [33m                        D[0m
-  [33m                         [0m
+  [33m                              [0m
+  [33m  Prim.Coerce.Coercible Main.D[0m
+  [33m                        Main.D[0m
+  [33m                              [0m
   Instance declarations of this type class are disallowed.
 
 

--- a/tests/purs/failing/KindError.out
+++ b/tests/purs/failing/KindError.out
@@ -8,7 +8,7 @@ at tests/purs/failing/KindError.purs:6:35 - 6:36 (line 6, column 35 - line 6, co
   [33m      [0m
   with kind
   [33m          [0m
-  [33m  t8 -> t9[0m
+  [33m  t0 -> t1[0m
   [33m          [0m
 
 while checking that type [33mf[0m

--- a/tests/purs/failing/KindStar.out
+++ b/tests/purs/failing/KindStar.out
@@ -8,9 +8,9 @@ at tests/purs/failing/KindStar.purs:7:1 - 7:13 (line 7, column 1 - line 7, colum
   [33m  List[0m
   [33m      [0m
   having the kind
-  [33m              [0m
-  [33m  Type -> Type[0m
-  [33m              [0m
+  [33m                        [0m
+  [33m  Prim.Type -> Prim.Type[0m
+  [33m                        [0m
   instead.
 
 in value declaration [33mtest[0m

--- a/tests/purs/failing/MissingClassMember.out
+++ b/tests/purs/failing/MissingClassMember.out
@@ -2,8 +2,8 @@ Error found:
 at tests/purs/failing/MissingClassMember.purs:9:1 - 10:10 (line 9, column 1 - line 10, column 10)
 
   The following type class members have not been implemented:
-  [33mb :: String -> Number[0m
-  [33mc :: forall f. String -> f String[0m
+  [33mb :: Prim.String -> Prim.Number[0m
+  [33mc :: forall f. Prim.String -> f Prim.String[0m
 
 in type class instance
 [33m               [0m

--- a/tests/purs/failing/OverlapAcrossModulesUnnamedInstance.out
+++ b/tests/purs/failing/OverlapAcrossModulesUnnamedInstance.out
@@ -10,7 +10,7 @@ at tests/purs/failing/OverlapAcrossModulesUnnamedInstance.purs:6:1 - 6:15 (line 
   The following instances were found:
 
     [33mOverlapAcrossModules.X.cX[0m
-    instance in module [33mOverlapAcrossModules[0m with type [33mC X Y[0m (line 6, column 1 - line 6, column 15)
+    instance in module [33mOverlapAcrossModules[0m with type [33mOverlapAcrossModules.Class.C X Y[0m (line 6, column 1 - line 6, column 15)
 
 
 in type class instance

--- a/tests/purs/failing/OverlappingUnnamedInstances.out
+++ b/tests/purs/failing/OverlappingUnnamedInstances.out
@@ -8,8 +8,8 @@ at tests/purs/failing/OverlappingUnnamedInstances.purs:10:1 - 11:13 (line 10, co
   [33m               [0m
   The following instances were found:
 
-    instance in module [33mMain[0m with type [33mforall a. Test a[0m (line 7, column 1 - line 8, column 13)
-    instance in module [33mMain[0m with type [33mTest Int[0m (line 10, column 1 - line 11, column 13)
+    instance in module [33mMain[0m with type [33mforall a. Main.Test a[0m (line 7, column 1 - line 8, column 13)
+    instance in module [33mMain[0m with type [33mMain.Test Int[0m (line 10, column 1 - line 11, column 13)
 
 
 in type class instance

--- a/tests/purs/failing/PolykindUnnamedInstanceOverlapping.out
+++ b/tests/purs/failing/PolykindUnnamedInstanceOverlapping.out
@@ -8,8 +8,8 @@ at tests/purs/failing/PolykindUnnamedInstanceOverlapping.purs:12:1 - 13:19 (line
   [33m                      [0m
   The following instances were found:
 
-    instance in module [33mMain[0m with type [33mforall a. ShowP (Proxy a)[0m (line 9, column 1 - line 10, column 19)
-    instance in module [33mMain[0m with type [33mforall a. ShowP (Proxy a)[0m (line 12, column 1 - line 13, column 19)
+    instance in module [33mMain[0m with type [33mforall a. Main.ShowP (Proxy a)[0m (line 9, column 1 - line 10, column 19)
+    instance in module [33mMain[0m with type [33mforall a. Main.ShowP (Proxy a)[0m (line 12, column 1 - line 13, column 19)
 
 
 in type class instance

--- a/tests/purs/failing/ProgrammablePolykindedTypeErrorsTypeString.out
+++ b/tests/purs/failing/ProgrammablePolykindedTypeErrorsTypeString.out
@@ -2,10 +2,10 @@ Error found:
 in module [33mMain[0m
 at tests/purs/failing/ProgrammablePolykindedTypeErrorsTypeString.purs:23:7 - 23:17 (line 23, column 7 - line 23, column 17)
 
-  A custom type error occurred while solving type class constraints:
-
-    Don't want to show Just @Type String because.
-
+  No type class instance was found for
+  [33m                                                                                                              [0m
+  [33m  Prim.TypeError.Fail (Beside (Beside (Text "Don\'t want to show ") (Quote (Just String))) (Text " because."))[0m
+  [33m                                                                                                              [0m
 
 while checking that type [33mFail (Beside (Beside (Text "Don\'t want to show ") (... ...)) (Text " because.")) => String[0m
   is at least as general as type [33mString[0m

--- a/tests/purs/failing/ProgrammableTypeErrors.out
+++ b/tests/purs/failing/ProgrammableTypeErrors.out
@@ -2,10 +2,10 @@ Error found:
 in module [33mMain[0m
 at tests/purs/failing/ProgrammableTypeErrors.purs:17:13 - 17:27 (line 17, column 13 - line 17, column 27)
 
-  A custom type error occurred while solving type class constraints:
-
-    Cannot show functions
-
+  No type class instance was found for
+  [33m                                                    [0m
+  [33m  Prim.TypeError.Fail (Text "Cannot show functions")[0m
+  [33m                                                    [0m
 
 while solving type class constraint
 [33m                          [0m

--- a/tests/purs/failing/ProgrammableTypeErrorsTypeString.out
+++ b/tests/purs/failing/ProgrammableTypeErrorsTypeString.out
@@ -2,10 +2,10 @@ Error found:
 in module [33mMain[0m
 at tests/purs/failing/ProgrammableTypeErrorsTypeString.purs:24:9 - 24:24 (line 24, column 9 - line 24, column 24)
 
-  A custom type error occurred while solving type class constraints:
-
-    Don't want to show MyType Int because.
-
+  No type class instance was found for
+  [33m                                                                                                             [0m
+  [33m  Prim.TypeError.Fail (Beside (Beside (Text "Don\'t want to show ") (Quote (MyType Int))) (Text " because."))[0m
+  [33m                                                                                                             [0m
 
 while solving type class constraint
 [33m                             [0m

--- a/tests/purs/failing/RowsInKinds.out
+++ b/tests/purs/failing/RowsInKinds.out
@@ -5,7 +5,7 @@ at tests/purs/failing/RowsInKinds.purs:14:16 - 14:17 (line 14, column 16 - line 
   Could not match kind
   [33m             [0m
   [33m  ( z :: Type[0m
-  [33m  | t25      [0m
+  [33m  | t0       [0m
   [33m  )          [0m
   [33m             [0m
   with kind
@@ -22,6 +22,8 @@ while checking that type [33mZ[0m
            [33m  )          [0m
 while inferring the kind of [33mP Z[0m
 in type synonym [33mTest3[0m
+
+where [33mt0[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/KindsDoNotUnify.md for more information,
 or to contribute content related to this error.

--- a/tests/purs/failing/SkolemEscape.out
+++ b/tests/purs/failing/SkolemEscape.out
@@ -7,9 +7,9 @@ at tests/purs/failing/SkolemEscape.purs:8:1 - 8:19 (line 8, column 1 - line 8, c
     tests/purs/failing/SkolemEscape.purs:8:18 - 8:19 (line 8, column 18 - line 8, column 19)
 
   has escaped its scope, appearing in the type
-  [33m                      [0m
-  [33m  (a0 -> a0) -> Number[0m
-  [33m                      [0m
+  [33m                           [0m
+  [33m  (a0 -> a0) -> Prim.Number[0m
+  [33m                           [0m
 
 in the expression [33m[33m\x ->  [0m[0m
                   [33m[33m  foo x[0m[0m

--- a/tests/purs/failing/SkolemEscape2.out
+++ b/tests/purs/failing/SkolemEscape2.out
@@ -7,9 +7,9 @@ at tests/purs/failing/SkolemEscape2.purs:9:1 - 11:9 (line 9, column 1 - line 11,
     tests/purs/failing/SkolemEscape2.purs:10:21 - 10:34 (line 10, column 21 - line 10, column 34)
 
   has escaped its scope, appearing in the type
-  [33m                         [0m
-  [33m  t1 -> t2 (STRef r0 Int)[0m
-  [33m                         [0m
+  [33m                                                        [0m
+  [33m  t1 -> t2 (Control.Monad.ST.Internal.STRef r0 Prim.Int)[0m
+  [33m                                                        [0m
 
 in the expression [33m[33m\$0 ->                                        [0m[0m
                   [33m[33m  ((bind $dictBind1) ((...) (...))) (\r ->    [0m[0m

--- a/tests/purs/failing/SkolemEscapeKinds.out
+++ b/tests/purs/failing/SkolemEscapeKinds.out
@@ -7,9 +7,9 @@ at tests/purs/failing/SkolemEscapeKinds.purs:8:10 - 8:17 (line 8, column 10 - li
     tests/purs/failing/SkolemEscapeKinds.purs:8:16 - 8:17 (line 8, column 16 - line 8, column 17)
 
   has escaped its scope, appearing in the type
-  [33m       [0m
-  [33m  Proxy[0m
-  [33m       [0m
+  [33m            [0m
+  [33m  Main.Proxy[0m
+  [33m            [0m
 
 in type synonym [33mB[0m
 

--- a/tests/purs/failing/SuggestComposition.out
+++ b/tests/purs/failing/SuggestComposition.out
@@ -3,13 +3,13 @@ in module [33mSuggestComposition[0m
 at tests/purs/failing/SuggestComposition.purs:7:5 - 7:6 (line 7, column 5 - line 7, column 6)
 
   Could not match type
-  [33m        [0m
-  [33m  Record[0m
-  [33m        [0m
+  [33m             [0m
+  [33m  Prim.Record[0m
+  [33m             [0m
   with type
-  [33m              [0m
-  [33m  Function Int[0m
-  [33m              [0m
+  [33m                   [0m
+  [33m  Prim.Function Int[0m
+  [33m                   [0m
 
 while trying to match type [33m{ g :: t0[0m
                            [33m| t1     [0m

--- a/tests/purs/failing/TypeQualification1.out
+++ b/tests/purs/failing/TypeQualification1.out
@@ -1,0 +1,22 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/TypeQualification1.purs:10:6 - 10:13 (line 10, column 6 - line 10, column 13)
+
+  Could not match type
+  [33m        [0m
+  [33m  String[0m
+  [33m        [0m
+  with type
+  [33m      [0m
+  [33m  L1.X[0m
+  [33m      [0m
+
+while checking that type [33mString[0m
+  is at least as general as type [33mX[0m
+while checking that expression [33m"wrong"[0m
+  has type [33mX[0m
+in value declaration [33mx1[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/TypeQualification1.purs
+++ b/tests/purs/failing/TypeQualification1.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith TypesDoNotUnify
+module Main where
+
+import Lib1 as L
+import Lib1 as L1
+import Lib2 as M
+import Lib3 as L
+
+x1 :: L1.X
+x1 = "wrong"

--- a/tests/purs/failing/TypeQualification1/Lib1.purs
+++ b/tests/purs/failing/TypeQualification1/Lib1.purs
@@ -1,0 +1,4 @@
+module Lib1 where
+
+data X
+data Y

--- a/tests/purs/failing/TypeQualification1/Lib2.purs
+++ b/tests/purs/failing/TypeQualification1/Lib2.purs
@@ -1,0 +1,4 @@
+module Lib2 where
+
+data X
+data Y

--- a/tests/purs/failing/TypeQualification1/Lib3.purs
+++ b/tests/purs/failing/TypeQualification1/Lib3.purs
@@ -1,0 +1,5 @@
+module Lib3 where
+
+data X
+data Y
+data Z

--- a/tests/purs/failing/TypeQualification2.out
+++ b/tests/purs/failing/TypeQualification2.out
@@ -1,0 +1,22 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/TypeQualification2.purs:10:6 - 10:13 (line 10, column 6 - line 10, column 13)
+
+  Could not match type
+  [33m        [0m
+  [33m  String[0m
+  [33m        [0m
+  with type
+  [33m     [0m
+  [33m  M.Y[0m
+  [33m     [0m
+
+while checking that type [33mString[0m
+  is at least as general as type [33mY[0m
+while checking that expression [33m"wrong"[0m
+  has type [33mY[0m
+in value declaration [33mx2[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/TypeQualification2.purs
+++ b/tests/purs/failing/TypeQualification2.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith TypesDoNotUnify
+module Main where
+
+import Lib1 as L
+import Lib1 as L1
+import Lib2 as M
+import Lib3 as L
+
+x2 :: M.Y
+x2 = "wrong"

--- a/tests/purs/failing/TypeQualification2/Lib1.purs
+++ b/tests/purs/failing/TypeQualification2/Lib1.purs
@@ -1,0 +1,4 @@
+module Lib1 where
+
+data X
+data Y

--- a/tests/purs/failing/TypeQualification2/Lib2.purs
+++ b/tests/purs/failing/TypeQualification2/Lib2.purs
@@ -1,0 +1,4 @@
+module Lib2 where
+
+data X
+data Y

--- a/tests/purs/failing/TypeQualification2/Lib3.purs
+++ b/tests/purs/failing/TypeQualification2/Lib3.purs
@@ -1,0 +1,5 @@
+module Lib3 where
+
+data X
+data Y
+data Z

--- a/tests/purs/failing/TypeQualification3.out
+++ b/tests/purs/failing/TypeQualification3.out
@@ -1,0 +1,22 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/TypeQualification3.purs:10:6 - 10:13 (line 10, column 6 - line 10, column 13)
+
+  Could not match type
+  [33m        [0m
+  [33m  String[0m
+  [33m        [0m
+  with type
+  [33m     [0m
+  [33m  L.Z[0m
+  [33m     [0m
+
+while checking that type [33mString[0m
+  is at least as general as type [33mZ[0m
+while checking that expression [33m"wrong"[0m
+  has type [33mZ[0m
+in value declaration [33mx3[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/TypeQualification3.purs
+++ b/tests/purs/failing/TypeQualification3.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith TypesDoNotUnify
+module Main where
+
+import Lib1 as L
+import Lib1 as L1
+import Lib2 as M
+import Lib3 as L
+
+x3 :: L.Z
+x3 = "wrong"

--- a/tests/purs/failing/TypeQualification3/Lib1.purs
+++ b/tests/purs/failing/TypeQualification3/Lib1.purs
@@ -1,0 +1,4 @@
+module Lib1 where
+
+data X
+data Y

--- a/tests/purs/failing/TypeQualification3/Lib2.purs
+++ b/tests/purs/failing/TypeQualification3/Lib2.purs
@@ -1,0 +1,4 @@
+module Lib2 where
+
+data X
+data Y

--- a/tests/purs/failing/TypeQualification3/Lib3.purs
+++ b/tests/purs/failing/TypeQualification3/Lib3.purs
@@ -1,0 +1,5 @@
+module Lib3 where
+
+data X
+data Y
+data Z

--- a/tests/purs/failing/TypeSynonymsOverlappingUnnamedInstance.out
+++ b/tests/purs/failing/TypeSynonymsOverlappingUnnamedInstance.out
@@ -9,8 +9,8 @@ at tests/purs/failing/TypeSynonymsOverlappingUnnamedInstance.purs:14:1 - 15:16 (
   [33m                     [0m
   The following instances were found:
 
-    instance in module [33mMain[0m with type [33mConvert String String[0m (line 11, column 1 - line 12, column 16)
-    instance in module [33mMain[0m with type [33mConvert String String[0m (line 14, column 1 - line 15, column 16)
+    instance in module [33mMain[0m with type [33mMain.Convert String String[0m (line 11, column 1 - line 12, column 16)
+    instance in module [33mMain[0m with type [33mMain.Convert String String[0m (line 14, column 1 - line 15, column 16)
 
 
 in type class instance

--- a/tests/purs/failing/TypedBinders2.out
+++ b/tests/purs/failing/TypedBinders2.out
@@ -3,9 +3,9 @@ in module [33mMain[0m
 at tests/purs/failing/TypedBinders2.purs:8:3 - 8:14 (line 8, column 3 - line 8, column 14)
 
   Could not match type
-  [33m      [0m
-  [33m  Unit[0m
-  [33m      [0m
+  [33m                [0m
+  [33m  Data.Unit.Unit[0m
+  [33m                [0m
   with type
   [33m        [0m
   [33m  String[0m

--- a/tests/purs/failing/TypedHole.out
+++ b/tests/purs/failing/TypedHole.out
@@ -3,16 +3,16 @@ in module [33mMain[0m
 at tests/purs/failing/TypedHole.purs:8:8 - 8:13 (line 8, column 8 - line 8, column 13)
 
   Hole '[33mummm[0m' has the inferred type
-  [33m             [0m
-  [33m  Effect Unit[0m
-  [33m             [0m
+  [33m                       [0m
+  [33m  Effect Data.Unit.Unit[0m
+  [33m                       [0m
   You could substitute the hole with one of these values:
-  [33m                                                                  [0m
-  [33m  Data.Monoid.mempty          :: forall m. Monoid m => m          [0m
-  [33m  Effect.Class.Console.clear  :: forall m. MonadEffect m => m Unit[0m
-  [33m  Effect.Console.clear        :: Effect Unit                      [0m
-  [33m  Main.main                   :: Effect Unit                      [0m
-  [33m                                                                  [0m
+  [33m                                                                            [0m
+  [33m  Data.Monoid.mempty          :: forall m. Monoid m => m                    [0m
+  [33m  Effect.Class.Console.clear  :: forall m. MonadEffect m => m Data.Unit.Unit[0m
+  [33m  Effect.Console.clear        :: Effect Data.Unit.Unit                      [0m
+  [33m  Main.main                   :: Effect Data.Unit.Unit                      [0m
+  [33m                                                                            [0m
 
 in value declaration [33mmain[0m
 

--- a/tests/purs/failing/TypedHole2.out
+++ b/tests/purs/failing/TypedHole2.out
@@ -3,9 +3,9 @@ in module [33mMain[0m
 at tests/purs/failing/TypedHole2.purs:7:16 - 7:21 (line 7, column 16 - line 7, column 21)
 
   Hole '[33mummm[0m' has the inferred type
-  [33m      [0m
-  [33m  Unit[0m
-  [33m      [0m
+  [33m                [0m
+  [33m  Data.Unit.Unit[0m
+  [33m                [0m
 
 in value declaration [33mmain[0m
 

--- a/tests/purs/failing/TypedHole3.out
+++ b/tests/purs/failing/TypedHole3.out
@@ -7,23 +7,23 @@ at tests/purs/failing/TypedHole3.purs:4:10 - 4:15 (line 4, column 10 - line 4, c
   [33m  t0[0m
   [33m    [0m
   You could substitute the hole with one of these values:
-  [33m                                                                                                        [0m
-  [33m  Control.Alt.alt               :: forall f a. Alt f => f a -> f a -> f a                               [0m
-  [33m  Control.Alternative.guard     :: forall m. Alternative m => Boolean -> m Unit                         [0m
-  [33m  Control.Applicative.liftA1    :: forall f a b. Applicative f => (a -> b) -> f a -> f b                [0m
-  [33m  Control.Applicative.pure      :: forall f a. Applicative f => a -> f a                                [0m
-  [33m  Control.Applicative.unless    :: forall m. Applicative m => Boolean -> m Unit -> m Unit               [0m
-  [33m  Control.Applicative.when      :: forall m. Applicative m => Boolean -> m Unit -> m Unit               [0m
-  [33m  Control.Apply.apply           :: forall f a b. Apply f => f (a -> b) -> f a -> f b                    [0m
-  [33m  Control.Apply.applyFirst      :: forall a b f. Apply f => f a -> f b -> f a                           [0m
-  [33m  Control.Apply.applySecond     :: forall a b f. Apply f => f a -> f b -> f b                           [0m
-  [33m  Control.Apply.lift2           :: forall a b c f. Apply f => (a -> b -> c) -> f a -> ... -> ...        [0m
-  [33m  Control.Apply.lift3           :: forall a b c d f. Apply f => (a -> b -> ...) -> f a -> ... -> ...    [0m
-  [33m  Control.Apply.lift4           :: forall a b c d e f. Apply f => (a -> b -> ...) -> f a -> ... -> ...  [0m
-  [33m  Control.Apply.lift5           :: forall a b c d e f g. Apply f => (a -> b -> ...) -> f a -> ... -> ...[0m
-  [33m  Control.Biapplicative.bipure  :: forall w a b. Biapplicative w => a -> b -> w a b                     [0m
-  [33m  Control.Biapply.biapply       :: forall w a b c d. Biapply w => w (a -> b) (c -> d) -> w a c -> w b d [0m
-  [33m                                                                                                        [0m
+  [33m                                                                                                             [0m
+  [33m  Control.Alt.alt               :: forall f a. Alt f => f a -> f a -> f a                                    [0m
+  [33m  Control.Alternative.guard     :: forall m. Alternative m => Boolean -> m Data.Unit.Unit                    [0m
+  [33m  Control.Applicative.liftA1    :: forall f a b. Applicative f => (a -> b) -> f a -> f b                     [0m
+  [33m  Control.Applicative.pure      :: forall f a. Applicative f => a -> f a                                     [0m
+  [33m  Control.Applicative.unless    :: forall m. Applicative m => Boolean -> m Data.Unit.Unit -> m Data.Unit.Unit[0m
+  [33m  Control.Applicative.when      :: forall m. Applicative m => Boolean -> m Data.Unit.Unit -> m Data.Unit.Unit[0m
+  [33m  Control.Apply.apply           :: forall f a b. Apply f => f (a -> b) -> f a -> f b                         [0m
+  [33m  Control.Apply.applyFirst      :: forall a b f. Apply f => f a -> f b -> f a                                [0m
+  [33m  Control.Apply.applySecond     :: forall a b f. Apply f => f a -> f b -> f b                                [0m
+  [33m  Control.Apply.lift2           :: forall a b c f. Apply f => (a -> b -> c) -> f a -> ... -> ...             [0m
+  [33m  Control.Apply.lift3           :: forall a b c d f. Apply f => (a -> b -> ...) -> f a -> ... -> ...         [0m
+  [33m  Control.Apply.lift4           :: forall a b c d e f. Apply f => (a -> b -> ...) -> f a -> ... -> ...       [0m
+  [33m  Control.Apply.lift5           :: forall a b c d e f g. Apply f => (a -> b -> ...) -> f a -> ... -> ...     [0m
+  [33m  Control.Biapplicative.bipure  :: forall w a b. Biapplicative w => a -> b -> w a b                          [0m
+  [33m  Control.Biapply.biapply       :: forall w a b c d. Biapply w => w (a -> b) (c -> d) -> w a c -> w b d      [0m
+  [33m                                                                                                             [0m
 
 in value declaration [33mfn[0m
 

--- a/tests/purs/failing/UnsupportedTypeInKind.out
+++ b/tests/purs/failing/UnsupportedTypeInKind.out
@@ -4,7 +4,7 @@ at tests/purs/failing/UnsupportedTypeInKind.purs:7:28 - 7:38 (line 7, column 28 
 
   The type:
 
-    [33mOk => Type[0m
+    [33mOk => Prim.Type[0m
 
   is not supported in kinds.
 


### PR DESCRIPTION
Will hopefully fix #1647, reported by me a mere _7 years ago_. :exploding_head: 

The idea is to make a note of the `Imports` for the current module before type checking, and then if there are any errors, construct a reverse lookup of more or less the same information in the `Imports`, so that we can go from fully-qualified names back to names that are qualified as they would be in the source file, and then "requalify" any types in error messages according to that reverse lookup.

While this does what we want sometimes (see e.g. the new tests `TypeQualification{1,2,3}`), it doesn't quite do what we want most of the time, and I think one of the main reasons it's not doing what we want is because of missing cases in `onTypesInErrorMessage`.

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
