### PR TITLE
Remove base-compat as a dependency

### DIFF
--- a/CHANGELOG.d/internal_remove_base_compat.md
+++ b/CHANGELOG.d/internal_remove_base_compat.md
@@ -1,0 +1,1 @@
+* Remove base-compat as a dependency

--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -3,8 +3,7 @@
 
 module Command.REPL (command) where
 
-import           Prelude ()
-import           Prelude.Compat
+import           Prelude
 import           Control.Applicative (many, (<|>))
 import           Control.Monad
 import           Control.Monad.Catch (MonadMask)

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -131,7 +131,6 @@ common defaults
     ansi-terminal >=0.11.3 && <0.12,
     array >=0.5.4.0 && <0.6,
     base >=4.16.2.0 && <4.17,
-    base-compat >=0.12.1 && <0.13,
     blaze-html >=0.9.1.2 && <0.10,
     bower-json >=1.1.0.0 && <1.2,
     boxes >=0.1.5 && <0.2,

--- a/src/Control/Monad/Logger.hs
+++ b/src/Control/Monad/Logger.hs
@@ -3,7 +3,7 @@
 --
 module Control.Monad.Logger where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad (ap)
 import Control.Monad.Base (MonadBase(..))

--- a/src/Control/Monad/Supply.hs
+++ b/src/Control/Monad/Supply.hs
@@ -3,7 +3,7 @@
 --
 module Control.Monad.Supply where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Applicative
 import Control.Monad.Error.Class (MonadError(..))

--- a/src/Control/Monad/Supply/Class.hs
+++ b/src/Control/Monad/Supply/Class.hs
@@ -4,7 +4,7 @@
 
 module Control.Monad.Supply.Class where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad.RWS
 import Control.Monad.State

--- a/src/Language/PureScript/AST/Binders.hs
+++ b/src/Language/PureScript/AST/Binders.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.AST.Binders where
 
-import Prelude.Compat
+import Prelude
 
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.AST.Literals

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -6,7 +6,7 @@
 --
 module Language.PureScript.AST.Declarations where
 
-import Prelude.Compat
+import Prelude
 import Protolude.Exceptions (hush)
 
 import Codec.Serialise (Serialise)

--- a/src/Language/PureScript/AST/Exported.hs
+++ b/src/Language/PureScript/AST/Exported.hs
@@ -3,7 +3,7 @@ module Language.PureScript.AST.Exported
   , isExported
   ) where
 
-import Prelude.Compat
+import Prelude
 import Protolude (sortOn)
 
 import Control.Category ((>>>))

--- a/src/Language/PureScript/AST/Literals.hs
+++ b/src/Language/PureScript/AST/Literals.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.AST.Literals where
 
-import Prelude.Compat
+import Prelude
 import Language.PureScript.PSString (PSString)
 
 -- |

--- a/src/Language/PureScript/AST/Operators.hs
+++ b/src/Language/PureScript/AST/Operators.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.AST.Operators where
 
-import Prelude.Compat
+import Prelude
 
 import Codec.Serialise (Serialise)
 import GHC.Generics (Generic)

--- a/src/Language/PureScript/AST/SourcePos.hs
+++ b/src/Language/PureScript/AST/SourcePos.hs
@@ -4,7 +4,7 @@
 --
 module Language.PureScript.AST.SourcePos where
 
-import Prelude.Compat
+import Prelude
 
 import Codec.Serialise (Serialise)
 import Control.DeepSeq (NFData)

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.AST.Traversals where
 
-import Prelude.Compat
+import Prelude
 import Protolude (swap)
 
 import Control.Monad

--- a/src/Language/PureScript/Bundle.hs
+++ b/src/Language/PureScript/Bundle.hs
@@ -16,7 +16,7 @@ module Language.PureScript.Bundle
   , Module
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad.Error.Class
 

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -6,7 +6,7 @@ module Language.PureScript.CodeGen.JS
   , moduleToJs
   ) where
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub)
 
 import Control.Applicative (liftA2)

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -1,7 +1,7 @@
 -- | Common code generation utility functions
 module Language.PureScript.CodeGen.JS.Common where
 
-import Prelude.Compat
+import Prelude
 
 import Data.Char
 import Data.Text (Text)

--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -4,7 +4,7 @@ module Language.PureScript.CodeGen.JS.Printer
   , prettyPrintJSWithSourceMaps
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Arrow ((<+>))
 import Control.Monad (forM, mzero)

--- a/src/Language/PureScript/Comments.hs
+++ b/src/Language/PureScript/Comments.hs
@@ -5,7 +5,7 @@
 --
 module Language.PureScript.Comments where
 
-import Prelude.Compat
+import Prelude
 import Codec.Serialise (Serialise)
 import Control.DeepSeq (NFData)
 import Data.Text (Text)

--- a/src/Language/PureScript/CoreFn/Ann.hs
+++ b/src/Language/PureScript/CoreFn/Ann.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.CoreFn.Ann where
 
-import Prelude.Compat
+import Prelude
 
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.Comments

--- a/src/Language/PureScript/CoreFn/Binders.hs
+++ b/src/Language/PureScript/CoreFn/Binders.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.CoreFn.Binders where
 
-import Prelude.Compat
+import Prelude
 
 import Language.PureScript.AST.Literals
 import Language.PureScript.Names

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.CoreFn.Desugar (moduleToCoreFn) where
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub, orEmpty)
 
 import Control.Arrow (second)

--- a/src/Language/PureScript/CoreFn/Expr.hs
+++ b/src/Language/PureScript/CoreFn/Expr.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.CoreFn.Expr where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Arrow ((***))
 

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -7,7 +7,7 @@ module Language.PureScript.CoreFn.FromJSON
   , parseVersion'
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import           Control.Applicative ((<|>))
 

--- a/src/Language/PureScript/CoreFn/Meta.hs
+++ b/src/Language/PureScript/CoreFn/Meta.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.CoreFn.Meta where
 
-import Prelude.Compat
+import Prelude
 
 import Language.PureScript.Names
 

--- a/src/Language/PureScript/CoreFn/Module.hs
+++ b/src/Language/PureScript/CoreFn/Module.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.CoreFn.Module where
 
-import Prelude.Compat
+import Prelude
 
 import Data.Map.Strict (Map)
 

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -7,7 +7,7 @@ module Language.PureScript.CoreFn.ToJSON
   ( moduleToJSON
   ) where
 
-import           Prelude.Compat
+import           Prelude
 
 import           Control.Arrow ((***))
 import           Data.Either (isLeft)

--- a/src/Language/PureScript/CoreFn/Traversals.hs
+++ b/src/Language/PureScript/CoreFn/Traversals.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.CoreFn.Traversals where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Arrow (second, (***), (+++))
 import Data.Bitraversable (bitraverse)

--- a/src/Language/PureScript/CoreImp/AST.hs
+++ b/src/Language/PureScript/CoreImp/AST.hs
@@ -1,7 +1,7 @@
 -- | Data types for the imperative core AST
 module Language.PureScript.CoreImp.AST where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad ((>=>))
 import Control.Monad.Identity (Identity(..), runIdentity)

--- a/src/Language/PureScript/CoreImp/Optimizer.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer.hs
@@ -19,7 +19,7 @@
 --  * Inlining primitive JavaScript operators
 module Language.PureScript.CoreImp.Optimizer (optimize) where
 
-import Prelude.Compat
+import Prelude
 
 import Data.Text (Text)
 

--- a/src/Language/PureScript/CoreImp/Optimizer/Blocks.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Blocks.hs
@@ -4,7 +4,7 @@ module Language.PureScript.CoreImp.Optimizer.Blocks
   , collapseNestedIfs
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Language.PureScript.CoreImp.AST
 

--- a/src/Language/PureScript/CoreImp/Optimizer/Common.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Common.hs
@@ -1,7 +1,7 @@
 -- | Common functions used by the various optimizer phases
 module Language.PureScript.CoreImp.Optimizer.Common where
 
-import Prelude.Compat
+import Prelude
 
 import Data.Text (Text)
 import Data.List (foldl')

--- a/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
@@ -12,7 +12,7 @@ module Language.PureScript.CoreImp.Optimizer.Inliner
   , evaluateIifes
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad.Supply.Class (MonadSupply, freshName)
 

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -2,7 +2,7 @@
 -- and bind for the Eff monad, as well as some of its actions.
 module Language.PureScript.CoreImp.Optimizer.MagicDo (magicDoEffect, magicDoEff, magicDoST, inlineST) where
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub)
 
 import Data.Maybe (fromJust, isJust)

--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -1,7 +1,7 @@
 -- | This module implements tail call elimination.
 module Language.PureScript.CoreImp.Optimizer.TCO (tco) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Applicative (empty, liftA2)
 import Control.Monad (guard)

--- a/src/Language/PureScript/CoreImp/Optimizer/Unused.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Unused.hs
@@ -5,7 +5,7 @@ module Language.PureScript.CoreImp.Optimizer.Unused
   , removeUnusedEffectFreeVars
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad (filterM)
 import Data.Monoid (Any(..))

--- a/src/Language/PureScript/Crash.hs
+++ b/src/Language/PureScript/Crash.hs
@@ -1,21 +1,8 @@
-{-# LANGUAGE CPP #-}
-
-module Language.PureScript.Crash where
+module Language.PureScript.Crash (HasCallStack, internalError) where
 
 import Prelude
 
-import qualified GHC.Stack
-
--- | A compatibility wrapper for the @GHC.Stack.HasCallStack@ constraint.
-#if __GLASGOW_HASKELL__ >= 800
-type HasCallStack = GHC.Stack.HasCallStack
-#elif MIN_VERSION_GLASGOW_HASKELL(7,10,2,0)
-type HasCallStack = (?callStack :: GHC.Stack.CallStack)
-#else
-import GHC.Exts (Constraint)
--- CallStack wasn't present in GHC 7.10.1
-type HasCallStack = (() :: Constraint)
-#endif
+import GHC.Stack (HasCallStack)
 
 -- | Exit with an error message and a crash report link.
 internalError :: HasCallStack => String -> a

--- a/src/Language/PureScript/Crash.hs
+++ b/src/Language/PureScript/Crash.hs
@@ -2,7 +2,7 @@
 
 module Language.PureScript.Crash where
 
-import Prelude.Compat
+import Prelude
 
 import qualified GHC.Stack
 

--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -5,7 +5,7 @@ module Language.PureScript.Docs.AsMarkdown
   , codeToString
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad (unless, zipWithM_)
 import Control.Monad.Writer (Writer, tell, execWriter)

--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -2,7 +2,7 @@ module Language.PureScript.Docs.Convert.ReExports
   ( updateReExports
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Arrow ((&&&), first, second)
 import Control.Monad

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -6,7 +6,7 @@ module Language.PureScript.Docs.Prim
   , primModules
   ) where
 
-import Prelude.Compat hiding (fail)
+import Prelude hiding (fail)
 import Data.Functor (($>))
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -9,7 +9,7 @@
 
 module Language.PureScript.Docs.Render where
 
-import Prelude.Compat
+import Prelude
 
 import Data.Maybe (maybeToList)
 import Data.Text (Text)

--- a/src/Language/PureScript/Docs/RenderedCode/RenderType.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/RenderType.hs
@@ -12,7 +12,7 @@ module Language.PureScript.Docs.RenderedCode.RenderType
   , renderRow
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Data.Maybe (fromMaybe)
 import Data.Text (Text, pack)

--- a/src/Language/PureScript/Docs/RenderedCode/Types.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Types.hs
@@ -32,7 +32,7 @@ module Language.PureScript.Docs.RenderedCode.Types
  , aliasName
  ) where
 
-import Prelude.Compat
+import Prelude
 import GHC.Generics (Generic)
 
 import Control.DeepSeq (NFData)

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Environment where
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub)
 
 import GHC.Generics (Generic)

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -3,7 +3,7 @@ module Language.PureScript.Errors
   , module Language.PureScript.Errors
   ) where
 
-import           Prelude.Compat
+import           Prelude
 
 import           Control.Arrow ((&&&))
 import           Control.Exception (displayException)

--- a/src/Language/PureScript/Errors/JSON.hs
+++ b/src/Language/PureScript/Errors/JSON.hs
@@ -2,7 +2,7 @@
 
 module Language.PureScript.Errors.JSON where
 
-import Prelude.Compat
+import Prelude
 
 import qualified Data.Aeson.TH as A
 import qualified Data.List.NonEmpty as NEL

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -14,7 +14,7 @@ module Language.PureScript.Externs
   , externsFileName
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Codec.Serialise (Serialise)
 import Control.Monad (join)

--- a/src/Language/PureScript/Graph.hs
+++ b/src/Language/PureScript/Graph.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Graph (graph) where
 
-import Prelude.Compat
+import Prelude
 
 import qualified Data.Aeson as Json
 import qualified Data.Aeson.Key as Json.Key

--- a/src/Language/PureScript/Hierarchy.hs
+++ b/src/Language/PureScript/Hierarchy.hs
@@ -15,7 +15,7 @@
 
 module Language.PureScript.Hierarchy where
 
-import           Prelude.Compat
+import           Prelude
 import           Protolude (ordNub)
 
 import           Data.List (sort)

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -9,8 +9,7 @@ module Language.PureScript.Interactive
   , runMake
   ) where
 
-import           Prelude ()
-import           Prelude.Compat
+import           Prelude
 import           Protolude (ordNub)
 
 import           Data.List (sort, find, foldl')

--- a/src/Language/PureScript/Interactive/Completion.hs
+++ b/src/Language/PureScript/Interactive/Completion.hs
@@ -6,7 +6,7 @@ module Language.PureScript.Interactive.Completion
   , formatCompletions
   ) where
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub)
 
 import           Control.Monad.IO.Class (MonadIO(..))

--- a/src/Language/PureScript/Interactive/Directive.hs
+++ b/src/Language/PureScript/Interactive/Directive.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.Interactive.Directive where
 
-import Prelude.Compat
+import Prelude
 
 import Data.Maybe (fromJust)
 import Data.List (isPrefixOf)

--- a/src/Language/PureScript/Interactive/IO.hs
+++ b/src/Language/PureScript/Interactive/IO.hs
@@ -2,7 +2,7 @@
 
 module Language.PureScript.Interactive.IO (findNodeProcess, readNodeProcessWithExitCode, getHistoryFilename) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad (msum, void)
 import Control.Monad.Error.Class (throwError)

--- a/src/Language/PureScript/Interactive/Message.hs
+++ b/src/Language/PureScript/Interactive/Message.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Interactive.Message where
 
-import           Prelude.Compat
+import           Prelude
 
 import           Data.List (intercalate)
 import           Data.Version (showVersion)

--- a/src/Language/PureScript/Interactive/Module.hs
+++ b/src/Language/PureScript/Interactive/Module.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Interactive.Module where
 
-import           Prelude.Compat
+import           Prelude
 
 import qualified Language.PureScript as P
 import qualified Language.PureScript.CST as CST

--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -6,7 +6,7 @@ module Language.PureScript.Interactive.Parser
   , parseCommand
   ) where
 
-import           Prelude.Compat hiding (lex)
+import           Prelude
 
 import           Control.Monad (join)
 import           Data.Bifunctor (bimap)

--- a/src/Language/PureScript/Interactive/Printer.hs
+++ b/src/Language/PureScript/Interactive/Printer.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Interactive.Printer where
 
-import           Prelude.Compat
+import           Prelude
 
 import           Data.List (intersperse)
 import qualified Data.Map as M

--- a/src/Language/PureScript/Interactive/Types.hs
+++ b/src/Language/PureScript/Interactive/Types.hs
@@ -28,7 +28,7 @@ module Language.PureScript.Interactive.Types
   , Directive(..)
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import qualified Language.PureScript as P
 import qualified Data.Map as M

--- a/src/Language/PureScript/Label.hs
+++ b/src/Language/PureScript/Label.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Label (Label(..)) where
 
-import Prelude.Compat hiding (lex)
+import Prelude hiding (lex)
 import GHC.Generics (Generic)
 import Codec.Serialise (Serialise)
 import Control.DeepSeq (NFData)

--- a/src/Language/PureScript/Label.hs
+++ b/src/Language/PureScript/Label.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Label (Label(..)) where
 
-import Prelude hiding (lex)
+import Prelude
 import GHC.Generics (Generic)
 import Codec.Serialise (Serialise)
 import Control.DeepSeq (NFData)

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.Linter (lint, module L) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad.Writer.Class
 

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -8,7 +8,7 @@ module Language.PureScript.Linter.Exhaustive
   ( checkExhaustiveExpr
   ) where
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub)
 
 import Control.Applicative

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -4,7 +4,7 @@ module Language.PureScript.Linter.Imports
   , UsedImports()
   ) where
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub)
 
 import Control.Monad (join, unless, foldM, (<=<))

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -9,7 +9,7 @@ module Language.PureScript.Make
   , module Actions
   ) where
 
-import           Prelude.Compat
+import           Prelude
 
 import           Control.Concurrent.Lifted as C
 import           Control.Exception.Base (onException)

--- a/src/Language/PureScript/Names.hs
+++ b/src/Language/PureScript/Names.hs
@@ -5,7 +5,7 @@
 --
 module Language.PureScript.Names where
 
-import Prelude.Compat
+import Prelude
 
 import Codec.Serialise (Serialise)
 import Control.Applicative ((<|>))

--- a/src/Language/PureScript/Options.hs
+++ b/src/Language/PureScript/Options.hs
@@ -1,7 +1,7 @@
 -- | The data type of compiler options
 module Language.PureScript.Options where
 
-import Prelude.Compat
+import Prelude
 import qualified Data.Set as S
 import Data.Map (Map)
 import qualified Data.Map as Map

--- a/src/Language/PureScript/PSString.hs
+++ b/src/Language/PureScript/PSString.hs
@@ -9,7 +9,7 @@ module Language.PureScript.PSString
   , mkString
   ) where
 
-import Prelude.Compat
+import Prelude
 import GHC.Generics (Generic)
 import Codec.Serialise (Serialise)
 import Control.DeepSeq (NFData)

--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.Pretty.Common where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad.State (StateT, modify, get)
 

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -19,7 +19,7 @@ module Language.PureScript.Pretty.Types
   , prettyPrintObjectKey
   ) where
 
-import Prelude.Compat hiding ((<>))
+import Prelude hiding ((<>))
 
 import Control.Arrow ((<+>))
 import Control.PatternArrows as PA

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -7,7 +7,7 @@ module Language.PureScript.Pretty.Values
   , prettyPrintBinderAtom
   ) where
 
-import Prelude.Compat hiding ((<>))
+import Prelude hiding ((<>))
 
 import Control.Arrow (second)
 

--- a/src/Language/PureScript/Publish/BoxesHelpers.hs
+++ b/src/Language/PureScript/Publish/BoxesHelpers.hs
@@ -4,7 +4,7 @@ module Language.PureScript.Publish.BoxesHelpers
   , module Language.PureScript.Publish.BoxesHelpers
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -12,7 +12,7 @@ module Language.PureScript.Publish.ErrorsWarnings
   , renderWarnings
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Exception (IOException)
 

--- a/src/Language/PureScript/Publish/Utils.hs
+++ b/src/Language/PureScript/Publish/Utils.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Publish.Utils where
 
-import Prelude.Compat
+import Prelude
 
 import System.Directory
 import System.FilePath.Glob (Pattern, compile, globDir1)

--- a/src/Language/PureScript/Renamer.hs
+++ b/src/Language/PureScript/Renamer.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.Renamer (renameInModule) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad.State
 

--- a/src/Language/PureScript/Roles.hs
+++ b/src/Language/PureScript/Roles.hs
@@ -8,7 +8,7 @@ module Language.PureScript.Roles
   , displayRole
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Codec.Serialise (Serialise)
 import Control.DeepSeq (NFData)

--- a/src/Language/PureScript/Sugar/AdoNotation.hs
+++ b/src/Language/PureScript/Sugar/AdoNotation.hs
@@ -3,7 +3,7 @@
 
 module Language.PureScript.Sugar.AdoNotation (desugarAdoModule) where
 
-import           Prelude
+import           Prelude hiding (abs)
 
 import           Control.Monad (foldM)
 import           Control.Monad.Error.Class (MonadError(..))

--- a/src/Language/PureScript/Sugar/AdoNotation.hs
+++ b/src/Language/PureScript/Sugar/AdoNotation.hs
@@ -3,7 +3,7 @@
 
 module Language.PureScript.Sugar.AdoNotation (desugarAdoModule) where
 
-import           Prelude.Compat hiding (abs)
+import           Prelude
 
 import           Control.Monad (foldM)
 import           Control.Monad.Error.Class (MonadError(..))

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -8,7 +8,7 @@ module Language.PureScript.Sugar.BindingGroups
   , collapseBindingGroups
   ) where
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub)
 
 import Control.Monad ((<=<), guard)

--- a/src/Language/PureScript/Sugar/CaseDeclarations.hs
+++ b/src/Language/PureScript/Sugar/CaseDeclarations.hs
@@ -8,7 +8,7 @@ module Language.PureScript.Sugar.CaseDeclarations
   , desugarCaseGuards
   ) where
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub)
 
 import Data.List (groupBy, foldl1')

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -3,7 +3,7 @@
 
 module Language.PureScript.Sugar.DoNotation (desugarDoModule) where
 
-import           Prelude.Compat
+import           Prelude
 
 import           Control.Applicative ((<|>))
 import           Control.Monad.Error.Class (MonadError(..))

--- a/src/Language/PureScript/Sugar/LetPattern.hs
+++ b/src/Language/PureScript/Sugar/LetPattern.hs
@@ -4,7 +4,7 @@
 --
 module Language.PureScript.Sugar.LetPattern (desugarLetPatternModule) where
 
-import Prelude.Compat
+import Prelude
 
 import Data.List (groupBy)
 import Data.Function (on)

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -9,7 +9,7 @@ module Language.PureScript.Sugar.Names
   , Exports(..)
   ) where
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub, sortOn, swap, foldl')
 
 import Control.Arrow (first, second)

--- a/src/Language/PureScript/Sugar/Names/Common.hs
+++ b/src/Language/PureScript/Sugar/Names/Common.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Sugar.Names.Common (warnDuplicateRefs) where
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub)
 
 import Control.Monad.Writer (MonadWriter(..))

--- a/src/Language/PureScript/Sugar/Names/Env.hs
+++ b/src/Language/PureScript/Sugar/Names/Env.hs
@@ -18,7 +18,7 @@ module Language.PureScript.Sugar.Names.Env
   , checkImportConflicts
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -3,7 +3,7 @@ module Language.PureScript.Sugar.Names.Exports
   , resolveExports
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad
 import Control.Monad.Writer.Class (MonadWriter(..))

--- a/src/Language/PureScript/Sugar/Names/Imports.hs
+++ b/src/Language/PureScript/Sugar/Names/Imports.hs
@@ -5,7 +5,7 @@ module Language.PureScript.Sugar.Names.Imports
   , findImports
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))

--- a/src/Language/PureScript/Sugar/ObjectWildcards.hs
+++ b/src/Language/PureScript/Sugar/ObjectWildcards.hs
@@ -3,7 +3,7 @@ module Language.PureScript.Sugar.ObjectWildcards
   , desugarDecl
   ) where
 
-import           Prelude.Compat
+import           Prelude
 
 import           Control.Monad (forM)
 import           Control.Monad.Error.Class (MonadError(..))

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -13,7 +13,7 @@ module Language.PureScript.Sugar.Operators
   , checkFixityExports
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Language.PureScript.AST
 import Language.PureScript.Crash

--- a/src/Language/PureScript/Sugar/Operators/Binders.hs
+++ b/src/Language/PureScript/Sugar/Operators/Binders.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Sugar.Operators.Binders where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad.Except
 

--- a/src/Language/PureScript/Sugar/Operators/Common.hs
+++ b/src/Language/PureScript/Sugar/Operators/Common.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Sugar.Operators.Common where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad.State
 import Control.Monad.Except

--- a/src/Language/PureScript/Sugar/Operators/Expr.hs
+++ b/src/Language/PureScript/Sugar/Operators/Expr.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Sugar.Operators.Expr where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad.Except
 import Data.Functor.Identity

--- a/src/Language/PureScript/Sugar/Operators/Types.hs
+++ b/src/Language/PureScript/Sugar/Operators/Types.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Sugar.Operators.Types where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad.Except
 import Language.PureScript.AST

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -8,7 +8,7 @@ module Language.PureScript.Sugar.TypeClasses
   , superClassDictionaryNames
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import           Control.Arrow (first, second)
 import           Control.Monad.Error.Class (MonadError(..))

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -1,7 +1,7 @@
 -- | This module implements the generic deriving elaboration that takes place during desugaring.
 module Language.PureScript.Sugar.TypeClasses.Deriving (deriveInstances) where
 
-import           Prelude.Compat
+import           Prelude
 import           Protolude (note)
 
 import           Control.Monad.Error.Class (MonadError(..))

--- a/src/Language/PureScript/Sugar/TypeDeclarations.hs
+++ b/src/Language/PureScript/Sugar/TypeDeclarations.hs
@@ -6,7 +6,7 @@ module Language.PureScript.Sugar.TypeDeclarations
   ( desugarTypeDeclarationsModule
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad (unless)
 import Control.Monad.Error.Class (MonadError(..))

--- a/src/Language/PureScript/Traversals.hs
+++ b/src/Language/PureScript/Traversals.hs
@@ -1,7 +1,7 @@
 -- | Common functions for implementing generic traversals
 module Language.PureScript.Traversals where
 
-import Prelude.Compat
+import Prelude
 
 sndM :: (Functor f) => (b -> f c) -> (a, b) -> f (a, c)
 sndM f (a, b) = (a, ) <$> f b

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -7,7 +7,7 @@ module Language.PureScript.TypeChecker
   , checkNewtype
   ) where
 
-import Prelude.Compat
+import Prelude
 import Protolude (headMay, maybeToLeft, ordNub)
 
 import Control.Lens ((^..), _2)

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -9,7 +9,7 @@ module Language.PureScript.TypeChecker.Entailment
   , entails
   ) where
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub)
 
 import Control.Arrow (second, (&&&))

--- a/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
@@ -13,7 +13,7 @@ module Language.PureScript.TypeChecker.Entailment.Coercible
   , insoluble
   ) where
 
-import Prelude.Compat hiding (interact)
+import Prelude hiding (interact)
 
 import Control.Applicative ((<|>), empty)
 import Control.Arrow ((&&&))

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -25,7 +25,7 @@ module Language.PureScript.TypeChecker.Kinds
   , freshKindWithKind
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Arrow ((***))
 import Control.Lens ((^.), _1, _2, _3)

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -5,7 +5,7 @@
 --
 module Language.PureScript.TypeChecker.Monad where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Arrow (second)
 import Control.Monad.Error.Class (MonadError(..))

--- a/src/Language/PureScript/TypeChecker/Roles.hs
+++ b/src/Language/PureScript/TypeChecker/Roles.hs
@@ -11,7 +11,7 @@ module Language.PureScript.TypeChecker.Roles
   , inferDataBindingGroupRoles
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Arrow ((&&&))
 import Control.Monad (unless, when, zipWithM_)

--- a/src/Language/PureScript/TypeChecker/Skolems.hs
+++ b/src/Language/PureScript/TypeChecker/Skolems.hs
@@ -8,7 +8,7 @@ module Language.PureScript.TypeChecker.Skolems
   , skolemEscapeCheck
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Class (MonadState(..), gets, modify)

--- a/src/Language/PureScript/TypeChecker/Subsumption.hs
+++ b/src/Language/PureScript/TypeChecker/Subsumption.hs
@@ -5,7 +5,7 @@ module Language.PureScript.TypeChecker.Subsumption
   ( subsumes
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad (when)
 import Control.Monad.Error.Class (MonadError(..))

--- a/src/Language/PureScript/TypeChecker/Synonyms.hs
+++ b/src/Language/PureScript/TypeChecker/Synonyms.hs
@@ -10,7 +10,7 @@ module Language.PureScript.TypeChecker.Synonyms
   , replaceAllTypeSynonymsM
   ) where
 
-import           Prelude.Compat
+import           Prelude
 
 import           Control.Monad.Error.Class (MonadError(..))
 import           Control.Monad.State

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -23,7 +23,7 @@ module Language.PureScript.TypeChecker.Types
       Check a function of a given type returns a value of another type when applied to its arguments
 -}
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub, fold, atMay)
 
 import Control.Arrow (first, second, (***))

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -14,7 +14,7 @@ module Language.PureScript.TypeChecker.Unify
   , varIfUnknown
   ) where
 
-import Prelude.Compat
+import Prelude
 
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))

--- a/src/Language/PureScript/TypeClassDictionaries.hs
+++ b/src/Language/PureScript/TypeClassDictionaries.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.TypeClassDictionaries where
 
-import Prelude.Compat
+import Prelude
 
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -3,7 +3,7 @@
 --
 module Language.PureScript.Types where
 
-import Prelude.Compat
+import Prelude
 import Protolude (ordNub)
 
 import Codec.Serialise (Serialise)

--- a/src/System/IO/UTF8.hs
+++ b/src/System/IO/UTF8.hs
@@ -1,6 +1,6 @@
 module System.IO.UTF8 where
 
-import Prelude.Compat
+import Prelude
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -2,7 +2,6 @@
 
 module Main (main) where
 
-import Prelude ()
 import Prelude
 
 import Test.Hspec

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -3,7 +3,7 @@
 module Main (main) where
 
 import Prelude ()
-import Prelude.Compat
+import Prelude
 
 import Test.Hspec
 

--- a/tests/TestCompiler.hs
+++ b/tests/TestCompiler.hs
@@ -22,7 +22,6 @@ module TestCompiler where
 -- missing, and can be updated by setting the "HSPEC_ACCEPT" environment
 -- variable, e.g. by running `HSPEC_ACCEPT=true stack test`.
 
-import Prelude ()
 import Prelude
 
 import qualified Language.PureScript as P

--- a/tests/TestCompiler.hs
+++ b/tests/TestCompiler.hs
@@ -23,7 +23,7 @@ module TestCompiler where
 -- variable, e.g. by running `HSPEC_ACCEPT=true stack test`.
 
 import Prelude ()
-import Prelude.Compat
+import Prelude
 
 import qualified Language.PureScript as P
 import Language.PureScript.Interactive.IO (readNodeProcessWithExitCode)

--- a/tests/TestCoreFn.hs
+++ b/tests/TestCoreFn.hs
@@ -2,7 +2,6 @@
 
 module TestCoreFn (spec) where
 
-import Prelude ()
 import Prelude
 
 import Data.Aeson

--- a/tests/TestCoreFn.hs
+++ b/tests/TestCoreFn.hs
@@ -3,7 +3,7 @@
 module TestCoreFn (spec) where
 
 import Prelude ()
-import Prelude.Compat
+import Prelude
 
 import Data.Aeson
 import Data.Aeson.Types as Aeson

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -1,7 +1,7 @@
 module TestDocs where
 
 import Prelude ()
-import Prelude.Compat
+import Prelude
 
 import Data.Bifunctor (first)
 import Data.List (findIndex)

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -1,6 +1,5 @@
 module TestDocs where
 
-import Prelude ()
 import Prelude
 
 import Data.Bifunctor (first)

--- a/tests/TestGraph.hs
+++ b/tests/TestGraph.hs
@@ -1,7 +1,7 @@
 module TestGraph where
 
 import Prelude ()
-import Prelude.Compat
+import Prelude
 
 import Test.Hspec
 import Data.Either (isLeft)

--- a/tests/TestGraph.hs
+++ b/tests/TestGraph.hs
@@ -1,6 +1,5 @@
 module TestGraph where
 
-import Prelude ()
 import Prelude
 
 import Test.Hspec

--- a/tests/TestMake.hs
+++ b/tests/TestMake.hs
@@ -3,7 +3,6 @@
 
 module TestMake where
 
-import Prelude ()
 import Prelude
 
 import qualified Language.PureScript as P

--- a/tests/TestMake.hs
+++ b/tests/TestMake.hs
@@ -4,7 +4,7 @@
 module TestMake where
 
 import Prelude ()
-import Prelude.Compat
+import Prelude
 
 import qualified Language.PureScript as P
 import qualified Language.PureScript.CST as CST

--- a/tests/TestPsci.hs
+++ b/tests/TestPsci.hs
@@ -1,6 +1,5 @@
 module TestPsci where
 
-import Prelude ()
 
 import TestPsci.CommandTest (commandTests)
 import TestPsci.CompletionTest (completionTests)

--- a/tests/TestPsci/CommandTest.hs
+++ b/tests/TestPsci/CommandTest.hs
@@ -1,6 +1,5 @@
 module TestPsci.CommandTest where
 
-import Prelude ()
 import Prelude
 
 import Control.Monad.IO.Class (liftIO)

--- a/tests/TestPsci/CommandTest.hs
+++ b/tests/TestPsci/CommandTest.hs
@@ -1,7 +1,7 @@
 module TestPsci.CommandTest where
 
 import Prelude ()
-import Prelude.Compat
+import Prelude
 
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.RWS.Strict (get)

--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -1,6 +1,5 @@
 module TestPsci.CompletionTest where
 
-import Prelude ()
 import Prelude
 
 import Test.Hspec

--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -1,7 +1,7 @@
 module TestPsci.CompletionTest where
 
 import Prelude ()
-import Prelude.Compat
+import Prelude
 
 import Test.Hspec
 

--- a/tests/TestPsci/EvalTest.hs
+++ b/tests/TestPsci/EvalTest.hs
@@ -1,6 +1,5 @@
 module TestPsci.EvalTest where
 
-import Prelude ()
 import Prelude
 
 import           Control.Monad (forM_, foldM_)

--- a/tests/TestPsci/EvalTest.hs
+++ b/tests/TestPsci/EvalTest.hs
@@ -1,7 +1,7 @@
 module TestPsci.EvalTest where
 
 import Prelude ()
-import Prelude.Compat
+import Prelude
 
 import           Control.Monad (forM_, foldM_)
 import           Control.Monad.IO.Class (liftIO)

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -1,6 +1,5 @@
 module TestPsci.TestEnv where
 
-import Prelude ()
 import Prelude
 
 import           Control.Exception.Lifted (bracket_)

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -1,7 +1,7 @@
 module TestPsci.TestEnv where
 
 import Prelude ()
-import Prelude.Compat
+import Prelude
 
 import           Control.Exception.Lifted (bracket_)
 import           Control.Monad (void, when)

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -1,7 +1,7 @@
 module TestUtils where
 
 import Prelude ()
-import Prelude.Compat
+import Prelude
 
 import qualified Language.PureScript as P
 import qualified Language.PureScript.CST as CST

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -1,6 +1,5 @@
 module TestUtils where
 
-import Prelude ()
 import Prelude
 
 import qualified Language.PureScript as P


### PR DESCRIPTION
**Description of the change**

Fixes #4377. This replaces all `Prelude.Compat` imports with just `Prelude`. Ideally, we want most of the codebase to use `Protolude` as it encourages usage `Text` and such, but I think replacing most usages of `s/String/Text` should come with a separate PR.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
