### PR TITLE
Fix inconsistency between `stack test` and `cabal test`

### DIFF
--- a/CHANGELOG.d/internal_golden_json_tests.md
+++ b/CHANGELOG.d/internal_golden_json_tests.md
@@ -1,0 +1,4 @@
+* Compare json files through `aeson` in tests
+
+  This fixes the tests for the graph and source map outputs, as the
+  ordering is inconsistent between `stack test` and `cabal test`.

--- a/CHANGELOG.d/internal_test_suite_version_bounds.md
+++ b/CHANGELOG.d/internal_test_suite_version_bounds.md
@@ -1,0 +1,1 @@
+* Add version bounds to the test suite's `build-depends`.

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -415,12 +415,12 @@ test-suite tests
   ghc-options: -Wno-incomplete-uni-patterns
   build-depends:
       purescript
-    , generic-random
-    , hspec
-    , HUnit
-    , newtype
-    , QuickCheck
-    , regex-base
+    , generic-random >=1.4.0.0 && <1.5
+    , hspec ==2.8.3
+    , HUnit >=1.6.2.0 && <1.7
+    , newtype >=0.2.2.0 && <0.3
+    , QuickCheck >=2.14.2 && <2.15
+    , regex-base >=0.94.0.1 && <0.95
   build-tool-depends:
       hspec-discover:hspec-discover -any
     -- we need the compiler's executable available for the ide tests

--- a/tests/TestGraph.hs
+++ b/tests/TestGraph.hs
@@ -24,9 +24,9 @@ spec = do
     eitherGraph <- fst <$> P.graph modulePaths
     case eitherGraph of
       Left err -> error $ "Graph creation failed. Errors: " <> show err
-      Right res ->
-        let textRes = Text.decodeUtf8 $ ByteString.toStrict $ Json.encode res
-        in graphFixture `shouldBe` textRes
+      Right res -> do
+        let graphFixture' = Json.decode $ ByteString.fromStrict $ Text.encodeUtf8 graphFixture
+        graphFixture' `shouldBe` Just res
 
   it "should fail when trying to include non-existing modules in the graph" $ do
     let modulePath = sourcesDir <> "ModuleFailing.purs"


### PR DESCRIPTION
**Description of the change**

This fixes an inconsistency between `stack test` and `cabal test` on `TestGraph` and `TestSourceMaps` by using `aeson`'s `Value` type for equality.

Similarly, this also adds version bounds to the `test-suite` which I pulled from `stack ls dependencies --test`.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
