### PR TITLE
Update internal scripts to latest resolvers

### DIFF
--- a/CHANGELOG.d/internal_update-script-resolvers.md
+++ b/CHANGELOG.d/internal_update-script-resolvers.md
@@ -1,0 +1,1 @@
+* Update license/changelog scrips to latest Stack resolver

--- a/license-generator/generate.hs
+++ b/license-generator/generate.hs
@@ -1,5 +1,13 @@
 #!/usr/bin/env stack
--- stack --resolver lts-20.9 script
+{- stack
+  --resolver lts-20.9 script
+  --package bytestring
+  --package http-client-tls
+  --package http-client
+  --package http-types
+  --package text
+  --package split
+-}
 
 {-# LANGUAGE TupleSections #-}
 -- |

--- a/license-generator/generate.hs
+++ b/license-generator/generate.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-13.12 script
+-- stack --resolver lts-20.9 script
 
 {-# LANGUAGE TupleSections #-}
 -- |

--- a/update-changelog.hs
+++ b/update-changelog.hs
@@ -50,7 +50,7 @@ import qualified Protolude
 
 import           Control.Monad.Fail (fail)
 import qualified Data.Aeson as JSON
-import qualified Data.Aeson.KeyMap as HM
+import qualified Data.Aeson.KeyMap as KM
 import           Data.Attoparsec.ByteString (maybeResult, parse)
 import "bifunctors"
                  Data.Bifunctor.Flip (Flip(..))
@@ -162,7 +162,7 @@ lookupPRAuthor prNum =
                         , ghData = []
                         }
     >>= \case
-      JSON.Object (HM.lookup "user" -> Just (JSON.Object (HM.lookup "login" -> Just (JSON.String name)))) -> pure name
+      JSON.Object (KM.lookup "user" -> Just (JSON.Object (KM.lookup "login" -> Just (JSON.String name)))) -> pure name
       _ -> fail "error accessing GitHub API"
 
 commaSeparate :: [Text] -> Text
@@ -175,7 +175,7 @@ commaSeparate = \case
 getVersion :: (MonadFail m, MonadIO m) => m Text
 getVersion =
   (liftIO . BS.readFile) ("npm-package" </> "package.json") >>= \case
-    (maybeResult . parse JSON.json -> Just (JSON.Object (HM.lookup "version" -> Just (JSON.String v)))) -> pure v
+    (maybeResult . parse JSON.json -> Just (JSON.Object (KM.lookup "version" -> Just (JSON.String v)))) -> pure v
     _ -> fail "could not read version from npm-package/package.json"
 
 conditionalSection :: Text -> [ChangelogEntry] -> Text


### PR DESCRIPTION
**Description of the change**

The longer these go un-updated, the harder it may be to fix them later due to depending on older GHCs. It also avoids running into issues like https://gitlab.haskell.org/ghc/ghc/-/issues/19452.

Note: this shouldn't block #4444.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
