### PR TITLE
POC: More aggressive dirty module checking

### DIFF
--- a/lib/purescript-cst/src/Language/PureScript/AST/SourcePos.hs
+++ b/lib/purescript-cst/src/Language/PureScript/AST/SourcePos.hs
@@ -7,10 +7,12 @@ module Language.PureScript.AST.SourcePos where
 import Prelude.Compat
 
 import Codec.Serialise (Serialise)
+import qualified Codec.Serialise as Serialise
+import qualified Codec.Serialise.Class as Serialise
 import Control.DeepSeq (NFData)
 import Data.Aeson ((.=), (.:))
 import Data.Text (Text)
-import GHC.Generics (Generic)
+import GHC.Generics (Generic, from, to)
 import Language.PureScript.Comments
 import qualified Data.Aeson as A
 import qualified Data.Text as T
@@ -25,7 +27,12 @@ data SourcePos = SourcePos
     -- ^ Line number
   , sourcePosColumn :: Int
     -- ^ Column number
-  } deriving (Show, Eq, Ord, Generic, NFData, Serialise)
+  } deriving (Show, Eq, Ord, Generic, NFData)
+
+instance Serialise SourcePos where
+  -- NOTE[fh]: this is quite bad to push to main, since I'm sure it'll break ide integrations etc, but I'm only trying shit out now
+  encode (SourcePos _ _) = Serialise.gencode $ from (SourcePos 0 0)
+  decode = to <$> Serialise.gdecode
 
 displaySourcePos :: SourcePos -> Text
 displaySourcePos sp =

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -243,6 +243,7 @@ make ma@MakeActions{..} ms = do
       _ :: Bool <- elem WasRebuilt . maybe [] (fmap (\(_,_,c) -> c)) . sequence <$> results
       let ourPrebuiltIfSourceFilesDidntChange = didModuleSourceFilesChange buildPlan moduleName
       let ourCacheFileIfSourceFilesDidntChange = pbExternsFile <$> ourPrebuiltIfSourceFilesDidntChange
+      let ourDirtyCacheFile = getDirtyCacheFile buildPlan moduleName
       let didOurSourceFilesChange = isNothing ourCacheFileIfSourceFilesDidntChange
       -- _ <- trace ((show :: (String, ModuleName, String, [ModuleName], String, Int, Maybe [ModuleName]) -> String) ("buildModule start", moduleName, "deps", deps, "mexterns", length mexterns, fmap efModuleName . snd <$> mexterns)) (pure ())
 
@@ -296,7 +297,7 @@ make ma@MakeActions{..} ms = do
             (Just _, _) -> do
               (exts, warnings) <- listen $ rebuildModule' ma env externs m
 
-              case buildJobSuccess ourPrebuiltIfSourceFilesDidntChange (BuildJobSucceeded (pwarnings' <> warnings) exts) of
+              case buildJobSuccess ourDirtyCacheFile (BuildJobSucceeded (pwarnings' <> warnings) exts) of
                 Just (_, _, NotRebuilt) -> do
                   _ <- trace (show ("buildModule post rebuildModule' cache-noop" :: String, moduleName)) (pure ())
                   return $ BuildJobNotNeeded exts

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -72,7 +72,7 @@ data ProgressMessage
 
 -- | Render a progress message
 renderProgressMessage :: ProgressMessage -> T.Text
-renderProgressMessage (CompilingModule mn) = T.append "Compiling " (runModuleName mn)
+renderProgressMessage (CompilingModule mn) = T.append "CompilingX2 " (runModuleName mn)
 
 -- | Actions that require implementations when running in "make" mode.
 --


### PR DESCRIPTION
**Description of the change**

Goal:
I wanted to get closer to the compilation performance of the Elm compiler. This is a POC, it's hacky, it seems to work, it's absolutely not ready to be merged in, it's based of an old compiler version (v0.14.3), I'm not even sure it should be merged in, but I hope it shows that this can be done.

The basic idea:
Elm looks at the public api of each module, and if the public api of a module didn't change after recompiling, no downstream dependencies need to be recompiled, because everything they depend on will still be there, but possibly with a different implementation. This only works if you're not doing general cross-module inlining, which neither Elm nor Purescript seems to do.
Thus, modifying a comment on your prelude should result in just a single module being recompiled. Same for modifying a constant, a function body, or adding something new without touching anything already in the file.

Example performance:
```
adding a space to the end of an average file
5 files are directly depending on the modified file
19 files transitively depend on the modified file
136 files in the project, most of which don't transitively depend on the modified file
16s before this change
2.8s with this change
```
```
adding a space to the end of our custom Prelude
127 files are directly depending on the modified file
135 files transitively depend on the modified file
136 files in the project, most of which don't transitively depend on the modified file
44s before this change
4.4s with this change
```

Some debug prints when trying it out:
```
cache-none = src file changed or first time build, recompile for sure
cache-noop = recompiled but all artifacts turned out identical, so this was wasted work
cache-miss = recompiled and files changed, so this was useful work
cache-hit = no dependency changed, so don't bother compiling
```

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
