### PR TITLE
Add note about tests that do not produce warnings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,21 @@ If you would like to contribute, please consider the issues in the current miles
 
 When submitting a pull request, please follow the following guidelines:
 
-- Add at least a test to `tests/purs/passing/` and possibly to `tests/purs/failing/`.
+- Add tests according to the next section
 - Build the binaries and libraries with `stack build --fast`. The `--fast` flag is recommended but not required; it disables optimizations, which can speed things up quite a bit.
 - Make sure that all test suites are passing. Run the test suites with `stack test --fast`.
 - Please try to keep changes small and isolated: smaller pull requests which only address one issue are much easier to review.
 - For any code change, please append a copyright and licensing notice to the [CONTRIBUTORS.md](CONTRIBUTORS.md) file if your name is not in there already.
+
+### Writing Tests
+
+When writing tests, try to have at least one passing test and one failing test, if applicable.
+
+- Passing tests go in `tests/purs/passing/`
+- Failing tests go in `tests/purs/failing/`
+- Tests that check warnings go in `tests/purs/warning/`
+
+Passing tests may produce warnings. Tests in `tests/purs/warning/` can ensure no warning is emitted by having no annotations and an empty `.out` file. 
 
 ### Running Tests
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -44,6 +44,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@kleeneplus](https://github.com/dgendill) | Dominick Gendill | [MIT license](http://opensource.org/licenses/MIT) |
 | [@ealmansi](https://github.com/ealmansi) | Emilio Almansi | MIT license |
 | [@eamelink](https://github.com/eamelink) | Erik Bakker | MIT license |
+| [@EMattfolk](https://github.com/EMattfolk) | Erik Mattfolk | [MIT license](http://opensource.org/licenses/MIT) |
 | [@epost](https://github.com/epost) | Erik Post | MIT license |
 | [@erdeszt](https://github.com/erdeszt) | Tibor Erdesz | [MIT license](http://opensource.org/licenses/MIT) |
 | [@etrepum](https://github.com/etrepum) | Bob Ippolito | [MIT license](http://opensource.org/licenses/MIT) |


### PR DESCRIPTION
**Description of the change**

Closes #4270

Wanted my first contribution to be something small, so here it is!

I added the start of a section about writing tests. It should be enough to close #4270 but is probably not enough in the long run. Ideally every folder should have clear documentation, but that seemed out of scope for that particular issue. I also do not know what is relevant to write about the other folders, so I just documented the mentioned [comment thread](https://github.com/purescript/purescript/pull/4269#discussion_r828014982).

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
