### PR TITLE
Allow ide module rebuilds without touching fs output/cache-db

### DIFF
--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -14,6 +14,7 @@ import qualified Data.Map.Lazy                   as M
 import           Data.Maybe                      (fromJust)
 import qualified Data.Set                        as S
 import qualified Data.Time                       as Time
+import qualified Data.Text                       as Text
 import qualified Language.PureScript             as P
 import           Language.PureScript.Make.Cache (CacheInfo(..), normaliseForCache)
 import qualified Language.PureScript.CST         as CST
@@ -51,7 +52,10 @@ rebuildFile
   -- ^ A runner for the second build with open exports
   -> m Success
 rebuildFile file actualFile codegenTargets runOpenBuild = do
-  (fp, input) <- ideReadFile file
+  (fp, input) <-
+    case List.stripPrefix "data:" file of
+      Just source -> pure ("", Text.pack source)
+      _ -> ideReadFile file
   let fp' = fromMaybe fp actualFile
   (pwarnings, m) <- case sequence $ CST.parseFromFile fp' input of
     Left parseError ->
@@ -65,13 +69,16 @@ rebuildFile file actualFile codegenTargets runOpenBuild = do
   -- For rebuilding, we want to 'RebuildAlways', but for inferring foreign
   -- modules using their file paths, we need to specify the path in the 'Map'.
   let filePathMap = M.singleton moduleName (Left P.RebuildAlways)
+  let pureRebuild = S.null codegenTargets
   foreigns <- P.inferForeignModules (M.singleton moduleName (Right file))
   let makeEnv = P.buildMakeActions outputDirectory filePathMap foreigns False
+        & (if pureRebuild then shushCodegen else identity)
+        & shushProgress
   -- Rebuild the single module using the cached externs
   (result, warnings) <- logPerf (labelTimespec "Rebuilding Module") $
     liftIO $ P.runMake (P.defaultOptions { P.optionsCodegenTargets = codegenTargets }) do
-      newExterns <- P.rebuildModule (shushProgress makeEnv) externs m
-      unless (S.null codegenTargets)
+      newExterns <- P.rebuildModule makeEnv externs m
+      unless pureRebuild
         $ updateCacheDb codegenTargets outputDirectory file actualFile moduleName
       pure newExterns
   case result of

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -71,7 +71,8 @@ rebuildFile file actualFile codegenTargets runOpenBuild = do
   (result, warnings) <- logPerf (labelTimespec "Rebuilding Module") $
     liftIO $ P.runMake (P.defaultOptions { P.optionsCodegenTargets = codegenTargets }) do
       newExterns <- P.rebuildModule (shushProgress makeEnv) externs m
-      updateCacheDb codegenTargets outputDirectory file actualFile moduleName
+      unless (S.null codegenTargets)
+        $ updateCacheDb codegenTargets outputDirectory file actualFile moduleName
       pure newExterns
   case result of
     Left errors ->

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -246,10 +246,9 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
 
   codegen :: CF.Module CF.Ann -> Docs.Module -> ExternsFile -> SupplyT Make ()
   codegen m docs exts = do
-    let mn = CF.moduleName m    
+    let mn = CF.moduleName m
+    lift $ writeCborFile (outputFilename mn externsFileName) exts
     codegenTargets <- lift $ asks optionsCodegenTargets
-    unless (S.null codegenTargets)
-      $ lift $ writeCborFile (outputFilename mn externsFileName) exts
     when (S.member CoreFn codegenTargets) $ do
       let coreFnFile = targetFilename mn CoreFn
           json = CFJ.moduleToJSON Paths.version m

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -246,9 +246,10 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
 
   codegen :: CF.Module CF.Ann -> Docs.Module -> ExternsFile -> SupplyT Make ()
   codegen m docs exts = do
-    let mn = CF.moduleName m
-    lift $ writeCborFile (outputFilename mn externsFileName) exts
+    let mn = CF.moduleName m    
     codegenTargets <- lift $ asks optionsCodegenTargets
+    unless (S.null codegenTargets)
+      $ lift $ writeCborFile (outputFilename mn externsFileName) exts
     when (S.member CoreFn codegenTargets) $ do
       let coreFnFile = targetFilename mn CoreFn
           json = CFJ.moduleToJSON Paths.version m


### PR DESCRIPTION
**Description of the change**

This PR allows ide rebuilds without involving the file system by directly sending module source code (instead of file path) and expecting that it will affect ide state, but not file system output (compiled source, externs, and cache-db.json).

This is needed to enable a more robust version of getting IDE [diagnostics on type feature](https://github.com/nwolverson/purescript-language-server/pull/170).

**Summary of actual changes**

src\Language\PureScript\Make\Actions.hs
added `ffiCodegen'` exported function that allows performing FFI check with/without actual codegen (copying the foreign module to the output).

src\Language\PureScript\Ide\Rebuild.hs
Added check if in place of file name to rebuild we got text `data:...` expecting actual module source after `data:` prefix. If so, assume to make a "pure rebuild" i.e., without any file system codegen and modifying `cache-db.json`.

Prior work: https://github.com/purescript/purescript/pull/4178

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
