### PR TITLE
Upgrade to GHC 9.2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ defaults:
 env:
   CI_PRERELEASE: "${{ github.event_name == 'push' }}"
   CI_RELEASE: "${{ github.event_name == 'release' }}"
-  STACK_VERSION: "2.7.5"
+  STACK_VERSION: "2.9.1"
 
 concurrency:
   # We never want two prereleases building at the same time, since they would

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         include:
           - # If upgrading the Haskell image, also upgrade it in the lint job below
             os: "ubuntu-latest"
-            image: "ghcr.io/purescript/haskell:9.2.3-stretch@sha256:70fd2b6255deb5daa961e6983591a0e21e9ac1e793923bee54aa2cc62e01f867"
+            image: haskell:9.2.4@sha256:dceec00f8ad896c327c2b5c77ba91c9824bf3e26a837f538ccfb80fb379dc52f
           - os: "macOS-11"
           - os: "windows-2019"
 
@@ -172,7 +172,7 @@ jobs:
     # means our published binaries will work on the widest number of platforms.
     # But the HLint binary downloaded by this job requires a newer glibc
     # version.
-    container: "haskell:9.2.3-buster@sha256:51e250369e4671a15c247cdc5047397be88d7eb8e95b97b0fd9f417854a78bec"
+    image: haskell:9.2.4@sha256:dceec00f8ad896c327c2b5c77ba91c9824bf3e26a837f538ccfb80fb379dc52f
 
     steps:
       - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
     # means our published binaries will work on the widest number of platforms.
     # But the HLint binary downloaded by this job requires a newer glibc
     # version.
-    image: haskell:9.2.4@sha256:dceec00f8ad896c327c2b5c77ba91c9824bf3e26a837f538ccfb80fb379dc52f
+    container: haskell:9.2.4@sha256:dceec00f8ad896c327c2b5c77ba91c9824bf3e26a837f538ccfb80fb379dc52f
 
     steps:
       - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone

--- a/CHANGELOG.d/misc_bump-ghc.md
+++ b/CHANGELOG.d/misc_bump-ghc.md
@@ -1,0 +1,1 @@
+* Bump Stackage snapshot to 2022-11-12 and GHC to 9.2.4

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,12 +4,12 @@ If you are having difficulty installing the PureScript compiler, feel free to as
 
 ## Requirements
 
-The PureScript compiler is built using GHC 9.2.4, and should be able to run on any operating system supported by GHC 9.2.3. In particular:
+The PureScript compiler is built using GHC 9.2.4, and should be able to run on any operating system supported by GHC 9.2.4. In particular:
 
 * for Windows users, versions predating Vista are not officially supported,
 * for macOS / OS X users, versions predating Mac OS X 10.7 (Lion) are not officially supported.
 
-See also <https://www.haskell.org/ghc/download_ghc_9.2.4.html> for more details about the operating systems which GHC 9.2.3 supports.
+See also <https://www.haskell.org/ghc/download_ghc_9_2_4.html> for more details about the operating systems which GHC 9.2.4 supports.
 
 ## Official prebuilt binaries
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,12 +4,12 @@ If you are having difficulty installing the PureScript compiler, feel free to as
 
 ## Requirements
 
-The PureScript compiler is built using GHC 9.2.3, and should be able to run on any operating system supported by GHC 9.2.3. In particular:
+The PureScript compiler is built using GHC 9.2.4, and should be able to run on any operating system supported by GHC 9.2.3. In particular:
 
 * for Windows users, versions predating Vista are not officially supported,
 * for macOS / OS X users, versions predating Mac OS X 10.7 (Lion) are not officially supported.
 
-See also <https://www.haskell.org/ghc/download_ghc_9_2_3.html> for more details about the operating systems which GHC 9.2.3 supports.
+See also <https://www.haskell.org/ghc/download_ghc_9.2.4.html> for more details about the operating systems which GHC 9.2.3 supports.
 
 ## Official prebuilt binaries
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # Please update Haskell image versions under .github/workflows/ci.yml together to use the same GHC version
 # (or the CI build will fail)
-resolver: nightly-2022-06-09
+resolver: nightly-2022-11-12
 pvp-bounds: both
 packages:
 - '.'


### PR DESCRIPTION
**Description of the change**

This upgrades the GHC we use to build the compiler to `9.2.4`. While `9.2.5` has LTS support from Stackage, it doesn't have LSP support yet.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
