### PR TITLE
Bump depend purescript-installer to ^0.3.1

### DIFF
--- a/CHANGELOG.d/internal_bump-npm-purescript-installer-0-3-1.md
+++ b/CHANGELOG.d/internal_bump-npm-purescript-installer-0-3-1.md
@@ -1,0 +1,1 @@
+* Bump depend NPM purescript-installer to ^0.3.1

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -157,6 +157,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@i-am-the-slime](https://github.com/i-am-the-slime) | Mark Eibes | [MIT license](http://opensource.org/licenses/MIT) |
 | [@sd-yip](https://github.com/sd-yip) | Nicholas Yip | [MIT license](http://opensource.org/licenses/MIT) |
 | [@j-nava](https://github.com/j-nava) | Jesse Nava | [MIT license](http://opensource.org/licenses/MIT) |
+| [@imcotton](https://github.com/imcotton) | Cotton Hou | [MIT license](http://opensource.org/licenses/MIT) |
 
 ### Contributors using Modified Terms
 

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -15,7 +15,7 @@
     "purs": "purs.bin"
   },
   "dependencies": {
-    "purescript-installer": "^0.2.6"
+    "purescript-installer": "^0.3.1"
   },
   "homepage": "https://github.com/purescript/purescript",
   "repository": {


### PR DESCRIPTION
**Description of the change**

This bump is to address outdated NPM packages of the installer, see original issue at purescript/npm-installer#32 and its fixing PR purescript/npm-installer#33

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)


