### PR TITLE
Remove references to `purescript-cst` from Makefile

### DIFF
--- a/CHANGELOG.d/internal_remove-purescript-cst-from-makefile.md
+++ b/CHANGELOG.d/internal_remove-purescript-cst-from-makefile.md
@@ -1,0 +1,1 @@
+* Remove `purescript-cst` from Makefile

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ help: ## Print documentation
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 ghcid: ## Run ghcid to quickly reload code on save.
-	ghcid --command "stack ghci purescript:exe:purs purescript:lib purescript:test:tests purescript-cst --main-is purescript:exe:purs --ghci-options -fno-code"
+	ghcid --command "stack ghci purescript:exe:purs purescript:lib purescript:test:tests --main-is purescript:exe:purs --ghci-options -fno-code"
 
 ghcid-test: ## Run ghcid to quickly reload code and run tests on save.
-	ghcid --command "stack ghci purescript:lib purescript:test:tests purescript-cst --ghci-options -fobject-code" \
+	ghcid --command "stack ghci purescript:lib purescript:test:tests --ghci-options -fobject-code" \
 	    --test "Main.main"
 
 build: ## Build the package.


### PR DESCRIPTION
**Description of the change**

Fixes #4388 

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
