### PR TITLE
Allow most leading and trailing delimiters

### DIFF
--- a/CHANGELOG.d/feature_leading-and-trailing-delimiters.md
+++ b/CHANGELOG.d/feature_leading-and-trailing-delimiters.md
@@ -1,0 +1,15 @@
+* Allow leading and trailing delimiters in many syntax positions
+
+  PureScript's syntax contains multiple places where sequences of words or
+  clauses are expected, delimited by commas or vertical bars. To
+  facilitate editing these elements when placed on their own lines,
+  PureScript's parser now supports an optional leading or trailing
+  delimiter in most such locations, specifically:
+
+    * Array and object literals (and patterns)
+    * Sum type definitions
+    * Object updates
+    * Row types
+    * Import and export lists
+    * Functional dependencies
+    * Compound constraints and superclasses

--- a/src/Language/PureScript/CST/Convert.hs
+++ b/src/Language/PureScript/CST/Convert.hs
@@ -107,7 +107,7 @@ convertType fileName = go
         let ann = sourceAnnCommented fileName (lblTok a) (snd $ typeRange ty)
         T.RCons ann (L.Label $ lblName a) (go ty) c
     case labels of
-      Just (Separated h t) ->
+      Just (SeparatedExtra _ h t _) ->
         rowCons h $ foldr (rowCons . snd) rowTail t
       Nothing ->
         rowTail
@@ -276,7 +276,7 @@ convertExpr fileName = go
       let
         ann = sourceAnnCommented fileName a c
         vals = case bs of
-          Just (Separated x xs) -> go x : (go . snd <$> xs)
+          Just (SeparatedExtra _ x xs _) -> go x : (go . snd <$> xs)
           Nothing -> []
       positioned ann . AST.Literal (fst ann) $ AST.ArrayLiteral vals
     ExprRecord z (Wrapped a bs c) -> do
@@ -286,7 +286,7 @@ convertExpr fileName = go
           RecordPun f -> (mkString . getIdent $ nameValue f, go . ExprIdent z $ QualifiedName (nameTok f) Nothing (nameValue f))
           RecordField f _ v -> (lblName f, go v)
         vals = case bs of
-          Just (Separated x xs) -> lbl x : (lbl . snd <$> xs)
+          Just (SeparatedExtra _ x xs _) -> lbl x : (lbl . snd <$> xs)
           Nothing -> []
       positioned ann . AST.Literal (fst ann) $ AST.ObjectLiteral vals
     ExprParens _ (Wrapped a b c) ->
@@ -399,7 +399,7 @@ convertBinder fileName = go
       let
         ann = sourceAnnCommented fileName a c
         vals = case bs of
-          Just (Separated x xs) -> go x : (go . snd <$> xs)
+          Just (SeparatedExtra _ x xs _) -> go x : (go . snd <$> xs)
           Nothing -> []
       positioned ann . AST.LiteralBinder (fst ann) $ AST.ArrayLiteral vals
     BinderRecord z (Wrapped a bs c) -> do
@@ -409,7 +409,7 @@ convertBinder fileName = go
           RecordPun f -> (mkString . getIdent $ nameValue f, go $ BinderVar z f)
           RecordField f _ v -> (lblName f, go v)
         vals = case bs of
-          Just (Separated x xs) -> lbl x : (lbl . snd <$> xs)
+          Just (SeparatedExtra _ x xs _) -> lbl x : (lbl . snd <$> xs)
           Nothing -> []
       positioned ann . AST.LiteralBinder (fst ann) $ AST.ObjectLiteral vals
     BinderParens _ (Wrapped a b c) ->
@@ -442,7 +442,7 @@ convertDeclaration fileName decl = case decl of
             [] -> []
             (st', ctor) : tl' -> ctrs st' ctor tl'
           )
-    pure $ AST.DataDeclaration ann Env.Data (nameValue a) (goTypeVar <$> vars) (maybe [] (\(st, Separated hd tl) -> ctrs st hd tl) bd)
+    pure $ AST.DataDeclaration ann Env.Data (nameValue a) (goTypeVar <$> vars) (maybe [] (\(st, SeparatedExtra _ hd tl _) -> ctrs st hd tl) bd)
   DeclType _ (DataHead _ a vars) _ bd ->
     pure $ AST.TypeSynonymDeclaration ann
       (nameValue a)

--- a/src/Language/PureScript/CST/Positions.hs
+++ b/src/Language/PureScript/CST/Positions.hs
@@ -98,6 +98,10 @@ sepLast :: Separated a -> a
 sepLast (Separated hd []) = hd
 sepLast (Separated _ tl) = snd $ last tl
 
+sepXLast :: SeparatedExtra a -> a
+sepXLast (SeparatedExtra _ hd [] _) = hd
+sepXLast (SeparatedExtra _ _ tl _) = snd $ last tl
+
 type TokenRange = (SourceToken, SourceToken)
 
 toSourceRange :: TokenRange -> SourceRange
@@ -160,7 +164,7 @@ dataMembersRange = \case
 declRange :: Declaration a -> TokenRange
 declRange = \case
   DeclData _ hd ctors
-    | Just (_, cs) <- ctors -> (fst start, snd . dataCtorRange $ sepLast cs)
+    | Just (_, cs) <- ctors -> (fst start, fromMaybe (snd . dataCtorRange $ sepXLast cs) $ sepXTrailing cs)
     | otherwise -> start
     where start = dataHeadRange hd
   DeclType _ a _ b -> (fst $ dataHeadRange a,  snd $ typeRange b)
@@ -191,7 +195,7 @@ dataCtorRange (DataCtor _ name fields)
 
 classHeadRange :: ClassHead a -> TokenRange
 classHeadRange (ClassHead kw _ name vars fdeps)
-  | Just (_, fs) <- fdeps = (kw, snd .classFundepRange $ sepLast fs)
+  | Just (_, fs) <- fdeps = (kw, fromMaybe (snd . classFundepRange $ sepXLast fs) $ sepXTrailing fs)
   | [] <- vars = (kw, snd $ nameRange name)
   | otherwise = (kw, snd . typeVarBindingRange $ last vars)
 

--- a/src/Language/PureScript/CST/Traversals.hs
+++ b/src/Language/PureScript/CST/Traversals.hs
@@ -4,8 +4,8 @@ import Prelude
 
 import Language.PureScript.CST.Types
 
-everythingOnSeparated :: (r -> r -> r) -> (a -> r) -> Separated a -> r
-everythingOnSeparated op k (Separated hd tl) = go hd tl
+everythingOnSeparated :: (r -> r -> r) -> (a -> r) -> SeparatedExtra a -> r
+everythingOnSeparated op k (SeparatedExtra _ hd tl _) = go hd tl
   where
   go a [] = k a
   go a (b : bs) = k a `op` go (snd b) bs

--- a/src/Language/PureScript/CST/Types.hs
+++ b/src/Language/PureScript/CST/Types.hs
@@ -117,14 +117,21 @@ data Separated a = Separated
   , sepTail :: [(SourceToken, a)]
   } deriving (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
 
+data SeparatedExtra a = SeparatedExtra
+  { sepXLeading :: Maybe SourceToken
+  , sepXHead :: a
+  , sepXTail :: [(SourceToken, a)]
+  , sepXTrailing :: Maybe SourceToken
+  } deriving (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
+
 data Labeled a b = Labeled
   { lblLabel :: a
   , lblSep :: SourceToken
   , lblValue  :: b
   } deriving (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
 
-type Delimited a = Wrapped (Maybe (Separated a))
-type DelimitedNonEmpty a = Wrapped (Separated a)
+type Delimited a = Wrapped (Maybe (SeparatedExtra a))
+type DelimitedNonEmpty a = Wrapped (SeparatedExtra a)
 
 data OneOrDelimited a
   = One a
@@ -163,7 +170,7 @@ data Constraint a
   deriving (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
 
 data Row a = Row
-  { rowLabels :: Maybe (Separated (Labeled Label (Type a)))
+  { rowLabels :: Maybe (SeparatedExtra (Labeled Label (Type a)))
   , rowTail :: Maybe (SourceToken, Type a)
   } deriving (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
 
@@ -193,7 +200,7 @@ data DataMembers a
   deriving (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
 
 data Declaration a
-  = DeclData a (DataHead a) (Maybe (SourceToken, Separated (DataCtor a)))
+  = DeclData a (DataHead a) (Maybe (SourceToken, SeparatedExtra (DataCtor a)))
   | DeclType a (DataHead a) SourceToken (Type a)
   | DeclNewtype a (DataHead a) SourceToken (Name (N.ProperName 'N.ConstructorName)) (Type a)
   | DeclClass a (ClassHead a) (Maybe (SourceToken, NonEmpty (Labeled (Name Ident) (Type a))))
@@ -250,7 +257,7 @@ data ClassHead a = ClassHead
   , clsSuper :: Maybe (OneOrDelimited (Constraint a), SourceToken)
   , clsName :: Name (N.ProperName 'N.ClassName)
   , clsVars :: [TypeVarBinding a]
-  , clsFundeps :: Maybe (SourceToken, Separated ClassFundep)
+  , clsFundeps :: Maybe (SourceToken, SeparatedExtra ClassFundep)
   } deriving (Show, Eq, Ord, Functor, Foldable, Traversable, Generic)
 
 data ClassFundep

--- a/src/Language/PureScript/CST/Utils.hs
+++ b/src/Language/PureScript/CST/Utils.hs
@@ -110,6 +110,13 @@ separated = go []
   go accum (x : xs) = go (x : accum) xs
   go _ [] = internalError "Separated should not be empty"
 
+separatedExtra :: Maybe SourceToken -> Maybe SourceToken -> [(SourceToken, a)] -> SeparatedExtra a
+separatedExtra lead trail = go []
+  where
+  go accum [(_, a)] = SeparatedExtra lead a accum trail
+  go accum (x : xs) = go (x : accum) xs
+  go _ [] = internalError "SeparatedExtra should not be empty"
+
 internalError :: String -> a
 internalError = error . ("Internal parser error: " <>)
 
@@ -221,13 +228,13 @@ toBinderConstructor = \case
 
 toRecordFields
   :: Monoid a
-  => Separated (Either (RecordLabeled (Expr a)) (RecordUpdate a))
-  -> Parser (Either (Separated (RecordLabeled (Expr a))) (Separated (RecordUpdate a)))
+  => SeparatedExtra (Either (RecordLabeled (Expr a)) (RecordUpdate a))
+  -> Parser (Either (SeparatedExtra (RecordLabeled (Expr a))) (SeparatedExtra (RecordUpdate a)))
 toRecordFields = \case
-  Separated (Left a) as ->
-    Left . Separated a <$> traverse (traverse unLeft) as
-  Separated (Right a) as ->
-    Right . Separated a <$> traverse (traverse unRight) as
+  SeparatedExtra ld (Left a) as tr ->
+    Left . flip (SeparatedExtra ld a) tr <$> traverse (traverse unLeft) as
+  SeparatedExtra ld (Right a) as tr ->
+    Right . flip (SeparatedExtra ld a) tr <$> traverse (traverse unRight) as
   where
   unLeft (Left tok) = pure tok
   unLeft (Right tok) =

--- a/tests/purs/passing/LeadingDelimiters.purs
+++ b/tests/purs/passing/LeadingDelimiters.purs
@@ -1,0 +1,86 @@
+module Main
+  (
+  , main
+  ) where
+
+import Prelude
+  hiding
+  (
+  , map
+  , unit
+  )
+import Data.Maybe
+  (
+  , Maybe(
+         , Nothing
+         , Just
+         )
+  )
+import Effect.Console
+  (
+  , log
+  )
+
+data X =
+  | A
+
+data Y =
+  | B
+  | C
+
+alpha :: Array X
+alpha =
+  [
+  , A
+  ]
+
+bravo ::
+  {
+  , foo :: Y
+  }
+bravo = 
+  {
+  , foo: B
+  }
+
+charlie :: Array X -> Int
+charlie
+  [
+  , A
+  ]
+  = 1
+charlie _ = 0
+
+delta
+  :: Record (
+            , foo :: Y
+            )
+  -> Y
+delta
+  {
+  , foo
+  }
+  = foo
+
+setBarToC
+  :: {
+     , foo :: Y
+     | ()
+     }
+  -> {
+     , foo :: Y
+     }
+setBarToC x =
+  x {
+    , foo = C
+    }
+
+class
+  (
+  , Functor f
+  , Functor g
+  ) <= F2 f g | 
+              , f -> g
+              , g -> f
+
+main = log "Done"

--- a/tests/purs/passing/TrailingDelimiters.purs
+++ b/tests/purs/passing/TrailingDelimiters.purs
@@ -1,0 +1,74 @@
+module Main (
+  main,
+) where
+
+import Prelude hiding (
+  map,
+  unit,
+)
+import Data.Maybe (
+  Maybe(
+    Nothing,
+    Just,
+  ),
+)
+import Effect.Console (
+  log,
+)
+
+data X =
+  A |
+
+data Y =
+  B |
+  C |
+
+alpha :: Array X
+alpha = [
+  A,
+]
+
+bravo :: {
+  foo :: Y,
+}
+bravo = {
+  foo: B,
+}
+
+charlie :: Array X -> Int
+charlie [
+    A,
+  ]
+  = 1
+charlie _ = 0
+
+delta
+  :: Record (
+       foo :: Y,
+     )
+  -> Y
+delta {
+    foo,
+  }
+  = foo
+
+setBarToC
+  :: {
+       foo :: Y,
+       | ()
+     }
+  -> {
+       foo :: Y,
+     }
+setBarToC x = x {
+  foo = C,
+}
+
+class (
+  Functor f,
+  Functor g,
+) <= F2 f g | 
+  f -> g,
+  g -> f,
+
+main = log "Done"


### PR DESCRIPTION
**Description of the change**

Inspired by [this Discourse post](https://discourse.purescript.org/t/adt-formatting-why-no-leading-pipe-support/3027), I made a small patch to the CST to support optional leading and trailing delimiters in almost every location in the grammar where I didn't think it would cause problems.

The one place I was less than maximally liberal was in multi-headed `case` expressions. When I tried to make extra delimiters optional in patterns, something prevented it from working in my tests—probably related to the fancy ad-hoc monadic parsing that is used in that part of the grammar.

Example of what I'm talking about:

```purs
case
  , expr1
  , expr2
of
  , BigPattern1
  , BigPattern2
    -> ...
  , BigPattern3 -- this is where the issue was
  , BigPattern4
    -> ...
```

Rather than try to fix it, I chose not to enable extra delimiters in that part of the grammar; and then, for consistency, also removed support for extra delimiters from the head of the `case` as well (even though those worked fine). While this shortcoming is regrettable, I think it'd be quite low down on the list of places in the grammar where users would want to use extra delimiters.

Also note that using leading and trailing delimiters together, a la `[,1,]`, is not supported anywhere. It would have been trivial to do so but I have standards, sir, standards!

Despite submitting this PR and the voiced support for at least some of the syntax changes included here, I have two misgivings. The first is that I don't know if any of these changes break any assumptions made during the layout phase of lexing, which does seem to be sensitive to where commas appear. I haven't noticed any issues but I don't have a thorough understanding of that algorithm. The second is that, by cravenly refraining from picking a side between the delimiters-first versus delimiters-last styles of code formatting, I fear I may stoke the flames of utterly unproductive format wars. There is definitely an argument for having one clear way to do simple things in a language and I don't know how strongly that argument should apply here.

Regardless of the above reservations, this PR is ready for review and discussion, though I don't consider it all that urgent.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
