### PR TITLE
Enable more GHC warnings

### DIFF
--- a/CHANGELOG.d/internal_enable-ghc-warnings.md
+++ b/CHANGELOG.d/internal_enable-ghc-warnings.md
@@ -1,0 +1,1 @@
+* Enable more GHC warnings

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -53,12 +53,40 @@ flag release
   default: False
 
 common defaults
-  -- Note: -Wall-incomplete-uni-patterns and -Wincomplete-record-updates can be
-  -- removed once we upgrade to GHC 9.2.1 since they are now included in -Wall.
   ghc-options:
-    -Wall
-    -Wincomplete-uni-patterns
-    -Wincomplete-record-updates
+    -- This list taken from https://medium.com/mercury-bank/enable-all-the-warnings-a0517bc081c3
+    -- Enable all warnings with -Weverything, then disable the ones we don’t care about
+    -Weverything
+
+    -- missing-exported-signatures turns off the more strict -Wmissing-signatures. See https://ghc.haskell.org/trac/ghc/ticket/14794#ticket
+    -Wno-missing-exported-signatures
+
+    -- Requires explicit imports of _every_ function (e.g. ‘$’); too strict
+    -Wno-missing-import-lists
+
+    -- When GHC can’t specialize a polymorphic function. No big deal and requires fixing underlying libraries to solve.
+    -Wno-missed-specialisations
+    -Wno-all-missed-specialisations
+
+    -- Don’t use Safe Haskell warnings
+    -Wno-unsafe
+    -Wno-safe
+    -Wno-trustworthy-safe
+    -Wno-inferred-safe-imports
+    -Wno-missing-safe-haskell-mode
+
+    -- Warning for polymorphic local bindings; nothing wrong with those.
+    -Wno-missing-local-signatures
+
+    -- Don’t warn if the monomorphism restriction is used
+    -Wno-monomorphism-restriction
+
+    -- Remaining options don't come from the above blog post
+    -Wno-missing-deriving-strategies
+    -Wno-missing-export-lists
+    -Wno-missing-kind-signatures
+    -Wno-partial-fields
+    -Wno-prepositive-qualified-module
   default-language: Haskell2010
   default-extensions:
     BangPatterns
@@ -127,7 +155,6 @@ common defaults
     -- specific version.
     aeson >=2.0.3.0 && <2.1,
     aeson-better-errors >=0.9.1.1 && <0.10,
-    aeson-pretty >=0.8.9 && <0.9,
     ansi-terminal >=0.11.3 && <0.12,
     array >=0.5.4.0 && <0.6,
     base >=4.16.2.0 && <4.17,
@@ -149,7 +176,6 @@ common defaults
     edit-distance >=0.2.2.1 && <0.3,
     file-embed >=0.0.15.0 && <0.1,
     filepath >=1.4.2.2 && <1.5,
-    fsnotify >=0.3.0.1 && <0.4,
     Glob >=0.10.2 && <0.11,
     haskeline >=0.8.2 && <0.9,
     language-javascript ==0.7.0.0,
@@ -172,19 +198,14 @@ common defaults
     semigroups ==0.20.*,
     semialign >=1.2.0.1 && <1.3,
     sourcemap >=0.1.7 && <0.2,
-    split >=0.2.3.4 && <0.3,
     stm >=2.5.0.2 && <2.6,
     stringsearch >=0.3.6.6 && <0.4,
-    syb >=0.7.2.1 && <0.8,
     template-haskell >=2.18.0.0 && <2.19,
     text >=1.2.5.0 && <1.3,
     these >=1.1.1.1 && <1.2,
     time >=1.11.1.1 && <1.12,
     transformers >=0.5.6.2 && <0.6,
     transformers-base >=0.4.6 && <0.5,
-    transformers-compat >=0.7.1 && <0.8,
-    typed-process >=0.2.10.1 && <0.3,
-    unordered-containers >=0.2.19.1 && <0.3,
     utf8-string >=1.0.2 && <1.1,
     vector >=0.12.3.1 && <0.13,
     witherable >=0.4.2 && <0.5
@@ -379,12 +400,10 @@ executable purs
   import: defaults
   hs-source-dirs: app
   main-is: Main.hs
-  ghc-options: -fno-warn-unused-do-bind -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -fno-warn-unused-do-bind -threaded -rtsopts -with-rtsopts=-N -Wno-unused-packages
   build-depends:
     ansi-wl-pprint >=0.6.9 && <0.7,
     exceptions >=0.10.4 && <0.11,
-    file-embed >=0.0.13.0 && <0.1,
-    http-types >=0.12.3 && <0.13,
     network >=3.1.2.7 && <3.2,
     optparse-applicative >=0.17.0.0 && <0.18,
     purescript
@@ -415,7 +434,7 @@ test-suite tests
   hs-source-dirs: tests
   main-is: Main.hs
   -- Not a problem for this warning to arise in tests
-  ghc-options: -Wno-incomplete-uni-patterns
+  ghc-options: -Wno-incomplete-uni-patterns -Wno-unused-packages
   build-depends:
     purescript,
     generic-random >=1.5.0.1 && <1.6,
@@ -423,7 +442,9 @@ test-suite tests
     HUnit >=1.6.2.0 && <1.7,
     newtype >=0.2.2.0 && <0.3,
     QuickCheck >=2.14.2 && <2.15,
-    regex-base >=0.94.0.2 && <0.95
+    regex-base >=0.94.0.2 && <0.95,
+    split >=0.2.3.4 && <0.3,
+    typed-process >=0.2.10.1 && <0.3
   build-tool-depends:
       hspec-discover:hspec-discover -any
     -- we need the compiler's executable available for the ide tests

--- a/src/Language/PureScript/CST/Lexer.hs
+++ b/src/Language/PureScript/CST/Lexer.hs
@@ -201,7 +201,7 @@ breakComments = k0 []
   goWs a _ = a
 
   goSpace a !n (' ' : ls) = goSpace a (n + 1) ls
-  goSpace a !n ls = goWs (Space n : a) ls
+  goSpace a n ls = goWs (Space n : a) ls
 
   isBlockComment = Parser $ \inp _ ksucc ->
     case Text.uncons inp of
@@ -725,7 +725,7 @@ digitsToScientific :: String -> String -> (Integer, Int)
 digitsToScientific = go 0 . reverse
   where
   go !exp is [] = (digitsToInteger (reverse is), exp)
-  go !exp is (f : fs) = go (exp - 1) (f : is) fs
+  go exp is (f : fs) = go (exp - 1) (f : is) fs
 
 isSymbolChar :: Char -> Bool
 isSymbolChar c = (c `elem` (":!#$%&*+./<=>?@\\^|-~" :: String)) || (not (Char.isAscii c) && Char.isSymbol c)

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -52,7 +52,7 @@ import System.FilePath.Posix ((</>))
 -- module.
 moduleToJs
   :: forall m
-   . (Monad m, MonadReader Options m, MonadSupply m, MonadError MultipleErrors m)
+   . (MonadReader Options m, MonadSupply m, MonadError MultipleErrors m)
   => Module Ann
   -> Maybe PSString
   -> m AST.Module
@@ -232,7 +232,7 @@ moduleToJs (Module _ coms mn _ imps exps reExps foreigns decls) foreignInclude =
 
 moduleBindToJs
   :: forall m
-   . (Monad m, MonadReader Options m, MonadSupply m, MonadWriter Any m, MonadError MultipleErrors m)
+   . (MonadReader Options m, MonadSupply m, MonadWriter Any m, MonadError MultipleErrors m)
   => ModuleName
   -> Bind Ann
   -> m [AST]

--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -147,8 +147,7 @@ collectDeclarations reExports = do
   where
 
   collect
-    :: (Eq a, Show a)
-    => (P.ModuleName -> a -> m (P.ModuleName, [b]))
+    :: (P.ModuleName -> a -> m (P.ModuleName, [b]))
     -> Map a P.ExportSource
     -> m (Map P.ModuleName [b])
   collect lookup' exps = do

--- a/src/Language/PureScript/Ide/CaseSplit.hs
+++ b/src/Language/PureScript/Ide/CaseSplit.hs
@@ -91,8 +91,8 @@ splitTypeConstructor = go []
 prettyCtor :: WildcardAnnotations -> Constructor -> Text
 prettyCtor _ (ctorName, []) = P.runProperName ctorName
 prettyCtor wsa (ctorName, ctorArgs) =
-  "("<> P.runProperName ctorName <> " "
-  <> T.unwords (map (prettyPrintWildcard wsa) ctorArgs) <>")"
+  "(" <> P.runProperName ctorName <> " "
+  <> T.unwords (map (prettyPrintWildcard wsa) ctorArgs) <> ")"
 
 prettyPrintWildcard :: WildcardAnnotations -> P.Type a -> Text
 prettyPrintWildcard (WildcardAnnotations True) = prettyWildcard

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -89,7 +89,7 @@ groupCompletionReexports initial =
   where
     go (Match (moduleName, d@(IdeDeclarationAnn ann decl))) =
       let
-        origin = fromMaybe moduleName (ann^.annExportedFrom)
+        origin = fromMaybe moduleName (ann ^. annExportedFrom)
       in
         Map.alter
         (insertDeclaration moduleName origin d)

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -90,7 +90,7 @@ textError :: IdeError -> Text
 textError (GeneralError msg)          = msg
 textError (NotFound ident)            = "Symbol '" <> ident <> "' not found."
 textError (ModuleNotFound ident)      = "Module '" <> ident <> "' not found."
-textError (ModuleFileNotFound ident)  = "Extern file for module " <> ident <>" could not be found"
+textError (ModuleFileNotFound ident)  = "Extern file for module " <> ident <> " could not be found"
 textError (RebuildError _ err)        = show err
 
 prettyPrintTypeSingleLine :: P.Type a -> Text

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -69,14 +69,14 @@ resolveSynonymsAndClasses trs decls = foldr go decls trs
           Nothing ->
             acc
           Just tyDecl -> IdeDeclTypeClass
-            (IdeTypeClass tcn (tyDecl^.ideTypeKind) [])
+            (IdeTypeClass tcn (tyDecl ^. ideTypeKind) [])
             : filter (not . anyOf (_IdeDeclType . ideTypeName) (== P.coerceProperName tcn)) acc
       SynonymToResolve tn ty ->
         case findType tn acc of
           Nothing ->
             acc
           Just tyDecl ->
-            IdeDeclTypeSynonym (IdeTypeSynonym tn ty (tyDecl^.ideTypeKind))
+            IdeDeclTypeSynonym (IdeTypeSynonym tn ty (tyDecl ^. ideTypeKind))
             : filter (not . anyOf (_IdeDeclType . ideTypeName) (== tn)) acc
 
 findType :: P.ProperName 'P.TypeName -> [IdeDeclaration] -> Maybe IdeType
@@ -103,14 +103,14 @@ convertDecl ed = case ed of
   -- because those are typechecker internal definitions that shouldn't
   -- be user facing
   P.EDType{..} -> Right do
-    guard (isNothing (Text.find (== '$') (edTypeName^.properNameT)))
+    guard (isNothing (Text.find (== '$') (edTypeName ^. properNameT)))
     Just (IdeDeclType (IdeType edTypeName edTypeKind []))
   P.EDTypeSynonym{..} ->
-    if isNothing (Text.find (== '$') (edTypeSynonymName^.properNameT))
+    if isNothing (Text.find (== '$') (edTypeSynonymName ^. properNameT))
       then Left (SynonymToResolve edTypeSynonymName edTypeSynonymType)
       else Right Nothing
   P.EDDataConstructor{..} -> Right do
-    guard (isNothing (Text.find (== '$') (edDataCtorName^.properNameT)))
+    guard (isNothing (Text.find (== '$') (edDataCtorName ^. properNameT)))
     Just
       (IdeDeclDataConstructor
         (IdeDataConstructor edDataCtorName edDataCtorTypeCtor edDataCtorType))

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -148,7 +148,7 @@ instance FromJSON Filter where
         search <- params .: "search"
         pure (exactFilter search)
       "prefix" -> do
-        params <- o.: "params"
+        params <- o .: "params"
         search <- params .: "search"
         pure (prefixFilter search)
       "namespace" -> do
@@ -156,10 +156,10 @@ instance FromJSON Filter where
         namespaces <- params .: "namespaces"
         pure (namespaceFilter (Set.fromList namespaces))
       "declarations" -> do
-        declarations <- o.: "params"
+        declarations <- o .: "params"
         pure (declarationTypeFilter (Set.fromList declarations))
       "dependencies" -> do
-        params <- o.: "params"
+        params <- o .: "params"
         moduleText <- params .: "moduleText"
         qualifier <- fmap P.moduleNameFromString <$> params .:? "qualifier"
         case sliceImportSection (T.lines moduleText) of

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -207,7 +207,7 @@ populateVolatileStateSync = do
     (\mn -> logWarnN . prettyPrintReexportResult (const (P.runModuleName mn)))
     (Map.filter reexportHasFailures results)
 
-populateVolatileState :: (Ide m, MonadLogger m) => m (Async ())
+populateVolatileState :: Ide m => m (Async ())
 populateVolatileState = do
   env <- ask
   let ll = confLogLevel (ideConfiguration env)

--- a/src/Language/PureScript/Ide/Usage.hs
+++ b/src/Language/PureScript/Ide/Usage.hs
@@ -25,7 +25,7 @@ import           Language.PureScript.Ide.Util
 -- module.
 -- 3. Apply the collected search specifications and collect the results
 findUsages
-  :: (MonadIO m, Ide m)
+  :: Ide m
   => IdeDeclaration
   -> P.ModuleName
   -> m (ModuleMap (NonEmpty P.SourceSpan))

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -178,7 +178,7 @@ handleDecls ds = do
 
 -- | Show actual loaded modules in psci.
 handleShowLoadedModules
-  :: (MonadState PSCiState m, MonadIO m)
+  :: MonadState PSCiState m
   => (String -> m ())
   -> m ()
 handleShowLoadedModules print' = do
@@ -189,7 +189,7 @@ handleShowLoadedModules print' = do
 
 -- | Show the imported modules in psci.
 handleShowImportedModules
-  :: (MonadState PSCiState m, MonadIO m)
+  :: MonadState PSCiState m
   => (String -> m ())
   -> m ()
 handleShowImportedModules print' = do
@@ -230,7 +230,7 @@ handleShowImportedModules print' = do
   commaList = T.intercalate ", "
 
 handleShowPrint
-  :: (MonadState PSCiState m, MonadIO m)
+  :: MonadState PSCiState m
   => (String -> m ())
   -> m ()
 handleShowPrint print' = do
@@ -305,7 +305,7 @@ handleKindOf print' typ = do
 
 -- | Browse a module and displays its signature
 handleBrowse
-  :: (MonadReader PSCiConfig m, MonadState PSCiState m, MonadIO m)
+  :: (MonadReader PSCiConfig m, MonadState PSCiState m)
   => (String -> m ())
   -> P.ModuleName
   -> m ()

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -15,7 +15,6 @@ import Control.Applicative
 import Control.Arrow (first, second)
 import Control.Monad (unless)
 import Control.Monad.Writer.Class
-import Control.Monad.Supply.Class (MonadSupply)
 
 import Data.List (foldl', sortOn)
 import Data.Maybe (fromMaybe)
@@ -237,7 +236,7 @@ missingAlternative env mn ca uncovered
 --
 checkExhaustive
   :: forall m
-   . (MonadWriter MultipleErrors m, MonadSupply m)
+   . MonadWriter MultipleErrors m
    => SourceSpan
    -> Environment
    -> ModuleName
@@ -292,7 +291,7 @@ checkExhaustive ss env mn numArgs cas expr = makeResult . first ordNub $ foldl' 
 --
 checkExhaustiveExpr
   :: forall m
-   . (MonadWriter MultipleErrors m, MonadSupply m)
+   . MonadWriter MultipleErrors m
    => SourceSpan
    -> Environment
    -> ModuleName

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -56,7 +56,7 @@ import           System.FilePath (replaceExtension)
 -- This function is used for fast-rebuild workflows (PSCi and psc-ide are examples).
 rebuildModule
   :: forall m
-   . (Monad m, MonadBaseControl IO m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
+   . (MonadBaseControl IO m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
   => MakeActions m
   -> [ExternsFile]
   -> Module
@@ -67,7 +67,7 @@ rebuildModule actions externs m = do
 
 rebuildModule'
   :: forall m
-   . (Monad m, MonadBaseControl IO m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
+   . (MonadBaseControl IO m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
   => MakeActions m
   -> Env
   -> [ExternsFile]
@@ -77,7 +77,7 @@ rebuildModule' act env ext mdl = rebuildModuleWithIndex act env ext mdl Nothing
 
 rebuildModuleWithIndex
   :: forall m
-   . (Monad m, MonadBaseControl IO m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
+   . (MonadBaseControl IO m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
   => MakeActions m
   -> Env
   -> [ExternsFile]
@@ -136,7 +136,7 @@ rebuildModuleWithIndex MakeActions{..} exEnv externs m@(Module _ _ moduleName _ 
 --
 -- If timestamps or hashes have not changed, existing externs files can be used to provide upstream modules' types without
 -- having to typecheck those modules again.
-make :: forall m. (Monad m, MonadBaseControl IO m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
+make :: forall m. (MonadBaseControl IO m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
      => MakeActions m
      -> [CST.PartialResult Module]
      -> m [ExternsFile]

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -293,7 +293,7 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
       map (\(SMap _ orig gen) -> Mapping {
           mapOriginal = Just $ convertPos $ add 0 (-1) orig
         , mapSourceFile = sourceFile
-        , mapGenerated = convertPos $ add (extraLines+1) 0 gen
+        , mapGenerated = convertPos $ add (extraLines + 1) 0 gen
         , mapName = Nothing
         }) mappings
     }
@@ -301,7 +301,7 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
     writeJSONFile mapFile mapping
     where
     add :: Int -> Int -> SourcePos -> SourcePos
-    add n m (SourcePos n' m') = SourcePos (n+n') (m+m')
+    add n m (SourcePos n' m') = SourcePos (n + n') (m + m')
 
     convertPos :: SourcePos -> Pos
     convertPos SourcePos { sourcePosLine = l, sourcePosColumn = c } =

--- a/src/Language/PureScript/Make/BuildPlan.hs
+++ b/src/Language/PureScript/Make/BuildPlan.hs
@@ -127,7 +127,7 @@ getResult buildPlan moduleName =
 -- The given MakeActions are used to collect various timestamps in order to
 -- determine whether a module needs rebuilding.
 construct
-  :: forall m. (Monad m, MonadBaseControl IO m)
+  :: forall m. MonadBaseControl IO m
   => MakeActions m
   -> CacheDb
   -> ([CST.PartialResult Module], [(ModuleName, [ModuleName])])

--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -96,8 +96,8 @@ bumpPos :: SourcePos -> SMap -> SMap
 bumpPos p (SMap f s g) = SMap f s $ p `addPos` g
 
 addPos :: SourcePos -> SourcePos -> SourcePos
-addPos (SourcePos n m) (SourcePos 0 m') = SourcePos n (m+m')
-addPos (SourcePos n _) (SourcePos n' m') = SourcePos (n+n') m'
+addPos (SourcePos n m) (SourcePos 0 m') = SourcePos n (m + m')
+addPos (SourcePos n _) (SourcePos n' m') = SourcePos (n + n') m'
 
 
 data PrinterState = PrinterState { indent :: Int }

--- a/src/Language/PureScript/Sugar/Names/Common.hs
+++ b/src/Language/PureScript/Sugar/Names/Common.hs
@@ -40,7 +40,7 @@ warnDuplicateRefs pos toError refs = do
   -- but that requires additional changes in how warnings are printed.
   -- Example of keeping all duplicates (not what this code currently does):
   --  removeUnique [1,2,2,3,3,3,4] == [2,2,3,3,3]
-  removeUnique :: Eq a => Ord a => [a] -> [a]
+  removeUnique :: Ord a => [a] -> [a]
   removeUnique = concatMap (drop 1) . group . sort
 
   -- Deletes the constructor information from TypeRefs so that only the

--- a/src/Language/PureScript/TypeChecker/Deriving.hs
+++ b/src/Language/PureScript/TypeChecker/Deriving.hs
@@ -109,7 +109,6 @@ deriveNewtypeInstance
   :: forall m
    . MonadError MultipleErrors m
   => MonadState CheckState m
-  => MonadSupply m
   => MonadWriter MultipleErrors m
   => ModuleName
   -> Qualified (ProperName 'ClassName)

--- a/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
@@ -779,7 +779,6 @@ decompose env tyName axs bxs = do
 -- @D@ is not a newtype, yield constraints on their arguments.
 canonDecomposition
   :: MonadError MultipleErrors m
-  => MonadState CheckState m
   => Environment
   -> SourceType
   -> SourceType
@@ -797,7 +796,6 @@ canonDecomposition env a b
 -- newtypes, are insoluble.
 canonDecompositionFailure
   :: MonadError MultipleErrors m
-  => MonadState CheckState m
   => Environment
   -> SourceType
   -> SourceType
@@ -847,7 +845,6 @@ canonDecompositionFailure env k a b
 -- to discharge it with the given.
 canonNewtypeDecomposition
   :: MonadError MultipleErrors m
-  => MonadState CheckState m
   => Environment
   -> Maybe [(SourceType, SourceType, SourceType)]
   -> SourceType

--- a/tests/TestMake.hs
+++ b/tests/TestMake.hs
@@ -166,7 +166,7 @@ spec = do
           moduleContent2 = moduleContent1 <> "\ny :: Int\ny = 1"
           optsWithDocs = P.defaultOptions { P.optionsCodegenTargets = Set.fromList [P.JS, P.Docs] }
           go opts = compileWithOptions opts [modulePath] >>= assertSuccess
-          oneSecond = 10^(6::Int) -- microseconds.
+          oneSecond = 10 ^ (6::Int) -- microseconds.
 
       writeFileWithTimestamp modulePath timestampA moduleContent1
       go optsWithDocs `shouldReturn` moduleNames ["Module"]
@@ -184,7 +184,7 @@ spec = do
           moduleContent2 = moduleContent1 <> "\ny :: Int\ny = 1"
           optsCorefnOnly = P.defaultOptions { P.optionsCodegenTargets = Set.singleton P.CoreFn }
           go opts = compileWithOptions opts [modulePath] >>= assertSuccess
-          oneSecond = 10^(6::Int) -- microseconds.
+          oneSecond = 10 ^ (6::Int) -- microseconds.
 
       writeFileWithTimestamp modulePath timestampA moduleContent1
       go optsCorefnOnly `shouldReturn` moduleNames ["Module"]


### PR DESCRIPTION
**Description of the change**

Who doesn't love more compiler warnings?

Following the advice in the linked blog post, this enables every warning GHC can throw at us and blocklists the ones we want to ignore, instead of allowlisting the ones we want above and beyond the misleadingly-named `-Wall` group.

Thanks to this, GHC tipped me off to a few unused package dependencies, which have been removed. Note that this will result in an updated LICENSE file the next time we run that. This is probably not important enough to hold up the 0.15.7 release for but if for some reason this is merged before that release happens, LICENSE will need to be generated again.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
