### PR TITLE
Dark mode support for Pursuit documentation

### DIFF
--- a/CHANGELOG.d/feature_pursuit-dark-theme.md
+++ b/CHANGELOG.d/feature_pursuit-dark-theme.md
@@ -1,0 +1,5 @@
+* Generated documentation now supports dark mode
+
+  PureScript documentation has a new dark theme available.  It will
+  automatically be used based on your browser or system's color scheme
+  preferences.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -146,6 +146,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@sigma-andex](https://github.com/sigma-andex) | Jan Schulte | [MIT license] |
 | [@simonyangme](https://github.com/simonyangme) | Simon Yang | [MIT license] |
 | [@sloosch](https://github.com/sloosch) | Simon Looschen | [MIT license] |
+| [@sometimes-i-send-pull-requests](https://github.com/sometimes-i-send-pull-requests) | Alexander Kirchhoff | [MIT license] |
 | [@soupi](https://github.com/soupi) | Gil Mizrahi | [MIT license] |
 | [@stefanholzmueller](https://github.com/stefanholzmueller) | Stefan Holzmüller | [MIT license] |
 | [@sztupi](https://github.com/sztupi) | Attila Sztupak | [MIT license] |

--- a/app/static/pursuit.css
+++ b/app/static/pursuit.css
@@ -499,8 +499,8 @@ ol li {
 }
 @media (prefers-color-scheme: dark) {
   .decl__signature {
-    border-top: 1px solid #43434e;
-    border-bottom: 1px solid #43434e;
+    border-top-color: #43434e;
+    border-bottom-color: #43434e;
   }
 }
 .decl__signature code {
@@ -884,6 +884,11 @@ ol li {
   color: #777;
   border-left: 0.25em solid #ddd;
 }
+@media (prefers-color-scheme: dark) {
+  .markdown-body blockquote {
+    border-left-color: #444;
+  }
+}
 .markdown-body blockquote > :first-child {
   margin-top: 0;
 }
@@ -897,6 +902,11 @@ ol li {
 .markdown-body .pl-k {
   /* Keyword */
   color: #a0a0a0;
+}
+@media (prefers-color-scheme: dark) {
+  .markdown-body .pl-k {
+    color: #676767;
+  }
 }
 .markdown-body .pl-c1,
 .markdown-body .pl-en {

--- a/app/static/pursuit.css
+++ b/app/static/pursuit.css
@@ -49,6 +49,9 @@
  * ========================================================================== */
 /* Section: Document Styles
  * ========================================================================== */
+:root {
+  color-scheme: light dark;
+}
 html {
   box-sizing: border-box;
   /* This overflow rule prevents everything from shifting slightly to the side
@@ -63,10 +66,16 @@ html {
 }
 body {
   background-color: #ffffff;
-  color: #000;
+  color: #000000;
   font-family: "Roboto", sans-serif;
   font-size: 87.5%;
   line-height: 1.563;
+}
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #141417;
+    color: #dedede;
+  }
 }
 @media (min-width: 38em) {
   body {
@@ -158,6 +167,12 @@ body {
   background-color: #1d222d;
   color: #f0f0f0;
 }
+@media (prefers-color-scheme: dark) {
+  .footer {
+    background-color: #1d222d;
+    color: #f0f0f0;
+  }
+}
 .footer * {
   margin-bottom: 0;
 }
@@ -169,15 +184,31 @@ body {
 :target {
   background-color: #f1f5f9;
 }
+@media (prefers-color-scheme: dark) {
+  :target {
+    background-color: #232327;
+  }
+}
 a,
 a:visited {
   color: #c4953a;
   text-decoration: none;
   font-weight: bold;
 }
+@media (prefers-color-scheme: dark) {
+  a,
+  a:visited {
+    color: #d8ac55;
+  }
+}
 a:hover {
   color: #7b5904;
   text-decoration: none;
+}
+@media (prefers-color-scheme: dark) {
+  a:hover {
+    color: #f0dcab;
+  }
 }
 code,
 pre {
@@ -187,9 +218,22 @@ pre {
   font-family: "Roboto Mono", monospace;
   font-size: 87.5%;
 }
+@media (prefers-color-scheme: dark) {
+  code,
+  pre {
+    background-color: #232327;
+    color: #c1d3da;
+  }
+}
 :target code,
 :target pre {
   background-color: #dfe8f1;
+}
+@media (prefers-color-scheme: dark) {
+  :target code,
+  :target pre {
+    background-color: #2f2f34;
+  }
 }
 code {
   padding: 0.2em 0;
@@ -211,6 +255,11 @@ a > code::before {
 }
 a:hover > code {
   color: #c4953a;
+}
+@media (prefers-color-scheme: dark) {
+  a:hover > code {
+    color: #d8ac55;
+  }
 }
 pre {
   margin-top: 0;
@@ -255,14 +304,14 @@ h1 {
 h2 {
   font-size: 1.953em;
   font-weight: normal;
-  line-height: 1.250;
+  line-height: 1.25;
   margin-top: 3.052rem;
   margin-bottom: 1rem;
 }
 h3 {
   font-size: 1.563em;
   font-weight: normal;
-  line-height: 1.250;
+  line-height: 1.25;
   margin-top: 2.441rem;
   margin-bottom: 1rem;
 }
@@ -285,6 +334,11 @@ hr {
   height: 1px;
   background-color: #cccccc;
 }
+@media (prefers-color-scheme: dark) {
+  hr {
+    background-color: #43434e;
+  }
+}
 img {
   border-style: none;
   max-width: 100%;
@@ -302,6 +356,11 @@ table {
   margin-bottom: 1rem;
   width: 100%;
 }
+@media (prefers-color-scheme: dark) {
+  table {
+    border-bottom-color: #43434e;
+  }
+}
 td,
 th {
   text-align: left;
@@ -309,6 +368,11 @@ th {
 }
 td {
   border-top: 1px solid #cccccc;
+}
+@media (prefers-color-scheme: dark) {
+  td {
+    border-top-color: #43434e;
+  }
 }
 td:first-child,
 th:first-child {
@@ -326,7 +390,7 @@ ul {
 }
 ul li {
   position: relative;
-  padding-left: 1.250em;
+  padding-left: 1.25em;
 }
 ul li::before {
   position: absolute;
@@ -334,7 +398,12 @@ ul li::before {
   content: "–";
   display: inline-block;
   margin-left: -1.25em;
-  width: 1.250em;
+  width: 1.25em;
+}
+@media (prefers-color-scheme: dark) {
+  ul li::before {
+    color: #a0a0a0;
+  }
 }
 /* Tying this tightly to ul at the moment because it's a slight variation thereof */
 ul.ul--search li::before {
@@ -345,7 +414,7 @@ ul.ul--search li::before {
 ol {
   margin-top: 1rem;
   margin-bottom: 1rem;
-  padding-left: 1.250em;
+  padding-left: 1.25em;
 }
 ol li {
   position: relative;
@@ -359,9 +428,9 @@ ol li {
   position: relative;
   top: -0.1em;
   display: inline-block;
-  background-color: #000;
+  background-color: #000000;
   border-radius: 1.3em;
-  color: #fff;
+  color: #ffffff;
   font-size: 77%;
   font-weight: bold;
   line-height: 1.563;
@@ -369,9 +438,20 @@ ol li {
   height: 1.5em;
   width: 1.5em;
 }
+@media (prefers-color-scheme: dark) {
+  .badge {
+    background-color: #dedede;
+    color: #141417;
+  }
+}
 .badge.badge--package {
   background-color: #c4953a;
   letter-spacing: -0.1em;
+}
+@media (prefers-color-scheme: dark) {
+  .badge.badge--package {
+    background-color: #d8ac55;
+  }
 }
 .badge.badge--module {
   background-color: #75B134;
@@ -396,8 +476,19 @@ ol li {
   left: -0.8em;
   color: #bababa;
 }
+@media (prefers-color-scheme: dark) {
+  .decl__anchor,
+  .decl__anchor:visited {
+    color: #878787;
+  }
+}
 .decl__anchor:hover {
   color: #c4953a;
+}
+@media (prefers-color-scheme: dark) {
+  .decl__anchor:hover {
+    color: #d8ac55;
+  }
 }
 .decl__signature {
   background-color: transparent;
@@ -405,6 +496,12 @@ ol li {
   border-top: 1px solid #cccccc;
   border-bottom: 1px solid #cccccc;
   padding: 0;
+}
+@media (prefers-color-scheme: dark) {
+  .decl__signature {
+    border-top: 1px solid #43434e;
+    border-bottom: 1px solid #43434e;
+  }
 }
 .decl__signature code {
   display: block;
@@ -437,6 +534,11 @@ ol li {
 .decl__kind {
   border-bottom: 1px solid #cccccc;
 }
+@media (prefers-color-scheme: dark) {
+  .decl__kind {
+    border-bottom-color: #43434e;
+  }
+}
 :target .decl__signature,
 :target .decl__signature code {
   /* We want the background to be transparent, even when the parent is a target */
@@ -444,7 +546,13 @@ ol li {
 }
 .decl__body .keyword,
 .decl__body .syntax {
-  color: #0B71B4;
+  color: #0b71b4;
+}
+@media (prefers-color-scheme: dark) {
+  .decl__body .keyword,
+  .decl__body .syntax {
+    color: #3796d5;
+  }
 }
 .decl__child_comments {
   margin-top: 1rem;
@@ -465,11 +573,21 @@ ol li {
   font-size: 0.8em;
   line-height: 1;
 }
+@media (prefers-color-scheme: dark) {
+  .deplink__version {
+    color: #a0a0a0;
+  }
+}
 /* Component: Grouped List
  * -------------------------------------------------------------------------- */
 .grouped-list {
   border-top: 1px solid #cccccc;
   margin: 0 0 2.44em 0;
+}
+@media (prefers-color-scheme: dark) {
+  .grouped-list {
+    border-top-color: #43434e;
+  }
 }
 .grouped-list__title {
   color: #666666;
@@ -478,6 +596,11 @@ ol li {
   letter-spacing: 1px;
   margin: 0.8em 0 -0.1em 0;
   text-transform: uppercase;
+}
+@media (prefers-color-scheme: dark) {
+  .grouped-list__title {
+    border-top-color: #a0a0a0;
+  }
 }
 .grouped-list__item {
   margin: 0;
@@ -493,9 +616,21 @@ ol li {
   background-color: #fff0f0;
   border-color: #c85050;
 }
+@media (prefers-color-scheme: dark) {
+  .message.message--error {
+    background-color: #6b0e0e;
+    border-color: #c85050;
+  }
+}
 .message.message--not-available {
   background-color: #f0f096;
   border-color: #e3e33d;
+}
+@media (prefers-color-scheme: dark) {
+  .message.message--not-available {
+    background-color: #56560b;
+    border-color: #b0b017;
+  }
 }
 /* Component: Multi Col
  * Multiple columns side by side
@@ -548,12 +683,23 @@ ol li {
   text-transform: uppercase;
   z-index: 1;
 }
+@media (prefers-color-scheme: dark) {
+  .page-title__label {
+    color: #a0a0a0;
+  }
+}
 /* Component: Top Banner
  * -------------------------------------------------------------------------- */
 .top-banner {
   background-color: #1d222d;
   color: #f0f0f0;
   font-weight: normal;
+}
+@media (prefers-color-scheme: dark) {
+  .top-banner {
+    background-color: #1d222d;
+    color: #f0f0f0;
+  }
 }
 .top-banner__logo,
 .top-banner__logo:visited {
@@ -563,6 +709,12 @@ ol li {
   font-weight: 300;
   line-height: 90px;
   margin: 0;
+}
+@media (prefers-color-scheme: dark) {
+  .top-banner__logo,
+  .top-banner__logo:visited {
+    color: #f0f0f0;
+  }
 }
 .top-banner__logo:hover {
   color: #c4953a;
@@ -574,11 +726,19 @@ ol li {
 .top-banner__form input {
   border: 1px solid #1d222d;
   border-radius: 3px;
+  background-color: #ffffff;
   color: #1d222d;
   font-weight: 300;
   line-height: 2;
   padding: 0.21em 0.512em;
   width: 100%;
+}
+@media (prefers-color-scheme: dark) {
+  .top-banner__form input {
+    border-color: #1d222d;
+    background-color: #141417;
+    color: #dedede;
+  }
 }
 .top-banner__actions {
   float: right;
@@ -597,8 +757,19 @@ ol li {
 .top-banner__actions__item a:visited {
   color: #f0f0f0;
 }
+@media (prefers-color-scheme: dark) {
+  .top-banner__actions__item a,
+  .top-banner__actions__item a:visited {
+    color: #f0f0f0;
+  }
+}
 .top-banner__actions__item a:hover {
   color: #c4953a;
+}
+@media (prefers-color-scheme: dark) {
+  .top-banner__actions__item a:hover {
+    color: #d8ac55;
+  }
 }
 @media (min-width: 38em) {
   .top-banner__logo {
@@ -640,6 +811,12 @@ ol li {
   border-top: 1px solid #cccccc;
   border-bottom: 1px solid #cccccc;
   padding: 0.328em 0;
+}
+@media (prefers-color-scheme: dark) {
+  .result__signature {
+    border-top-color: #43434e;
+    border-bottom-color: #43434e;
+  }
 }
 .result__signature code {
   display: block;

--- a/app/static/pursuit.less
+++ b/app/static/pursuit.less
@@ -49,9 +49,9 @@
 /* Section: Variables
  * ========================================================================== */
 @background: rgb(255, 255, 255);
+@foreground: rgb(0, 0, 0);
 @banner_background: rgb(29, 34, 45);
-@package_banner_background: lighten(@banner_background, 30%);
-@dark_foreground: rgb(240, 240, 240);
+@dim_foreground: rgb(240, 240, 240);
 @link: rgb(196, 149, 58);
 @link_active: rgb(123, 89, 4);
 @error_background: rgb(255, 240, 240);
@@ -59,11 +59,31 @@
 @not_available_background: rgb(240, 240, 150);
 @code_foreground: rgb(25, 74, 91);
 @code_background: rgb(241, 245, 249);
-@light_glyph: rgb(160, 160, 160);
-@light_type: rgb(102, 102, 102);
+@dim_glyph: rgb(160, 160, 160);
+@dim_type: rgb(102, 102, 102);
+@keyword: rgb(11, 113, 180);
+
+@dark_background: rgb(20, 20, 23);
+@dark_foreground: rgb(222, 222, 222);
+@dark_banner_background: rgb(29, 34, 45);
+@dark_dim_foreground: rgb(240, 240, 240);
+@dark_link: rgb(216, 172, 85);
+@dark_link_active: rgb(240, 220, 171);
+@dark_error_background: rgb(107, 14, 14);
+@dark_error_border: rgb(200, 80, 80);
+@dark_not_available_background: rgb(86, 86, 11);
+@dark_code_foreground: rgb(193, 211, 218);
+@dark_code_background: rgb(35, 35, 39);
+@dark_dim_glyph: rgb(160, 160, 160);
+@dark_dim_type: rgb(160, 160, 160);
+@dark_keyword: rgb(55, 150, 213);
 
 /* Section: Document Styles
  * ========================================================================== */
+
+:root {
+  color-scheme: light dark;
+}
 
 html {
   box-sizing: border-box;
@@ -80,10 +100,15 @@ html {
 
 body {
   background-color: @background;
-  color: #000;
+  color: @foreground;
   font-family: "Roboto", sans-serif;
   font-size: 87.5%;
   line-height: 1.563;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: @dark_background;
+    color: @dark_foreground;
+  }
 }
 
 @media (min-width: 38em) {
@@ -193,7 +218,12 @@ html, body {
   width: 100%;
   text-align: center;
   background-color: @banner_background;
-  color: @dark_foreground;
+  color: @dim_foreground;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: @dark_banner_background;
+    color: @dark_dim_foreground;
+  }
 }
 
 .footer * {
@@ -209,17 +239,29 @@ html, body {
 
 :target {
   background-color: @code_background;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: @dark_code_background;
+  }
 }
 
 a, a:visited {
   color: @link;
   text-decoration: none;
   font-weight: bold;
+
+  @media (prefers-color-scheme: dark) {
+    color: @dark_link;
+  }
 }
 
 a:hover {
   color: @link_active;
   text-decoration: none;
+
+  @media (prefers-color-scheme: dark) {
+    color: @dark_link_active;
+  }
 }
 
 code, pre {
@@ -228,11 +270,20 @@ code, pre {
   color: @code_foreground;
   font-family: "Roboto Mono", monospace;
   font-size: 87.5%;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: @dark_code_background;
+    color: @dark_code_foreground;
+  }
 }
 
 :target code,
 :target pre {
   background-color: darken(@code_background, 5%);
+
+  @media (prefers-color-scheme: dark) {
+    background-color: lighten(@dark_code_background, 5%);
+  }
 }
 
 code {
@@ -259,6 +310,10 @@ a > code::before {
 
 a:hover > code {
   color: @link;
+
+  @media (prefers-color-scheme: dark) {
+    color: @dark_link;
+  }
 }
 
 pre {
@@ -341,6 +396,10 @@ hr {
   border: none;
   height: 1px;
   background-color: darken(@background, 20%);
+
+  @media (prefers-color-scheme: dark) {
+    background-color: lighten(@dark_background, 20%);
+  }
 }
 
 img {
@@ -361,6 +420,10 @@ table {
   margin-top: 1rem;
   margin-bottom: 1rem;
   width: 100%;
+
+  @media (prefers-color-scheme: dark) {
+    border-bottom-color: lighten(@dark_background, 20%);
+  }
 }
 
 td, th {
@@ -370,6 +433,10 @@ td, th {
 
 td {
   border-top: 1px solid darken(@background, 20%);
+
+  @media (prefers-color-scheme: dark) {
+    border-top-color: lighten(@dark_background, 20%);
+  }
 }
 
 td:first-child, th:first-child {
@@ -394,11 +461,15 @@ ul li {
 
 ul li::before {
   position: absolute;
-  color: @light_glyph;
+  color: @dim_glyph;
   content: "–";
   display: inline-block;
   margin-left: -1.250em;
   width: 1.250em;
+
+  @media (prefers-color-scheme: dark) {
+    color: @dark_dim_glyph;
+  }
 }
 
 /* Tying this tightly to ul at the moment because it's a slight variation thereof */
@@ -430,20 +501,29 @@ ol li {
   position: relative;
   top: -0.1em;
   display: inline-block;
-  background-color: #000;
+  background-color: @foreground;
   border-radius: 1.3em;
-  color: #fff;
+  color: @background;
   font-size: 77%;
   font-weight: bold;
   line-height: 1.563;
   text-align: center;
   height: 1.5em;
   width: 1.5em;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: @dark_foreground;
+    color: @dark_background;
+  }
 }
 
 .badge.badge--package {
   background-color: @link;
   letter-spacing: -0.1em;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: @dark_link;
+  }
 }
 
 .badge.badge--module {
@@ -473,11 +553,19 @@ ol li {
 .decl__anchor, .decl__anchor:visited {
   position: absolute;
   left: -0.8em;
-  color: lighten(@light_glyph, 10%);
+  color: lighten(@dim_glyph, 10%);
+
+  @media (prefers-color-scheme: dark) {
+    color: darken(@dark_dim_glyph, 10%);
+  }
 }
 
 .decl__anchor:hover {
   color: @link;
+
+  @media (prefers-color-scheme: dark) {
+    color: @dark_link;
+  }
 }
 
 .decl__signature {
@@ -486,6 +574,11 @@ ol li {
   border-top: 1px solid darken(@background, 20%);
   border-bottom: 1px solid darken(@background, 20%);
   padding: 0;
+
+  @media (prefers-color-scheme: dark) {
+    border-top: 1px solid lighten(@dark_background, 20%);
+    border-bottom: 1px solid lighten(@dark_background, 20%);
+  }
 }
 
 .decl__signature code {
@@ -524,6 +617,10 @@ ol li {
 
 .decl__kind {
   border-bottom: 1px solid darken(@background, 20%);
+
+  @media (prefers-color-scheme: dark) {
+    border-bottom-color: lighten(@dark_background, 20%);
+  }
 }
 
 :target .decl__signature,
@@ -534,7 +631,11 @@ ol li {
 
 .decl__body .keyword,
 .decl__body .syntax {
-  color: #0B71B4;
+  color: @keyword;
+
+  @media (prefers-color-scheme: dark) {
+    color: @dark_keyword;
+  }
 }
 
 .decl__child_comments {
@@ -553,10 +654,14 @@ ol li {
 }
 
 .deplink__version {
-  color: @light_type;
+  color: @dim_type;
   display: inline-block;
   font-size: 0.8em;
   line-height: 1;
+
+  @media (prefers-color-scheme: dark) {
+    color: @dark_dim_type;
+  }
 }
 
 
@@ -566,15 +671,23 @@ ol li {
 .grouped-list {
   border-top: 1px solid darken(@background, 20%);
   margin: 0 0 2.44em 0;
+
+  @media (prefers-color-scheme: dark) {
+    border-top-color: lighten(@dark_background, 20%);
+  }
 }
 
 .grouped-list__title {
-  color: @light_type;
+  color: @dim_type;
   font-size: 0.8em;
   font-weight: 300;
   letter-spacing: 1px;
   margin: 0.8em 0 -0.1em 0;
   text-transform: uppercase;
+
+  @media (prefers-color-scheme: dark) {
+    border-top-color: @dark_dim_type;
+  }
 }
 
 .grouped-list__item {
@@ -594,11 +707,21 @@ ol li {
 .message.message--error {
   background-color: @error_background;
   border-color: @error_border;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: @dark_error_background;
+    border-color: @dark_error_border;
+  }
 }
 
 .message.message--not-available {
   background-color: @not_available_background;
   border-color: darken(@not_available_background, 20%);
+
+  @media (prefers-color-scheme: dark) {
+    background-color: @dark_not_available_background;
+    border-color: lighten(@dark_not_available_background, 20%);
+  }
 }
 
 
@@ -655,13 +778,17 @@ ol li {
 
 .page-title__label {
   position: relative;
-  color: @light_type;
+  color: @dim_type;
   font-size: 0.8rem;
   font-weight: 300;
   letter-spacing: 1px;
   margin-bottom: -0.8em;
   text-transform: uppercase;
   z-index: 1;
+
+  @media (prefers-color-scheme: dark) {
+    color: @dark_dim_type;
+  }
 }
 
 
@@ -670,18 +797,27 @@ ol li {
 
 .top-banner {
   background-color: @banner_background;
-  color: @dark_foreground;
+  color: @dim_foreground;
   font-weight: normal;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: @dark_banner_background;
+    color: @dark_dim_foreground;
+  }
 }
 
 .top-banner__logo,
 .top-banner__logo:visited {
   float: left;
-  color: @dark_foreground;
+  color: @dim_foreground;
   font-size: 2.44em;
   font-weight: 300;
   line-height: 90px;
   margin: 0;
+
+  @media (prefers-color-scheme: dark) {
+    color: @dark_dim_foreground;
+  }
 }
 
 .top-banner__logo:hover {
@@ -696,11 +832,18 @@ ol li {
 .top-banner__form input {
   border: 1px solid @banner_background;
   border-radius: 3px;
+  background-color: @background;
   color: @banner_background;
   font-weight: 300;
   line-height: 2;
   padding: 0.21em 0.512em;
   width: 100%;
+
+  @media (prefers-color-scheme: dark) {
+    border-color: @dark_banner_background;
+    background-color: @dark_background;
+    color: @dark_foreground;
+  }
 }
 
 .top-banner__actions {
@@ -721,11 +864,19 @@ ol li {
 
 .top-banner__actions__item a,
 .top-banner__actions__item a:visited {
-  color: @dark_foreground;
+  color: @dim_foreground;
+
+  @media (prefers-color-scheme: dark) {
+    color: @dark_dim_foreground;
+  }
 }
 
 .top-banner__actions__item a:hover {
   color: @link;
+
+  @media (prefers-color-scheme: dark) {
+    color: @dark_link;
+  }
 }
 
 @media (min-width: 38em) {
@@ -780,6 +931,11 @@ ol li {
   border-top: 1px solid darken(@background, 20%);
   border-bottom: 1px solid darken(@background, 20%);
   padding: 0.328em 0;
+
+  @media (prefers-color-scheme: dark) {
+    border-top-color: lighten(@dark_background, 20%);
+    border-bottom-color: lighten(@dark_background, 20%);
+  }
 }
 
 .result__signature code {

--- a/app/static/pursuit.less
+++ b/app/static/pursuit.less
@@ -576,8 +576,8 @@ ol li {
   padding: 0;
 
   @media (prefers-color-scheme: dark) {
-    border-top: 1px solid lighten(@dark_background, 20%);
-    border-bottom: 1px solid lighten(@dark_background, 20%);
+    border-top-color: lighten(@dark_background, 20%);
+    border-bottom-color: lighten(@dark_background, 20%);
   }
 }
 
@@ -1020,6 +1020,10 @@ ol li {
   padding: 0 1em;
   color: #777;
   border-left: 0.25em solid #ddd;
+
+  @media (prefers-color-scheme: dark) {
+    border-left-color: #444;
+  }
 }
 
 .markdown-body blockquote>:first-child {
@@ -1038,6 +1042,10 @@ ol li {
 .markdown-body .pl-k {
   /* Keyword */
   color: #a0a0a0;
+
+  @media (prefers-color-scheme: dark) {
+    color: #676767;
+  }
 }
 
 .markdown-body .pl-c1,


### PR DESCRIPTION
**Description of the change**

This adds dark mode support to Pursuit documentation.  Fixes purescript/pursuit#462.

The implementation is fairly ordinary.  Unlike #4093 (which I didn't see until I had already finished this), nothing fancy like CSS variables are used. Instead, new Less variables for dark colors are introduced, and color scheme media queries are peppered about whenever a color is used in a rule.

I also renamed some of the existing "dark" color names to "dim" so as to not be confusing with the new "dark" prefix, removed the unused `@package_banner_background` variable, and introduced `@foreground` and `@keyword` (which were previously hard-coded colors).

I have tested this on a variety of pages and I think it looks acceptable.  I have checked every color variable to make sure that that color looks good in dark mode, including the not-available and error messages.  The only thing I've discovered that looks weird is the "load more" button in Pursuit search results, due to [this hard-coded color in the Pursuit repository](https://github.com/purescript/pursuit/blob/4a1b3726b71518ce206da9db58e2acbef2fca158/templates/search.lucius#L10) which I can fix in a separate PR.

I know there were previously some concerns about the extra maintenance burden of supporting dark mode.  I don't know what I can do to mitigate that, unfortunately, though I can say that swapping between dark mode and light mode using my browser's developer tools is as easy as cake, and the code makes it abundantly clear that dark mode is supported, so anyone modifying this in the future ought to be able to figure out that it is a concern that should be tested.  That said, the CSS has not been touched in two years at this point, so it seems like it would not be a frequent burden, at least.

Screenshot:

<img width="1099" alt="Prelude module shown in dark mode" src="https://user-images.githubusercontent.com/26161409/220566971-7eb34ffc-0560-47e1-87dd-8a8a1e851550.png">

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [X] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
