### PR TITLE
Shorten error prefix of custom errors

### DIFF
--- a/CHANGELOG.d/feature_shorten-error-message.md
+++ b/CHANGELOG.d/feature_shorten-error-message.md
@@ -1,3 +1,3 @@
-* `feature`: Shorten the prefix for custom user defined error
+* Shorten the prefix for custom user defined error
   messages to improve clarity and get to the relevant information
   more quickly

--- a/CHANGELOG.d/feature_shorten-error-message.md
+++ b/CHANGELOG.d/feature_shorten-error-message.md
@@ -1,0 +1,3 @@
+* `feature`: shorten the prefix for custom user defined error
+  messages to improve clarity and get to the relevant information
+  more quickly

--- a/CHANGELOG.d/feature_shorten-error-message.md
+++ b/CHANGELOG.d/feature_shorten-error-message.md
@@ -1,3 +1,3 @@
-* `feature`: shorten the prefix for custom user defined error
+* `feature`: Shorten the prefix for custom user defined error
   messages to improve clarity and get to the relevant information
   more quickly

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -884,7 +884,7 @@ prettyPrintSingleError (PPEOptions codeColor full level showDocs relPath fileCon
             , line "because the class was not in scope. Perhaps it was not exported."
             ]
     renderSimpleErrorMessage (NoInstanceFound (Constraint _ C.Fail _ [ ty ] _) _ _) | Just box <- toTypelevelString ty =
-      paras [ line "A custom type error occurred while solving type class constraints:"
+      paras [ line "Custom error:"
             , indent box
             ]
     renderSimpleErrorMessage (NoInstanceFound (Constraint _ C.Partial

--- a/tests/purs/failing/2567.out
+++ b/tests/purs/failing/2567.out
@@ -2,7 +2,7 @@ Error found:
 in module [33mMain[0m
 at tests/purs/failing/2567.purs:7:8 - 7:67 (line 7, column 8 - line 7, column 67)
 
-  A custom type error occurred while solving type class constraints:
+  Custom error:
 
     This constraint should be checked
 
@@ -15,4 +15,3 @@ in value declaration [33mfoo[0m
 
 See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
 or to contribute content related to this error.
-

--- a/tests/purs/failing/2567.out
+++ b/tests/purs/failing/2567.out
@@ -15,3 +15,4 @@ in value declaration [33mfoo[0m
 
 See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
 or to contribute content related to this error.
+

--- a/tests/purs/failing/ProgrammablePolykindedTypeErrorsTypeString.out
+++ b/tests/purs/failing/ProgrammablePolykindedTypeErrorsTypeString.out
@@ -2,7 +2,7 @@ Error found:
 in module [33mMain[0m
 at tests/purs/failing/ProgrammablePolykindedTypeErrorsTypeString.purs:23:7 - 23:17 (line 23, column 7 - line 23, column 17)
 
-  A custom type error occurred while solving type class constraints:
+  Custom error:
 
     Don't want to show Just @Type String because.
 
@@ -15,4 +15,3 @@ in value declaration [33mmain[0m
 
 See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
 or to contribute content related to this error.
-

--- a/tests/purs/failing/ProgrammablePolykindedTypeErrorsTypeString.out
+++ b/tests/purs/failing/ProgrammablePolykindedTypeErrorsTypeString.out
@@ -15,3 +15,4 @@ in value declaration [33mmain[0m
 
 See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
 or to contribute content related to this error.
+

--- a/tests/purs/failing/ProgrammableTypeErrors.out
+++ b/tests/purs/failing/ProgrammableTypeErrors.out
@@ -2,7 +2,7 @@ Error found:
 in module [33mMain[0m
 at tests/purs/failing/ProgrammableTypeErrors.purs:17:13 - 17:27 (line 17, column 13 - line 17, column 27)
 
-  A custom type error occurred while solving type class constraints:
+  Custom error:
 
     Cannot show functions
 
@@ -25,4 +25,3 @@ where [33mt0[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
 or to contribute content related to this error.
-

--- a/tests/purs/failing/ProgrammableTypeErrors.out
+++ b/tests/purs/failing/ProgrammableTypeErrors.out
@@ -25,3 +25,4 @@ where [33mt0[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
 or to contribute content related to this error.
+

--- a/tests/purs/failing/ProgrammableTypeErrorsTypeString.out
+++ b/tests/purs/failing/ProgrammableTypeErrorsTypeString.out
@@ -22,3 +22,4 @@ where [33mt0[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
 or to contribute content related to this error.
+

--- a/tests/purs/failing/ProgrammableTypeErrorsTypeString.out
+++ b/tests/purs/failing/ProgrammableTypeErrorsTypeString.out
@@ -2,7 +2,7 @@ Error found:
 in module [33mMain[0m
 at tests/purs/failing/ProgrammableTypeErrorsTypeString.purs:24:9 - 24:24 (line 24, column 9 - line 24, column 24)
 
-  A custom type error occurred while solving type class constraints:
+  Custom error:
 
     Don't want to show MyType Int because.
 
@@ -22,4 +22,3 @@ where [33mt0[0m is an unknown type
 
 See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
 or to contribute content related to this error.
-


### PR DESCRIPTION
**Description of the change**

Shorten error prefix of custom errors.
Don't think this qualifies as breaking or even for a changelog entry.

Closes #4417 
---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
