### PR TITLE
CONTRIBUTORS: Single link reference to MIT license

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,177 +14,181 @@ If you would prefer to use different terms, please use the section below instead
 
 | Username | Name | License |
 | :------- | :--- | :------ |
-| [@5outh](https://github.com/5outh) | Benjamin Kovach | MIT license |
-| [@actionshrimp](https://github.com/actionshrimp) | David Aitken | [MIT license](http://opensource.org/licenses/MIT) |
-| [@alexbiehl](https://github.com/alexbiehl) | Alexander Biehl | [MIT license](http://opensource.org/licenses/MIT) |
-| [@andreypopp](https://github.com/andreypopp) | Andrey Popp | MIT license |
-| [@andyarvanitis](https://github.com/andyarvanitis) | Andy Arvanitis | [MIT license](http://opensource.org/licenses/MIT) |
-| [@anthok88](https://github.com/anthok88) | anthoq88 | MIT license |
-| [@ardumont](https://github.com/ardumont) | Antoine R. Dumont | [MIT license](http://opensource.org/licenses/MIT) |
-| [@arrowd](https://github.com/arrowd) | Gleb Popov | [MIT license](http://opensource.org/licenses/MIT) |
-| [@aspidites](https://github.com/aspidites) | Edwin Marshall | [MIT license](http://opensource.org/licenses/MIT) |
-| [@bagl](https://github.com/bagl) | Petr Vapenka | [MIT license](http://opensource.org/licenses/MIT) |
-| [@balajirrao](https://github.com/balajirrao) | Balaji Rao | MIT license |
-| [@bbqbaron](https://github.com/bbqbaron) | Eric Loren | [MIT license](http://opensource.org/licenses/MIT) |
-| [@bergmark](https://github.com/bergmark) | Adam Bergmark | MIT license |
-| [@bitemyapp](https://github.com/bitemyapp) | Chris Allen | [MIT license](http://opensource.org/licenses/MIT) |
-| [@bmjames](https://github.com/bmjames) | Ben James | [MIT license](http://opensource.org/licenses/MIT) |
-| [@Bogdanp](https://github.com/Bogdanp) | Bogdan Paul Popa | [MIT license](http://opensource.org/licenses/MIT) |
-| [@brandonhamilton](https://github.com/brandonhamilton) | Brandon Hamilton | [MIT license](http://opensource.org/licenses/MIT) |
-| [@bsermons](https://github.com/bsermons) | Brian Sermons | [MIT license](http://opensource.org/licenses/MIT) |
-| [@cdepillabout](https://github.com/cdepillabout) | Dennis Gosnell | [MIT license](http://opensource.org/licenses/MIT) |
-| [@chexxor](https://github.com/chexxor) | Alex Berg | [MIT license](http://opensource.org/licenses/MIT) |
-| [@chrisdone](https://github.com/chrisdone) | Chris Done | MIT license |
-| [@cmdv](https://github.com/cmdv) | Vincent Orr | MIT license |
-| [@codedmart](https://github.com/codedmart) | Brandon Martin | [MIT license](http://opensource.org/licenses/MIT) |
-| [@coot](https://github.com/coot) | Marcin Szamotulski | [MIT license](http://opensource.org/licenses/MIT) |
-| [@davidchambers](https://github.com/davidchambers) | David Chambers | [MIT license](http://opensource.org/licenses/MIT) |
-| [@DavidLindbom](https://github.com/DavidLindbom) | David Lindbom | [MIT license](http://opensource.org/licenses/MIT) |
-| [@dckc](https://github.com/dckc) | Dan Connolly | [MIT license](http://opensource.org/licenses/MIT) |
-| [@kleeneplus](https://github.com/dgendill) | Dominick Gendill | [MIT license](http://opensource.org/licenses/MIT) |
-| [@ealmansi](https://github.com/ealmansi) | Emilio Almansi | MIT license |
-| [@eamelink](https://github.com/eamelink) | Erik Bakker | MIT license |
-| [@EMattfolk](https://github.com/EMattfolk) | Erik Mattfolk | [MIT license](http://opensource.org/licenses/MIT) |
-| [@epost](https://github.com/epost) | Erik Post | MIT license |
-| [@erdeszt](https://github.com/erdeszt) | Tibor Erdesz | [MIT license](http://opensource.org/licenses/MIT) |
-| [@etrepum](https://github.com/etrepum) | Bob Ippolito | [MIT license](http://opensource.org/licenses/MIT) |
-| [@faineance](https://github.com/faineance) | faineance | [MIT license](http://opensource.org/licenses/MIT) |
-| [@fehrenbach](https://github.com/fehrenbach) | Stefan Fehrenbach | [MIT license](http://opensource.org/licenses/MIT) |
-| [@felixSchl](https://github.com/felixSchl) | Felix Schlitter | [MIT license](http://opensource.org/licenses/MIT) |
-| [@FrigoEU](https://github.com/FrigoEU) | Simon Van Casteren | [MIT license](http://opensource.org/licenses/MIT) |
-| [@fsoikin](https://github.com/fsoikin) | Fyodor Soikin | [MIT license](http://opensource.org/licenses/MIT) |
-| [@f-f](https://github.com/f-f) | Fabrizio Ferrai | [MIT license](http://opensource.org/licenses/MIT) |
-| [@garyb](https://github.com/garyb) | Gary Burgess | [MIT license](http://opensource.org/licenses/MIT) |
-| [@hdgarrood](https://github.com/hdgarrood) | Harry Garrood | [MIT license](http://opensource.org/licenses/MIT) |
-| [@houli](https://github.com/houli) | Eoin Houlihan | [MIT license](http://opensource.org/licenses/MIT) |
-| [@ianbollinger](https://github.com/ianbollinger) | Ian D. Bollinger | [MIT license](http://opensource.org/licenses/MIT) |
-| [@ilovezfs](https://github.com/ilovezfs) | ilovezfs | MIT license |
-| [@i-am-tom](https://github.com/i-am-tom) | i-am-tom | [MIT license](http://opensource.org/licenses/MIT)  |
-| [@izgzhen](https://github.com/izgzhen) | Zhen Zhang | [MIT license](http://opensource.org/licenses/MIT) |
-| [@jacereda](https://github.com/jacereda) | Jorge Acereda | [MIT license](http://opensource.org/licenses/MIT) |
-| [@japesinator](https://github.com/japesinator) | JP Smith | [MIT license](http://opensource.org/licenses/MIT) |
-| [@jkachmar](https://github.com/jkachmar) | Joe Kachmar | MIT license |
-| [@joneshf](https://github.com/joneshf) | Hardy Jones | MIT license |
-| [@jy14898](https://github.com/jy14898) | Joseph Young | MIT license |
-| [@kika](https://github.com/kika) | Kirill Pertsev | MIT license |
-| [@kRITZCREEK](https://github.com/kRITZCREEK) | Christoph Hegemann | MIT license |
-| [@L8D](https://github.com/L8D) | Tenor Biel | [MIT license](http://opensource.org/licenses/MIT) |
-| [@legrostdg](https://github.com/legrostdg) | Félix Sipma | [MIT license](http://opensource.org/licenses/MIT) |
-| [@LiamGoodacre](https://github.com/LiamGoodacre) | Liam Goodacre | [MIT license](http://opensource.org/licenses/MIT) |
-| [@lukerandall](https://github.com/lukerandall) | Luke Randall | [MIT license](http://opensource.org/licenses/MIT) |
-| [@lunaris](https://github.com/lunaris) | Will Jones | [MIT license](http://opensource.org/licenses/MIT) |
-| [@matthewleon](https://github.com/matthewleon) | Matthew Leon | [MIT license](http://opensource.org/licenses/MIT) |
-| [@mcoffin](https://github.com/mcoffin) | Matt Coffin | [MIT license](http://opensource.org/licenses/MIT) |
-| [@mhcurylo](https://github.com/mhcurylo) | Mateusz Curylo | [MIT license](http://opensource.org/licenses/MIT) |
-| [@mikesol](https://github.com/mikesol) | Mike Solomon | [MIT license](http://opensource.org/licenses/MIT) |
-| [@MiracleBlue](https://github.com/MiracleBlue) | Nicholas Kircher | [MIT license](http://opensource.org/licenses/MIT) |
-| [@mrkgnao](https://github.com/mrkgnao) | Soham Chowdhury | [MIT license](http://opensource.org/licenses/MIT) |
-| [@mgmeier](https://github.com/mgmeier) | Michael Gilliland | [MIT license](http://opensource.org/licenses/MIT) |
-| [@michaelficarra](https://github.com/michaelficarra) | Michael Ficarra | [MIT license](http://opensource.org/licenses/MIT) |
-| [@MichaelXavier](https://github.com/MichaelXavier) | Michael Xavier | MIT license |
-| [@milesfrain](https://github.com/milesfrain) | Miles Frain | [MIT license](http://opensource.org/licenses/MIT) |
-| [@mjgpy3](https://github.com/mjgpy3) | Michael Gilliland | [MIT license](http://opensource.org/licenses/MIT) |
-| [@mpietrzak](https://github.com/mpietrzak) | Maciej Pietrzak | [MIT license](http://opensource.org/licenses/MIT) |
-| [@mrhania](https://github.com/mrhania) | Łukasz Hanuszczak | [MIT license](http://opensource.org/licenses/MIT) |
-| [@natefaubion](https://github.com/natefaubion) | Nathan Faubion | [MIT license](http://opensource.org/licenses/MIT) |
-| [@ncaq](https://github.com/ncaq) | ncaq | [MIT license](http://opensource.org/licenses/MIT) |
-| [@NickMolloy](https://github.com/NickMolloy) | Nick Molloy | [MIT license](http://opensource.org/licenses/MIT) |
-| [@nicodelpiano](https://github.com/nicodelpiano) | Nicolas Del Piano | [MIT license](http://opensource.org/licenses/MIT) |
-| [@noraesae](https://github.com/noraesae) | Hyunje Jun | [MIT license](http://opensource.org/licenses/MIT) |
-| [@nullobject](https://github.com/nullobject) | Josh Bassett | [MIT license](http://opensource.org/licenses/MIT) |
-| [@osa1](https://github.com/osa1) | Ömer Sinan Ağacan | MIT license |
-| [@paf31](https://github.com/paf31) | Phil Freeman | [MIT license](http://opensource.org/licenses/MIT) |
-| [@parsonsmatt](https://github.com/parsonsmatt) | Matt Parsons | [MIT license](http://opensource.org/licenses/MIT) |
-| [@passy](https://github.com/passy) | Pascal Hartig | [MIT license](http://opensource.org/licenses/MIT) |
-| [@paulyoung](https://github.com/paulyoung) | Paul Young | [MIT license](http://opensource.org/licenses/MIT) |
-| [@pelotom](https://github.com/pelotom) | Thomas Crockett | [MIT license](http://opensource.org/licenses/MIT) |
-| [@peterbecich](https://github.com/peterbecich) | Peter Becich | [MIT license](http://opensource.org/licenses/MIT) |
-| [@phadej](https://github.com/phadej) | Oleg Grenrus | [MIT license](http://opensource.org/licenses/MIT) |
-| [@phiggins](https://github.com/phiggins) | Pete Higgins | [MIT license](http://opensource.org/licenses/MIT) |
-| [@philopon](https://github.com/philopon) | Hirotomo Moriwaki | [MIT license](http://opensource.org/licenses/MIT) |
-| [@pseudonom](https://github.com/pseudonom) | Eric Easley | [MIT license](http://opensource.org/licenses/MIT) |
-| [@ptrfrncsmrph](https://github.com/ptrfrncsmrph) | Peter Murphy | [MIT license](http://opensource.org/licenses/MIT) |
-| [@quesebifurcan](https://github.com/quesebifurcan) | Fredrik Wallberg | [MIT license](http://opensource.org/licenses/MIT) |
-| [@radrow](https://github.com/radrow) | Radosław Rowicki | [MIT license](http://opensource.org/licenses/MIT) |
-| [@rhendric](https://github.com/rhendric) | Ryan Hendrickson | [MIT license](http://opensource.org/licenses/MIT) |
-| [@rightfold](https://github.com/rightfold) | rightfold | [MIT license](https://opensource.org/licenses/MIT) |
-| [@rndnoise](https://www.github.com/rndnoise) | rndnoise | [MIT license](http://opensource.org/licenses/MIT) |
-| [@robdaemon](https://github.com/robdaemon) | Robert Roland | [MIT license](http://opensource.org/licenses/MIT) |
-| [@RossMeikleham](https://github.com/RossMeikleham) | Ross Meikleham | [MIT license](http://opensource.org/licenses/MIT) |
-| [@Rufflewind](https://github.com/Rufflewind) | Phil Ruffwind | [MIT license](https://opensource.org/licenses/MIT) |
-| [@rvion](https://github.com/rvion) | Rémi Vion | [MIT license](http://opensource.org/licenses/MIT) |
-| [@RyanGlScott](https://github.com/RyanGlScott) | Ryan Scott | [MIT license](http://opensource.org/licenses/MIT) |
-| [@sebastiaanvisser](https://github.com/sebastiaanvisser) | Sebastiaan Visser | MIT license |
-| [@sectore](https://github.com/sectore) | Jens Krause | [MIT license](http://opensource.org/licenses/MIT) |
-| [@senju](https://github.com/senju) | senju | [MIT license](http://opensource.org/licenses/MIT) |
-| [@seungha-kim](https://github.com/seungha-kim) | Seungha Kim | [MIT license](http://opensource.org/licenses/MIT) |
-| [@simonyangme](https://github.com/simonyangme) | Simon Yang | [MIT license](http://opensource.org/licenses/MIT) |
-| [@sharkdp](https://github.com/sharkdp) | David Peter | [MIT license](http://opensource.org/licenses/MIT) |
-| [@soupi](https://github.com/soupi) | Gil Mizrahi | [MIT license](http://opensource.org/licenses/MIT) |
-| [@stefanholzmueller](https://github.com/stefanholzmueller) | Stefan Holzmüller | [MIT license](http://opensource.org/licenses/MIT) |
-| [@sztupi](https://github.com/sztupi) | Attila Sztupak | [MIT license](http://opensource.org/licenses/MIT) |
-| [@taktoa](https://github.com/taktoa) | Remy Goldschmidt | [MIT license](http://opensource.org/licenses/MIT) |
-| [@taku0](https://github.com/taku0) | taku0 | [MIT license](http://opensource.org/licenses/MIT) |
-| [@tfausak](https://github.com/tfausak) | Taylor Fausak | [MIT license](http://opensource.org/licenses/MIT) |
-| [@thoradam](https://github.com/thoradam) | Thor Adam | [MIT license](http://opensource.org/licenses/MIT) |
-| [@tmcgilchrist](https://github.com/tmcgilchrist) | Tim McGilchrist | [MIT license](http://opensource.org/licenses/MIT) |
-| [@trofi](https://github.com/trofi) | Sergei Trofimovich | [MIT license](http://opensource.org/licenses/MIT) |
-| [@utkarshkukreti](https://github.com/utkarshkukreti) | Utkarsh Kukreti | [MIT license](http://opensource.org/licenses/MIT) |
-| [@vkorablin](https://github.com/vkorablin) | Vladimir Korablin | MIT license |
-| [@vladciobanu](https://github.com/vladciobanu) | Vladimir Ciobanu | [MIT license](http://opensource.org/licenses/MIT) |
-| [@zudov](https://github.com/zudov) | Konstantin Zudov | [MIT license](http://opensource.org/licenses/MIT) |
-| [@b123400](https://github.com/b123400) | b123400 | [MIT license](https://opensource.org/licenses/MIT) |
-| [@kcsongor](https://github.com/kcsongor) | Csongor Kiss | [MIT license](http://opensource.org/licenses/MIT) |
-| [@drets](https://github.com/drets) | Dmytro Rets | [MIT license](http://opensource.org/licenses/MIT) |
-| [@bjornmelgaaard](https://github.com/BjornMelgaard) | Sergey Homa | [MIT license](http://opensource.org/licenses/MIT) |
-| [@thimoteus](https://github.com/Thimoteus) | thimoteus | [MIT license](http://opensource.org/licenses/MIT) |
-| [@sloosch](https://github.com/sloosch) | Simon Looschen | [MIT license](http://opensource.org/licenses/MIT) |
-| [@rgrinberg](https://github.com/rgrinberg) | Rudi Grinberg | [MIT license](http://opensource.org/licenses/MIT) |
-| [@gabejohnson](https://github.com/gabejohnson) | Gabe Johnson | [MIT license](http://opensource.org/licenses/MIT) |
-| [@dariooddenino](https://github.com/dariooddenino) | Dario Oddenino | [MIT license](http://opensource.org/licenses/MIT) |
-| [@jordanmartinez](https://github.com/jordanmartinez) | Jordan Martinez | [MIT license](http://opensource.org/licenses/MIT) |
-| [@Saulukass](https://github.com/Saulukass) | Saulius Skliutas | [MIT license](http://opensource.org/licenses/MIT) |
-| [@adnelson](https://github.com/adnelson) | Allen Nelson | [MIT license](http://opensource.org/licenses/MIT) |
-| [@dyerw](https://github.com/dyerw) | Liam Dyer | [MIT license](http://opensource.org/licenses/MIT) |
-| [@marcosh](https://github.com/marcosh) | Marco Perone | [MIT license](http://opensource.org/licenses/MIT) |
-| [@matthew-hilty](https://github.com/matthew-hilty) | Matthew Hilty | [MIT license](http://opensource.org/licenses/MIT) |
-| [@woody88](https://github.com/woody88) | Woodson Delhia | [MIT license](http://opensource.org/licenses/MIT) |
-| [@mhmdanas](https://github.com/mhmdanas) | Mohammed Anas | [MIT license](http://opensource.org/licenses/MIT) |
-| [@kl0tl](https://github.com/kl0tl) | Cyril Sobierajewicz | [MIT license](http://opensource.org/licenses/MIT) |
-| [@PureFunctor](https://github.com/PureFunctor), [@sjpgarcia](https://github.com/sjpgarcia) | Justin Garcia | [MIT license](http://opensource.org/licenses/MIT) |
-| [@xgrommx](https://github.com/xgrommx) | Denis Stoyanov | [MIT license](http://opensource.org/licenses/MIT) |
-| [@MonoidMusician](https://github.com/MonoidMusician) | Verity Scheel | [MIT license](http://opensource.org/licenses/MIT) |
-| [@thomashoneyman](https://github.com/thomashoneyman) | Thomas Honeyman | [MIT license](http://opensource.org/licenses/MIT) |
-| [@sigma-andex](https://github.com/sigma-andex) | Jan Schulte | [MIT license](http://opensource.org/licenses/MIT) |
-| [@i-am-the-slime](https://github.com/i-am-the-slime) | Mark Eibes | [MIT license](http://opensource.org/licenses/MIT) |
-| [@sd-yip](https://github.com/sd-yip) | Nicholas Yip | [MIT license](http://opensource.org/licenses/MIT) |
-| [@j-nava](https://github.com/j-nava) | Jesse Nava | [MIT license](http://opensource.org/licenses/MIT) |
-| [@imcotton](https://github.com/imcotton) | Cotton Hou | [MIT license](http://opensource.org/licenses/MIT) |
-| [@FredTheDino](https://github.com/FredTheDino) | Edvard Thörnros | [MIT license](http://opensource.org/licenses/MIT) |
-| [@wclr](https://github.com/wclr) | Alex Osh | [MIT license](http://opensource.org/licenses/MIT) |
-| [@Deltaspace0](https://github.com/Deltaspace0) | Ruslan Gadeev | [MIT license](http://opensource.org/licenses/MIT) |
+| [@5outh](https://github.com/5outh) | Benjamin Kovach | [MIT license] |
+| [@actionshrimp](https://github.com/actionshrimp) | David Aitken | [MIT license] |
+| [@adnelson](https://github.com/adnelson) | Allen Nelson | [MIT license] |
+| [@alexbiehl](https://github.com/alexbiehl) | Alexander Biehl | [MIT license] |
+| [@andreypopp](https://github.com/andreypopp) | Andrey Popp | [MIT license] |
+| [@andyarvanitis](https://github.com/andyarvanitis) | Andy Arvanitis | [MIT license] |
+| [@andys8](https://github.com/andys8) | andys8 | [MIT license] |
+| [@anthok88](https://github.com/anthok88) | anthoq88 | [MIT license] |
+| [@ardumont](https://github.com/ardumont) | Antoine R. Dumont | [MIT license] |
+| [@arrowd](https://github.com/arrowd) | Gleb Popov | [MIT license] |
+| [@aspidites](https://github.com/aspidites) | Edwin Marshall | [MIT license] |
+| [@b123400](https://github.com/b123400) | b123400 | [MIT license] |
+| [@bagl](https://github.com/bagl) | Petr Vapenka | [MIT license] |
+| [@balajirrao](https://github.com/balajirrao) | Balaji Rao | [MIT license] |
+| [@bbqbaron](https://github.com/bbqbaron) | Eric Loren | [MIT license] |
+| [@bergmark](https://github.com/bergmark) | Adam Bergmark | [MIT license] |
+| [@bitemyapp](https://github.com/bitemyapp) | Chris Allen | [MIT license] |
+| [@bjornmelgaaard](https://github.com/BjornMelgaard) | Sergey Homa | [MIT license] |
+| [@bmjames](https://github.com/bmjames) | Ben James | [MIT license] |
+| [@Bogdanp](https://github.com/Bogdanp) | Bogdan Paul Popa | [MIT license] |
+| [@brandonhamilton](https://github.com/brandonhamilton) | Brandon Hamilton | [MIT license] |
+| [@bsermons](https://github.com/bsermons) | Brian Sermons | [MIT license] |
+| [@cdepillabout](https://github.com/cdepillabout) | Dennis Gosnell | [MIT license] |
+| [@chexxor](https://github.com/chexxor) | Alex Berg | [MIT license] |
+| [@chrisdone](https://github.com/chrisdone) | Chris Done | [MIT license] |
+| [@cmdv](https://github.com/cmdv) | Vincent Orr | [MIT license] |
+| [@codedmart](https://github.com/codedmart) | Brandon Martin | [MIT license] |
+| [@coot](https://github.com/coot) | Marcin Szamotulski | [MIT license] |
+| [@dariooddenino](https://github.com/dariooddenino) | Dario Oddenino | [MIT license] |
+| [@davidchambers](https://github.com/davidchambers) | David Chambers | [MIT license] |
+| [@DavidLindbom](https://github.com/DavidLindbom) | David Lindbom | [MIT license] |
+| [@dckc](https://github.com/dckc) | Dan Connolly | [MIT license] |
+| [@Deltaspace0](https://github.com/Deltaspace0) | Ruslan Gadeev | [MIT license] |
+| [@drets](https://github.com/drets) | Dmytro Rets | [MIT license] |
+| [@dyerw](https://github.com/dyerw) | Liam Dyer | [MIT license] |
+| [@ealmansi](https://github.com/ealmansi) | Emilio Almansi | [MIT license] |
+| [@eamelink](https://github.com/eamelink) | Erik Bakker | [MIT license] |
+| [@EMattfolk](https://github.com/EMattfolk) | Erik Mattfolk | [MIT license] |
+| [@epost](https://github.com/epost) | Erik Post | [MIT license] |
+| [@erdeszt](https://github.com/erdeszt) | Tibor Erdesz | [MIT license] |
+| [@etrepum](https://github.com/etrepum) | Bob Ippolito | [MIT license] |
+| [@f-f](https://github.com/f-f) | Fabrizio Ferrai | [MIT license] |
+| [@faineance](https://github.com/faineance) | faineance | [MIT license] |
+| [@fehrenbach](https://github.com/fehrenbach) | Stefan Fehrenbach | [MIT license] |
+| [@felixSchl](https://github.com/felixSchl) | Felix Schlitter | [MIT license] |
+| [@FredTheDino](https://github.com/FredTheDino) | Edvard Thörnros | [MIT license] |
+| [@FrigoEU](https://github.com/FrigoEU) | Simon Van Casteren | [MIT license] |
+| [@fsoikin](https://github.com/fsoikin) | Fyodor Soikin | [MIT license] |
+| [@gabejohnson](https://github.com/gabejohnson) | Gabe Johnson | [MIT license] |
+| [@garyb](https://github.com/garyb) | Gary Burgess | [MIT license] |
+| [@hdgarrood](https://github.com/hdgarrood) | Harry Garrood | [MIT license] |
+| [@houli](https://github.com/houli) | Eoin Houlihan | [MIT license] |
+| [@i-am-the-slime](https://github.com/i-am-the-slime) | Mark Eibes | [MIT license] |
+| [@i-am-tom](https://github.com/i-am-tom) | i-am-tom | [MIT license]  |
+| [@ianbollinger](https://github.com/ianbollinger) | Ian D. Bollinger | [MIT license] |
+| [@ilovezfs](https://github.com/ilovezfs) | ilovezfs | [MIT license] |
+| [@imcotton](https://github.com/imcotton) | Cotton Hou | [MIT license] |
+| [@izgzhen](https://github.com/izgzhen) | Zhen Zhang | [MIT license] |
+| [@j-nava](https://github.com/j-nava) | Jesse Nava | [MIT license] |
+| [@jacereda](https://github.com/jacereda) | Jorge Acereda | [MIT license] |
+| [@japesinator](https://github.com/japesinator) | JP Smith | [MIT license] |
+| [@jkachmar](https://github.com/jkachmar) | Joe Kachmar | [MIT license] |
+| [@joneshf](https://github.com/joneshf) | Hardy Jones | [MIT license] |
+| [@jordanmartinez](https://github.com/jordanmartinez) | Jordan Martinez | [MIT license] |
+| [@jy14898](https://github.com/jy14898) | Joseph Young | [MIT license] |
+| [@kcsongor](https://github.com/kcsongor) | Csongor Kiss | [MIT license] |
+| [@kika](https://github.com/kika) | Kirill Pertsev | [MIT license] |
+| [@kl0tl](https://github.com/kl0tl) | Cyril Sobierajewicz | [MIT license] |
+| [@kleeneplus](https://github.com/dgendill) | Dominick Gendill | [MIT license] |
+| [@kRITZCREEK](https://github.com/kRITZCREEK) | Christoph Hegemann | [MIT license] |
+| [@L8D](https://github.com/L8D) | Tenor Biel | [MIT license] |
+| [@legrostdg](https://github.com/legrostdg) | Félix Sipma | [MIT license] |
+| [@LiamGoodacre](https://github.com/LiamGoodacre) | Liam Goodacre | [MIT license] |
+| [@lukerandall](https://github.com/lukerandall) | Luke Randall | [MIT license] |
+| [@lunaris](https://github.com/lunaris) | Will Jones | [MIT license] |
+| [@marcosh](https://github.com/marcosh) | Marco Perone | [MIT license] |
+| [@matthew-hilty](https://github.com/matthew-hilty) | Matthew Hilty | [MIT license] |
+| [@matthewleon](https://github.com/matthewleon) | Matthew Leon | [MIT license] |
+| [@mcoffin](https://github.com/mcoffin) | Matt Coffin | [MIT license] |
+| [@mgmeier](https://github.com/mgmeier) | Michael Gilliland | [MIT license] |
+| [@mhcurylo](https://github.com/mhcurylo) | Mateusz Curylo | [MIT license] |
+| [@mhmdanas](https://github.com/mhmdanas) | Mohammed Anas | [MIT license] |
+| [@michaelficarra](https://github.com/michaelficarra) | Michael Ficarra | [MIT license] |
+| [@MichaelXavier](https://github.com/MichaelXavier) | Michael Xavier | [MIT license] |
+| [@mikesol](https://github.com/mikesol) | Mike Solomon | [MIT license] |
+| [@milesfrain](https://github.com/milesfrain) | Miles Frain | [MIT license] |
+| [@MiracleBlue](https://github.com/MiracleBlue) | Nicholas Kircher | [MIT license] |
+| [@mjgpy3](https://github.com/mjgpy3) | Michael Gilliland | [MIT license] |
+| [@MonoidMusician](https://github.com/MonoidMusician) | Verity Scheel | [MIT license] |
+| [@mpietrzak](https://github.com/mpietrzak) | Maciej Pietrzak | [MIT license] |
+| [@mrhania](https://github.com/mrhania) | Łukasz Hanuszczak | [MIT license] |
+| [@mrkgnao](https://github.com/mrkgnao) | Soham Chowdhury | [MIT license] |
+| [@natefaubion](https://github.com/natefaubion) | Nathan Faubion | [MIT license] |
+| [@ncaq](https://github.com/ncaq) | ncaq | [MIT license] |
+| [@NickMolloy](https://github.com/NickMolloy) | Nick Molloy | [MIT license] |
+| [@nicodelpiano](https://github.com/nicodelpiano) | Nicolas Del Piano | [MIT license] |
+| [@noraesae](https://github.com/noraesae) | Hyunje Jun | [MIT license] |
+| [@nullobject](https://github.com/nullobject) | Josh Bassett | [MIT license] |
+| [@osa1](https://github.com/osa1) | Ömer Sinan Ağacan | [MIT license] |
+| [@paf31](https://github.com/paf31) | Phil Freeman | [MIT license] |
+| [@parsonsmatt](https://github.com/parsonsmatt) | Matt Parsons | [MIT license] |
+| [@passy](https://github.com/passy) | Pascal Hartig | [MIT license] |
+| [@paulyoung](https://github.com/paulyoung) | Paul Young | [MIT license] |
+| [@pelotom](https://github.com/pelotom) | Thomas Crockett | [MIT license] |
+| [@peterbecich](https://github.com/peterbecich) | Peter Becich | [MIT license] |
+| [@phadej](https://github.com/phadej) | Oleg Grenrus | [MIT license] |
+| [@phiggins](https://github.com/phiggins) | Pete Higgins | [MIT license] |
+| [@philopon](https://github.com/philopon) | Hirotomo Moriwaki | [MIT license] |
+| [@pseudonom](https://github.com/pseudonom) | Eric Easley | [MIT license] |
+| [@ptrfrncsmrph](https://github.com/ptrfrncsmrph) | Peter Murphy | [MIT license] |
+| [@PureFunctor](https://github.com/PureFunctor), [@sjpgarcia](https://github.com/sjpgarcia) | Justin Garcia | [MIT license] |
+| [@quesebifurcan](https://github.com/quesebifurcan) | Fredrik Wallberg | [MIT license] |
+| [@radrow](https://github.com/radrow) | Radosław Rowicki | [MIT license] |
+| [@rgrinberg](https://github.com/rgrinberg) | Rudi Grinberg | [MIT license] |
+| [@rhendric](https://github.com/rhendric) | Ryan Hendrickson | [MIT license] |
+| [@rightfold](https://github.com/rightfold) | rightfold | [MIT license] |
+| [@rndnoise](https://www.github.com/rndnoise) | rndnoise | [MIT license] |
+| [@robdaemon](https://github.com/robdaemon) | Robert Roland | [MIT license] |
+| [@RossMeikleham](https://github.com/RossMeikleham) | Ross Meikleham | [MIT license] |
+| [@Rufflewind](https://github.com/Rufflewind) | Phil Ruffwind | [MIT license] |
+| [@rvion](https://github.com/rvion) | Rémi Vion | [MIT license] |
+| [@RyanGlScott](https://github.com/RyanGlScott) | Ryan Scott | [MIT license] |
+| [@Saulukass](https://github.com/Saulukass) | Saulius Skliutas | [MIT license] |
+| [@sd-yip](https://github.com/sd-yip) | Nicholas Yip | [MIT license] |
+| [@sebastiaanvisser](https://github.com/sebastiaanvisser) | Sebastiaan Visser | [MIT license] |
+| [@sectore](https://github.com/sectore) | Jens Krause | [MIT license] |
+| [@senju](https://github.com/senju) | senju | [MIT license] |
+| [@seungha-kim](https://github.com/seungha-kim) | Seungha Kim | [MIT license] |
+| [@sharkdp](https://github.com/sharkdp) | David Peter | [MIT license] |
+| [@sigma-andex](https://github.com/sigma-andex) | Jan Schulte | [MIT license] |
+| [@simonyangme](https://github.com/simonyangme) | Simon Yang | [MIT license] |
+| [@sloosch](https://github.com/sloosch) | Simon Looschen | [MIT license] |
+| [@soupi](https://github.com/soupi) | Gil Mizrahi | [MIT license] |
+| [@stefanholzmueller](https://github.com/stefanholzmueller) | Stefan Holzmüller | [MIT license] |
+| [@sztupi](https://github.com/sztupi) | Attila Sztupak | [MIT license] |
+| [@taktoa](https://github.com/taktoa) | Remy Goldschmidt | [MIT license] |
+| [@taku0](https://github.com/taku0) | taku0 | [MIT license] |
+| [@tfausak](https://github.com/tfausak) | Taylor Fausak | [MIT license] |
+| [@thimoteus](https://github.com/Thimoteus) | thimoteus | [MIT license] |
+| [@thomashoneyman](https://github.com/thomashoneyman) | Thomas Honeyman | [MIT license] |
+| [@thoradam](https://github.com/thoradam) | Thor Adam | [MIT license] |
+| [@tmcgilchrist](https://github.com/tmcgilchrist) | Tim McGilchrist | [MIT license] |
+| [@trofi](https://github.com/trofi) | Sergei Trofimovich | [MIT license] |
+| [@utkarshkukreti](https://github.com/utkarshkukreti) | Utkarsh Kukreti | [MIT license] |
+| [@vkorablin](https://github.com/vkorablin) | Vladimir Korablin | [MIT license] |
+| [@vladciobanu](https://github.com/vladciobanu) | Vladimir Ciobanu | [MIT license] |
+| [@wclr](https://github.com/wclr) | Alex Osh | [MIT license] |
+| [@woody88](https://github.com/woody88) | Woodson Delhia | [MIT license] |
+| [@xgrommx](https://github.com/xgrommx) | Denis Stoyanov | [MIT license] |
+| [@zudov](https://github.com/zudov) | Konstantin Zudov | [MIT license] |
+
 
 ### Contributors using Modified Terms
 
 | Username | Name | Terms |
 | :------- | :--- | :------ |
-| [@charleso](https://github.com/charleso) | Charles O'Farrell | My existing contributions to the PureScript compiler and all future contributions to the PureScript compiler until further notice, are Copyright Charles O'Farrell, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT). |
-| [@chrissmoak](https://github.com/chrissmoak) | Chris Smoak | My existing contributions to the PureScript compiler and all future contributions to the PureScript compiler until further notice, are Copyright Chris Smoak, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT). |
+| [@charleso](https://github.com/charleso) | Charles O'Farrell | My existing contributions to the PureScript compiler and all future contributions to the PureScript compiler until further notice, are Copyright Charles O'Farrell, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license]. |
+| [@chrissmoak](https://github.com/chrissmoak) | Chris Smoak | My existing contributions to the PureScript compiler and all future contributions to the PureScript compiler until further notice, are Copyright Chris Smoak, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license]. |
 | [@citizengabe](https://github.com/citizengabe) | Gabe Johnson | All contributions I have or will make using the @citizengabe GitHub account are during employment at [CitizenNet Inc.](#companies) who owns the copyright. All of my existing or future contributions made using the @gabejohnson GitHub account are personal contributions and subject to the terms specified [above](#contributors-using-standard-terms). |
-| [@dylex](https://github.com/dylex) | Dylan Simon | My existing and all future contributions to the PureScript compiler until further notice are Copyright Dylan Simon, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT). |
-| [@leighman](http://github.com/leighman) | Jack Leigh | My existing contributions and all future contributions until further notice are Copyright Jack Leigh, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT). |
+| [@dylex](https://github.com/dylex) | Dylan Simon | My existing and all future contributions to the PureScript compiler until further notice are Copyright Dylan Simon, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license]. |
+| [@leighman](http://github.com/leighman) | Jack Leigh | My existing contributions and all future contributions until further notice are Copyright Jack Leigh, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license]. |
 | [@nagisa](https://github.com/nagisa) | nagisa | I hereby release my [only contribution](https://github.com/purescript/purescript/commit/80287a5d0de619862d3b4cda9c1ee276d18fdcd8) into public domain. |
 | [@puffnfresh](https://github.com/puffnfresh) | Brian McKenna | All contributions I made during June 2015 were during employment at [SlamData, Inc.](#companies) who owns the copyright. I assign copyright of all my personal contributions before June 2015 to the owners of the PureScript compiler. |
-| [@nwolverson](https://github.com/nwolverson) | Nicholas Wolverson | Contributions I made during March 2020 until further notice are in employment of [Id3as Company](#companies), who own the copyright. All other contributions remain Copyright Nicholas Wolverson, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT). |
-
+| [@nwolverson](https://github.com/nwolverson) | Nicholas Wolverson | Contributions I made during March 2020 until further notice are in employment of [Id3as Company](#companies), who own the copyright. All other contributions remain Copyright Nicholas Wolverson, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license]. |
 
 
 ### Companies
 
 | Username | Company | Terms |
 | :------- | :--- | :------ |
-| [@citizennet](https://github.com/citizennet) | CitizenNet Inc. | Our existing contributions to the PureScript compiler and all future contributions to the PureScript compiler until further notice, are Copyright CitizenNet Inc., and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT). - [@dbenyamin-cn](https://github.com/dbenyamin-cn) |
-| [@slamdata](https://github.com/slamdata) | SlamData, Inc. | Speaking on behalf of SlamData for SlamData employees, our existing contributions and all future contributions to the PureScript compiler are, until further notice, Copyright SlamData Inc., and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT). - @jdegoes |
-| [@qfpl](https://github.com/qfpl) | qfpl @ Data61 / CSIRO | Our existing contributions to the PureScript compiler and all future contributions to the PureScript compiler until further notice, are Copyright Data61 / CSIRO, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT). - [@lightandlight](https://github.com/lightandlight) |
-| [@id3as](https://github.com/id3as) | id3as-company Ltd. | Speaking on behalf of id3as for id3as employees, our existing contributions and all future contributions to the PureScript compiler are, until further notice, Copyright id3as-company Ltd, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT). - @adrianroe |
-| [@aeternity](https://aeternity.com/) | Aeternity Establishment | Our existing contributions to the PureScript compiler and all future contributions to the PureScript compiler until further notice, are Copyright Aeternity Establishment, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license](http://opensource.org/licenses/MIT). |
+| [@citizennet](https://github.com/citizennet) | CitizenNet Inc. | Our existing contributions to the PureScript compiler and all future contributions to the PureScript compiler until further notice, are Copyright CitizenNet Inc., and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license]. - [@dbenyamin-cn](https://github.com/dbenyamin-cn) |
+| [@slamdata](https://github.com/slamdata) | SlamData, Inc. | Speaking on behalf of SlamData for SlamData employees, our existing contributions and all future contributions to the PureScript compiler are, until further notice, Copyright SlamData Inc., and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license]. - @jdegoes |
+| [@qfpl](https://github.com/qfpl) | qfpl @ Data61 / CSIRO | Our existing contributions to the PureScript compiler and all future contributions to the PureScript compiler until further notice, are Copyright Data61 / CSIRO, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license]. - [@lightandlight](https://github.com/lightandlight) |
+| [@id3as](https://github.com/id3as) | id3as-company Ltd. | Speaking on behalf of id3as for id3as employees, our existing contributions and all future contributions to the PureScript compiler are, until further notice, Copyright id3as-company Ltd, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license]. - @adrianroe |
+| [@aeternity](https://aeternity.com/) | Aeternity Establishment | Our existing contributions to the PureScript compiler and all future contributions to the PureScript compiler until further notice, are Copyright Aeternity Establishment, and are licensed to the owners and users of the PureScript compiler project under the terms of the [MIT license]. |
+
+
+[MIT license]: https://opensource.org/licenses/MIT


### PR DESCRIPTION
**Description of the change**

Adding a single MIT markdown link reference because previously `http` and `https` where mixed and some instances were not linked. Also sorted the list of contributors.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
