### PR TITLE
Incorporate Add/Mul dictionaries in Int.Compare type class solver

### DIFF
--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -560,11 +560,13 @@ entails SolverOptions{..} constraint context hints =
           args' = [arg0, arg1, srcTypeConstructor ordering]
       in pure [TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.IntCompare [] [] args' Nothing Nothing]
     solveIntCompare ctx args@[a, b, _] = do
-      let compareDictsInScope = findDicts ctx C.IntCompare Nothing
-          givens = flip mapMaybe compareDictsInScope $ \case
-            dict | [a', b', c'] <- tcdInstanceTypes dict -> mkRelation a' b' c'
-                 | otherwise -> Nothing
-          facts = mkFacts (args : (tcdInstanceTypes <$> compareDictsInScope))
+      let
+        compareDictsInScope = findDicts ctx C.IntCompare Nothing
+        givens = flip mapMaybe compareDictsInScope $ \case
+          dict | [a', b', c'] <- tcdInstanceTypes dict -> mkOrdRelation a' b' c'
+               | otherwise -> Nothing
+        facts = mkFacts (args : (tcdInstanceTypes <$> compareDictsInScope))
+      traceM $ show $ fmap (fmap (() <$)) (givens <> facts)
       c' <- solveRelation (givens <> facts) a b
       pure [TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.IntCompare [] [] [a, b, srcTypeConstructor c'] Nothing Nothing]
     solveIntCompare _ _ = Nothing

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -594,7 +594,7 @@ entails SolverOptions{..} constraint context hints =
           dict | [a', b', c'] <- tcdInstanceTypes dict -> mkOrdRelation a' b' c'
                | otherwise -> Nothing
         facts = mkFacts (args : (tcdInstanceTypes <$> compareDictsInScope))
-      traceM $ show $ fmap (fmap (() <$)) (givens <> facts)
+      traceM $ "Context: " <> show (fmap (fmap (() <$)) (givens <> facts))
       c' <- solveRelation (givens <> addGivens <> mulGivens <> facts) a b
       pure [TypeClassDictionaryInScope Nothing 0 EmptyClassInstance [] C.IntCompare [] [] [a, b, srcTypeConstructor c'] Nothing Nothing]
     solveIntCompare _ _ = Nothing

--- a/src/Language/PureScript/TypeChecker/Entailment/IntCompare.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment/IntCompare.hs
@@ -76,6 +76,13 @@ solveRelation context lhs rhs =
     clean :: forall k. Ord k => [(k, [k])] -> [(k, [k])]
     clean = M.toList . M.fromListWith (<>)
 
+mkIntRelation :: P.Type a -> P.Type a -> Maybe (Relation (P.Type a))
+mkIntRelation lhs@(P.TypeLevelInt _ l) rhs@(P.TypeLevelInt _ r) = case compare l r of
+  EQ -> pure $ Equal lhs rhs
+  LT -> pure $ LessThan lhs rhs
+  GT -> pure $ LessThan rhs lhs
+mkIntRelation _ _ = Nothing
+
 mkOrdRelation :: P.Type a -> P.Type a -> P.Type a -> Maybe (Relation (P.Type a))
 mkOrdRelation lhs rhs rel = case rel of
   P.TypeConstructor _ ordering

--- a/src/Language/PureScript/TypeChecker/Entailment/IntCompare.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment/IntCompare.hs
@@ -76,8 +76,8 @@ solveRelation context lhs rhs =
     clean :: forall k. Ord k => [(k, [k])] -> [(k, [k])]
     clean = M.toList . M.fromListWith (<>)
 
-mkRelation :: P.Type a -> P.Type a -> P.Type a -> Maybe (Relation (P.Type a))
-mkRelation lhs rhs rel = case rel of
+mkOrdRelation :: P.Type a -> P.Type a -> P.Type a -> Maybe (Relation (P.Type a))
+mkOrdRelation lhs rhs rel = case rel of
   P.TypeConstructor _ ordering
     | ordering == P.orderingEQ -> pure $ Equal lhs rhs
     | ordering == P.orderingLT -> pure $ LessThan lhs rhs

--- a/tests/purs/passing/4333.purs
+++ b/tests/purs/passing/4333.purs
@@ -6,40 +6,109 @@ import Effect.Console (log)
 import Data.Reflectable (class Reflectable, reflectType)
 import Prim.Int as PI
 import Prim.Ordering as PO
-import Type.Proxy (Proxy)
+import Type.Proxy (Proxy(..))
 
--- | Valid bounds are between 1 and 5
-newtype N = N Int
+-- | Valid bounds are i where 1 <= i <= 5
+newtype TestAddCompare = TestAddCompare Int
 
-type MinN :: Int
-type MinN = 1
+type TestAddCompareLower :: Int
+type TestAddCompareLower = 1
 
-type MaxN :: Int
-type MaxN = 5
+type TestAddCompareUpper :: Int
+type TestAddCompareUpper = 5
 
-mkN
+mkTestAddCompare
   :: forall i lower upper
    . Reflectable i Int
-  => PI.Add MinN (-1) lower
+  => PI.Add TestAddCompareLower (-1) lower
   => PI.Compare i lower PO.GT
-  => PI.Add MaxN 1 upper
+  => PI.Add TestAddCompareUpper 1 upper
   => PI.Compare i upper PO.LT
   => Proxy i
-  -> N
-mkN p = N (reflectType p)
+  -> TestAddCompare
+mkTestAddCompare p = TestAddCompare (reflectType p)
 
-data Something = Something N Int
+data AddCompare = AddCompare TestAddCompare Int
 
-mkSomething
+mkAddCompare
   :: forall i lower upper
    . Reflectable i Int
-  => PI.Add MinN (-1) lower
+  => PI.Add TestAddCompareLower (-1) lower
   => PI.Compare i lower PO.GT
-  => PI.Add MaxN 1 upper
+  => PI.Add TestAddCompareUpper 1 upper
   => PI.Compare i upper PO.LT
   => Proxy i
   -> Int
-  -> Something
-mkSomething p i = Something (mkN p) i
+  -> AddCompare
+mkAddCompare p i = AddCompare (mkTestAddCompare p) i
+
+addCompare :: AddCompare
+addCompare = mkAddCompare (Proxy :: Proxy 3) 1
+
+
+-- | Valid values are i where (i * 4) < 100
+newtype TestMulCompare = TestMulCompare Int
+
+type TestMulCompareUpper :: Int
+type TestMulCompareUpper = 100
+
+type TestMulCompareScale :: Int
+type TestMulCompareScale = 4
+
+mkTestMulCompare
+  :: forall i val upper
+   . Reflectable i Int
+  => PI.Mul i TestMulCompareScale val
+  => PI.Compare val TestMulCompareUpper PO.LT
+  => Proxy i
+  -> TestMulCompare
+mkTestMulCompare p = TestMulCompare (reflectType p)
+
+data MulCompare = MulCompare TestMulCompare Int
+
+mkMulCompare
+  :: forall i val upper
+   . Reflectable i Int
+  => PI.Mul i TestMulCompareScale val
+  => PI.Compare val TestMulCompareUpper PO.LT
+  => Proxy i
+  -> Int
+  -> MulCompare
+mkMulCompare p i = MulCompare (mkTestMulCompare p) i
+
+mulCompare :: MulCompare
+mulCompare = mkMulCompare (Proxy :: Proxy 3) 1
+
+
+-- | Valid values are i where 2 <= i <= 100
+newtype TestAddMulCompare = TestAddMulCompare Int
+
+
+mkTestAddMulCompare
+  :: forall i one two
+   . Reflectable i Int
+  => PI.Add 0 1 one
+  => PI.Mul one 2 two
+  => PI.Compare i two PO.GT
+  => Proxy i
+  -> TestAddMulCompare
+mkTestAddMulCompare p = TestAddMulCompare (reflectType p)
+
+data AddMulCompare = AddMulCompare TestAddMulCompare Int
+
+mkAddMulCompare
+  :: forall i one two
+   . Reflectable i Int
+  => PI.Add 0 1 one
+  => PI.Mul one 2 two
+  => PI.Compare i two PO.GT
+  => Proxy i
+  -> Int
+  -> AddMulCompare
+mkAddMulCompare p i = AddMulCompare (mkTestAddMulCompare p) i
+
+addMulCompare :: AddMulCompare
+addMulCompare = mkAddMulCompare (Proxy :: Proxy 8) 1
+
 
 main = log "Done"

--- a/tests/purs/passing/4333.purs
+++ b/tests/purs/passing/4333.purs
@@ -1,0 +1,45 @@
+module Main where
+
+import Prelude
+import Effect.Console (log)
+
+import Data.Reflectable (class Reflectable, reflectType)
+import Prim.Int as PI
+import Prim.Ordering as PO
+import Type.Proxy (Proxy)
+
+-- | Valid bounds are between 1 and 5
+newtype N = N Int
+
+type MinN :: Int
+type MinN = 1
+
+type MaxN :: Int
+type MaxN = 5
+
+mkN
+  :: forall i lower upper
+   . Reflectable i Int
+  => PI.Add MinN (-1) lower
+  => PI.Compare i lower PO.GT
+  => PI.Add MaxN 1 upper
+  => PI.Compare i upper PO.LT
+  => Proxy i
+  -> N
+mkN p = N (reflectType p)
+
+data Something = Something N Int
+
+mkSomething
+  :: forall i lower upper
+   . Reflectable i Int
+  => PI.Add MinN (-1) lower
+  => PI.Compare i lower PO.GT
+  => PI.Add MaxN 1 upper
+  => PI.Compare i upper PO.LT
+  => Proxy i
+  -> Int
+  -> Something
+mkSomething p i = Something (mkN p) i
+
+main = log "Done"


### PR DESCRIPTION
**Description of the change**

Fixes #4333. Currently a WIP used to help facilitate discussion on this bug fix.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
