### PR TITLE
Allow parentheses around operators when defining aliases

### DIFF
--- a/CHANGELOG.d/feature_parenthesis_in_infix.md
+++ b/CHANGELOG.d/feature_parenthesis_in_infix.md
@@ -1,0 +1,11 @@
+* Allow parentheses around operators when defining aliases
+
+  The compiler now allows operators in alias declarations to be wrapped in parentheses,
+  similar to how custom operators would be defined in languages like Haskell or OCaml.
+
+  ```purs
+  pairUp :: forall a b. a -> b -> { a :: a, b :: b }
+  pairUp a b = { a, b }
+
+  infixr 4 pairUp as (/\)
+  ```

--- a/src/Language/PureScript/CST/Parser.y
+++ b/src/Language/PureScript/CST/Parser.y
@@ -751,9 +751,13 @@ instBinding :: { InstanceBinding () }
   | ident manyOrEmpty(binderAtom) guardedDecl { InstanceBindingName () (ValueBindingFields $1 $2 $3) }
 
 fixity :: { FixityFields }
-  : infix int qualIdent 'as' op { FixityFields $1 $2 (FixityValue (fmap Left $3) $4 (getOpName $5)) }
-  | infix int qualProperName 'as' op { FixityFields $1 $2 (FixityValue (fmap Right (getQualifiedProperName $3)) $4 (getOpName $5)) }
-  | infix int 'type' qualProperName 'as' op { FixityFields $1 $2 (FixityType $3 (getQualifiedProperName $4) $5 (getOpName $6)) }
+  : infix int qualIdent 'as' fixityOp { FixityFields $1 $2 (FixityValue (fmap Left $3) $4 (getOpName $5)) }
+  | infix int qualProperName 'as' fixityOp { FixityFields $1 $2 (FixityValue (fmap Right (getQualifiedProperName $3)) $4 (getOpName $5)) }
+  | infix int 'type' qualProperName 'as' fixityOp { FixityFields $1 $2 (FixityType $3 (getQualifiedProperName $4) $5 (getOpName $6)) }
+
+fixityOp :: { OpName }
+  : op { $1 }
+  | symbol { $1 }
 
 infix :: { (SourceToken, Fixity) }
   : 'infix' { ($1, Infix) }

--- a/tests/purs/passing/Operators.purs
+++ b/tests/purs/passing/Operators.purs
@@ -71,6 +71,14 @@ test18 = negate $ negate 1.0
 test19 :: Number
 test19 = negate $ negate (-1.0)
 
+pairUp :: forall a b. a -> b -> { a :: a, b :: b }
+pairUp = \a -> \b -> { a, b }
+
+infixr 4 pairUp as (/\)
+
+test20 :: { a :: Int, b :: { a :: Int, b :: Int } }
+test20 = 1 /\ 2 /\ 3
+
 main = do
   let t1 = test1 1.0 2.0 (\x y -> x + y)
   let t2 = test2
@@ -88,4 +96,5 @@ main = do
   let t17 = test17
   let t18 = test18
   let t19 = test19
+  let t20 = test20
   log "Done"


### PR DESCRIPTION
**Description of the change**

This makes it possible to wrap operators in parentheses when defining aliases.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
