### PR TITLE
Remove unused SimpleErrorMessage constructors

### DIFF
--- a/CHANGELOG.d/internal_remove-unused-error-constructors.md
+++ b/CHANGELOG.d/internal_remove-unused-error-constructors.md
@@ -1,0 +1,1 @@
+* Removed a couple of unused SimpleErrorMessage constructors

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -145,7 +145,6 @@ data SimpleErrorMessage
   | MissingKindDeclaration KindSignatureFor (ProperName 'TypeName) SourceType
   | OverlappingPattern [[Binder]] Bool
   | IncompleteExhaustivityCheck
-  | MisleadingEmptyTypeImport ModuleName (ProperName 'TypeName)
   | ImportHidingModule ModuleName
   | UnusedImport ModuleName (Maybe ModuleName)
   | UnusedExplicitImport ModuleName [Name] (Maybe ModuleName) [DeclarationRef]
@@ -318,7 +317,6 @@ errorCode em = case unwrapErrorMessage em of
   MissingKindDeclaration{} -> "MissingKindDeclaration"
   OverlappingPattern{} -> "OverlappingPattern"
   IncompleteExhaustivityCheck{} -> "IncompleteExhaustivityCheck"
-  MisleadingEmptyTypeImport{} -> "MisleadingEmptyTypeImport"
   ImportHidingModule{} -> "ImportHidingModule"
   UnusedImport{} -> "UnusedImport"
   UnusedExplicitImport{} -> "UnusedExplicitImport"
@@ -1086,8 +1084,6 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
       line $ "Declaration " <> markCode (showIdent nm) <> " was not used, and is not exported."
     renderSimpleErrorMessage (UnusedTypeVar tv) =
       line $ "Type variable " <> markCode tv <> " is ambiguous, since it is unused in the polymorphic type which introduces it."
-    renderSimpleErrorMessage (MisleadingEmptyTypeImport mn name) =
-      line $ "Importing type " <> markCode (runProperName name <> "(..)") <> " from " <> markCode (runModuleName mn) <> " is misleading as it has no exported data constructors."
     renderSimpleErrorMessage (ImportHidingModule name) =
       paras [ line "hiding imports cannot be used to hide modules."
             , line $ "An attempt was made to hide the import of " <> markCode (runModuleName name)

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -25,14 +25,12 @@ import qualified Language.PureScript as P
 import           Language.PureScript.Errors.JSON
 import           Language.PureScript.Ide.Types   (ModuleIdent, Completion(..))
 import           Protolude
-import qualified Text.Parsec.Error               as Parsec
 
 data IdeError
     = GeneralError Text
     | NotFound Text
     | ModuleNotFound ModuleIdent
     | ModuleFileNotFound ModuleIdent
-    | ParseError Parsec.ParseError Text
     | RebuildError P.MultipleErrors
     deriving (Show)
 
@@ -93,11 +91,6 @@ textError (GeneralError msg)          = msg
 textError (NotFound ident)            = "Symbol '" <> ident <> "' not found."
 textError (ModuleNotFound ident)      = "Module '" <> ident <> "' not found."
 textError (ModuleFileNotFound ident)  = "Extern file for module " <> ident <>" could not be found"
-textError (ParseError parseError msg) = let escape = show
-                                            -- escape newlines and other special
-                                            -- chars so we can send the error
-                                            -- over the socket as a single line
-                                        in msg <> ": " <> escape parseError
 textError (RebuildError err)          = show err
 
 prettyPrintTypeSingleLine :: P.Type a -> Text


### PR DESCRIPTION
This PR just removes a small amount of unused code. I identified the unused SimpleErrorMessage constructors by looking for references to each error message in at least one module in `src/` besides Language.PureScript.Errors - as far as I can tell there are just two:

- The ErrorParsingModule constructor, and the ParseError constructor of IdeError, are no longer used since we switched to the CST parser
- The MisleadingEmptyTypeImport error was superseded by unused import checking - if you try to import a type with no constructors with the `Type(..)` syntax, you get the following warning:
```
  The import of type Effect from module Effect includes data constructors but only the type is used
  It could be replaced with:

    import Effect (Effect)
```

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
