### PR TITLE
Add compiler-support for deriving `Debug` type class

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -212,6 +212,7 @@ library
     Language.PureScript.CodeGen.JS.Common
     Language.PureScript.CodeGen.JS.Printer
     Language.PureScript.Constants.Prelude
+    Language.PureScript.Constants.Data.Debug
     Language.PureScript.Constants.Data.Generic.Rep
     Language.PureScript.Constants.Data.Newtype
     Language.PureScript.CoreFn

--- a/src/Language/PureScript/AST/Utils.hs
+++ b/src/Language/PureScript/AST/Utils.hs
@@ -5,6 +5,7 @@ import Protolude
 import Language.PureScript.AST
 import Language.PureScript.Names
 import Language.PureScript.Types
+import Language.PureScript.PSString (PSString, mkString)
 
 lam :: Ident -> Expr -> Expr
 lam = Abs . mkBinder
@@ -29,6 +30,18 @@ mkBinder = VarBinder nullSourceSpan
 
 mkLit :: Literal Expr -> Expr
 mkLit = Literal nullSourceSpan
+
+mkLitString :: PSString -> Expr
+mkLitString = mkLit . StringLiteral
+
+mkLitString' :: Text -> Expr
+mkLitString' = mkLit . StringLiteral . mkString
+
+mkLitArray :: [Expr] -> Expr
+mkLitArray = mkLit . ArrayLiteral
+
+mkLitObject :: [(PSString, Expr)] -> Expr
+mkLitObject = mkLit . ObjectLiteral
 
 mkCtor :: ModuleName -> ProperName 'ConstructorName -> Expr
 mkCtor mn name = Constructor nullSourceSpan (Qualified (ByModuleName mn) name)

--- a/src/Language/PureScript/Constants/Data/Debug.hs
+++ b/src/Language/PureScript/Constants/Data/Debug.hs
@@ -66,12 +66,6 @@ constructor = "constructor"
 identConstructor :: Qualified Ident
 identConstructor = Qualified (ByModuleName DataDebugType) (Ident constructor)
 
-opaque :: forall a. (IsString a) => a
-opaque = "opaque"
-
-identOpaque :: Qualified Ident
-identOpaque = Qualified (ByModuleName DataDebugType) (Ident opaque)
-
 opaque_ :: forall a. (IsString a) => a
 opaque_ = "opaque_"
 

--- a/src/Language/PureScript/Constants/Data/Debug.hs
+++ b/src/Language/PureScript/Constants/Data/Debug.hs
@@ -1,0 +1,79 @@
+module Language.PureScript.Constants.Data.Debug where
+
+import Data.String (IsString)
+import Language.PureScript.Names
+
+pattern DataDebug :: ModuleName
+pattern DataDebug = ModuleName "Data.Debug"
+
+pattern Debug :: Qualified (ProperName 'ClassName)
+pattern Debug = Qualified (ByModuleName DataDebug) (ProperName "Debug")
+
+debug :: forall a. (IsString a) => a
+debug = "debug"
+
+identDebug :: Qualified Ident
+identDebug = Qualified (ByModuleName DataDebug) (Ident debug)
+
+pattern DataDebugType :: ModuleName
+pattern DataDebugType = ModuleName "Data.Debug.Type"
+
+int :: forall a. (IsString a) => a
+int = "int"
+
+identInt :: Qualified Ident
+identInt = Qualified (ByModuleName DataDebugType) (Ident int)
+
+number :: forall a. (IsString a) => a
+number = "number"
+
+identNumber :: Qualified Ident
+identNumber = Qualified (ByModuleName DataDebugType) (Ident number)
+
+boolean :: forall a. (IsString a) => a
+boolean = "boolean"
+
+identBoolean :: Qualified Ident
+identBoolean = Qualified (ByModuleName DataDebugType) (Ident boolean)
+
+char :: forall a. (IsString a) => a
+char = "char"
+
+identChar :: Qualified Ident
+identChar = Qualified (ByModuleName DataDebugType) (Ident char)
+
+string :: forall a. (IsString a) => a
+string = "string"
+
+identString :: Qualified Ident
+identString = Qualified (ByModuleName DataDebugType) (Ident string)
+
+array :: forall a. (IsString a) => a
+array = "array"
+
+identArray :: Qualified Ident
+identArray = Qualified (ByModuleName DataDebugType) (Ident array)
+
+record :: forall a. (IsString a) => a
+record = "record"
+
+identRecord :: Qualified Ident
+identRecord = Qualified (ByModuleName DataDebugType) (Ident record)
+
+constructor :: forall a. (IsString a) => a
+constructor = "constructor"
+
+identConstructor :: Qualified Ident
+identConstructor = Qualified (ByModuleName DataDebugType) (Ident constructor)
+
+opaque :: forall a. (IsString a) => a
+opaque = "opaque"
+
+identOpaque :: Qualified Ident
+identOpaque = Qualified (ByModuleName DataDebugType) (Ident opaque)
+
+opaque_ :: forall a. (IsString a) => a
+opaque_ = "opaque_"
+
+identOpaque_ :: Qualified Ident
+identOpaque_ = Qualified (ByModuleName DataDebugType) (Ident opaque_)

--- a/src/Language/PureScript/Constants/Prim.hs
+++ b/src/Language/PureScript/Constants/Prim.hs
@@ -35,6 +35,21 @@ pattern Array = Qualified (ByModuleName Prim) (ProperName "Array")
 pattern Row :: Qualified (ProperName 'TypeName)
 pattern Row = Qualified (ByModuleName Prim) (ProperName "Row")
 
+pattern Number :: Qualified (ProperName 'TypeName)
+pattern Number = Qualified (ByModuleName Prim) (ProperName "Number")
+
+pattern Int :: Qualified (ProperName 'TypeName)
+pattern Int = Qualified (ByModuleName Prim) (ProperName "Int")
+
+pattern String :: Qualified (ProperName 'TypeName)
+pattern String = Qualified (ByModuleName Prim) (ProperName "String")
+
+pattern Char :: Qualified (ProperName 'TypeName)
+pattern Char = Qualified (ByModuleName Prim) (ProperName "Char")
+
+pattern Boolean :: Qualified (ProperName 'TypeName)
+pattern Boolean = Qualified (ByModuleName Prim) (ProperName "Boolean")
+
 -- Prim.Boolean
 
 pattern PrimBoolean :: ModuleName

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -188,6 +188,7 @@ data SimpleErrorMessage
   | UnsupportedRoleDeclaration
   | RoleDeclarationArityMismatch (ProperName 'TypeName) Int Int
   | DuplicateRoleDeclaration (ProperName 'TypeName)
+  | CannotDeriveInvalidConstructorDebugArg SourceSpan
   deriving (Show)
 
 data ErrorMessage = ErrorMessage
@@ -353,6 +354,7 @@ errorCode em = case unwrapErrorMessage em of
   UnsupportedRoleDeclaration {} -> "UnsupportedRoleDeclaration"
   RoleDeclarationArityMismatch {} -> "RoleDeclarationArityMismatch"
   DuplicateRoleDeclaration {} -> "DuplicateRoleDeclaration"
+  CannotDeriveInvalidConstructorDebugArg {} -> "CannotDeriveInvalidConstructorDebugArg"
 
 -- | A stack trace for an error
 newtype MultipleErrors = MultipleErrors
@@ -1366,6 +1368,9 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath) e = fl
 
     renderSimpleErrorMessage (DuplicateRoleDeclaration name) =
       line $ "Duplicate role declaration for " <> markCode (runProperName name) <> "."
+
+    renderSimpleErrorMessage (CannotDeriveInvalidConstructorDebugArg ss) =
+      line $ markCode "Debug" <> " deriving failued due to arg at " <> displaySourceSpan relPath ss
 
     renderHint :: ErrorMessageHint -> Box.Box -> Box.Box
     renderHint (ErrorUnifyingTypes t1@RCons{} t2@RCons{}) detail =

--- a/src/Language/PureScript/TypeChecker/Deriving.hs
+++ b/src/Language/PureScript/TypeChecker/Deriving.hs
@@ -252,7 +252,7 @@ deriveDebug mn tyConNm = do
         keyValuePairs <- for rows' $ \(lbl, valTy) -> do
           let lbl' = runLabel lbl
           val' <- toDebugExpr (Accessor lbl' argIdent) valTy
-          pure $ mkLit $ ObjectLiteral
+          pure $ mkLitObject
             [ (mkString "key", mkLitString lbl')
             , (mkString "value", val')
             ]

--- a/tests/purs/passing/DerivingDebug.purs
+++ b/tests/purs/passing/DerivingDebug.purs
@@ -1,9 +1,9 @@
 module Main where
 
 import Prelude
+
 import Data.Debug.Type as D
 import Data.Debug (class Debug, debug)
-import Data.Eq (class Eq1)
 import Effect.Console (log)
 import Test.Assert
 
@@ -16,7 +16,6 @@ data M f a
   | M5 (f a)
   | M6 (f (f a))
 
-derive instance eqM :: (Eq1 f, Eq a) => Eq (M f a)
 derive instance (Debug (f (f a)), Debug (f a), Debug a) => Debug (M f a)
 
 type MA = M Array
@@ -43,7 +42,7 @@ m2' = D.constructor "M2"
       ]
   ]
 
-m3 = M3 { bar: { baz: 9 } }
+m3 = M3 { bar: { baz: 9 } } :: MA Int
 m3' = D.constructor "M3" 
   [ D.record
       [ { key: "bar" 

--- a/tests/purs/passing/DerivingDebug.purs
+++ b/tests/purs/passing/DerivingDebug.purs
@@ -1,0 +1,86 @@
+module Main where
+
+import Prelude
+import Data.Debug.Type as D
+import Data.Debug (class Debug, debug)
+import Data.Eq (class Eq1)
+import Effect.Console (log)
+import Test.Assert
+
+data M f a
+  = M0
+  | M1 Int Boolean Char String Number (Array String) { foo :: Int }
+  | M2 (Array (Array String))
+  | M3 { bar :: { baz :: Int } }
+  | M4 a
+  | M5 (f a)
+  | M6 (f (f a))
+
+derive instance eqM :: (Eq1 f, Eq a) => Eq (M f a)
+derive instance (Debug (f (f a)), Debug (f a), Debug a) => Debug (M f a)
+
+type MA = M Array
+
+m0 = M0 :: MA Int
+m0' = D.constructor "M0" []
+
+m1 = M1 0 true 'a' "b" 1.0 [ "hello", "world" ] { foo: 8 } :: MA Int
+m1' = D.constructor "M1"
+  [ D.int 0
+  , D.boolean true
+  , D.char 'a'
+  , D.string "b"
+  , D.number 1.0
+  , D.array [ D.string "hello", D.string "world" ]
+  , D.record [ { key: "foo", value: D.int 8 } ]
+  ]
+
+m2 = M2 [ [ "a", "b", "c" ], [ "d" ] ] :: MA Int
+m2' = D.constructor "M2" 
+  [ D.array 
+      [ D.array $ map D.string [ "a", "b", "c" ]
+      , D.array [ D.string "d" ]
+      ]
+  ]
+
+m3 = M3 { bar: { baz: 9 } }
+m3' = D.constructor "M3" 
+  [ D.record
+      [ { key: "bar" 
+        , value: D.record
+            [ { key: "baz"
+              , value: D.int 9
+              }
+            ]
+        }
+      ]
+  ]
+
+m4 = M4 1 :: MA Int
+m4' = D.constructor "M4" [ D.int 1 ]
+
+m5 = M5 [ 2 ] :: MA Int
+m5' = D.constructor "M5" [ D.array [ D.int 2 ] ]
+
+m6 = M6 [ [ 2 ], [ 4 ] ] :: MA Int
+m6' = D.constructor "M6" 
+  [ D.array
+      [ D.array [ D.int 2 ]
+      , D.array [ D.int 4 ]
+      ]
+  ]
+
+data T a = T (forall t. Show t => t -> a)
+derive instance Debug (T a)
+
+main = do
+  assert $ debug m1 == m1'
+  assert $ debug m2 == m2'
+  assert $ debug m3 == m3'
+  assert $ debug m4 == m4'
+  assert $ debug m5 == m5'
+  assert $ debug m6 == m6'
+
+  assert $ debug (T \_ -> 42) == D.constructor "T" [ D.opaque_ "function" ]
+
+  log "Done"

--- a/tests/support/bower.json
+++ b/tests/support/bower.json
@@ -23,7 +23,7 @@
     "purescript-nonempty": "^7.0.0",
     "purescript-numbers": "^9.0.0",
     "purescript-partial": "^4.0.0",
-    "purescript-prelude": "^6.0.0",
+    "purescript-prelude": "https://github.com/JordanMartinez/purescript-prelude.git#prepare-for-prelude-merge",
     "purescript-psci-support": "^6.0.0",
     "purescript-refs": "^6.0.0",
     "purescript-safe-coerce": "^2.0.0",
@@ -35,5 +35,8 @@
     "purescript-typelevel-prelude": "^7.0.0",
     "purescript-unfoldable": "^6.0.0",
     "purescript-unsafe-coerce": "^6.0.0"
+  },
+  "resolutions": {
+    "purescript-prelude": "prepare-for-prelude-merge"
   }
 }


### PR DESCRIPTION
**Description of the change**

See https://github.com/purescript/purescript-prelude/issues/272 for more context.

By adding compiler support, it means most other types can get a `Debug` instance by just deriving it. Moreover, it means adding support across core libraries would be easy because each type could have its instance derived.

This implementation does not add support for deriving opaque types (e.g. `foreign import data X :: Type`) because one will likely want to write those types' `Debug` instances by hand.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
