### PR TITLE
Add variable name, spans to DuplicateDeclarationsInLet error

### DIFF
--- a/CHANGELOG.d/misc_overlapping-let.md
+++ b/CHANGELOG.d/misc_overlapping-let.md
@@ -1,0 +1,1 @@
+* Improve `DuplicateDeclarationsInLet` error so that it mentions what variable names were duplicated, reporting several in separate errors as necessary.

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -79,7 +79,7 @@ data SimpleErrorMessage
   | OrphanKindDeclaration (ProperName 'TypeName)
   | OrphanRoleDeclaration (ProperName 'TypeName)
   | RedefinedIdent Ident
-  | OverlappingNamesInLet
+  | OverlappingNamesInLet Ident
   | UnknownName (Qualified Name)
   | UnknownImport ModuleName Name
   | UnknownImportDataConstructor ModuleName (ProperName 'TypeName) (ProperName 'ConstructorName)
@@ -258,7 +258,7 @@ errorCode em = case unwrapErrorMessage em of
   OrphanKindDeclaration{} -> "OrphanKindDeclaration"
   OrphanRoleDeclaration{} -> "OrphanRoleDeclaration"
   RedefinedIdent{} -> "RedefinedIdent"
-  OverlappingNamesInLet -> "OverlappingNamesInLet"
+  OverlappingNamesInLet{} -> "OverlappingNamesInLet"
   UnknownName{} -> "UnknownName"
   UnknownImport{} -> "UnknownImport"
   UnknownImportDataConstructor{} -> "UnknownImportDataConstructor"
@@ -731,8 +731,8 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath fileCon
       line "The last statement in a 'do' block must be an expression, but this block ends with a binder."
     renderSimpleErrorMessage InvalidDoLet =
       line "The last statement in a 'do' block must be an expression, but this block ends with a let binding."
-    renderSimpleErrorMessage OverlappingNamesInLet =
-      line "The same name was used more than once in a let binding."
+    renderSimpleErrorMessage (OverlappingNamesInLet name) =
+      line $ "The name " <> markCode (showIdent name) <> " was defined multiple times in a binding group"
     renderSimpleErrorMessage (InfiniteType ty) =
       paras [ line "An infinite type was inferred for an expression: "
             , markCodeBox $ indent $ prettyType ty

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -10,14 +10,15 @@ module Language.PureScript.Sugar.Names
   ) where
 
 import Prelude
-import Protolude (ordNub, sortOn, swap, foldl')
+import Protolude (sortOn, swap, foldl')
 
-import Control.Arrow (first, second)
+import Control.Arrow (first, second, (&&&))
 import Control.Monad
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Lazy
 import Control.Monad.Writer (MonadWriter(..))
 
+import qualified Data.List.NonEmpty as NEL
 import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -253,9 +254,15 @@ renameInModule imports (Module modSS coms mn decls exps) =
   updateValue (pos, bound) (Abs (VarBinder ss arg) val') =
     return ((pos, M.insert arg (spanStart ss) bound), Abs (VarBinder ss arg) val')
   updateValue (pos, bound) (Let w ds val') = do
-    let args = mapMaybe letBoundVariable ds
-    unless (length (ordNub args) == length args) .
-      throwError . errorMessage' pos $ OverlappingNamesInLet
+    let
+      args = mapMaybe letBoundVariable ds
+      groupByFst = map (\ts -> (fst (NEL.head ts), snd <$> ts)) . NEL.groupAllWith fst
+      duplicateArgsErrs = foldMap mkArgError $ groupByFst args
+      mkArgError (ident, poses)
+        | NEL.length poses < 2 = mempty
+        | otherwise = errorMessage'' (NEL.reverse poses) (OverlappingNamesInLet ident)
+    when (nonEmpty duplicateArgsErrs) $
+      throwError duplicateArgsErrs
     return ((pos, declarationsToMap ds `M.union` bound), Let w ds val')
   updateValue (_, bound) (Var ss name'@(Qualified qualifiedBy ident)) =
     ((ss, bound), ) <$> case (M.lookup ident bound, qualifiedBy) of
@@ -324,8 +331,8 @@ renameInModule imports (Module modSS coms mn decls exps) =
     . fmap (second spanStart . swap)
     . binderNamesWithSpans
 
-  letBoundVariable :: Declaration -> Maybe Ident
-  letBoundVariable = fmap valdeclIdent . getValueDeclaration
+  letBoundVariable :: Declaration -> Maybe (Ident, SourceSpan)
+  letBoundVariable = fmap (valdeclIdent &&& (fst . valdeclSourceAnn)) . getValueDeclaration
 
   declarationsToMap :: [Declaration] -> M.Map Ident SourcePos
   declarationsToMap = foldl goDTM M.empty

--- a/tests/purs/failing/DuplicateDeclarationsInLet.out
+++ b/tests/purs/failing/DuplicateDeclarationsInLet.out
@@ -1,8 +1,8 @@
 Error found:
 in module [33mMain[0m
-at tests/purs/failing/DuplicateDeclarationsInLet.purs:6:7 - 6:8 (line 6, column 7 - line 6, column 8)
+at tests/purs/failing/DuplicateDeclarationsInLet.purs:9:3 - 9:14 (line 9, column 3 - line 9, column 14)
 
-  The same name was used more than once in a let binding.
+  The name [33ma[0m was defined multiple times in a binding group
 
 
 See https://github.com/purescript/documentation/blob/master/errors/OverlappingNamesInLet.md for more information,

--- a/tests/purs/failing/DuplicateDeclarationsInLet.purs
+++ b/tests/purs/failing/DuplicateDeclarationsInLet.purs
@@ -1,8 +1,6 @@
 -- @shouldFailWith OverlappingNamesInLet
 module Main where
 
-import Prelude
-
 foo = a
   where
   a :: Number

--- a/tests/purs/failing/DuplicateDeclarationsInLet2.out
+++ b/tests/purs/failing/DuplicateDeclarationsInLet2.out
@@ -1,0 +1,10 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/DuplicateDeclarationsInLet2.purs:10:3 - 10:24 (line 10, column 3 - line 10, column 24)
+
+  The name [33minterrupted[0m was defined multiple times in a binding group
+
+
+See https://github.com/purescript/documentation/blob/master/errors/OverlappingNamesInLet.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/DuplicateDeclarationsInLet2.purs
+++ b/tests/purs/failing/DuplicateDeclarationsInLet2.purs
@@ -1,0 +1,10 @@
+-- @shouldFailWith OverlappingNamesInLet
+module Main where
+
+foo = interrupted
+  where
+  interrupted true = 1
+
+  interrupter = 2
+
+  interrupted false = 3

--- a/tests/purs/failing/DuplicateDeclarationsInLet3.out
+++ b/tests/purs/failing/DuplicateDeclarationsInLet3.out
@@ -1,0 +1,22 @@
+Error 1 of 2:
+
+  in module [33mMain[0m
+  at tests/purs/failing/DuplicateDeclarationsInLet3.purs:9:3 - 9:11 (line 9, column 3 - line 9, column 11)
+
+    The name [33ma[0m was defined multiple times in a binding group
+
+
+  See https://github.com/purescript/documentation/blob/master/errors/OverlappingNamesInLet.md for more information,
+  or to contribute content related to this error.
+
+Error 2 of 2:
+
+  in module [33mMain[0m
+  at tests/purs/failing/DuplicateDeclarationsInLet3.purs:16:3 - 16:24 (line 16, column 3 - line 16, column 24)
+
+    The name [33minterrupted[0m was defined multiple times in a binding group
+
+
+  See https://github.com/purescript/documentation/blob/master/errors/OverlappingNamesInLet.md for more information,
+  or to contribute content related to this error.
+

--- a/tests/purs/failing/DuplicateDeclarationsInLet3.purs
+++ b/tests/purs/failing/DuplicateDeclarationsInLet3.purs
@@ -1,0 +1,16 @@
+-- @shouldFailWith OverlappingNamesInLet
+-- @shouldFailWith OverlappingNamesInLet
+module Main where
+
+-- Should see separate errors for `a` and `interrupted`
+foo = interrupter + a
+  where
+  a = 0
+  a :: Int
+  a = 0
+
+  interrupted true = 1
+
+  interrupter = 2
+
+  interrupted false = 3


### PR DESCRIPTION
The `NEL.reverse` puts the last of the duplicate variable declarations first, since that seems to be preferred for displaying in psa and IDEs, and it seems more useful to see the last one rather than the first one. The spans from all the declarations are included but I'm not sure it matters for most users.

```
$ psa build tests/purs/failing/DuplicateDeclarationsInLet.purs
[1/1 OverlappingNamesInLet] tests/purs/failing/DuplicateDeclarationsInLet.purs:9:3

  9    a :: Number
       ^^^^^^^^^^^
  
  The name a was defined multiple times in a binding group

           Src   Lib   All
Warnings   0     0     0  
Errors     1     0     1  

$ purs compile --json-errors tests/purs/failing/DuplicateDeclarationsInLet.purs
[1 of 1] Compiling Main
{"warnings":[],"errors":[{"position":{"startLine":9,"startColumn":3,"endLine":9,"endColumn":14},"message":"  The name a was defined multiple times in a binding group\n","errorCode":"OverlappingNamesInLet","errorLink":"https://github.com/purescript/documentation/blob/master/errors/OverlappingNamesInLet.md","filename":"tests/purs/failing/DuplicateDeclarationsInLet.purs","moduleName":"Main","suggestion":null,"allSpans":[{"end":[9,14],"name":"tests/purs/failing/DuplicateDeclarationsInLet.purs","start":[9,3]},{"end":[6,14],"name":"tests/purs/failing/DuplicateDeclarationsInLet.purs","start":[6,3]}]}]}
```

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
