### PR TITLE
Account for typed holes when checking declarations

### DIFF
--- a/CHANGELOG.d/fix_4408.md
+++ b/CHANGELOG.d/fix_4408.md
@@ -1,0 +1,49 @@
+* Account for typed holes when checking value declarations
+
+  The compiler now takes into account typed holes when ordering value declarations
+  for type checking, allowing more top-level values to be suggested instead of
+  being limited by reverse lexicographical ordering.
+
+  Given:
+  ```purescript
+  module Main where
+
+  newtype K = K Int
+
+  aRinku :: Int -> K
+  aRinku = K
+
+  bMaho :: K
+  bMaho = ?help 0
+
+  cMuni :: Int -> K
+  cMuni = K
+
+  dRei :: Int -> K
+  dRei _ = bMaho
+  ```
+
+  Before:
+  ```
+    Hole 'help' has the inferred type
+            
+      Int -> K
+            
+    You could substitute the hole with one of these values:
+                           
+      Main.cMuni  :: Int -> K
+      Main.K      :: Int -> K
+  ```
+
+  After:
+  ```
+  Hole 'help' has the inferred type
+            
+    Int -> K
+            
+  You could substitute the hole with one of these values:
+                            
+    Main.aRinku  :: Int -> K
+    Main.cMuni   :: Int -> K
+    Main.K       :: Int -> K
+  ```

--- a/CHANGELOG.d/fix_4408.md
+++ b/CHANGELOG.d/fix_4408.md
@@ -37,13 +37,13 @@
 
   After:
   ```
-  Hole 'help' has the inferred type
+    Hole 'help' has the inferred type
             
-    Int -> K
+      Int -> K
             
-  You could substitute the hole with one of these values:
+    You could substitute the hole with one of these values:
                             
-    Main.aRinku  :: Int -> K
-    Main.cMuni   :: Int -> K
-    Main.K       :: Int -> K
+      Main.aRinku  :: Int -> K
+      Main.cMuni   :: Int -> K
+      Main.K       :: Int -> K
   ```

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -104,7 +104,13 @@ createBindingGroups moduleName = mapM f <=< handleDecls
           in (d, (name, vty), self ++ deps)
         dataVerts = fmap mkVert allDecls
     dataBindingGroupDecls <- parU (stronglyConnCompR dataVerts) toDataBindingGroup
-    let 
+    let
+      -- #4437
+      --
+      -- The idea here is to create a `Graph` whose `key` is a tuple: `(Bool, Ident)`,
+      -- where the `Bool` encodes the absence of a type hole. This relies on an implementation
+      -- detail for `stronglyConnComp` which allows identifiers with no type holes to "float"
+      -- and get checked before those that do, while preserving reverse topological sorting.
       makeValueDeclarationKey = (,) <$> exprHasNoTypeHole . valdeclExpression <*> valdeclIdent
       valueDeclarationKeys = makeValueDeclarationKey <$> values
 

--- a/tests/purs/failing/4408Acyclic.out
+++ b/tests/purs/failing/4408Acyclic.out
@@ -1,0 +1,22 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/4408Acyclic.purs:16:9 - 16:14 (line 16, column 9 - line 16, column 14)
+
+  Hole '[33mhelp[0m' has the inferred type
+  [33m          [0m
+  [33m  Int -> K[0m
+  [33m          [0m
+  You could substitute the hole with one of these values:
+  [33m                                                                    [0m
+  [33m  Main.aRinku                 :: Int -> K                           [0m
+  [33m  Main.cMuni                  :: Int -> K                           [0m
+  [33m  Safe.Coerce.coerce          :: forall a b. Coercible a b => a -> b[0m
+  [33m  Unsafe.Coerce.unsafeCoerce  :: forall a b. a -> b                 [0m
+  [33m  Main.K                      :: Int -> K                           [0m
+  [33m                                                                    [0m
+
+in value declaration [33mbMaho[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/HoleInferredType.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/4408Acyclic.purs
+++ b/tests/purs/failing/4408Acyclic.purs
@@ -1,0 +1,22 @@
+-- @shouldFailWith HoleInferredType
+module Main where
+
+-- Expected:
+--
+-- aRinku+cMuni -> bMaho -> dRei
+--
+-- Both aRinku and cMuni is suggested
+
+newtype K = K Int
+
+aRinku :: Int -> K
+aRinku = K
+
+bMaho :: K
+bMaho = ?help 0
+
+cMuni :: Int -> K
+cMuni = K
+
+dRei :: Int -> K
+dRei _ = bMaho

--- a/tests/purs/failing/4408AcyclicRecursive.out
+++ b/tests/purs/failing/4408AcyclicRecursive.out
@@ -1,0 +1,23 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/4408AcyclicRecursive.purs:17:11 - 17:16 (line 17, column 11 - line 17, column 16)
+
+  Hole '[33mhelp[0m' has the inferred type
+  [33m          [0m
+  [33m  Int -> K[0m
+  [33m          [0m
+  You could substitute the hole with one of these values:
+  [33m                                                                    [0m
+  [33m  Main.aRinku                 :: Int -> K                           [0m
+  [33m  Main.bMaho                  :: Int -> K                           [0m
+  [33m  Main.cMuni                  :: Int -> K                           [0m
+  [33m  Safe.Coerce.coerce          :: forall a b. Coercible a b => a -> b[0m
+  [33m  Unsafe.Coerce.unsafeCoerce  :: forall a b. a -> b                 [0m
+  [33m  Main.K                      :: Int -> K                           [0m
+  [33m                                                                    [0m
+
+in value declaration [33mbMaho[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/HoleInferredType.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/4408AcyclicRecursive.purs
+++ b/tests/purs/failing/4408AcyclicRecursive.purs
@@ -1,0 +1,23 @@
+-- @shouldFailWith HoleInferredType
+module Main where
+
+-- Expected:
+--
+-- aRinku+cMuni -> bMaho -> dRei
+--
+-- aRinku, cMuni, and bMaho are all suggested.
+-- bMaho can be aware of itself during checking.
+
+newtype K = K Int
+
+aRinku :: Int -> K
+aRinku = K
+
+bMaho :: Int -> K
+bMaho _ = ?help 0
+
+cMuni :: Int -> K
+cMuni = K
+
+dRei :: Int -> K
+dRei _ = bMaho

--- a/tests/purs/failing/4408Cyclic.out
+++ b/tests/purs/failing/4408Cyclic.out
@@ -1,0 +1,31 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/4408Cyclic.purs:23:29 - 23:34 (line 23, column 29 - line 23, column 34)
+
+  Hole '[33mhelp[0m' has the inferred type
+  [33m          [0m
+  [33m  Int -> K[0m
+  [33m          [0m
+  You could substitute the hole with one of these values:
+  [33m                                                                    [0m
+  [33m  Main.aSaki                  :: Int -> K                           [0m
+  [33m  Main.bNoa                   :: forall a. a -> K                   [0m
+  [33m  Main.cTowa                  :: forall a. a -> K                   [0m
+  [33m  Main.eSaki                  :: Int -> K                           [0m
+  [33m  Safe.Coerce.coerce          :: forall a b. Coercible a b => a -> b[0m
+  [33m  Unsafe.Coerce.unsafeCoerce  :: forall a b. a -> b                 [0m
+  [33m  Main.K                      :: Int -> K                           [0m
+  [33m                                                                    [0m
+  in the following context:
+
+    a :: [33ma0[0m
+
+
+in binding group cTowa, bNoa
+
+where [33ma0[0m is a rigid type variable
+        bound at (line 0, column 0 - line 0, column 0)
+
+See https://github.com/purescript/documentation/blob/master/errors/HoleInferredType.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/4408Cyclic.purs
+++ b/tests/purs/failing/4408Cyclic.purs
@@ -1,0 +1,29 @@
+-- @shouldFailWith HoleInferredType
+module Main where
+
+-- Expected:
+--
+-- aSaki/eSaki -> bNoa~cTowa -> dIbuki
+--
+-- Only aSaki/eSaki, bNoa, and cTowa is suggested.
+--
+-- The mutual recursion between bNoa and cTowa
+-- ensures they exist "at the same time". dIbuki
+-- depends on cTowa, so it's checked much later.
+
+newtype K = K Int
+
+aSaki :: Int -> K
+aSaki = K
+
+bNoa :: forall a. a -> K
+bNoa a = let _ = cTowa a in K 0
+
+cTowa :: forall a. a -> K
+cTowa a = let _ = bNoa a in ?help 0
+
+dIbuki :: Int -> K
+dIbuki = bNoa
+
+eSaki :: Int -> K
+eSaki = K

--- a/tests/purs/failing/4408CyclicTail.out
+++ b/tests/purs/failing/4408CyclicTail.out
@@ -1,0 +1,26 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/4408CyclicTail.purs:22:11 - 22:16 (line 22, column 11 - line 22, column 16)
+
+  Hole '[33mhelp[0m' has the inferred type
+  [33m          [0m
+  [33m  Int -> K[0m
+  [33m          [0m
+  You could substitute the hole with one of these values:
+  [33m                                                                    [0m
+  [33m  Main.aKyoko                 :: Int -> K                           [0m
+  [33m  Main.bShinobu               :: forall a. a -> K                   [0m
+  [33m  Main.cEsora                 :: forall a. a -> K                   [0m
+  [33m  Main.dYuka                  :: Int -> K                           [0m
+  [33m  Main.eShinobu               :: forall a. a -> K                   [0m
+  [33m  Main.fEsora                 :: forall a. a -> K                   [0m
+  [33m  Safe.Coerce.coerce          :: forall a b. Coercible a b => a -> b[0m
+  [33m  Unsafe.Coerce.unsafeCoerce  :: forall a b. a -> b                 [0m
+  [33m  Main.K                      :: Int -> K                           [0m
+  [33m                                                                    [0m
+
+in value declaration [33mdYuka[0m
+
+See https://github.com/purescript/documentation/blob/master/errors/HoleInferredType.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/4408CyclicTail.purs
+++ b/tests/purs/failing/4408CyclicTail.purs
@@ -1,0 +1,28 @@
+-- @shouldFailWith HoleInferredType
+module Main where
+
+-- Expected:
+--
+-- aKyoko -> bShinobu~cEsora/eShinobu~fEsora -> dYuka
+--
+-- All are suggested, as dYuka is also recursive.
+
+newtype K = K Int
+
+aKyoko :: Int -> K
+aKyoko = K
+
+bShinobu :: forall a. a -> K
+bShinobu a = let _ = cEsora a in K 0
+
+cEsora :: forall a. a -> K
+cEsora a = let _ = bShinobu a in K 0
+
+dYuka :: Int -> K
+dYuka _ = ?help 0
+
+eShinobu :: forall a. a -> K
+eShinobu a = let _ = fEsora a in K 0
+
+fEsora :: forall a. a -> K
+fEsora a = let _ = eShinobu a in K 0

--- a/tests/purs/failing/4408CyclicTriple.out
+++ b/tests/purs/failing/4408CyclicTriple.out
@@ -1,0 +1,32 @@
+Error found:
+in module [33mMain[0m
+at tests/purs/failing/4408CyclicTriple.purs:22:33 - 22:38 (line 22, column 33 - line 22, column 38)
+
+  Hole '[33mhelp[0m' has the inferred type
+  [33m          [0m
+  [33m  Int -> K[0m
+  [33m          [0m
+  You could substitute the hole with one of these values:
+  [33m                                                                    [0m
+  [33m  Main.aHaruna                :: Int -> K                           [0m
+  [33m  Main.bMiyu                  :: forall a. a -> K                   [0m
+  [33m  Main.cKurumi                :: forall a. a -> K                   [0m
+  [33m  Main.dMiiko                 :: forall a. a -> K                   [0m
+  [33m  Main.eHaruna                :: Int -> K                           [0m
+  [33m  Safe.Coerce.coerce          :: forall a b. Coercible a b => a -> b[0m
+  [33m  Unsafe.Coerce.unsafeCoerce  :: forall a b. a -> b                 [0m
+  [33m  Main.K                      :: Int -> K                           [0m
+  [33m                                                                    [0m
+  in the following context:
+
+    a :: [33ma0[0m
+
+
+in binding group dMiiko, cKurumi, bMiyu
+
+where [33ma0[0m is a rigid type variable
+        bound at (line 0, column 0 - line 0, column 0)
+
+See https://github.com/purescript/documentation/blob/master/errors/HoleInferredType.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/4408CyclicTriple.purs
+++ b/tests/purs/failing/4408CyclicTriple.purs
@@ -1,0 +1,25 @@
+-- @shouldFailWith HoleInferredType
+module Main where
+
+-- Expected:
+--
+-- aHaruna/eHaruna -> bMiyu~cKurumi~dMiiko
+--
+-- All are suggested.
+
+newtype K = K Int
+
+aHaruna :: Int -> K
+aHaruna = K
+
+bMiyu :: forall a. a -> K
+bMiyu a = let _ = dMiiko a in K 0
+
+cKurumi :: forall a. a -> K
+cKurumi a = let _ = bMiyu a in K 0
+
+dMiiko :: forall a. a -> K
+dMiiko a = let _ = cKurumi a in ?help 0
+
+eHaruna :: Int -> K
+eHaruna = K


### PR DESCRIPTION
**Description of the change**

Closes #4408. The compiler now accounts for typed holes when checking value declarations, allowing for more values to be suggested rather than being limited by reverse lexicographical ordering. It does this by attaching more data to the graph that's built internally for reverse topological sorting of value declarations that need to be checked.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
