### PR TITLE
Invalidate the CI cache when containers are changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           path: |
             /root/.stack
             ${{ steps.haskell.outputs.stack-root }}
-          key: "${{ runner.os }}-MdyPsf-${{ hashFiles('stack.yaml') }}"
+          key: "${{ runner.os }}-${{ job.container.id }}-MdyPsf-${{ hashFiles('stack.yaml') }}"
 
       - name: "(Windows only) Configure Stack to store its programs in STACK_ROOT"
         # This ensures that the local GHC and MSYS binaries that Stack installs
@@ -186,7 +186,7 @@ jobs:
         with:
           path: |
             /root/.stack
-          key: "${{ runner.os }}-UnWw0N-lint-${{ hashFiles('stack.yaml') }}"
+          key: "${{ runner.os }}-${{ job.container.id }}-UnWw0N-lint-${{ hashFiles('stack.yaml') }}"
 
       - run: "ci/fix-home ci/run-hlint.sh --git"
         env:


### PR DESCRIPTION
**Description of the change**

This changes the cache keys for the workflows to take into account the container they're being run on. As mentioned in https://github.com/purescript/purescript/pull/4391#issuecomment-1258910594, CI is currently failing with a `libtinfo` error:
```
/root/.stack/compiler-tools/x86_64-linux/ghc-9.2.3/bin/weeder: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory
```

My guess is that it has to do with the cache being retained _after_ the container was changed since #4391 itself didn't run into this failure as it built its own `weeder`.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
