### PR TITLE
Upgrade to GHC 9.2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ defaults:
 env:
   CI_PRERELEASE: "${{ github.event_name == 'push' }}"
   CI_RELEASE: "${{ github.event_name == 'release' }}"
-  STACK_VERSION: "2.9.1"
+  STACK_VERSION: "2.9.3"
 
 concurrency:
   # We never want two prereleases building at the same time, since they would

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         include:
           - # If upgrading the Haskell image, also upgrade it in the lint job below
             os: "ubuntu-latest"
-            image: haskell:9.2.4@sha256:dceec00f8ad896c327c2b5c77ba91c9824bf3e26a837f538ccfb80fb379dc52f
+            image: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
           - os: "macOS-11"
           - os: "windows-2019"
 
@@ -172,7 +172,7 @@ jobs:
     # means our published binaries will work on the widest number of platforms.
     # But the HLint binary downloaded by this job requires a newer glibc
     # version.
-    container: haskell:9.2.4@sha256:dceec00f8ad896c327c2b5c77ba91c9824bf3e26a837f538ccfb80fb379dc52f
+    container: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
 
     steps:
       - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone

--- a/CHANGELOG.d/misc_bump-ghc.md
+++ b/CHANGELOG.d/misc_bump-ghc.md
@@ -1,0 +1,1 @@
+* Bump Stackage snapshot to lts-20.9 and GHC to 9.2.5

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@alexbiehl](https://github.com/alexbiehl) | Alexander Biehl | [MIT license](http://opensource.org/licenses/MIT) |
 | [@andreypopp](https://github.com/andreypopp) | Andrey Popp | MIT license |
 | [@andyarvanitis](https://github.com/andyarvanitis) | Andy Arvanitis | [MIT license](http://opensource.org/licenses/MIT) |
+| [@andys8](https://github.com/andys8) | andys8 | [MIT license](http://opensource.org/licenses/MIT) |
 | [@anthok88](https://github.com/anthok88) | anthoq88 | MIT license |
 | [@ardumont](https://github.com/ardumont) | Antoine R. Dumont | [MIT license](http://opensource.org/licenses/MIT) |
 | [@arrowd](https://github.com/arrowd) | Gleb Popov | [MIT license](http://opensource.org/licenses/MIT) |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,12 +4,12 @@ If you are having difficulty installing the PureScript compiler, feel free to as
 
 ## Requirements
 
-The PureScript compiler is built using GHC 9.2.4, and should be able to run on any operating system supported by GHC 9.2.4. In particular:
+The PureScript compiler is built using GHC 9.2.5, and should be able to run on any operating system supported by GHC 9.2.5. In particular:
 
 * for Windows users, versions predating Vista are not officially supported,
 * for macOS / OS X users, versions predating Mac OS X 10.7 (Lion) are not officially supported.
 
-See also <https://www.haskell.org/ghc/download_ghc_9_2_4.html> for more details about the operating systems which GHC 9.2.4 supports.
+See also <https://www.haskell.org/ghc/download_ghc_9_2_5.html> for more details about the operating systems which GHC 9.2.5 supports.
 
 ## Official prebuilt binaries
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,8 +18,6 @@ extra-deps:
 - process-1.6.13.1
 # The Cabal library is not in Stackage
 - Cabal-3.6.3.0
-# Protolude is not yet in resolver snapshot
-- protolude-0.3.1
 # hspec@2.9.3 is the first version that starts depending on ghc
 # ghc depends on terminfo by default, but that can be ignored
 # if one uses the '-terminfo' flag.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # Please update Haskell image versions under .github/workflows/ci.yml together to use the same GHC version
 # (or the CI build will fail)
-resolver: nightly-2022-11-12
+resolver: lts-20.9
 pvp-bounds: both
 packages:
 - '.'


### PR DESCRIPTION
**Description of the change**

Updates GHC to 9.2.5 and the Stackage snapshot to LTS-20.9.

The changes are very similar to the [previous GHC upgrade](https://github.com/purescript/purescript/pull/4422).

As of today, GHC 9.2.5 is both recommended and hls-powered (LSP support). See `ghcup` screenshot:

![image](https://user-images.githubusercontent.com/13085980/216028292-990c5e0c-1eb5-4dbb-b87c-d6b0b6d471e4.png)

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
