### PR TITLE
Bump actions environment to macOS-11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           - # If upgrading the Haskell image, also upgrade it in the lint job below
             os: "ubuntu-latest"
             image: "ghcr.io/purescript/haskell:9.2.3-stretch@sha256:70fd2b6255deb5daa961e6983591a0e21e9ac1e793923bee54aa2cc62e01f867"
-          - os: "macOS-10.15"
+          - os: "macOS-11"
           - os: "windows-2019"
 
     runs-on: "${{ matrix.os }}"

--- a/CHANGELOG.d/misc_macos_11_runner.md
+++ b/CHANGELOG.d/misc_macos_11_runner.md
@@ -1,0 +1,1 @@
+* Bump actions environment to `macOS-11`


### PR DESCRIPTION
**Description of the change**

The `macOS-10.15` runner will by removed by the end of August as per <https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/>

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
