### PR TITLE
Improve error spans for class and instance declarations

### DIFF
--- a/CHANGELOG.d/fix_4382.md
+++ b/CHANGELOG.d/fix_4382.md
@@ -1,0 +1,40 @@
+* Improve error spans for class and instance declarations
+
+  This improves the error spans for class and instance
+  declarations. Instead of highlighting the entire class or instance
+  declaration when `UnknownName` is thrown, the compiler now
+  highlights the class name and its arguments.
+
+  Before:
+  ```purs
+  [1/2 UnknownName]
+
+    5  class G a <= F a
+       ^^^^^^^^^^^^^^^^
+
+    Unknown type class G
+
+  [2/2 UnknownName]
+
+    7  instance G a => F a
+       ^^^^^^^^^^^^^^^^^^^
+
+    Unknown type class G
+  ```
+
+  After:
+  ```purs
+  [1/2 UnknownName]
+
+    5  class G a <= F a
+             ^^^
+
+    Unknown type class G
+
+  [2/2 UnknownName]
+
+    7  instance G a => F a
+                ^^^
+
+    Unknown type class G
+  ```

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -428,7 +428,10 @@ data Declaration
   -- A type instance declaration (instance chain, chain index, name,
   -- dependencies, class name, instance types, member declarations)
   --
-  | TypeInstanceDeclaration SourceAnn ChainId Integer (Either Text Ident) [SourceConstraint] (Qualified (ProperName 'ClassName)) [SourceType] TypeInstanceBody
+  -- The first @SourceAnn@ serves as the annotation for the entire
+  -- declaration, while the second @SourceAnn@ serves as the
+  -- annotation for the type class and its arguments.
+  | TypeInstanceDeclaration SourceAnn SourceAnn ChainId Integer (Either Text Ident) [SourceConstraint] (Qualified (ProperName 'ClassName)) [SourceType] TypeInstanceBody
   deriving (Show)
 
 data ValueFixity = ValueFixity Fixity (Qualified (Either Ident (ProperName 'ConstructorName))) (OpName 'ValueOpName)
@@ -491,7 +494,7 @@ declSourceAnn (ExternDataDeclaration sa _ _) = sa
 declSourceAnn (FixityDeclaration sa _) = sa
 declSourceAnn (ImportDeclaration sa _ _ _) = sa
 declSourceAnn (TypeClassDeclaration sa _ _ _ _ _) = sa
-declSourceAnn (TypeInstanceDeclaration sa _ _ _ _ _ _ _) = sa
+declSourceAnn (TypeInstanceDeclaration sa _ _ _ _ _ _ _ _) = sa
 
 declSourceSpan :: Declaration -> SourceSpan
 declSourceSpan = fst . declSourceAnn
@@ -508,7 +511,7 @@ declName (ExternDataDeclaration _ n _) = Just (TyName n)
 declName (FixityDeclaration _ (Left (ValueFixity _ _ n))) = Just (ValOpName n)
 declName (FixityDeclaration _ (Right (TypeFixity _ _ n))) = Just (TyOpName n)
 declName (TypeClassDeclaration _ n _ _ _ _) = Just (TyClassName n)
-declName (TypeInstanceDeclaration _ _ _ n _ _ _ _) = IdentName <$> hush n
+declName (TypeInstanceDeclaration _ _ _ _ n _ _ _ _) = IdentName <$> hush n
 declName (RoleDeclaration RoleDeclarationData{..}) = Just (TyName rdeclIdent)
 declName ImportDeclaration{} = Nothing
 declName BindingGroupDeclaration{} = Nothing

--- a/src/Language/PureScript/AST/Exported.hs
+++ b/src/Language/PureScript/AST/Exported.hs
@@ -104,7 +104,7 @@ filterInstances mn (Just exps) =
 -- Get all type and type class names referenced by a type instance declaration.
 --
 typeInstanceConstituents :: Declaration -> [Either (Qualified (ProperName 'ClassName)) (Qualified (ProperName 'TypeName))]
-typeInstanceConstituents (TypeInstanceDeclaration _ _ _ _ constraints className tys _) =
+typeInstanceConstituents (TypeInstanceDeclaration _ _ _ _ _ constraints className tys _) =
   Left className : (concatMap fromConstraint constraints ++ concatMap fromType tys)
   where
 

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -62,7 +62,7 @@ everywhereOnValues f g h = (f', g', h')
   f' (BoundValueDeclaration sa b expr) = f (BoundValueDeclaration sa (h' b) (g' expr))
   f' (BindingGroupDeclaration ds) = f (BindingGroupDeclaration (fmap (\(name, nameKind, val) -> (name, nameKind, g' val)) ds))
   f' (TypeClassDeclaration sa name args implies deps ds) = f (TypeClassDeclaration sa name args implies deps (fmap f' ds))
-  f' (TypeInstanceDeclaration sa ch idx name cs className args ds) = f (TypeInstanceDeclaration sa ch idx name cs className args (mapTypeInstanceBody (fmap f') ds))
+  f' (TypeInstanceDeclaration sa na ch idx name cs className args ds) = f (TypeInstanceDeclaration sa na ch idx name cs className args (mapTypeInstanceBody (fmap f') ds))
   f' other = f other
 
   g' :: Expr -> Expr
@@ -135,7 +135,7 @@ everywhereOnValuesTopDownM f g h = (f' <=< f, g' <=< g, h' <=< h)
      ValueDecl sa name nameKind <$> traverse (h' <=< h) bs <*> traverse (guardedExprM handleGuard (g' <=< g)) val
   f' (BindingGroupDeclaration ds) = BindingGroupDeclaration <$> traverse (\(name, nameKind, val) -> (name, nameKind, ) <$> (g val >>= g')) ds
   f' (TypeClassDeclaration sa name args implies deps ds) = TypeClassDeclaration sa name args implies deps <$> traverse (f' <=< f) ds
-  f' (TypeInstanceDeclaration sa ch idx name cs className args ds) = TypeInstanceDeclaration sa ch idx name cs className args <$> traverseTypeInstanceBody (traverse (f' <=< f)) ds
+  f' (TypeInstanceDeclaration sa na ch idx name cs className args ds) = TypeInstanceDeclaration sa na ch idx name cs className args <$> traverseTypeInstanceBody (traverse (f' <=< f)) ds
   f' (BoundValueDeclaration sa b expr) = BoundValueDeclaration sa <$> (h' <=< h) b <*> (g' <=< g) expr
   f' other = f other
 
@@ -205,7 +205,7 @@ everywhereOnValuesM f g h = (f', g', h')
   f' (BindingGroupDeclaration ds) = (BindingGroupDeclaration <$> traverse (\(name, nameKind, val) -> (name, nameKind, ) <$> g' val) ds) >>= f
   f' (BoundValueDeclaration sa b expr) = (BoundValueDeclaration sa <$> h' b <*> g' expr) >>= f
   f' (TypeClassDeclaration sa name args implies deps ds) = (TypeClassDeclaration sa name args implies deps <$> traverse f' ds) >>= f
-  f' (TypeInstanceDeclaration sa ch idx name cs className args ds) = (TypeInstanceDeclaration sa ch idx name cs className args <$> traverseTypeInstanceBody (traverse f') ds) >>= f
+  f' (TypeInstanceDeclaration sa na ch idx name cs className args ds) = (TypeInstanceDeclaration sa na ch idx name cs className args <$> traverseTypeInstanceBody (traverse f') ds) >>= f
   f' other = f other
 
   g' :: Expr -> m Expr
@@ -276,7 +276,7 @@ everythingOnValues (<>.) f g h i j = (f', g', h', i', j')
   f' d@(ValueDeclaration vd) = foldl (<>.) (f d) (fmap h' (valdeclBinders vd) ++ concatMap (\(GuardedExpr grd v) -> fmap k' grd ++ [g' v]) (valdeclExpression vd))
   f' d@(BindingGroupDeclaration ds) = foldl (<>.) (f d) (fmap (\(_, _, val) -> g' val) ds)
   f' d@(TypeClassDeclaration _ _ _ _ _ ds) = foldl (<>.) (f d) (fmap f' ds)
-  f' d@(TypeInstanceDeclaration _ _ _ _ _ _ _ (ExplicitInstance ds)) = foldl (<>.) (f d) (fmap f' ds)
+  f' d@(TypeInstanceDeclaration _ _ _ _ _ _ _ _ (ExplicitInstance ds)) = foldl (<>.) (f d) (fmap f' ds)
   f' d@(BoundValueDeclaration _ b expr) = f d <>. h' b <>. g' expr
   f' d = f d
 
@@ -355,7 +355,7 @@ everythingWithContextOnValues s0 r0 (<>.) f g h i j = (f'' s0, g'' s0, h'' s0, i
   f' s (ValueDeclaration vd) = foldl (<>.) r0 (fmap (h'' s) (valdeclBinders vd) ++ concatMap (\(GuardedExpr grd v) -> fmap (k' s) grd ++ [g'' s v]) (valdeclExpression vd))
   f' s (BindingGroupDeclaration ds) = foldl (<>.) r0 (fmap (\(_, _, val) -> g'' s val) ds)
   f' s (TypeClassDeclaration _ _ _ _ _ ds) = foldl (<>.) r0 (fmap (f'' s) ds)
-  f' s (TypeInstanceDeclaration _ _ _ _ _ _ _ (ExplicitInstance ds)) = foldl (<>.) r0 (fmap (f'' s) ds)
+  f' s (TypeInstanceDeclaration _ _ _ _ _ _ _ _ (ExplicitInstance ds)) = foldl (<>.) r0 (fmap (f'' s) ds)
   f' _ _ = r0
 
   g'' :: s -> Expr -> r
@@ -465,7 +465,7 @@ everywhereWithContextOnValuesM s0 f g h i j k = (f'' s0, g'' s0, h'' s0, i'' s0,
     ValueDecl sa name nameKind <$> traverse (h'' s) bs <*> traverse (guardedExprM (k' s) (g'' s)) val
   f' s (BindingGroupDeclaration ds) = BindingGroupDeclaration <$> traverse (thirdM (g'' s)) ds
   f' s (TypeClassDeclaration sa name args implies deps ds) = TypeClassDeclaration sa name args implies deps <$> traverse (f'' s) ds
-  f' s (TypeInstanceDeclaration sa ch idx name cs className args ds) = TypeInstanceDeclaration sa ch idx name cs className args <$> traverseTypeInstanceBody (traverse (f'' s)) ds
+  f' s (TypeInstanceDeclaration sa na ch idx name cs className args ds) = TypeInstanceDeclaration sa na ch idx name cs className args <$> traverseTypeInstanceBody (traverse (f'' s)) ds
   f' _ other = return other
 
   g'' s = uncurry g' <=< g s
@@ -569,7 +569,7 @@ everythingWithScope f g h i j = (f'', g'', h'', i'', \s -> snd . j'' s)
     let s' = S.union s (S.fromList (NEL.toList (fmap (\((_, name), _, _) -> ToplevelIdent name) ds)))
     in foldMap (\(_, _, val) -> g'' s' val) ds
   f' s (TypeClassDeclaration _ _ _ _ _ ds) = foldMap (f'' s) ds
-  f' s (TypeInstanceDeclaration _ _ _ _ _ _ _ (ExplicitInstance ds)) = foldMap (f'' s) ds
+  f' s (TypeInstanceDeclaration _ _ _ _ _ _ _ _ (ExplicitInstance ds)) = foldMap (f'' s) ds
   f' _ _ = mempty
 
   g'' :: S.Set ScopedIdent -> Expr -> r
@@ -677,7 +677,7 @@ accumTypes f = everythingOnValues mappend forDecls forValues forBinders (const m
   forDecls (TypeClassDeclaration _ _ args implies _ _) =
     foldMap (foldMap (foldMap f)) args <>
     foldMap (foldMap f . constraintArgs) implies
-  forDecls (TypeInstanceDeclaration _ _ _ _ cs _ tys _) =
+  forDecls (TypeInstanceDeclaration _ _ _ _ _ cs _ tys _) =
     foldMap (foldMap f . constraintArgs) cs <> foldMap f tys
   forDecls (TypeSynonymDeclaration _ _ args ty) =
     foldMap (foldMap f . snd) args <>

--- a/src/Language/PureScript/CST/Convert.hs
+++ b/src/Language/PureScript/CST/Convert.hs
@@ -477,7 +477,12 @@ convertDeclaration fileName decl = case decl of
       chainId = mkChainId fileName $ startSourcePos $ instKeyword $ instHead $ sepHead insts
       goInst ix inst@(Instance (InstanceHead _ nameSep ctrs cls args) bd) = do
         let ann' = uncurry (sourceAnnCommented fileName) $ instanceRange inst
-        AST.TypeInstanceDeclaration ann' chainId ix
+            clsAnn = uncurry (sourceAnnCommented fileName) $
+              if null args then
+                qualRange cls
+              else
+                (fst $ qualRange cls, snd $ typeRange $ last args)
+        AST.TypeInstanceDeclaration ann' clsAnn chainId ix
           (mkPartialInstanceName nameSep cls args)
           (convertConstraint fileName <$> maybe [] (toList . fst) ctrs)
           (qualified cls)
@@ -491,7 +496,12 @@ convertDeclaration fileName decl = case decl of
       instTy
         | isJust new = AST.NewtypeInstance
         | otherwise = AST.DerivedInstance
-    pure $ AST.TypeInstanceDeclaration ann chainId 0 name'
+      clsAnn = uncurry (sourceAnnCommented fileName) $
+        if null args then
+          qualRange cls
+        else
+          (fst $ qualRange cls, snd $ typeRange $ last args)
+    pure $ AST.TypeInstanceDeclaration ann clsAnn chainId 0 name'
       (convertConstraint fileName <$> maybe [] (toList . fst) ctrs)
       (qualified cls)
       (convertType fileName <$> args)

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -213,7 +213,7 @@ findQualModules decls =
   in f `concatMap` decls
   where
   fqDecls :: A.Declaration -> [ModuleName]
-  fqDecls (A.TypeInstanceDeclaration _ _ _ _ _ q _ _) = getQual' q
+  fqDecls (A.TypeInstanceDeclaration _ _ _ _ _ _ q _ _) = getQual' q
   fqDecls (A.ValueFixityDeclaration _ _ q _) = getQual' q
   fqDecls (A.TypeFixityDeclaration _ _ q _) = getQual' q
   fqDecls _ = []

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -134,7 +134,7 @@ getDeclarationTitle (P.DataDeclaration _ _ name _ _) = Just (P.runProperName nam
 getDeclarationTitle (P.ExternDataDeclaration _ name _) = Just (P.runProperName name)
 getDeclarationTitle (P.TypeSynonymDeclaration _ name _ _) = Just (P.runProperName name)
 getDeclarationTitle (P.TypeClassDeclaration _ name _ _ _ _) = Just (P.runProperName name)
-getDeclarationTitle (P.TypeInstanceDeclaration _ _ _ name _ _ _ _) = Just $ either (const "<anonymous>") P.showIdent name
+getDeclarationTitle (P.TypeInstanceDeclaration _ _ _ _ name _ _ _ _) = Just $ either (const "<anonymous>") P.showIdent name
 getDeclarationTitle (P.TypeFixityDeclaration _ _ _ op) = Just ("type " <> P.showOp op)
 getDeclarationTitle (P.ValueFixityDeclaration _ _ _ op) = Just (P.showOp op)
 getDeclarationTitle (P.KindDeclaration _ _ n _) = Just (P.runProperName n)
@@ -187,7 +187,7 @@ convertDeclaration (P.TypeClassDeclaration sa _ args implies fundeps ds) title =
     ChildDeclaration (P.showIdent ident') (convertComments com) (Just ss) (ChildTypeClassMember (ty $> ()))
   convertClassMember _ =
     P.internalError "convertDeclaration: Invalid argument to convertClassMember."
-convertDeclaration (P.TypeInstanceDeclaration (ss, com) _ _ _ constraints className tys _) title =
+convertDeclaration (P.TypeInstanceDeclaration (ss, com) _ _ _ _ constraints className tys _) title =
   Just (Left ((classNameString, AugmentClass) : map (, AugmentType) typeNameStrings, AugmentChild childDecl))
   where
   classNameString = unQual className

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -183,7 +183,7 @@ lintUnused (Module modSS _ mn modDecls exports) =
         in
           (vars, errs')
 
-    goDecl (TypeInstanceDeclaration _ _ _ _ _ _ _ (ExplicitInstance decls)) = mconcat $ map goDecl decls
+    goDecl (TypeInstanceDeclaration _ _ _ _ _ _ _ _ (ExplicitInstance decls)) = mconcat $ map goDecl decls
     goDecl _ = mempty
 
     go :: Expr -> (S.Set Ident, MultipleErrors)

--- a/src/Language/PureScript/Sugar/CaseDeclarations.hs
+++ b/src/Language/PureScript/Sugar/CaseDeclarations.hs
@@ -327,8 +327,8 @@ desugarCases :: forall m. (MonadSupply m, MonadError MultipleErrors m) => [Decla
 desugarCases = desugarRest <=< fmap join . flip parU toDecls . groupBy inSameGroup
   where
     desugarRest :: [Declaration] -> m [Declaration]
-    desugarRest (TypeInstanceDeclaration sa cd idx name constraints className tys ds : rest) =
-      (:) <$> (TypeInstanceDeclaration sa cd idx name constraints className tys <$> traverseTypeInstanceBody desugarCases ds) <*> desugarRest rest
+    desugarRest (TypeInstanceDeclaration sa na cd idx name constraints className tys ds : rest) =
+      (:) <$> (TypeInstanceDeclaration sa na cd idx name constraints className tys <$> traverseTypeInstanceBody desugarCases ds) <*> desugarRest rest
     desugarRest (ValueDecl sa name nameKind bs result : rest) =
       let (_, f, _) = everywhereOnValuesTopDownM return go return
           f' = mapM (\(GuardedExpr gs e) -> GuardedExpr gs <$> f e)

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -196,17 +196,17 @@ renameInModule imports (Module modSS coms mn decls exps) =
       TypeSynonymDeclaration sa name
         <$> updateTypeArguments ps
         <*> updateTypesEverywhere ty
-  updateDecl bound (TypeClassDeclaration sa@(ss, _) className args implies deps ds) =
+  updateDecl bound (TypeClassDeclaration sa className args implies deps ds) =
     fmap (bound,) $
       TypeClassDeclaration sa className
         <$> updateTypeArguments args
-        <*> updateConstraints ss implies
+        <*> updateConstraints implies
         <*> pure deps
         <*> pure ds
-  updateDecl bound (TypeInstanceDeclaration sa@(ss, _) ch idx name cs cn ts ds) =
+  updateDecl bound (TypeInstanceDeclaration sa na@(ss, _) ch idx name cs cn ts ds) =
     fmap (bound,) $
-      TypeInstanceDeclaration sa ch idx name
-        <$> updateConstraints ss cs
+      TypeInstanceDeclaration sa na ch idx name
+        <$> updateConstraints cs
         <*> updateClassName cn ss
         <*> traverse updateTypesEverywhere ts
         <*> pure ds
@@ -352,8 +352,8 @@ renameInModule imports (Module modSS coms mn decls exps) =
     updateInConstraint (Constraint ann@(ss, _) name ks ts info) =
       Constraint ann <$> updateClassName name ss <*> pure ks <*> pure ts <*> pure info
 
-  updateConstraints :: SourceSpan -> [SourceConstraint] -> m [SourceConstraint]
-  updateConstraints pos = traverse $ \(Constraint ann name ks ts info) ->
+  updateConstraints :: [SourceConstraint] -> m [SourceConstraint]
+  updateConstraints = traverse $ \(Constraint ann@(pos, _) name ks ts info) ->
     Constraint ann
       <$> updateClassName name pos
       <*> traverse updateTypesEverywhere ks

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -380,10 +380,10 @@ updateTypes goType = (goDecl, goExpr, goBinder)
     implies' <- traverse (overConstraintArgs (traverse (goType' ss))) implies
     args' <- traverse (traverse (traverse (goType' ss))) args
     return $ TypeClassDeclaration sa name args' implies' deps decls
-  goDecl (TypeInstanceDeclaration sa@(ss, _) ch idx name cs className tys impls) = do
+  goDecl (TypeInstanceDeclaration sa@(ss, _) na ch idx name cs className tys impls) = do
     cs' <- traverse (overConstraintArgs (traverse (goType' ss))) cs
     tys' <- traverse (goType' ss) tys
-    return $ TypeInstanceDeclaration sa ch idx name cs' className tys' impls
+    return $ TypeInstanceDeclaration sa na ch idx name cs' className tys' impls
   goDecl (TypeSynonymDeclaration sa@(ss, _) name args ty) =
     TypeSynonymDeclaration sa name
       <$> traverse (traverse (traverse (goType' ss))) args

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -206,9 +206,9 @@ desugarDecl mn exps = go
   go d@(TypeClassDeclaration sa name args implies deps members) = do
     modify (M.insert (mn, name) (makeTypeClassData args (map memberToNameAndType members) implies deps False))
     return (Nothing, d : typeClassDictionaryDeclaration sa name args implies members : map (typeClassMemberToDictionaryAccessor mn name args) members)
-  go (TypeInstanceDeclaration sa chainId idx name deps className tys body) = do
+  go (TypeInstanceDeclaration sa na chainId idx name deps className tys body) = do
     name' <- desugarInstName name
-    let d = TypeInstanceDeclaration sa chainId idx (Right name') deps className tys body
+    let d = TypeInstanceDeclaration sa na chainId idx (Right name') deps className tys body
     let explicitOrNot = case body of
           DerivedInstance -> Left $ DerivedInstancePlaceholder className KnownClassStrategy
           NewtypeInstance -> Left $ DerivedInstancePlaceholder className NewtypeStrategy

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -46,7 +46,7 @@ deriveInstance
   -> m Declaration
 deriveInstance mn ds decl =
   case decl of
-    TypeInstanceDeclaration sa@(ss, _) ch idx nm deps className tys DerivedInstance -> let
+    TypeInstanceDeclaration sa@(ss, _) na ch idx nm deps className tys DerivedInstance -> let
       binaryWildcardClass :: (Declaration -> [SourceType] -> m ([Declaration], SourceType)) -> m Declaration
       binaryWildcardClass f = case tys of
         [ty1, ty2] -> case unwrapTypeConstructor ty1 of
@@ -54,7 +54,7 @@ deriveInstance mn ds decl =
             checkIsWildcard ss tyCon ty2
             tyConDecl <- findTypeDecl ss tyCon ds
             (members, ty2') <- f tyConDecl args
-            pure $ TypeInstanceDeclaration sa ch idx nm deps className [ty1, ty2'] (ExplicitInstance members)
+            pure $ TypeInstanceDeclaration sa na ch idx nm deps className [ty1, ty2'] (ExplicitInstance members)
           _ -> throwError . errorMessage' ss $ ExpectedTypeConstructor className tys ty1
         _ -> throwError . errorMessage' ss $ InvalidDerivedInstance className tys 2
 

--- a/src/Language/PureScript/Sugar/TypeDeclarations.hs
+++ b/src/Language/PureScript/Sugar/TypeDeclarations.hs
@@ -51,8 +51,8 @@ desugarTypeDeclarationsModule (Module modSS coms name ds exps) =
     where
     go (Let w ds' val') = Let w <$> desugarTypeDeclarations ds' <*> pure val'
     go other = return other
-  desugarTypeDeclarations (TypeInstanceDeclaration sa ch idx nm deps cls args (ExplicitInstance ds') : rest) =
-    (:) <$> (TypeInstanceDeclaration sa ch idx nm deps cls args . ExplicitInstance <$> desugarTypeDeclarations ds')
+  desugarTypeDeclarations (TypeInstanceDeclaration sa na ch idx nm deps cls args (ExplicitInstance ds') : rest) =
+    (:) <$> (TypeInstanceDeclaration sa na ch idx nm deps cls args . ExplicitInstance <$> desugarTypeDeclarations ds')
         <*> desugarTypeDeclarations rest
   desugarTypeDeclarations (d:rest) = (:) d <$> desugarTypeDeclarations rest
   desugarTypeDeclarations [] = return []

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -409,8 +409,8 @@ typeCheckAll moduleName = traverse go
       (args', implies', tys', kind) <- kindOfClass moduleName (sa, pn, args, implies, tys)
       addTypeClass moduleName qualifiedClassName (fmap Just <$> args') implies' deps tys' kind
       return d
-  go (TypeInstanceDeclaration _ _ _ (Left _) _ _ _ _) = internalError "typeCheckAll: type class instance generated name should have been desugared"
-  go d@(TypeInstanceDeclaration sa@(ss, _) ch idx (Right dictName) deps className tys body) =
+  go (TypeInstanceDeclaration _ _ _ _ (Left _) _ _ _ _) = internalError "typeCheckAll: type class instance generated name should have been desugared"
+  go d@(TypeInstanceDeclaration sa@(ss, _) _ ch idx (Right dictName) deps className tys body) =
     rethrow (addHint (ErrorInInstance className tys) . addHint (positionedError ss)) $ do
       env <- getEnv
       let qualifiedDictName = Qualified (ByModuleName moduleName) dictName

--- a/tests/purs/failing/4382.out
+++ b/tests/purs/failing/4382.out
@@ -1,0 +1,55 @@
+Error 1 of 5:
+
+  in module [33mMain[0m
+  at tests/purs/failing/4382.purs:10:7 - 10:14 (line 10, column 7 - line 10, column 14)
+
+    Unknown type class [33mRinku[0m
+
+
+  See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
+  or to contribute content related to this error.
+
+Error 2 of 5:
+
+  in module [33mMain[0m
+  at tests/purs/failing/4382.purs:13:10 - 13:17 (line 13, column 10 - line 13, column 17)
+
+    Unknown type class [33mRinku[0m
+
+
+  See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
+  or to contribute content related to this error.
+
+Error 3 of 5:
+
+  in module [33mMain[0m
+  at tests/purs/failing/4382.purs:16:10 - 16:17 (line 16, column 10 - line 16, column 17)
+
+    Unknown type class [33mRinku[0m
+
+
+  See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
+  or to contribute content related to this error.
+
+Error 4 of 5:
+
+  in module [33mMain[0m
+  at tests/purs/failing/4382.purs:18:17 - 18:28 (line 18, column 17 - line 18, column 28)
+
+    Unknown type class [33mRinku[0m
+
+
+  See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
+  or to contribute content related to this error.
+
+Error 5 of 5:
+
+  in module [33mMain[0m
+  at tests/purs/failing/4382.purs:20:25 - 20:36 (line 20, column 25 - line 20, column 36)
+
+    Unknown type class [33mRinku[0m
+
+
+  See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
+  or to contribute content related to this error.
+

--- a/tests/purs/failing/4382.purs
+++ b/tests/purs/failing/4382.purs
@@ -1,0 +1,20 @@
+-- @shouldFailWith UnknownName
+-- @shouldFailWith UnknownName
+-- @shouldFailWith UnknownName
+-- @shouldFailWith UnknownName
+-- @shouldFailWith UnknownName
+module Main where
+
+newtype T a = T a
+
+class Rinku a <= Maho a where
+  tPose :: a -> a
+
+instance Rinku a => Maho a where
+  tPose = \a -> a
+
+instance Rinku a
+
+derive instance Rinku (T a)
+
+derive newtype instance Rinku (T a)


### PR DESCRIPTION
**Description of the change**

Fixes #4382. This improves the error spans for class and instance declarations. Before:
```purs
[1/5 UnknownName]

     v
  5  class Rinku a <= Maho a where
  6    tPose :: a -> a
                     ^
  
  Unknown type class Rinku

[2/5 UnknownName]

     v
  8  instance Rinku a => Maho a where
  9    tPose = \a -> a
                     ^
  
  Unknown type class Rinku

[3/5 UnknownName]

  11  instance Rinku a
      ^^^^^^^^^^^^^^^^
  
  Unknown type class Rinku

[4/5 UnknownName]

  13  derive instance Rinku (T a)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  
  Unknown type class Rinku

[5/5 UnknownName]

  15  derive newtype instance Rinku (T a)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  
  Unknown type class Rinku
```

After:
```purs
[1/5 UnknownName]

  5  class Rinku a <= Maho a where
           ^^^^^^^
  
  Unknown type class Rinku

[2/5 UnknownName]

  8  instance Rinku a => Maho a where
              ^^^^^^^
  
  Unknown type class Rinku

[3/5 UnknownName]

  11  instance Rinku a
               ^^^^^^^
  
  Unknown type class Rinku

[4/5 UnknownName]

  13  derive instance Rinku (T a)
                      ^^^^^^^^^^^
  
  Unknown type class Rinku

[5/5 UnknownName]

  15  derive newtype instance Rinku (T a)
                              ^^^^^^^^^^^
  
  Unknown type class Rinku
```

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
