### PR TITLE
Simplify imports with post qualified style

### DIFF
--- a/CHANGELOG.d/internal_simplify-imports.md
+++ b/CHANGELOG.d/internal_simplify-imports.md
@@ -1,0 +1,1 @@
+* Refactor module imports to make identifiers' origins obvious

--- a/app/Command/Bundle.hs
+++ b/app/Command/Bundle.hs
@@ -5,7 +5,7 @@ import Prelude
 
 import           System.Exit (exitFailure)
 import           System.IO (stderr, hPutStrLn)
-import qualified Options.Applicative as Opts
+import Options.Applicative qualified as Opts
 
 app :: IO ()
 app = do

--- a/app/Command/Bundle.hs
+++ b/app/Command/Bundle.hs
@@ -3,8 +3,8 @@ module Command.Bundle (command) where
 
 import Prelude
 
-import           System.Exit (exitFailure)
-import           System.IO (stderr, hPutStrLn)
+import System.Exit (exitFailure)
+import System.IO (stderr, hPutStrLn)
 import Options.Applicative qualified as Opts
 
 app :: IO ()

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -2,27 +2,27 @@ module Command.Compile (command) where
 
 import Prelude
 
-import           Control.Applicative
-import           Control.Monad
+import Control.Applicative
+import Control.Monad
 import Data.Aeson qualified as A
-import           Data.Bool (bool)
+import Data.Bool (bool)
 import Data.ByteString.Lazy.UTF8 qualified as LBU8
-import           Data.List (intercalate)
+import Data.List (intercalate)
 import Data.Map qualified as M
 import Data.Set qualified as S
 import Data.Text qualified as T
-import           Data.Traversable (for)
+import Data.Traversable (for)
 import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
-import           Language.PureScript.Errors.JSON
-import           Language.PureScript.Make
+import Language.PureScript.Errors.JSON
+import Language.PureScript.Make
 import Options.Applicative qualified as Opts
 import System.Console.ANSI qualified as ANSI
-import           System.Exit (exitSuccess, exitFailure)
-import           System.Directory (getCurrentDirectory)
-import           System.FilePath.Glob (glob)
-import           System.IO (hPutStr, hPutStrLn, stderr, stdout)
-import           System.IO.UTF8 (readUTF8FilesT)
+import System.Exit (exitSuccess, exitFailure)
+import System.Directory (getCurrentDirectory)
+import System.FilePath.Glob (glob)
+import System.IO (hPutStr, hPutStrLn, stderr, stdout)
+import System.IO.UTF8 (readUTF8FilesT)
 
 data PSCMakeOptions = PSCMakeOptions
   { pscmInput        :: [FilePath]

--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -4,20 +4,20 @@ import Prelude
 
 import           Control.Applicative
 import           Control.Monad
-import qualified Data.Aeson as A
+import Data.Aeson qualified as A
 import           Data.Bool (bool)
-import qualified Data.ByteString.Lazy.UTF8 as LBU8
+import Data.ByteString.Lazy.UTF8 qualified as LBU8
 import           Data.List (intercalate)
-import qualified Data.Map as M
-import qualified Data.Set as S
-import qualified Data.Text as T
+import Data.Map qualified as M
+import Data.Set qualified as S
+import Data.Text qualified as T
 import           Data.Traversable (for)
-import qualified Language.PureScript as P
-import qualified Language.PureScript.CST as CST
+import Language.PureScript qualified as P
+import Language.PureScript.CST qualified as CST
 import           Language.PureScript.Errors.JSON
 import           Language.PureScript.Make
-import qualified Options.Applicative as Opts
-import qualified System.Console.ANSI as ANSI
+import Options.Applicative qualified as Opts
+import System.Console.ANSI qualified as ANSI
 import           System.Exit (exitSuccess, exitFailure)
 import           System.Directory (getCurrentDirectory)
 import           System.FilePath.Glob (glob)

--- a/app/Command/Docs.hs
+++ b/app/Command/Docs.hs
@@ -3,24 +3,24 @@ module Command.Docs (command, infoModList) where
 
 import Prelude
 
-import           Command.Docs.Html
-import           Command.Docs.Markdown
-import           Control.Applicative
-import           Control.Monad.Writer
-import           Control.Monad.Trans.Except (runExceptT)
-import           Data.Maybe (fromMaybe)
+import Command.Docs.Html
+import Command.Docs.Markdown
+import Control.Applicative
+import Control.Monad.Writer
+import Control.Monad.Trans.Except (runExceptT)
+import Data.Maybe (fromMaybe)
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.Docs qualified as D
-import           Language.PureScript.Docs.Tags (dumpCtags, dumpEtags)
+import Language.PureScript.Docs.Tags (dumpCtags, dumpEtags)
 import Options.Applicative qualified as Opts
 import Text.PrettyPrint.ANSI.Leijen qualified as PP
-import           System.Directory (getCurrentDirectory, createDirectoryIfMissing, removeFile)
-import           System.Exit (exitFailure)
-import           System.FilePath ((</>))
-import           System.FilePath.Glob (compile, glob, globDir1)
-import           System.IO (hPutStrLn, stderr)
-import           System.IO.UTF8 (writeUTF8FileT)
+import System.Directory (getCurrentDirectory, createDirectoryIfMissing, removeFile)
+import System.Exit (exitFailure)
+import System.FilePath ((</>))
+import System.FilePath.Glob (compile, glob, globDir1)
+import System.IO (hPutStrLn, stderr)
+import System.IO.UTF8 (writeUTF8FileT)
 
 -- | Available output formats
 data Format

--- a/app/Command/Docs.hs
+++ b/app/Command/Docs.hs
@@ -9,12 +9,12 @@ import           Control.Applicative
 import           Control.Monad.Writer
 import           Control.Monad.Trans.Except (runExceptT)
 import           Data.Maybe (fromMaybe)
-import qualified Data.Text as T
-import qualified Language.PureScript as P
-import qualified Language.PureScript.Docs as D
+import Data.Text qualified as T
+import Language.PureScript qualified as P
+import Language.PureScript.Docs qualified as D
 import           Language.PureScript.Docs.Tags (dumpCtags, dumpEtags)
-import qualified Options.Applicative as Opts
-import qualified Text.PrettyPrint.ANSI.Leijen as PP
+import Options.Applicative qualified as Opts
+import Text.PrettyPrint.ANSI.Leijen qualified as PP
 import           System.Directory (getCurrentDirectory, createDirectoryIfMissing, removeFile)
 import           System.Exit (exitFailure)
 import           System.FilePath ((</>))

--- a/app/Command/Docs/Html.hs
+++ b/app/Command/Docs/Html.hs
@@ -13,14 +13,14 @@ import           Control.Monad.Writer
 import           Data.List (sort)
 import           Data.Text (Text)
 import           Data.Text.Lazy (toStrict)
-import qualified Data.Text as T
-import qualified Language.PureScript as P
-import qualified Language.PureScript.Docs as D
-import qualified Language.PureScript.Docs.AsHtml as D
+import Data.Text qualified as T
+import Language.PureScript qualified as P
+import Language.PureScript.Docs qualified as D
+import Language.PureScript.Docs.AsHtml qualified as D
 import           Text.Blaze.Html5 (Html, (!), toMarkup)
-import qualified Text.Blaze.Html5 as H
-import qualified Text.Blaze.Html5.Attributes as A
-import qualified Text.Blaze.Html.Renderer.Text as Blaze
+import Text.Blaze.Html5 qualified as H
+import Text.Blaze.Html5.Attributes qualified as A
+import Text.Blaze.Html.Renderer.Text qualified as Blaze
 import           System.IO.UTF8 (writeUTF8FileT)
 import           Version (versionString)
 

--- a/app/Command/Docs/Html.hs
+++ b/app/Command/Docs/Html.hs
@@ -7,22 +7,22 @@ module Command.Docs.Html
 
 import Prelude
 
-import           Control.Applicative
-import           Control.Arrow ((&&&))
-import           Control.Monad.Writer
-import           Data.List (sort)
-import           Data.Text (Text)
-import           Data.Text.Lazy (toStrict)
+import Control.Applicative
+import Control.Arrow ((&&&))
+import Control.Monad.Writer
+import Data.List (sort)
+import Data.Text (Text)
+import Data.Text.Lazy (toStrict)
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.Docs qualified as D
 import Language.PureScript.Docs.AsHtml qualified as D
-import           Text.Blaze.Html5 (Html, (!), toMarkup)
+import Text.Blaze.Html5 (Html, (!), toMarkup)
 import Text.Blaze.Html5 qualified as H
 import Text.Blaze.Html5.Attributes qualified as A
 import Text.Blaze.Html.Renderer.Text qualified as Blaze
-import           System.IO.UTF8 (writeUTF8FileT)
-import           Version (versionString)
+import System.IO.UTF8 (writeUTF8FileT)
+import Version (versionString)
 
 writeHtmlModules :: FilePath -> [(P.ModuleName, D.HtmlOutputModule Html)] -> IO ()
 writeHtmlModules outputDir modules = do

--- a/app/Command/Docs/Markdown.hs
+++ b/app/Command/Docs/Markdown.hs
@@ -6,10 +6,10 @@ module Command.Docs.Markdown
 import Prelude
 
 import           Data.Text (Text)
-import qualified Data.Text as T
-import qualified Language.PureScript as P
-import qualified Language.PureScript.Docs as D
-import qualified Language.PureScript.Docs.AsMarkdown as D
+import Data.Text qualified as T
+import Language.PureScript qualified as P
+import Language.PureScript.Docs qualified as D
+import Language.PureScript.Docs.AsMarkdown qualified as D
 import           System.IO.UTF8 (writeUTF8FileT)
 
 asMarkdown :: D.Module -> (P.ModuleName, Text)

--- a/app/Command/Docs/Markdown.hs
+++ b/app/Command/Docs/Markdown.hs
@@ -5,12 +5,12 @@ module Command.Docs.Markdown
 
 import Prelude
 
-import           Data.Text (Text)
+import Data.Text (Text)
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.Docs qualified as D
 import Language.PureScript.Docs.AsMarkdown qualified as D
-import           System.IO.UTF8 (writeUTF8FileT)
+import System.IO.UTF8 (writeUTF8FileT)
 
 asMarkdown :: D.Module -> (P.ModuleName, Text)
 asMarkdown m = (D.modName m, D.runDocs . D.moduleAsMarkdown $ m)

--- a/app/Command/Graph.hs
+++ b/app/Command/Graph.hs
@@ -2,20 +2,20 @@ module Command.Graph (command) where
 
 import Prelude
 
-import           Control.Applicative (many)
-import           Control.Monad (unless, when)
+import Control.Applicative (many)
+import Control.Monad (unless, when)
 import Data.Aeson qualified as Json
-import           Data.Bool (bool)
+import Data.Bool (bool)
 import Data.ByteString.Lazy qualified as LB
 import Data.ByteString.Lazy.UTF8 qualified as LBU8
 import Language.PureScript qualified as P
-import           Language.PureScript.Errors.JSON
+import Language.PureScript.Errors.JSON
 import Options.Applicative qualified as Opts
 import System.Console.ANSI qualified as ANSI
-import           System.Exit (exitFailure)
-import           System.Directory (getCurrentDirectory)
-import           System.FilePath.Glob (glob)
-import           System.IO (hPutStr, hPutStrLn, stderr)
+import System.Exit (exitFailure)
+import System.Directory (getCurrentDirectory)
+import System.FilePath.Glob (glob)
+import System.IO (hPutStr, hPutStrLn, stderr)
 
 data GraphOptions = GraphOptions
   { graphInput      :: [FilePath]

--- a/app/Command/Graph.hs
+++ b/app/Command/Graph.hs
@@ -4,14 +4,14 @@ import Prelude
 
 import           Control.Applicative (many)
 import           Control.Monad (unless, when)
-import qualified Data.Aeson as Json
+import Data.Aeson qualified as Json
 import           Data.Bool (bool)
-import qualified Data.ByteString.Lazy as LB
-import qualified Data.ByteString.Lazy.UTF8 as LBU8
-import qualified Language.PureScript as P
+import Data.ByteString.Lazy qualified as LB
+import Data.ByteString.Lazy.UTF8 qualified as LBU8
+import Language.PureScript qualified as P
 import           Language.PureScript.Errors.JSON
-import qualified Options.Applicative as Opts
-import qualified System.Console.ANSI as ANSI
+import Options.Applicative qualified as Opts
+import System.Console.ANSI qualified as ANSI
 import           System.Exit (exitFailure)
 import           System.Directory (getCurrentDirectory)
 import           System.FilePath.Glob (glob)

--- a/app/Command/Hierarchy.hs
+++ b/app/Command/Hierarchy.hs
@@ -20,18 +20,18 @@ import           Protolude (catMaybes)
 
 import           Control.Applicative (optional)
 import           Data.Foldable (for_)
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
 import           Options.Applicative (Parser)
-import qualified Options.Applicative as Opts
+import Options.Applicative qualified as Opts
 import           System.Directory (createDirectoryIfMissing)
 import           System.FilePath ((</>))
 import           System.FilePath.Glob (glob)
 import           System.Exit (exitFailure, exitSuccess)
 import           System.IO (hPutStr, stderr)
 import           System.IO.UTF8 (readUTF8FilesT)
-import qualified Language.PureScript as P
-import qualified Language.PureScript.CST as CST
+import Language.PureScript qualified as P
+import Language.PureScript.CST qualified as CST
 import           Language.PureScript.Hierarchy (Graph(..), _unDigraph, _unGraphName, typeClasses)
 
 data HierarchyOptions = HierarchyOptions

--- a/app/Command/Hierarchy.hs
+++ b/app/Command/Hierarchy.hs
@@ -15,24 +15,24 @@
 
 module Command.Hierarchy (command) where
 
-import           Prelude
-import           Protolude (catMaybes)
+import Prelude
+import Protolude (catMaybes)
 
-import           Control.Applicative (optional)
-import           Data.Foldable (for_)
+import Control.Applicative (optional)
+import Data.Foldable (for_)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
-import           Options.Applicative (Parser)
+import Options.Applicative (Parser)
 import Options.Applicative qualified as Opts
-import           System.Directory (createDirectoryIfMissing)
-import           System.FilePath ((</>))
-import           System.FilePath.Glob (glob)
-import           System.Exit (exitFailure, exitSuccess)
-import           System.IO (hPutStr, stderr)
-import           System.IO.UTF8 (readUTF8FilesT)
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.FilePath.Glob (glob)
+import System.Exit (exitFailure, exitSuccess)
+import System.IO (hPutStr, stderr)
+import System.IO.UTF8 (readUTF8FilesT)
 import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
-import           Language.PureScript.Hierarchy (Graph(..), _unDigraph, _unGraphName, typeClasses)
+import Language.PureScript.Hierarchy (Graph(..), _unDigraph, _unGraphName, typeClasses)
 
 data HierarchyOptions = HierarchyOptions
   { _hierarchyInput   :: FilePath

--- a/app/Command/Ide.hs
+++ b/app/Command/Ide.hs
@@ -26,7 +26,7 @@ import Data.IORef
 import qualified Data.Text.IO                      as T
 import qualified Data.ByteString.Char8             as BS8
 import qualified Data.ByteString.Lazy.Char8        as BSL8
-import GHC.IO.Exception                  (IOErrorType(..), IOException(..))
+import GHC.IO.Exception (IOErrorType(..), IOException(..))
 import Language.PureScript.Ide
 import Language.PureScript.Ide.Command
 import Language.PureScript.Ide.Util
@@ -38,7 +38,7 @@ import qualified Options.Applicative               as Opts
 import System.Directory
 import System.FilePath
 import System.IO hiding (putStrLn, print)
-import System.IO.Error                   (isEOFError)
+import System.IO.Error (isEOFError)
 
 listenOnLocalhost :: Network.PortNumber -> IO Network.Socket
 listenOnLocalhost port = do

--- a/app/Command/Ide.hs
+++ b/app/Command/Ide.hs
@@ -37,7 +37,7 @@ import qualified Network.Socket                    as Network
 import qualified Options.Applicative               as Opts
 import           System.Directory
 import           System.FilePath
-import           System.IO                         hiding (putStrLn, print)
+import System.IO hiding (putStrLn, print)
 import           System.IO.Error                   (isEOFError)
 
 listenOnLocalhost :: Network.PortNumber -> IO Network.Socket

--- a/app/Command/Ide.hs
+++ b/app/Command/Ide.hs
@@ -17,28 +17,28 @@
 
 module Command.Ide (command) where
 
-import           Protolude
+import Protolude
 
 import Data.Aeson qualified as Aeson
-import           Control.Concurrent.STM
+import Control.Concurrent.STM
 import           "monad-logger" Control.Monad.Logger
-import           Data.IORef
+import Data.IORef
 import qualified Data.Text.IO                      as T
 import qualified Data.ByteString.Char8             as BS8
 import qualified Data.ByteString.Lazy.Char8        as BSL8
-import           GHC.IO.Exception                  (IOErrorType(..), IOException(..))
-import           Language.PureScript.Ide
-import           Language.PureScript.Ide.Command
-import           Language.PureScript.Ide.Util
-import           Language.PureScript.Ide.Error
-import           Language.PureScript.Ide.State (updateCacheTimestamp)
-import           Language.PureScript.Ide.Types
+import GHC.IO.Exception                  (IOErrorType(..), IOException(..))
+import Language.PureScript.Ide
+import Language.PureScript.Ide.Command
+import Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Error
+import Language.PureScript.Ide.State (updateCacheTimestamp)
+import Language.PureScript.Ide.Types
 import qualified Network.Socket                    as Network
 import qualified Options.Applicative               as Opts
-import           System.Directory
-import           System.FilePath
+import System.Directory
+import System.FilePath
 import System.IO hiding (putStrLn, print)
-import           System.IO.Error                   (isEOFError)
+import System.IO.Error                   (isEOFError)
 
 listenOnLocalhost :: Network.PortNumber -> IO Network.Socket
 listenOnLocalhost port = do

--- a/app/Command/Ide.hs
+++ b/app/Command/Ide.hs
@@ -23,9 +23,9 @@ import Data.Aeson qualified as Aeson
 import Control.Concurrent.STM
 import           "monad-logger" Control.Monad.Logger
 import Data.IORef
-import qualified Data.Text.IO                      as T
-import qualified Data.ByteString.Char8             as BS8
-import qualified Data.ByteString.Lazy.Char8        as BSL8
+import Data.Text.IO qualified as T
+import Data.ByteString.Char8 qualified as BS8
+import Data.ByteString.Lazy.Char8 qualified as BSL8
 import GHC.IO.Exception (IOErrorType(..), IOException(..))
 import Language.PureScript.Ide
 import Language.PureScript.Ide.Command
@@ -33,8 +33,8 @@ import Language.PureScript.Ide.Util
 import Language.PureScript.Ide.Error
 import Language.PureScript.Ide.State (updateCacheTimestamp)
 import Language.PureScript.Ide.Types
-import qualified Network.Socket                    as Network
-import qualified Options.Applicative               as Opts
+import Network.Socket qualified as Network
+import Options.Applicative qualified as Opts
 import System.Directory
 import System.FilePath
 import System.IO hiding (putStrLn, print)

--- a/app/Command/Ide.hs
+++ b/app/Command/Ide.hs
@@ -21,7 +21,7 @@ import Protolude
 
 import Data.Aeson qualified as Aeson
 import Control.Concurrent.STM
-import           "monad-logger" Control.Monad.Logger
+import "monad-logger" Control.Monad.Logger
 import Data.IORef
 import Data.Text.IO qualified as T
 import Data.ByteString.Char8 qualified as BS8

--- a/app/Command/Ide.hs
+++ b/app/Command/Ide.hs
@@ -19,7 +19,7 @@ module Command.Ide (command) where
 
 import           Protolude
 
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import           Control.Concurrent.STM
 import           "monad-logger" Control.Monad.Logger
 import           Data.IORef

--- a/app/Command/Publish.hs
+++ b/app/Command/Publish.hs
@@ -2,14 +2,14 @@ module Command.Publish (command) where
 
 import Prelude
 
-import           Control.Monad.IO.Class (liftIO)
+import Control.Monad.IO.Class (liftIO)
 import Data.Aeson qualified as A
 import Data.ByteString.Lazy.Char8 qualified as BL
-import           Data.Time.Clock (getCurrentTime)
-import           Data.Version (Version(..))
-import           Language.PureScript.Publish
-import           Language.PureScript.Publish.ErrorsWarnings
-import           Options.Applicative (Parser)
+import Data.Time.Clock (getCurrentTime)
+import Data.Version (Version(..))
+import Language.PureScript.Publish
+import Language.PureScript.Publish.ErrorsWarnings
+import Options.Applicative (Parser)
 import Options.Applicative qualified as Opts
 
 data PublishOptionsCLI = PublishOptionsCLI

--- a/app/Command/Publish.hs
+++ b/app/Command/Publish.hs
@@ -3,14 +3,14 @@ module Command.Publish (command) where
 import Prelude
 
 import           Control.Monad.IO.Class (liftIO)
-import qualified Data.Aeson as A
-import qualified Data.ByteString.Lazy.Char8 as BL
+import Data.Aeson qualified as A
+import Data.ByteString.Lazy.Char8 qualified as BL
 import           Data.Time.Clock (getCurrentTime)
 import           Data.Version (Version(..))
 import           Language.PureScript.Publish
 import           Language.PureScript.Publish.ErrorsWarnings
 import           Options.Applicative (Parser)
-import qualified Options.Applicative as Opts
+import Options.Applicative qualified as Opts
 
 data PublishOptionsCLI = PublishOptionsCLI
   { cliManifestPath :: FilePath

--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -3,25 +3,25 @@
 
 module Command.REPL (command) where
 
-import           Prelude
-import           Control.Applicative (many, (<|>))
-import           Control.Monad
-import           Control.Monad.Catch (MonadMask)
-import           Control.Monad.IO.Class (liftIO, MonadIO)
-import           Control.Monad.Trans.Class
-import           Control.Monad.Trans.Except (ExceptT(..), runExceptT)
-import           Control.Monad.Trans.State.Strict (StateT, evalStateT)
-import           Control.Monad.Trans.Reader (ReaderT, runReaderT)
-import           Data.Foldable (for_)
+import Prelude
+import Control.Applicative (many, (<|>))
+import Control.Monad
+import Control.Monad.Catch (MonadMask)
+import Control.Monad.IO.Class (liftIO, MonadIO)
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
+import Control.Monad.Trans.State.Strict (StateT, evalStateT)
+import Control.Monad.Trans.Reader (ReaderT, runReaderT)
+import Data.Foldable (for_)
 import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
-import           Language.PureScript.Interactive
+import Language.PureScript.Interactive
 import Options.Applicative qualified as Opts
-import           System.Console.Haskeline
-import           System.IO.UTF8 (readUTF8File)
-import           System.Exit
-import           System.Directory (doesFileExist, getCurrentDirectory)
-import           System.FilePath ((</>))
+import System.Console.Haskeline
+import System.IO.UTF8 (readUTF8File)
+import System.Exit
+import System.Directory (doesFileExist, getCurrentDirectory)
+import System.FilePath ((</>))
 import System.FilePath.Glob qualified as Glob
 import System.IO (hPutStrLn, stderr)
 

--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -13,16 +13,16 @@ import           Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 import           Control.Monad.Trans.State.Strict (StateT, evalStateT)
 import           Control.Monad.Trans.Reader (ReaderT, runReaderT)
 import           Data.Foldable (for_)
-import qualified Language.PureScript as P
-import qualified Language.PureScript.CST as CST
+import Language.PureScript qualified as P
+import Language.PureScript.CST qualified as CST
 import           Language.PureScript.Interactive
-import qualified Options.Applicative as Opts
+import Options.Applicative qualified as Opts
 import           System.Console.Haskeline
 import           System.IO.UTF8 (readUTF8File)
 import           System.Exit
 import           System.Directory (doesFileExist, getCurrentDirectory)
 import           System.FilePath ((</>))
-import qualified System.FilePath.Glob as Glob
+import System.FilePath.Glob qualified as Glob
 import System.IO (hPutStrLn, stderr)
 
 -- | Command line options

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,13 +10,13 @@ import Command.Hierarchy qualified as Hierarchy
 import Command.Ide qualified as Ide
 import Command.Publish qualified as Publish
 import Command.REPL qualified as REPL
-import           Control.Monad (join)
-import           Data.Foldable (fold)
+import Control.Monad (join)
+import Data.Foldable (fold)
 import Options.Applicative qualified as Opts
-import           System.Environment (getArgs)
+import System.Environment (getArgs)
 import System.IO qualified as IO
 import Text.PrettyPrint.ANSI.Leijen qualified as Doc
-import           Version (versionString)
+import Version (versionString)
 
 
 main :: IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,20 +2,20 @@ module Main where
 
 import Prelude
 
-import qualified Command.Bundle as Bundle
-import qualified Command.Compile as Compile
-import qualified Command.Docs as Docs
-import qualified Command.Graph as Graph
-import qualified Command.Hierarchy as Hierarchy
-import qualified Command.Ide as Ide
-import qualified Command.Publish as Publish
-import qualified Command.REPL as REPL
+import Command.Bundle qualified as Bundle
+import Command.Compile qualified as Compile
+import Command.Docs qualified as Docs
+import Command.Graph qualified as Graph
+import Command.Hierarchy qualified as Hierarchy
+import Command.Ide qualified as Ide
+import Command.Publish qualified as Publish
+import Command.REPL qualified as REPL
 import           Control.Monad (join)
 import           Data.Foldable (fold)
-import qualified Options.Applicative as Opts
+import Options.Applicative qualified as Opts
 import           System.Environment (getArgs)
-import qualified System.IO as IO
-import qualified Text.PrettyPrint.ANSI.Leijen as Doc
+import System.IO qualified as IO
+import Text.PrettyPrint.ANSI.Leijen qualified as Doc
 import           Version (versionString)
 
 

--- a/app/Version.hs
+++ b/app/Version.hs
@@ -9,7 +9,7 @@ import Data.Version (showVersion)
 import Paths_purescript as Paths
 
 #ifndef RELEASE
-import qualified Development.GitRev as GitRev
+import Development.GitRev qualified as GitRev
 #endif
 
 -- Unfortunately, Cabal doesn't support prerelease identifiers on versions. To

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -86,7 +86,6 @@ common defaults
     -Wno-missing-export-lists
     -Wno-missing-kind-signatures
     -Wno-partial-fields
-    -Wno-prepositive-qualified-module
   default-language: Haskell2010
   default-extensions:
     BangPatterns

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -118,6 +118,7 @@ common defaults
     TupleSections
     TypeFamilies
     ViewPatterns
+    ImportQualifiedPost
   build-tool-depends:
     happy:happy ==1.20.0
   build-depends:

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -102,6 +102,7 @@ common defaults
     FlexibleContexts
     FlexibleInstances
     GeneralizedNewtypeDeriving
+    ImportQualifiedPost
     KindSignatures
     LambdaCase
     MultiParamTypeClasses
@@ -117,7 +118,6 @@ common defaults
     TupleSections
     TypeFamilies
     ViewPatterns
-    ImportQualifiedPost
   build-tool-depends:
     happy:happy ==1.20.0
   build-depends:

--- a/src/Language/PureScript.hs
+++ b/src/Language/PureScript.hs
@@ -30,7 +30,7 @@ import Language.PureScript.Sugar as P
 import Language.PureScript.TypeChecker as P
 import Language.PureScript.Types as P
 
-import qualified Paths_purescript as Paths
+import Paths qualified_purescript as Paths
 
 version :: Version
 version = Paths.version

--- a/src/Language/PureScript.hs
+++ b/src/Language/PureScript.hs
@@ -30,7 +30,7 @@ import Language.PureScript.Sugar as P
 import Language.PureScript.TypeChecker as P
 import Language.PureScript.Types as P
 
-import Paths qualified_purescript as Paths
+import Paths_purescript qualified as Paths
 
 version :: Version
 version = Paths.version

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -14,9 +14,9 @@ import Control.DeepSeq (NFData)
 import Data.Functor.Identity
 
 import Data.Aeson.TH
-import qualified Data.Map as M
+import Data.Map qualified as M
 import Data.Text (Text)
-import qualified Data.List.NonEmpty as NEL
+import Data.List.NonEmpty qualified as NEL
 import GHC.Generics (Generic)
 
 import Language.PureScript.AST.Binders
@@ -32,7 +32,7 @@ import Language.PureScript.Roles
 import Language.PureScript.TypeClassDictionaries
 import Language.PureScript.Comments
 import Language.PureScript.Environment
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Prim qualified as C
 
 -- | A map of locally-bound names in scope.
 type Context = [(Ident, SourceType)]

--- a/src/Language/PureScript/AST/Declarations/ChainId.hs
+++ b/src/Language/PureScript/AST/Declarations/ChainId.hs
@@ -4,7 +4,7 @@ module Language.PureScript.AST.Declarations.ChainId
   ) where
 
 import Prelude
-import qualified Language.PureScript.AST.SourcePos as Pos
+import Language.PureScript.AST.SourcePos qualified as Pos
 import Control.DeepSeq (NFData)
 import Codec.Serialise (Serialise)
 

--- a/src/Language/PureScript/AST/Exported.hs
+++ b/src/Language/PureScript/AST/Exported.hs
@@ -10,7 +10,7 @@ import Control.Category ((>>>))
 import Control.Applicative ((<|>))
 
 import Data.Maybe (mapMaybe)
-import qualified Data.Map as M
+import Data.Map qualified as M
 
 import Language.PureScript.AST.Declarations
 import Language.PureScript.Types

--- a/src/Language/PureScript/AST/Operators.hs
+++ b/src/Language/PureScript/AST/Operators.hs
@@ -9,7 +9,7 @@ import Codec.Serialise (Serialise)
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 import Data.Aeson ((.=))
-import qualified Data.Aeson as A
+import Data.Aeson qualified as A
 
 import Language.PureScript.Crash
 

--- a/src/Language/PureScript/AST/SourcePos.hs
+++ b/src/Language/PureScript/AST/SourcePos.hs
@@ -12,8 +12,8 @@ import Data.Aeson ((.=), (.:))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import Language.PureScript.Comments
-import qualified Data.Aeson as A
-import qualified Data.Text as T
+import Data.Aeson qualified as A
+import Data.Text qualified as T
 import System.FilePath (makeRelative)
 
 -- | Source annotation - position information and comments.

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -13,9 +13,9 @@ import Data.Foldable (fold)
 import Data.Functor.Identity (runIdentity)
 import Data.List (mapAccumL)
 import Data.Maybe (mapMaybe)
-import qualified Data.List.NonEmpty as NEL
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.List.NonEmpty qualified as NEL
+import Data.Map qualified as M
+import Data.Set qualified as S
 
 import Language.PureScript.AST.Binders
 import Language.PureScript.AST.Declarations

--- a/src/Language/PureScript/Bundle.hs
+++ b/src/Language/PureScript/Bundle.hs
@@ -24,8 +24,8 @@ import Data.Aeson ((.=))
 import Data.Char (chr, digitToInt)
 import Data.Foldable (fold)
 import Data.Maybe (mapMaybe, maybeToList)
-import qualified Data.Aeson as A
-import qualified Data.Text.Lazy as LT
+import Data.Aeson qualified as A
+import Data.Text.Lazy qualified as LT
 
 import Language.JavaScript.Parser
 import Language.JavaScript.Parser.AST

--- a/src/Language/PureScript/CST.hs
+++ b/src/Language/PureScript/CST.hs
@@ -22,10 +22,10 @@ import Prelude hiding (lex)
 
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Parallel.Strategies (withStrategy, parList, evalTuple2, r0, rseq)
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Text (Text)
-import qualified Language.PureScript.AST as AST
-import qualified Language.PureScript.Errors as E
+import Language.PureScript.AST qualified as AST
+import Language.PureScript.Errors qualified as E
 import Language.PureScript.CST.Convert
 import Language.PureScript.CST.Errors
 import Language.PureScript.CST.Lexer

--- a/src/Language/PureScript/CST/Convert.hs
+++ b/src/Language/PureScript/CST/Convert.hs
@@ -21,19 +21,19 @@ import Data.Bifunctor (bimap, first)
 import Data.Char (toLower)
 import Data.Foldable (foldl', toList)
 import Data.Functor (($>))
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (isJust, fromJust, mapMaybe)
-import qualified Data.Text as Text
-import qualified Language.PureScript.AST as AST
+import Data.Text qualified as Text
+import Language.PureScript.AST qualified as AST
 import Language.PureScript.AST.Declarations.ChainId (mkChainId)
-import qualified Language.PureScript.AST.SourcePos as Pos
-import qualified Language.PureScript.Comments as C
+import Language.PureScript.AST.SourcePos qualified as Pos
+import Language.PureScript.Comments qualified as C
 import Language.PureScript.Crash (internalError)
-import qualified Language.PureScript.Environment as Env
-import qualified Language.PureScript.Label as L
-import qualified Language.PureScript.Names as N
+import Language.PureScript.Environment qualified as Env
+import Language.PureScript.Label qualified as L
+import Language.PureScript.Names qualified as N
 import Language.PureScript.PSString (mkString, prettyPrintStringJS)
-import qualified Language.PureScript.Types as T
+import Language.PureScript.Types qualified as T
 import Language.PureScript.CST.Positions
 import Language.PureScript.CST.Print (printToken)
 import Language.PureScript.CST.Types

--- a/src/Language/PureScript/CST/Errors.hs
+++ b/src/Language/PureScript/CST/Errors.hs
@@ -11,7 +11,7 @@ module Language.PureScript.CST.Errors
 
 import Prelude
 
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Data.Char (isSpace, toUpper)
 import Language.PureScript.CST.Layout
 import Language.PureScript.CST.Print

--- a/src/Language/PureScript/CST/Layout.hs
+++ b/src/Language/PureScript/CST/Layout.hs
@@ -171,7 +171,7 @@ module Language.PureScript.CST.Layout where
 import Prelude
 
 import Data.DList (snoc)
-import qualified Data.DList as DList
+import Data.DList qualified as DList
 import Data.Foldable (find)
 import Data.Function ((&))
 import Language.PureScript.CST.Types

--- a/src/Language/PureScript/CST/Lexer.hs
+++ b/src/Language/PureScript/CST/Lexer.hs
@@ -10,15 +10,15 @@ module Language.PureScript.CST.Lexer
 import Prelude hiding (lex, exp, exponent, lines)
 
 import Control.Monad (join)
-import qualified Data.Char as Char
-import qualified Data.DList as DList
+import Data.Char qualified as Char
+import Data.DList qualified as DList
 import Data.Foldable (foldl')
 import Data.Functor (($>))
-import qualified Data.Scientific as Sci
+import Data.Scientific qualified as Sci
 import Data.String (fromString)
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.PureScript as Text
+import Data.Text qualified as Text
+import Data.Text.PureScript qualified as Text
 import Language.PureScript.CST.Errors
 import Language.PureScript.CST.Monad hiding (token)
 import Language.PureScript.CST.Layout

--- a/src/Language/PureScript/CST/Monad.hs
+++ b/src/Language/PureScript/CST/Monad.hs
@@ -3,7 +3,7 @@ module Language.PureScript.CST.Monad where
 import Prelude
 
 import Data.List (sortOn)
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Ord (comparing)
 import Data.Text (Text)
 import Language.PureScript.CST.Errors

--- a/src/Language/PureScript/CST/Positions.hs
+++ b/src/Language/PureScript/CST/Positions.hs
@@ -8,11 +8,11 @@ module Language.PureScript.CST.Positions where
 import Prelude
 
 import Data.Foldable (foldl')
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Void (Void)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Language.PureScript.CST.Types
 
 advanceToken :: SourcePos -> Token -> SourcePos

--- a/src/Language/PureScript/CST/Print.hs
+++ b/src/Language/PureScript/CST/Print.hs
@@ -12,9 +12,9 @@ module Language.PureScript.CST.Print
 
 import Prelude
 
-import qualified Data.DList as DList
+import Data.DList qualified as DList
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Language.PureScript.CST.Types
 import Language.PureScript.CST.Flatten (flattenModule)
 

--- a/src/Language/PureScript/CST/Types.hs
+++ b/src/Language/PureScript/CST/Types.hs
@@ -13,8 +13,8 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Text (Text)
 import Data.Void (Void)
 import GHC.Generics (Generic)
-import qualified Language.PureScript.Names as N
-import qualified Language.PureScript.Roles as R
+import Language.PureScript.Names qualified as N
+import Language.PureScript.Roles qualified as R
 import Language.PureScript.PSString (PSString)
 
 data SourcePos = SourcePos

--- a/src/Language/PureScript/CST/Utils.hs
+++ b/src/Language/PureScript/CST/Utils.hs
@@ -6,17 +6,17 @@ import Control.Monad (unless)
 import Data.Coerce (coerce)
 import Data.Foldable (for_)
 import Data.Functor (($>))
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Language.PureScript.CST.Errors
 import Language.PureScript.CST.Monad
 import Language.PureScript.CST.Positions
 import Language.PureScript.CST.Traversals.Type
 import Language.PureScript.CST.Types
-import qualified Language.PureScript.Names as N
+import Language.PureScript.Names qualified as N
 import Language.PureScript.PSString (PSString, mkString)
 
 -- |

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -18,21 +18,21 @@ import Control.Monad.Writer (MonadWriter, runWriterT, writer)
 
 import Data.Bifunctor (first)
 import Data.List ((\\), intersect)
-import qualified Data.List.NonEmpty as NEL (nonEmpty)
-import qualified Data.Foldable as F
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.List.NonEmpty qualified as NEL (nonEmpty)
+import Data.Foldable qualified as F
+import Data.Map qualified as M
+import Data.Set qualified as S
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Monoid (Any(..))
 import Data.String (fromString)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.CodeGen.JS.Common as Common
 import Language.PureScript.CoreImp.AST (AST, InitializerEffects(..), everywhere, everywhereTopDownM, withSourceSpan)
-import qualified Language.PureScript.CoreImp.AST as AST
-import qualified Language.PureScript.CoreImp.Module as AST
+import Language.PureScript.CoreImp.AST qualified as AST
+import Language.PureScript.CoreImp.Module qualified as AST
 import Language.PureScript.CoreImp.Optimizer
 import Language.PureScript.CoreFn
 import Language.PureScript.CoreFn.Laziness (applyLazinessTransform)
@@ -44,7 +44,7 @@ import Language.PureScript.Names
 import Language.PureScript.Options
 import Language.PureScript.PSString (PSString, mkString)
 import Language.PureScript.Traversals (sndM)
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Prim qualified as C
 
 import System.FilePath.Posix ((</>))
 

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -5,7 +5,7 @@ import Prelude
 
 import Data.Char
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Language.PureScript.Crash
 import Language.PureScript.Names

--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -10,12 +10,12 @@ import Control.Arrow ((<+>))
 import Control.Monad (forM, mzero)
 import Control.Monad.State (StateT, evalStateT)
 import Control.PatternArrows
-import qualified Control.Arrow as A
+import Control.Arrow qualified as A
 
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.List.NonEmpty as NEL (toList)
+import Data.Text qualified as T
+import Data.List.NonEmpty qualified as NEL (toList)
 
 import Language.PureScript.AST (SourceSpan(..))
 import Language.PureScript.CodeGen.JS.Common

--- a/src/Language/PureScript/Constants/Libs.hs
+++ b/src/Language/PureScript/Constants/Libs.hs
@@ -3,11 +3,11 @@
 -- | Various constants which refer to things in the Prelude and other core libraries
 module Language.PureScript.Constants.Libs where
 
-import qualified Protolude as P
+import Protolude qualified as P
 
 import Data.String (IsString)
 import Language.PureScript.PSString (PSString)
-import qualified Language.PureScript.Constants.TH as TH
+import Language.PureScript.Constants.TH qualified as TH
 
 -- Core lib values
 

--- a/src/Language/PureScript/Constants/Prim.hs
+++ b/src/Language/PureScript/Constants/Prim.hs
@@ -4,7 +4,7 @@
 module Language.PureScript.Constants.Prim where
 
 import Language.PureScript.Names
-import qualified Language.PureScript.Constants.TH as TH
+import Language.PureScript.Constants.TH qualified as TH
 
 $(TH.declare do
   TH.mod "Prim" do

--- a/src/Language/PureScript/CoreFn/CSE.hs
+++ b/src/Language/PureScript/CoreFn/CSE.hs
@@ -10,16 +10,16 @@ import Control.Monad.Supply.Class (MonadSupply)
 import Control.Monad.RWS (MonadWriter, RWST, censor, evalRWST, listen, pass, tell)
 import Data.Bitraversable (bitraverse)
 import Data.Functor.Compose (Compose(..))
-import qualified Data.IntMap.Monoidal as IM
-import qualified Data.IntSet as IS
-import qualified Data.Map as M
+import Data.IntMap.Monoidal qualified as IM
+import Data.IntSet qualified as IS
+import Data.Map qualified as M
 import Data.Maybe (fromJust)
 import Data.Semigroup (Min(..))
 import Data.Semigroup.Generic (GenericSemigroupMonoid(..))
 
 import Language.PureScript.AST.Literals
 import Language.PureScript.AST.SourcePos (nullSourceSpan)
-import qualified Language.PureScript.Constants.Libs as C
+import Language.PureScript.Constants.Libs qualified as C
 import Language.PureScript.CoreFn.Ann (Ann)
 import Language.PureScript.CoreFn.Binders
 import Language.PureScript.CoreFn.Expr

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -8,8 +8,8 @@ import Control.Arrow (second)
 import Data.Function (on)
 import Data.Maybe (mapMaybe)
 import Data.Tuple (swap)
-import qualified Data.List.NonEmpty as NEL
-import qualified Data.Map as M
+import Data.List.NonEmpty qualified as NEL
+import Data.Map qualified as M
 
 import Language.PureScript.AST.Literals
 import Language.PureScript.AST.SourcePos
@@ -24,8 +24,8 @@ import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Names
 import Language.PureScript.Types
-import qualified Language.PureScript.AST as A
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.AST qualified as A
+import Language.PureScript.Constants.Prim qualified as C
 
 -- | Desugars a module from AST to CoreFn representation.
 moduleToCoreFn :: Environment -> A.Module -> Module Ann

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -9,24 +9,24 @@ module Language.PureScript.CoreFn.FromJSON
 
 import Prelude
 
-import           Control.Applicative ((<|>))
+import Control.Applicative ((<|>))
 
-import           Data.Aeson
-import           Data.Aeson.Types (Parser, listParser)
+import Data.Aeson
+import Data.Aeson.Types (Parser, listParser)
 import Data.Map.Strict qualified as M
-import           Data.Text (Text)
+import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Vector qualified as V
-import           Data.Version (Version, parseVersion)
+import Data.Version (Version, parseVersion)
 
-import           Language.PureScript.AST.SourcePos (SourceSpan(..))
-import           Language.PureScript.AST.Literals
-import           Language.PureScript.CoreFn.Ann
-import           Language.PureScript.CoreFn
-import           Language.PureScript.Names
-import           Language.PureScript.PSString (PSString)
+import Language.PureScript.AST.SourcePos (SourceSpan(..))
+import Language.PureScript.AST.Literals
+import Language.PureScript.CoreFn.Ann
+import Language.PureScript.CoreFn
+import Language.PureScript.Names
+import Language.PureScript.PSString (PSString)
 
-import           Text.ParserCombinators.ReadP (readP_to_S)
+import Text.ParserCombinators.ReadP (readP_to_S)
 
 parseVersion' :: String -> Maybe Version
 parseVersion' str =

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -13,10 +13,10 @@ import           Control.Applicative ((<|>))
 
 import           Data.Aeson
 import           Data.Aeson.Types (Parser, listParser)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import           Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Vector as V
+import Data.Text qualified as T
+import Data.Vector qualified as V
 import           Data.Version (Version, parseVersion)
 
 import           Language.PureScript.AST.SourcePos (SourceSpan(..))

--- a/src/Language/PureScript/CoreFn/Laziness.hs
+++ b/src/Language/PureScript/CoreFn/Laziness.hs
@@ -6,18 +6,18 @@ import Protolude hiding (force)
 import Protolude.Unsafe (unsafeHead)
 
 import Control.Arrow ((&&&))
-import qualified Data.Array as A
+import Data.Array qualified as A
 import Data.Coerce (coerce)
 import Data.Graph (SCC(..), stronglyConnComp)
 import Data.List (foldl1', (!!))
-import qualified Data.IntMap.Monoidal as IM
-import qualified Data.IntSet as IS
-import qualified Data.Map.Monoidal as M
+import Data.IntMap.Monoidal qualified as IM
+import Data.IntSet qualified as IS
+import Data.Map.Monoidal qualified as M
 import Data.Semigroup (Max(..))
-import qualified Data.Set as S
+import Data.Set qualified as S
 
 import Language.PureScript.AST.SourcePos
-import qualified Language.PureScript.Constants.Libs as C
+import Language.PureScript.Constants.Libs qualified as C
 import Language.PureScript.CoreFn
 import Language.PureScript.Crash
 import Language.PureScript.Names

--- a/src/Language/PureScript/CoreFn/Optimizer.hs
+++ b/src/Language/PureScript/CoreFn/Optimizer.hs
@@ -13,8 +13,8 @@ import Language.PureScript.CoreFn.Module
 import Language.PureScript.CoreFn.Traversals
 import Language.PureScript.Label
 import Language.PureScript.Types
-import qualified Language.PureScript.Constants.Libs as C
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Libs qualified as C
+import Language.PureScript.Constants.Prim qualified as C
 
 -- |
 -- CoreFn optimization pass.

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -7,24 +7,24 @@ module Language.PureScript.CoreFn.ToJSON
   ( moduleToJSON
   ) where
 
-import           Prelude
+import Prelude
 
-import           Control.Arrow ((***))
-import           Data.Either (isLeft)
+import Control.Arrow ((***))
+import Data.Either (isLeft)
 import Data.Map.Strict qualified as M
-import           Data.Aeson hiding ((.=))
+import Data.Aeson hiding ((.=))
 import Data.Aeson qualified
 import Data.Aeson.Key qualified
-import           Data.Aeson.Types (Pair)
-import           Data.Version (Version, showVersion)
-import           Data.Text (Text)
+import Data.Aeson.Types (Pair)
+import Data.Version (Version, showVersion)
+import Data.Text (Text)
 import Data.Text qualified as T
 
-import           Language.PureScript.AST.Literals
-import           Language.PureScript.AST.SourcePos (SourceSpan(..))
-import           Language.PureScript.CoreFn
-import           Language.PureScript.Names
-import           Language.PureScript.PSString (PSString)
+import Language.PureScript.AST.Literals
+import Language.PureScript.AST.SourcePos (SourceSpan(..))
+import Language.PureScript.CoreFn
+import Language.PureScript.Names
+import Language.PureScript.PSString (PSString)
 
 constructorTypeToJSON :: ConstructorType -> Value
 constructorTypeToJSON ProductType = toJSON "ProductType"

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -13,8 +13,8 @@ import           Control.Arrow ((***))
 import           Data.Either (isLeft)
 import Data.Map.Strict qualified as M
 import           Data.Aeson hiding ((.=))
-import qualified Data.Aeson
-import qualified Data.Aeson.Key
+import Data.Aeson qualified
+import Data.Aeson.Key qualified
 import           Data.Aeson.Types (Pair)
 import           Data.Version (Version, showVersion)
 import           Data.Text (Text)

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -11,14 +11,14 @@ import           Prelude
 
 import           Control.Arrow ((***))
 import           Data.Either (isLeft)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import           Data.Aeson hiding ((.=))
 import qualified Data.Aeson
 import qualified Data.Aeson.Key
 import           Data.Aeson.Types (Pair)
 import           Data.Version (Version, showVersion)
 import           Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import           Language.PureScript.AST.Literals
 import           Language.PureScript.AST.SourcePos (SourceSpan(..))

--- a/src/Language/PureScript/CoreImp/Module.hs
+++ b/src/Language/PureScript/CoreImp/Module.hs
@@ -1,7 +1,7 @@
 module Language.PureScript.CoreImp.Module where
 
 import Protolude
-import qualified Data.List.NonEmpty as NEL (NonEmpty)
+import Data.List.NonEmpty qualified as NEL (NonEmpty)
 
 import Language.PureScript.Comments
 import Language.PureScript.CoreImp.AST

--- a/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
@@ -19,15 +19,15 @@ import Control.Monad.Supply.Class (MonadSupply, freshName)
 import Data.Either (rights)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Language.PureScript.Names (ModuleName)
 import Language.PureScript.PSString (PSString, mkString)
 import Language.PureScript.CoreImp.AST
 import Language.PureScript.CoreImp.Optimizer.Common
 import Language.PureScript.AST (SourceSpan(..))
-import qualified Language.PureScript.Constants.Libs as C
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Libs qualified as C
+import Language.PureScript.Constants.Prim qualified as C
 
 -- TODO: Potential bug:
 -- Shouldn't just inline this case: { var x = 0; x.toFixed(10); }

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -11,7 +11,7 @@ import Language.PureScript.CoreImp.AST
 import Language.PureScript.CoreImp.Optimizer.Common
 import Language.PureScript.Names (ModuleName)
 import Language.PureScript.PSString (mkString)
-import qualified Language.PureScript.Constants.Libs as C
+import Language.PureScript.Constants.Libs qualified as C
 
 -- | Inline type class dictionaries for >>= and return for the Eff monad
 --

--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -7,7 +7,7 @@ import Control.Applicative (empty, liftA2)
 import Control.Monad (guard)
 import Control.Monad.State (State, evalState, get, modify)
 import Data.Functor (($>), (<&>))
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Text (Text, pack)
 import Language.PureScript.CoreImp.AST
 import Language.PureScript.AST.SourcePos (SourceSpan)

--- a/src/Language/PureScript/CoreImp/Optimizer/Unused.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Unused.hs
@@ -9,12 +9,12 @@ import Prelude
 
 import Control.Monad (filterM)
 import Data.Monoid (Any(..))
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Text (Text)
 
 import Language.PureScript.CoreImp.AST
 import Language.PureScript.CoreImp.Optimizer.Common
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Prim qualified as C
 
 removeCodeAfterReturnStatements :: AST -> AST
 removeCodeAfterReturnStatements = everywhere (removeFromBlock go)

--- a/src/Language/PureScript/Docs/AsHtml.hs
+++ b/src/Language/PureScript/Docs/AsHtml.hs
@@ -29,7 +29,7 @@ import Data.Text qualified as T
 
 import Text.Blaze.Html5 as H hiding (map)
 import Text.Blaze.Html5.Attributes qualified as A
-import qualified Cheapskate
+import Cheapskate qualified
 
 import Language.PureScript qualified as P
 

--- a/src/Language/PureScript/Docs/AsHtml.hs
+++ b/src/Language/PureScript/Docs/AsHtml.hs
@@ -19,24 +19,24 @@ import Control.Monad (unless)
 import Data.Bifunctor (bimap)
 import Data.Char (isUpper)
 import Data.Either (isRight)
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe)
 import Data.Foldable (for_)
 import Data.String (fromString)
 
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Text.Blaze.Html5 as H hiding (map)
-import qualified Text.Blaze.Html5.Attributes as A
+import Text.Blaze.Html5.Attributes qualified as A
 import qualified Cheapskate
 
-import qualified Language.PureScript as P
+import Language.PureScript qualified as P
 
 import Language.PureScript.Docs.Types
 import Language.PureScript.Docs.RenderedCode hiding (sp)
-import qualified Language.PureScript.Docs.Render as Render
-import qualified Language.PureScript.CST as CST
+import Language.PureScript.Docs.Render qualified as Render
+import Language.PureScript.CST qualified as CST
 
 data HtmlOutput a = HtmlOutput
   { htmlIndex     :: [(Maybe Char, a)]

--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -13,12 +13,12 @@ import Control.Monad.Writer (Writer, tell, execWriter)
 import Data.Foldable (for_)
 import Data.List (partition)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Language.PureScript.Docs.RenderedCode
 import Language.PureScript.Docs.Types
-import qualified Language.PureScript as P
-import qualified Language.PureScript.Docs.Render as Render
+import Language.PureScript qualified as P
+import Language.PureScript.Docs.Render qualified as Render
 
 moduleAsMarkdown :: Module -> Docs
 moduleAsMarkdown Module{..} = do

--- a/src/Language/PureScript/Docs/Collect.hs
+++ b/src/Language/PureScript/Docs/Collect.hs
@@ -6,12 +6,12 @@ module Language.PureScript.Docs.Collect
 import Protolude hiding (check)
 
 import Control.Arrow ((&&&))
-import qualified Data.Aeson.BetterErrors as ABE
-import qualified Data.ByteString as BS
-import qualified Data.Map as Map
-import qualified Data.Set as Set
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
+import Data.Aeson.BetterErrors qualified as ABE
+import Data.ByteString qualified as BS
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import System.FilePath ((</>))
 import System.IO.UTF8 (readUTF8FileT, readUTF8FilesT)
 
@@ -19,14 +19,14 @@ import Language.PureScript.Docs.Convert.ReExports (updateReExports)
 import Language.PureScript.Docs.Prim (primModules)
 import Language.PureScript.Docs.Types
 
-import qualified Language.PureScript.AST as P
-import qualified Language.PureScript.CST as P
-import qualified Language.PureScript.Crash as P
-import qualified Language.PureScript.Errors as P
-import qualified Language.PureScript.Externs as P
-import qualified Language.PureScript.Make as P
-import qualified Language.PureScript.Names as P
-import qualified Language.PureScript.Options as P
+import Language.PureScript.AST qualified as P
+import Language.PureScript.CST qualified as P
+import Language.PureScript.Crash qualified as P
+import Language.PureScript.Errors qualified as P
+import Language.PureScript.Externs qualified as P
+import Language.PureScript.Make qualified as P
+import Language.PureScript.Names qualified as P
+import Language.PureScript.Options qualified as P
 
 import Web.Bower.PackageMeta (PackageName)
 

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -10,24 +10,24 @@ import Protolude hiding (check)
 import Control.Category ((>>>))
 import Control.Monad.Writer.Strict (runWriterT)
 import Control.Monad.Supply (evalSupplyT)
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Map as Map
+import Data.List.NonEmpty qualified as NE
+import Data.Map qualified as Map
 import Data.String (String)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Language.PureScript.Docs.Convert.Single (convertSingleModule)
 import Language.PureScript.Docs.Types
-import qualified Language.PureScript.CST as CST
-import qualified Language.PureScript.AST as P
-import qualified Language.PureScript.Crash as P
-import qualified Language.PureScript.Errors as P
-import qualified Language.PureScript.Externs as P
-import qualified Language.PureScript.Environment as P
-import qualified Language.PureScript.Names as P
-import qualified Language.PureScript.Roles as P
-import qualified Language.PureScript.Sugar as P
-import qualified Language.PureScript.Types as P
-import qualified Language.PureScript.Constants.Prim as Prim
+import Language.PureScript.CST qualified as CST
+import Language.PureScript.AST qualified as P
+import Language.PureScript.Crash qualified as P
+import Language.PureScript.Errors qualified as P
+import Language.PureScript.Externs qualified as P
+import Language.PureScript.Environment qualified as P
+import Language.PureScript.Names qualified as P
+import Language.PureScript.Roles qualified as P
+import Language.PureScript.Sugar qualified as P
+import Language.PureScript.Types qualified as P
+import Language.PureScript.Constants.Prim qualified as Prim
 import Language.PureScript.Sugar (RebracketCaller(CalledByDocs))
 
 -- |

--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -15,19 +15,19 @@ import Data.Either
 import Data.Foldable (fold, traverse_)
 import Data.Map (Map)
 import Data.Maybe (mapMaybe)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Language.PureScript.Docs.Types
 
-import qualified Language.PureScript.AST as P
-import qualified Language.PureScript.Crash as P
-import qualified Language.PureScript.Errors as P
-import qualified Language.PureScript.Externs as P
-import qualified Language.PureScript.ModuleDependencies as P
-import qualified Language.PureScript.Names as P
-import qualified Language.PureScript.Types as P
+import Language.PureScript.AST qualified as P
+import Language.PureScript.Crash qualified as P
+import Language.PureScript.Errors qualified as P
+import Language.PureScript.Externs qualified as P
+import Language.PureScript.ModuleDependencies qualified as P
+import Language.PureScript.Names qualified as P
+import Language.PureScript.Types qualified as P
 
 
 -- |

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -7,16 +7,16 @@ import Protolude hiding (moduleName)
 
 import Control.Category ((>>>))
 
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Language.PureScript.Docs.Types
 
-import qualified Language.PureScript.AST as P
-import qualified Language.PureScript.Comments as P
-import qualified Language.PureScript.Crash as P
-import qualified Language.PureScript.Names as P
-import qualified Language.PureScript.Roles as P
-import qualified Language.PureScript.Types as P
+import Language.PureScript.AST qualified as P
+import Language.PureScript.Comments qualified as P
+import Language.PureScript.Crash qualified as P
+import Language.PureScript.Names qualified as P
+import Language.PureScript.Roles qualified as P
+import Language.PureScript.Types qualified as P
 
 -- |
 -- Convert a single Module, but ignore re-exports; any re-exported types or

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -9,14 +9,14 @@ module Language.PureScript.Docs.Prim
 import Prelude hiding (fail)
 import Data.Functor (($>))
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Map as Map
+import Data.Text qualified as T
+import Data.Map qualified as Map
 import Language.PureScript.Docs.Types
 
-import qualified Language.PureScript.Constants.Prim as P
-import qualified Language.PureScript.Crash as P
-import qualified Language.PureScript.Environment as P
-import qualified Language.PureScript.Names as P
+import Language.PureScript.Constants.Prim qualified as P
+import Language.PureScript.Crash qualified as P
+import Language.PureScript.Environment qualified as P
+import Language.PureScript.Names qualified as P
 
 primModules :: [Module]
 primModules =

--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -13,16 +13,16 @@ import Prelude
 
 import Data.Maybe (maybeToList)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Language.PureScript.Docs.RenderedCode
 import Language.PureScript.Docs.Types
 import Language.PureScript.Docs.Utils.MonoidExtras
 
-import qualified Language.PureScript.AST as P
-import qualified Language.PureScript.Environment as P
-import qualified Language.PureScript.Names as P
-import qualified Language.PureScript.Types as P
+import Language.PureScript.AST qualified as P
+import Language.PureScript.Environment qualified as P
+import Language.PureScript.Names qualified as P
+import Language.PureScript.Types qualified as P
 
 renderKindSig :: Text -> KindInfo -> RenderedCode
 renderKindSig declTitle KindInfo{..} =

--- a/src/Language/PureScript/Docs/RenderedCode/Types.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Types.hs
@@ -39,11 +39,11 @@ import Control.DeepSeq (NFData)
 import Control.Monad.Error.Class (MonadError(..))
 
 import Data.Aeson.BetterErrors (Parse, nth, withText, withValue, toAesonParser, perhaps, asText)
-import qualified Data.Aeson as A
+import Data.Aeson qualified as A
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.ByteString.Lazy as BS
-import qualified Data.Text.Encoding as TE
+import Data.Text qualified as T
+import Data.ByteString.Lazy qualified as BS
+import Data.Text.Encoding qualified as TE
 
 import Language.PureScript.Names
 import Language.PureScript.AST (Associativity(..))

--- a/src/Language/PureScript/Docs/Tags.hs
+++ b/src/Language/PureScript/Docs/Tags.hs
@@ -6,9 +6,9 @@ module Language.PureScript.Docs.Tags
 
 import Prelude
 
-import           Control.Arrow (first)
-import           Data.List (sort)
-import           Data.Maybe (mapMaybe)
+import Control.Arrow (first)
+import Data.List (sort)
+import Data.Maybe (mapMaybe)
 import Data.Text qualified as T
 import Language.PureScript.AST (SourceSpan, sourcePosLine, spanStart)
 import Language.PureScript.Docs.Types

--- a/src/Language/PureScript/Docs/Tags.hs
+++ b/src/Language/PureScript/Docs/Tags.hs
@@ -9,7 +9,7 @@ import Prelude
 import           Control.Arrow (first)
 import           Data.List (sort)
 import           Data.Maybe (mapMaybe)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Language.PureScript.AST (SourceSpan, sourcePosLine, spanStart)
 import Language.PureScript.Docs.Types
 

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -31,7 +31,7 @@ import Language.PureScript.Environment qualified as P
 import Language.PureScript.Names qualified as P
 import Language.PureScript.Roles qualified as P
 import Language.PureScript.Types qualified as P
-import qualified Paths_purescript as Paths
+import Paths qualified_purescript as Paths
 
 import Web.Bower.PackageMeta hiding (Version, displayError)
 

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -10,27 +10,27 @@ import Prelude (String, unlines, lookup)
 import Control.Arrow ((***))
 
 import Data.Aeson ((.=))
-import qualified Data.Aeson.Key as A.Key
+import Data.Aeson.Key qualified as A.Key
 import Data.Aeson.BetterErrors
   (Parse, keyOrDefault, throwCustomError, key, asText,
    keyMay, withString, eachInArray, asNull, (.!), toAesonParser, toAesonParser',
    fromAesonParser, perhaps, withText, asIntegral, nth, eachInObjectWithKey,
    asString)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Time.Clock (UTCTime)
-import qualified Data.Time.Format as TimeFormat
+import Data.Time.Format qualified as TimeFormat
 import Data.Version
-import qualified Data.Aeson as A
-import qualified Data.Text as T
-import qualified Data.Vector as V
+import Data.Aeson qualified as A
+import Data.Text qualified as T
+import Data.Vector qualified as V
 
-import qualified Language.PureScript.AST as P
-import qualified Language.PureScript.CoreFn.FromJSON as P
-import qualified Language.PureScript.Crash as P
-import qualified Language.PureScript.Environment as P
-import qualified Language.PureScript.Names as P
-import qualified Language.PureScript.Roles as P
-import qualified Language.PureScript.Types as P
+import Language.PureScript.AST qualified as P
+import Language.PureScript.CoreFn.FromJSON qualified as P
+import Language.PureScript.Crash qualified as P
+import Language.PureScript.Environment qualified as P
+import Language.PureScript.Names qualified as P
+import Language.PureScript.Roles qualified as P
+import Language.PureScript.Types qualified as P
 import qualified Paths_purescript as Paths
 
 import Web.Bower.PackageMeta hiding (Version, displayError)

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -31,7 +31,7 @@ import Language.PureScript.Environment qualified as P
 import Language.PureScript.Names qualified as P
 import Language.PureScript.Roles qualified as P
 import Language.PureScript.Types qualified as P
-import Paths qualified_purescript as Paths
+import Paths_purescript qualified as Paths
 
 import Web.Bower.PackageMeta hiding (Version, displayError)
 

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -7,18 +7,18 @@ import Control.DeepSeq (NFData)
 import Control.Monad (unless)
 import Codec.Serialise (Serialise)
 import Data.Aeson ((.=), (.:))
-import qualified Data.Aeson as A
+import Data.Aeson qualified as A
 import Data.Foldable (find, fold)
 import Data.Functor ((<&>))
-import qualified Data.IntMap as IM
-import qualified Data.IntSet as IS
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.IntMap qualified as IM
+import Data.IntSet qualified as IS
+import Data.Map qualified as M
+import Data.Set qualified as S
 import Data.Maybe (fromMaybe)
 import Data.Semigroup (First(..))
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.List.NonEmpty as NEL
+import Data.Text qualified as T
+import Data.List.NonEmpty qualified as NEL
 
 import Language.PureScript.AST.SourcePos
 import Language.PureScript.Crash
@@ -26,7 +26,7 @@ import Language.PureScript.Names
 import Language.PureScript.Roles
 import Language.PureScript.TypeClassDictionaries
 import Language.PureScript.Types
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Prim qualified as C
 
 -- | The @Environment@ defines all values and types which are currently in scope:
 data Environment = Environment

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -32,7 +32,7 @@ import Data.Set qualified as S
 import Data.Text qualified as T
 import           Data.Text (Text)
 import           Data.Traversable (for)
-import qualified GHC.Stack
+import GHC.Stack qualified
 import           Language.PureScript.AST
 import Language.PureScript.Bundle qualified as Bundle
 import Language.PureScript.Constants.Libs qualified as C

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -3,56 +3,56 @@ module Language.PureScript.Errors
   , module Language.PureScript.Errors
   ) where
 
-import           Prelude
-import           Protolude (unsnoc)
+import Prelude
+import Protolude (unsnoc)
 
-import           Control.Arrow ((&&&))
-import           Control.Exception (displayException)
-import           Control.Lens (both, head1, over)
-import           Control.Monad
-import           Control.Monad.Error.Class (MonadError(..))
-import           Control.Monad.Trans.State.Lazy
-import           Control.Monad.Writer
-import           Data.Bifunctor (first, second)
-import           Data.Bitraversable (bitraverse)
-import           Data.Char (isSpace)
-import           Data.Containers.ListUtils (nubOrdOn)
-import           Data.Either (partitionEithers)
-import           Data.Foldable (fold)
-import           Data.Function (on)
-import           Data.Functor (($>))
-import           Data.Functor.Identity (Identity(..))
-import           Data.List (transpose, nubBy, partition, dropWhileEnd, sortOn, uncons)
+import Control.Arrow ((&&&))
+import Control.Exception (displayException)
+import Control.Lens (both, head1, over)
+import Control.Monad
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Trans.State.Lazy
+import Control.Monad.Writer
+import Data.Bifunctor (first, second)
+import Data.Bitraversable (bitraverse)
+import Data.Char (isSpace)
+import Data.Containers.ListUtils (nubOrdOn)
+import Data.Either (partitionEithers)
+import Data.Foldable (fold)
+import Data.Function (on)
+import Data.Functor (($>))
+import Data.Functor.Identity (Identity(..))
+import Data.List (transpose, nubBy, partition, dropWhileEnd, sortOn, uncons)
 import Data.List.NonEmpty qualified as NEL
-import           Data.List.NonEmpty (NonEmpty((:|)))
-import           Data.Maybe (maybeToList, fromMaybe, isJust, mapMaybe)
+import Data.List.NonEmpty (NonEmpty((:|)))
+import Data.Maybe (maybeToList, fromMaybe, isJust, mapMaybe)
 import Data.Map qualified as M
-import           Data.Ord (Down(..))
+import Data.Ord (Down(..))
 import Data.Set qualified as S
 import Data.Text qualified as T
-import           Data.Text (Text)
-import           Data.Traversable (for)
+import Data.Text (Text)
+import Data.Traversable (for)
 import GHC.Stack qualified
-import           Language.PureScript.AST
+import Language.PureScript.AST
 import Language.PureScript.Bundle qualified as Bundle
 import Language.PureScript.Constants.Libs qualified as C
 import Language.PureScript.Constants.Prim qualified as C
-import           Language.PureScript.Crash
+import Language.PureScript.Crash
 import Language.PureScript.CST.Errors qualified as CST
 import Language.PureScript.CST.Print qualified as CST
-import           Language.PureScript.Label (Label(..))
-import           Language.PureScript.Names
-import           Language.PureScript.Pretty
-import           Language.PureScript.Pretty.Common (endWith)
-import           Language.PureScript.PSString (decodeStringWithReplacement)
-import           Language.PureScript.Roles
-import           Language.PureScript.Traversals
-import           Language.PureScript.Types
+import Language.PureScript.Label (Label(..))
+import Language.PureScript.Names
+import Language.PureScript.Pretty
+import Language.PureScript.Pretty.Common (endWith)
+import Language.PureScript.PSString (decodeStringWithReplacement)
+import Language.PureScript.Roles
+import Language.PureScript.Traversals
+import Language.PureScript.Types
 import Language.PureScript.Publish.BoxesHelpers qualified as BoxHelpers
 import System.Console.ANSI qualified as ANSI
-import           System.FilePath (makeRelative)
+import System.FilePath (makeRelative)
 import Text.PrettyPrint.Boxes qualified as Box
-import           Witherable (wither)
+import Witherable (wither)
 
 -- | A type of error messages
 data SimpleErrorMessage

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -23,23 +23,23 @@ import           Data.Function (on)
 import           Data.Functor (($>))
 import           Data.Functor.Identity (Identity(..))
 import           Data.List (transpose, nubBy, partition, dropWhileEnd, sortOn, uncons)
-import qualified Data.List.NonEmpty as NEL
+import Data.List.NonEmpty qualified as NEL
 import           Data.List.NonEmpty (NonEmpty((:|)))
 import           Data.Maybe (maybeToList, fromMaybe, isJust, mapMaybe)
-import qualified Data.Map as M
+import Data.Map qualified as M
 import           Data.Ord (Down(..))
-import qualified Data.Set as S
-import qualified Data.Text as T
+import Data.Set qualified as S
+import Data.Text qualified as T
 import           Data.Text (Text)
 import           Data.Traversable (for)
 import qualified GHC.Stack
 import           Language.PureScript.AST
-import qualified Language.PureScript.Bundle as Bundle
-import qualified Language.PureScript.Constants.Libs as C
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Bundle qualified as Bundle
+import Language.PureScript.Constants.Libs qualified as C
+import Language.PureScript.Constants.Prim qualified as C
 import           Language.PureScript.Crash
-import qualified Language.PureScript.CST.Errors as CST
-import qualified Language.PureScript.CST.Print as CST
+import Language.PureScript.CST.Errors qualified as CST
+import Language.PureScript.CST.Print qualified as CST
 import           Language.PureScript.Label (Label(..))
 import           Language.PureScript.Names
 import           Language.PureScript.Pretty
@@ -48,10 +48,10 @@ import           Language.PureScript.PSString (decodeStringWithReplacement)
 import           Language.PureScript.Roles
 import           Language.PureScript.Traversals
 import           Language.PureScript.Types
-import qualified Language.PureScript.Publish.BoxesHelpers as BoxHelpers
-import qualified System.Console.ANSI as ANSI
+import Language.PureScript.Publish.BoxesHelpers qualified as BoxHelpers
+import System.Console.ANSI qualified as ANSI
 import           System.FilePath (makeRelative)
-import qualified Text.PrettyPrint.Boxes as Box
+import Text.PrettyPrint.Boxes qualified as Box
 import           Witherable (wither)
 
 -- | A type of error messages

--- a/src/Language/PureScript/Errors/JSON.hs
+++ b/src/Language/PureScript/Errors/JSON.hs
@@ -4,11 +4,11 @@ module Language.PureScript.Errors.JSON where
 
 import Prelude
 
-import qualified Data.Aeson.TH as A
-import qualified Data.List.NonEmpty as NEL
+import Data.Aeson.TH qualified as A
+import Data.List.NonEmpty qualified as NEL
 import Data.Text (Text)
 
-import qualified Language.PureScript as P
+import Language.PureScript qualified as P
 
 data ErrorPosition = ErrorPosition
   { startLine :: Int

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -23,10 +23,10 @@ import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.List (foldl', find)
 import Data.Foldable (fold)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Version (showVersion)
-import qualified Data.Map as M
-import qualified Data.List.NonEmpty as NEL
+import Data.Map qualified as M
+import Data.List.NonEmpty qualified as NEL
 
 import Language.PureScript.AST
 import Language.PureScript.AST.Declarations.ChainId (ChainId)

--- a/src/Language/PureScript/Graph.hs
+++ b/src/Language/PureScript/Graph.hs
@@ -2,10 +2,10 @@ module Language.PureScript.Graph (graph) where
 
 import Prelude
 
-import qualified Data.Aeson as Json
-import qualified Data.Aeson.Key as Json.Key
-import qualified Data.Aeson.KeyMap as Json.Map
-import qualified Data.Map as Map
+import Data.Aeson qualified as Json
+import Data.Aeson.Key qualified as Json.Key
+import Data.Aeson.KeyMap qualified as Json.Map
+import Data.Map qualified as Map
 
 import           Control.Monad (forM)
 import           Data.Aeson ((.=))
@@ -15,11 +15,11 @@ import           Data.Maybe (fromMaybe)
 import           Data.Text (Text)
 import           System.IO.UTF8 (readUTF8FileT)
 
-import qualified Language.PureScript.Crash as Crash
-import qualified Language.PureScript.CST as CST
-import qualified Language.PureScript.Make as Make
-import qualified Language.PureScript.ModuleDependencies as Dependencies
-import qualified Language.PureScript.Options as Options
+import Language.PureScript.Crash qualified as Crash
+import Language.PureScript.CST qualified as CST
+import Language.PureScript.Make qualified as Make
+import Language.PureScript.ModuleDependencies qualified as Dependencies
+import Language.PureScript.Options qualified as Options
 
 import           Language.PureScript.Errors (MultipleErrors)
 import           Language.PureScript.Names (ModuleName, runModuleName)

--- a/src/Language/PureScript/Graph.hs
+++ b/src/Language/PureScript/Graph.hs
@@ -7,13 +7,13 @@ import Data.Aeson.Key qualified as Json.Key
 import Data.Aeson.KeyMap qualified as Json.Map
 import Data.Map qualified as Map
 
-import           Control.Monad (forM)
-import           Data.Aeson ((.=))
-import           Data.Foldable (foldl')
-import           Data.Map (Map)
-import           Data.Maybe (fromMaybe)
-import           Data.Text (Text)
-import           System.IO.UTF8 (readUTF8FileT)
+import Control.Monad (forM)
+import Data.Aeson ((.=))
+import Data.Foldable (foldl')
+import Data.Map (Map)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import System.IO.UTF8 (readUTF8FileT)
 
 import Language.PureScript.Crash qualified as Crash
 import Language.PureScript.CST qualified as CST
@@ -21,8 +21,8 @@ import Language.PureScript.Make qualified as Make
 import Language.PureScript.ModuleDependencies qualified as Dependencies
 import Language.PureScript.Options qualified as Options
 
-import           Language.PureScript.Errors (MultipleErrors)
-import           Language.PureScript.Names (ModuleName, runModuleName)
+import Language.PureScript.Errors (MultipleErrors)
+import Language.PureScript.Names (ModuleName, runModuleName)
 
 
 -- | Given a set of filepaths, try to build the dependency graph and return

--- a/src/Language/PureScript/Hierarchy.hs
+++ b/src/Language/PureScript/Hierarchy.hs
@@ -15,10 +15,10 @@
 
 module Language.PureScript.Hierarchy where
 
-import           Prelude
-import           Protolude (ordNub)
+import Prelude
+import Protolude (ordNub)
 
-import           Data.List (sort)
+import Data.List (sort)
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 

--- a/src/Language/PureScript/Hierarchy.hs
+++ b/src/Language/PureScript/Hierarchy.hs
@@ -19,8 +19,8 @@ import           Prelude
 import           Protolude (ordNub)
 
 import           Data.List (sort)
-import qualified Data.Text as T
-import qualified Language.PureScript as P
+import Data.Text qualified as T
+import Language.PureScript qualified as P
 
 newtype SuperMap = SuperMap
   { _unSuperMap :: Either (P.ProperName 'P.ClassName) (P.ProperName 'P.ClassName, P.ProperName 'P.ClassName)

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -21,10 +21,10 @@ module Language.PureScript.Ide
 import           Protolude hiding (moduleName)
 
 import           "monad-logger" Control.Monad.Logger
-import qualified Data.Map                           as Map
-import qualified Data.Text                          as T
-import qualified Language.PureScript                as P
-import qualified Language.PureScript.Ide.CaseSplit  as CS
+import Data.Map qualified                           as Map
+import Data.Text qualified                          as T
+import Language.PureScript qualified                as P
+import Language.PureScript.Ide.CaseSplit qualified  as CS
 import           Language.PureScript.Ide.Command
 import           Language.PureScript.Ide.Completion
 import           Language.PureScript.Ide.Error

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -20,7 +20,7 @@ module Language.PureScript.Ide
 
 import Protolude hiding (moduleName)
 
-import           "monad-logger" Control.Monad.Logger
+import "monad-logger" Control.Monad.Logger
 import Data.Map qualified as Map
 import Data.Text qualified as T
 import Language.PureScript qualified as P

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -21,10 +21,10 @@ module Language.PureScript.Ide
 import Protolude hiding (moduleName)
 
 import           "monad-logger" Control.Monad.Logger
-import Data.Map qualified                           as Map
-import Data.Text qualified                          as T
-import Language.PureScript qualified                as P
-import Language.PureScript.Ide.CaseSplit qualified  as CS
+import Data.Map qualified as Map
+import Data.Text qualified as T
+import Language.PureScript qualified as P
+import Language.PureScript.Ide.CaseSplit qualified as CS
 import Language.PureScript.Ide.Command
 import Language.PureScript.Ide.Completion
 import Language.PureScript.Ide.Error

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -18,31 +18,31 @@ module Language.PureScript.Ide
        ( handleCommand
        ) where
 
-import           Protolude hiding (moduleName)
+import Protolude hiding (moduleName)
 
 import           "monad-logger" Control.Monad.Logger
 import Data.Map qualified                           as Map
 import Data.Text qualified                          as T
 import Language.PureScript qualified                as P
 import Language.PureScript.Ide.CaseSplit qualified  as CS
-import           Language.PureScript.Ide.Command
-import           Language.PureScript.Ide.Completion
-import           Language.PureScript.Ide.Error
-import           Language.PureScript.Ide.Externs
-import           Language.PureScript.Ide.Filter
-import           Language.PureScript.Ide.Imports hiding (Import)
-import           Language.PureScript.Ide.Imports.Actions
-import           Language.PureScript.Ide.Matcher
-import           Language.PureScript.Ide.Prim
-import           Language.PureScript.Ide.Rebuild
-import           Language.PureScript.Ide.SourceFile
-import           Language.PureScript.Ide.State
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util
-import           Language.PureScript.Ide.Usage (findUsages)
-import           System.Directory (getCurrentDirectory, getDirectoryContents, doesDirectoryExist, doesFileExist)
-import           System.FilePath ((</>), normalise)
-import           System.FilePath.Glob (glob)
+import Language.PureScript.Ide.Command
+import Language.PureScript.Ide.Completion
+import Language.PureScript.Ide.Error
+import Language.PureScript.Ide.Externs
+import Language.PureScript.Ide.Filter
+import Language.PureScript.Ide.Imports hiding (Import)
+import Language.PureScript.Ide.Imports.Actions
+import Language.PureScript.Ide.Matcher
+import Language.PureScript.Ide.Prim
+import Language.PureScript.Ide.Rebuild
+import Language.PureScript.Ide.SourceFile
+import Language.PureScript.Ide.State
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Usage (findUsages)
+import System.Directory (getCurrentDirectory, getDirectoryContents, doesDirectoryExist, doesFileExist)
+import System.FilePath ((</>), normalise)
+import System.FilePath.Glob (glob)
 
 -- | Accepts a Command and runs it against psc-ide's State. This is the main
 -- entry point for the server.

--- a/src/Language/PureScript/Ide/CaseSplit.hs
+++ b/src/Language/PureScript/Ide/CaseSplit.hs
@@ -21,7 +21,7 @@ module Language.PureScript.Ide.CaseSplit
        , caseSplit
        ) where
 
-import           Protolude                     hiding (Constructor)
+import Protolude                     hiding (Constructor)
 
 import Data.List.NonEmpty qualified            as NE
 import Data.Map qualified                      as M
@@ -29,10 +29,10 @@ import Data.Text qualified                     as T
 import Language.PureScript qualified           as P
 import Language.PureScript.CST qualified       as CST
 
-import           Language.PureScript.Externs
-import           Language.PureScript.Ide.Error
-import           Language.PureScript.Ide.State
-import           Language.PureScript.Ide.Types
+import Language.PureScript.Externs
+import Language.PureScript.Ide.Error
+import Language.PureScript.Ide.State
+import Language.PureScript.Ide.Types
 
 type Constructor = (P.ProperName 'P.ConstructorName, [P.SourceType])
 

--- a/src/Language/PureScript/Ide/CaseSplit.hs
+++ b/src/Language/PureScript/Ide/CaseSplit.hs
@@ -23,11 +23,11 @@ module Language.PureScript.Ide.CaseSplit
 
 import           Protolude                     hiding (Constructor)
 
-import qualified Data.List.NonEmpty            as NE
-import qualified Data.Map                      as M
-import qualified Data.Text                     as T
-import qualified Language.PureScript           as P
-import qualified Language.PureScript.CST       as CST
+import Data.List.NonEmpty qualified            as NE
+import Data.Map qualified                      as M
+import Data.Text qualified                     as T
+import Language.PureScript qualified           as P
+import Language.PureScript.CST qualified       as CST
 
 import           Language.PureScript.Externs
 import           Language.PureScript.Ide.Error

--- a/src/Language/PureScript/Ide/CaseSplit.hs
+++ b/src/Language/PureScript/Ide/CaseSplit.hs
@@ -23,11 +23,11 @@ module Language.PureScript.Ide.CaseSplit
 
 import Protolude                     hiding (Constructor)
 
-import Data.List.NonEmpty qualified            as NE
-import Data.Map qualified                      as M
-import Data.Text qualified                     as T
-import Language.PureScript qualified           as P
-import Language.PureScript.CST qualified       as CST
+import Data.List.NonEmpty qualified as NE
+import Data.Map qualified as M
+import Data.Text qualified as T
+import Language.PureScript qualified as P
+import Language.PureScript.CST qualified as CST
 
 import Language.PureScript.Externs
 import Language.PureScript.Ide.Error

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -14,18 +14,18 @@
 
 module Language.PureScript.Ide.Command where
 
-import           Protolude
+import Protolude
 
-import           Control.Monad.Fail (fail)
-import           Data.Aeson
+import Control.Monad.Fail (fail)
+import Data.Aeson
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Language.PureScript qualified               as P
-import           Language.PureScript.Ide.CaseSplit
-import           Language.PureScript.Ide.Completion
-import           Language.PureScript.Ide.Filter
-import           Language.PureScript.Ide.Matcher
-import           Language.PureScript.Ide.Types
+import Language.PureScript.Ide.CaseSplit
+import Language.PureScript.Ide.Completion
+import Language.PureScript.Ide.Filter
+import Language.PureScript.Ide.Matcher
+import Language.PureScript.Ide.Types
 
 data Command
     = Load [P.ModuleName]

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -20,7 +20,7 @@ import           Control.Monad.Fail (fail)
 import           Data.Aeson
 import Data.Map qualified as Map
 import Data.Set qualified as Set
-import qualified Language.PureScript               as P
+import Language.PureScript qualified               as P
 import           Language.PureScript.Ide.CaseSplit
 import           Language.PureScript.Ide.Completion
 import           Language.PureScript.Ide.Filter

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -18,8 +18,8 @@ import           Protolude
 
 import           Control.Monad.Fail (fail)
 import           Data.Aeson
-import qualified Data.Map as Map
-import qualified Data.Set as Set
+import Data.Map qualified as Map
+import Data.Set qualified as Set
 import qualified Language.PureScript               as P
 import           Language.PureScript.Ide.CaseSplit
 import           Language.PureScript.Ide.Completion

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -20,7 +20,7 @@ import Control.Monad.Fail (fail)
 import Data.Aeson
 import Data.Map qualified as Map
 import Data.Set qualified as Set
-import Language.PureScript qualified               as P
+import Language.PureScript qualified as P
 import Language.PureScript.Ide.CaseSplit
 import Language.PureScript.Ide.Completion
 import Language.PureScript.Ide.Filter

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -13,9 +13,9 @@ import           Protolude hiding ((<&>), moduleName)
 
 import           Control.Lens hiding (op, (&))
 import           Data.Aeson
-import qualified Data.Map as Map
-import qualified Data.Text as T
-import qualified Language.PureScript as P
+import Data.Map qualified as Map
+import Data.Text qualified as T
+import Language.PureScript qualified as P
 import           Language.PureScript.Ide.Error (prettyPrintTypeSingleLine)
 import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.Matcher

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -9,18 +9,18 @@ module Language.PureScript.Ide.Completion
        , applyCompletionOptions
        ) where
 
-import           Protolude hiding ((<&>), moduleName)
+import Protolude hiding ((<&>), moduleName)
 
-import           Control.Lens hiding (op, (&))
-import           Data.Aeson
+import Control.Lens hiding (op, (&))
+import Data.Aeson
 import Data.Map qualified as Map
 import Data.Text qualified as T
 import Language.PureScript qualified as P
-import           Language.PureScript.Ide.Error (prettyPrintTypeSingleLine)
-import           Language.PureScript.Ide.Filter
-import           Language.PureScript.Ide.Matcher
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Error (prettyPrintTypeSingleLine)
+import Language.PureScript.Ide.Filter
+import Language.PureScript.Ide.Matcher
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Util
 
 -- | Applies the CompletionFilters and the Matcher to the given Modules
 --   and sorts the found Completions according to the Matching Score

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -17,14 +17,14 @@ module Language.PureScript.Ide.Error
        , prettyPrintTypeSingleLine
        ) where
 
-import           Data.Aeson
+import Data.Aeson
 import Data.Aeson.Types qualified as Aeson
 import Data.Aeson.KeyMap qualified as KM
 import Data.Text qualified as T
 import Language.PureScript qualified as P
-import           Language.PureScript.Errors.JSON
-import           Language.PureScript.Ide.Types   (ModuleIdent, Completion(..))
-import           Protolude
+import Language.PureScript.Errors.JSON
+import Language.PureScript.Ide.Types   (ModuleIdent, Completion(..))
+import Protolude
 
 data IdeError
     = GeneralError Text

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -23,7 +23,7 @@ import Data.Aeson.KeyMap qualified as KM
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.Errors.JSON
-import Language.PureScript.Ide.Types   (ModuleIdent, Completion(..))
+import Language.PureScript.Ide.Types (ModuleIdent, Completion(..))
 import Protolude
 
 data IdeError

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -18,10 +18,10 @@ module Language.PureScript.Ide.Error
        ) where
 
 import           Data.Aeson
-import qualified Data.Aeson.Types as Aeson
-import qualified Data.Aeson.KeyMap as KM
-import qualified Data.Text as T
-import qualified Language.PureScript as P
+import Data.Aeson.Types qualified as Aeson
+import Data.Aeson.KeyMap qualified as KM
+import Data.Text qualified as T
+import Language.PureScript qualified as P
 import           Language.PureScript.Errors.JSON
 import           Language.PureScript.Ide.Types   (ModuleIdent, Completion(..))
 import           Protolude

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -11,9 +11,9 @@ import           Codec.CBOR.Term as Term
 import           Control.Lens hiding (anyOf)
 import           "monad-logger" Control.Monad.Logger
 import           Data.Version (showVersion)
-import qualified Data.Text as Text
-import qualified Language.PureScript as P
-import qualified Language.PureScript.Make.Monad as Make
+import Data.Text qualified as Text
+import Language.PureScript qualified as P
+import Language.PureScript.Make.Monad qualified as Make
 import           Language.PureScript.Ide.Error (IdeError (..))
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util (properNameT)

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -5,18 +5,18 @@ module Language.PureScript.Ide.Externs
   , convertExterns
   ) where
 
-import           Protolude hiding (to, from, (&))
+import Protolude hiding (to, from, (&))
 
-import           Codec.CBOR.Term as Term
-import           Control.Lens hiding (anyOf)
+import Codec.CBOR.Term as Term
+import Control.Lens hiding (anyOf)
 import           "monad-logger" Control.Monad.Logger
-import           Data.Version (showVersion)
+import Data.Version (showVersion)
 import Data.Text qualified as Text
 import Language.PureScript qualified as P
 import Language.PureScript.Make.Monad qualified as Make
-import           Language.PureScript.Ide.Error (IdeError (..))
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util (properNameT)
+import Language.PureScript.Ide.Error (IdeError (..))
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Util (properNameT)
 
 readExternFile
   :: (MonadIO m, MonadError IdeError m, MonadLogger m)

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -9,7 +9,7 @@ import Protolude hiding (to, from, (&))
 
 import Codec.CBOR.Term as Term
 import Control.Lens hiding (anyOf)
-import           "monad-logger" Control.Monad.Logger
+import "monad-logger" Control.Monad.Logger
 import Data.Version (showVersion)
 import Data.Text qualified as Text
 import Language.PureScript qualified as P

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -35,7 +35,7 @@ import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Imports
 import           Language.PureScript.Ide.Util
 
-import qualified Language.PureScript           as P
+import Language.PureScript qualified           as P
 import Data.Text qualified as T
 
 import Language.PureScript.Ide.Filter.Imports 

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -28,15 +28,15 @@ import           Protolude                     hiding (isPrefixOf, Prefix)
 import           Control.Monad.Fail (fail)
 import           Data.Aeson
 import           Data.Text (isPrefixOf)
-import qualified Data.Set as Set
-import qualified Data.Map as Map
+import Data.Set qualified as Set
+import Data.Map qualified as Map
 import           Language.PureScript.Ide.Filter.Declaration (DeclarationType)
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Imports
 import           Language.PureScript.Ide.Util
 
 import qualified Language.PureScript           as P
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Language.PureScript.Ide.Filter.Imports 
 

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -23,17 +23,17 @@ module Language.PureScript.Ide.Filter
        , applyFilters
        ) where
 
-import           Protolude                     hiding (isPrefixOf, Prefix)
+import Protolude                     hiding (isPrefixOf, Prefix)
 
-import           Control.Monad.Fail (fail)
-import           Data.Aeson
-import           Data.Text (isPrefixOf)
+import Control.Monad.Fail (fail)
+import Data.Aeson
+import Data.Text (isPrefixOf)
 import Data.Set qualified as Set
 import Data.Map qualified as Map
-import           Language.PureScript.Ide.Filter.Declaration (DeclarationType)
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Imports
-import           Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Filter.Declaration (DeclarationType)
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Imports
+import Language.PureScript.Ide.Util
 
 import Language.PureScript qualified           as P
 import Data.Text qualified as T

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -35,7 +35,7 @@ import Language.PureScript.Ide.Types
 import Language.PureScript.Ide.Imports
 import Language.PureScript.Ide.Util
 
-import Language.PureScript qualified           as P
+import Language.PureScript qualified as P
 import Data.Text qualified as T
 
 import Language.PureScript.Ide.Filter.Imports 

--- a/src/Language/PureScript/Ide/Filter/Declaration.hs
+++ b/src/Language/PureScript/Ide/Filter/Declaration.hs
@@ -2,10 +2,10 @@ module Language.PureScript.Ide.Filter.Declaration
        ( DeclarationType(..)
        ) where
 
-import           Protolude                     hiding (isPrefixOf)
+import Protolude                     hiding (isPrefixOf)
 
-import           Control.Monad.Fail (fail)
-import           Data.Aeson
+import Control.Monad.Fail (fail)
+import Data.Aeson
 
 data DeclarationType
   = Value

--- a/src/Language/PureScript/Ide/Filter/Imports.hs
+++ b/src/Language/PureScript/Ide/Filter/Imports.hs
@@ -6,7 +6,7 @@ import           Protolude                     hiding (isPrefixOf)
 import Language.PureScript.Ide.Types
 import Language.PureScript.Ide.Imports
 
-import qualified Language.PureScript as P
+import Language.PureScript qualified as P
 
 matchImport :: Maybe P.ModuleName -> P.ModuleName -> IdeDeclarationAnn -> Import -> Bool
 matchImport matchQualifier declMod (IdeDeclarationAnn _ decl) (Import importMod declTy qualifier) | declMod == importMod && matchQualifier == qualifier =

--- a/src/Language/PureScript/Ide/Filter/Imports.hs
+++ b/src/Language/PureScript/Ide/Filter/Imports.hs
@@ -1,7 +1,7 @@
 module Language.PureScript.Ide.Filter.Imports where
 
 
-import           Protolude                     hiding (isPrefixOf)
+import Protolude                     hiding (isPrefixOf)
 
 import Language.PureScript.Ide.Types
 import Language.PureScript.Ide.Imports

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -26,8 +26,8 @@ module Language.PureScript.Ide.Imports
 
 import Protolude hiding (moduleName)
 
-import Control.Lens                       ((^.), (%~), ix)
-import Data.List                          (partition)
+import Control.Lens ((^.), (%~), ix)
+import Data.List (partition)
 import Data.List.NonEmpty qualified as NE
 import Data.Text qualified as T
 import Language.PureScript qualified as P

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -24,16 +24,16 @@ module Language.PureScript.Ide.Imports
        )
        where
 
-import           Protolude hiding (moduleName)
+import Protolude hiding (moduleName)
 
-import           Control.Lens                       ((^.), (%~), ix)
-import           Data.List                          (partition)
+import Control.Lens                       ((^.), (%~), ix)
+import Data.List                          (partition)
 import Data.List.NonEmpty qualified                 as NE
 import Data.Text qualified                          as T
 import Language.PureScript qualified                as P
 import Language.PureScript.CST qualified            as CST
-import           Language.PureScript.Ide.Error
-import           Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Error
+import Language.PureScript.Ide.Util
 
 data Import = Import P.ModuleName P.ImportDeclarationType (Maybe P.ModuleName)
               deriving (Eq, Show)

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -28,10 +28,10 @@ import           Protolude hiding (moduleName)
 
 import           Control.Lens                       ((^.), (%~), ix)
 import           Data.List                          (partition)
-import qualified Data.List.NonEmpty                 as NE
-import qualified Data.Text                          as T
-import qualified Language.PureScript                as P
-import qualified Language.PureScript.CST            as CST
+import Data.List.NonEmpty qualified                 as NE
+import Data.Text qualified                          as T
+import Language.PureScript qualified                as P
+import Language.PureScript.CST qualified            as CST
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Util
 

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -28,10 +28,10 @@ import Protolude hiding (moduleName)
 
 import Control.Lens                       ((^.), (%~), ix)
 import Data.List                          (partition)
-import Data.List.NonEmpty qualified                 as NE
-import Data.Text qualified                          as T
-import Language.PureScript qualified                as P
-import Language.PureScript.CST qualified            as CST
+import Data.List.NonEmpty qualified as NE
+import Data.Text qualified as T
+import Language.PureScript qualified as P
+import Language.PureScript.CST qualified as CST
 import Language.PureScript.Ide.Error
 import Language.PureScript.Ide.Util
 

--- a/src/Language/PureScript/Ide/Imports/Actions.hs
+++ b/src/Language/PureScript/Ide/Imports/Actions.hs
@@ -15,9 +15,9 @@ import           Protolude hiding (moduleName)
 
 import           Control.Lens                       ((^.), has)
 import           Data.List                          (nubBy)
-import qualified Data.Map                           as Map
-import qualified Data.Text                          as T
-import qualified Language.PureScript                as P
+import Data.Map qualified                           as Map
+import Data.Text qualified                          as T
+import Language.PureScript qualified                as P
 import Language.PureScript.Constants.Prim qualified as C
 import           Language.PureScript.Ide.Completion
 import           Language.PureScript.Ide.Error

--- a/src/Language/PureScript/Ide/Imports/Actions.hs
+++ b/src/Language/PureScript/Ide/Imports/Actions.hs
@@ -15,9 +15,9 @@ import Protolude hiding (moduleName)
 
 import Control.Lens                       ((^.), has)
 import Data.List                          (nubBy)
-import Data.Map qualified                           as Map
-import Data.Text qualified                          as T
-import Language.PureScript qualified                as P
+import Data.Map qualified as Map
+import Data.Text qualified as T
+import Language.PureScript qualified as P
 import Language.PureScript.Constants.Prim qualified as C
 import Language.PureScript.Ide.Completion
 import Language.PureScript.Ide.Error

--- a/src/Language/PureScript/Ide/Imports/Actions.hs
+++ b/src/Language/PureScript/Ide/Imports/Actions.hs
@@ -11,23 +11,23 @@ module Language.PureScript.Ide.Imports.Actions
        )
 where
 
-import           Protolude hiding (moduleName)
+import Protolude hiding (moduleName)
 
-import           Control.Lens                       ((^.), has)
-import           Data.List                          (nubBy)
+import Control.Lens                       ((^.), has)
+import Data.List                          (nubBy)
 import Data.Map qualified                           as Map
 import Data.Text qualified                          as T
 import Language.PureScript qualified                as P
 import Language.PureScript.Constants.Prim qualified as C
-import           Language.PureScript.Ide.Completion
-import           Language.PureScript.Ide.Error
-import           Language.PureScript.Ide.Filter
-import           Language.PureScript.Ide.Imports
-import           Language.PureScript.Ide.State
-import           Language.PureScript.Ide.Prim
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util
-import           System.IO.UTF8                     (writeUTF8FileT)
+import Language.PureScript.Ide.Completion
+import Language.PureScript.Ide.Error
+import Language.PureScript.Ide.Filter
+import Language.PureScript.Ide.Imports
+import Language.PureScript.Ide.State
+import Language.PureScript.Ide.Prim
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Util
+import System.IO.UTF8                     (writeUTF8FileT)
 
 -- | Adds an implicit import like @import Prelude@ to a Sourcefile.
 addImplicitImport

--- a/src/Language/PureScript/Ide/Imports/Actions.hs
+++ b/src/Language/PureScript/Ide/Imports/Actions.hs
@@ -13,8 +13,8 @@ where
 
 import Protolude hiding (moduleName)
 
-import Control.Lens                       ((^.), has)
-import Data.List                          (nubBy)
+import Control.Lens ((^.), has)
+import Data.List (nubBy)
 import Data.Map qualified as Map
 import Data.Text qualified as T
 import Language.PureScript qualified as P
@@ -27,7 +27,7 @@ import Language.PureScript.Ide.State
 import Language.PureScript.Ide.Prim
 import Language.PureScript.Ide.Types
 import Language.PureScript.Ide.Util
-import System.IO.UTF8                     (writeUTF8FileT)
+import System.IO.UTF8 (writeUTF8FileT)
 
 -- | Adds an implicit import like @import Prelude@ to a Sourcefile.
 addImplicitImport

--- a/src/Language/PureScript/Ide/Imports/Actions.hs
+++ b/src/Language/PureScript/Ide/Imports/Actions.hs
@@ -18,7 +18,7 @@ import           Data.List                          (nubBy)
 import qualified Data.Map                           as Map
 import qualified Data.Text                          as T
 import qualified Language.PureScript                as P
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Prim qualified as C
 import           Language.PureScript.Ide.Completion
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Filter

--- a/src/Language/PureScript/Ide/Logging.hs
+++ b/src/Language/PureScript/Ide/Logging.hs
@@ -10,7 +10,7 @@ module Language.PureScript.Ide.Logging
 import           Protolude
 
 import           "monad-logger" Control.Monad.Logger
-import qualified Data.Text as T
+import Data.Text qualified as T
 import           Language.PureScript.Ide.Types
 import           System.Clock
 import           Text.Printf

--- a/src/Language/PureScript/Ide/Logging.hs
+++ b/src/Language/PureScript/Ide/Logging.hs
@@ -7,13 +7,13 @@ module Language.PureScript.Ide.Logging
        , labelTimespec
        ) where
 
-import           Protolude
+import Protolude
 
 import           "monad-logger" Control.Monad.Logger
 import Data.Text qualified as T
-import           Language.PureScript.Ide.Types
-import           System.Clock
-import           Text.Printf
+import Language.PureScript.Ide.Types
+import System.Clock
+import Text.Printf
 
 runLogger :: MonadIO m => IdeLogLevel -> LoggingT m a -> m a
 runLogger logLevel' =

--- a/src/Language/PureScript/Ide/Logging.hs
+++ b/src/Language/PureScript/Ide/Logging.hs
@@ -9,7 +9,7 @@ module Language.PureScript.Ide.Logging
 
 import Protolude
 
-import           "monad-logger" Control.Monad.Logger
+import "monad-logger" Control.Monad.Logger
 import Data.Text qualified as T
 import Language.PureScript.Ide.Types
 import System.Clock

--- a/src/Language/PureScript/Ide/Matcher.hs
+++ b/src/Language/PureScript/Ide/Matcher.hs
@@ -23,8 +23,8 @@ import           Protolude
 
 import           Control.Monad.Fail (fail)
 import           Data.Aeson
-import qualified Data.Text                     as T
-import qualified Data.Text.Encoding            as TE
+import Data.Text qualified                     as T
+import Data.Text.Encoding qualified            as TE
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
 import           Text.EditDistance

--- a/src/Language/PureScript/Ide/Matcher.hs
+++ b/src/Language/PureScript/Ide/Matcher.hs
@@ -19,16 +19,16 @@ module Language.PureScript.Ide.Matcher
        , flexMatcher
        ) where
 
-import           Protolude
+import Protolude
 
-import           Control.Monad.Fail (fail)
-import           Data.Aeson
+import Control.Monad.Fail (fail)
+import Data.Aeson
 import Data.Text qualified                     as T
 import Data.Text.Encoding qualified            as TE
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util
-import           Text.EditDistance
-import           Text.Regex.TDFA               ((=~))
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Util
+import Text.EditDistance
+import Text.Regex.TDFA               ((=~))
 
 
 type ScoredMatch a = (Match a, Double)

--- a/src/Language/PureScript/Ide/Matcher.hs
+++ b/src/Language/PureScript/Ide/Matcher.hs
@@ -28,7 +28,7 @@ import Data.Text.Encoding qualified as TE
 import Language.PureScript.Ide.Types
 import Language.PureScript.Ide.Util
 import Text.EditDistance
-import Text.Regex.TDFA               ((=~))
+import Text.Regex.TDFA ((=~))
 
 
 type ScoredMatch a = (Match a, Double)

--- a/src/Language/PureScript/Ide/Matcher.hs
+++ b/src/Language/PureScript/Ide/Matcher.hs
@@ -23,8 +23,8 @@ import Protolude
 
 import Control.Monad.Fail (fail)
 import Data.Aeson
-import Data.Text qualified                     as T
-import Data.Text.Encoding qualified            as TE
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import Language.PureScript.Ide.Types
 import Language.PureScript.Ide.Util
 import Text.EditDistance

--- a/src/Language/PureScript/Ide/Prim.hs
+++ b/src/Language/PureScript/Ide/Prim.hs
@@ -2,11 +2,11 @@ module Language.PureScript.Ide.Prim (idePrimDeclarations) where
 
 import           Protolude
 
-import qualified Data.Text as T
-import qualified Data.Map as Map
-import qualified Language.PureScript as P
-import qualified Language.PureScript.Constants.Prim as C
-import qualified Language.PureScript.Environment as PEnv
+import Data.Text qualified as T
+import Data.Map qualified as Map
+import Language.PureScript qualified as P
+import Language.PureScript.Constants.Prim qualified as C
+import Language.PureScript.Environment qualified as PEnv
 import           Language.PureScript.Ide.Types
 
 idePrimDeclarations :: ModuleMap [IdeDeclarationAnn]

--- a/src/Language/PureScript/Ide/Prim.hs
+++ b/src/Language/PureScript/Ide/Prim.hs
@@ -1,13 +1,13 @@
 module Language.PureScript.Ide.Prim (idePrimDeclarations) where
 
-import           Protolude
+import Protolude
 
 import Data.Text qualified as T
 import Data.Map qualified as Map
 import Language.PureScript qualified as P
 import Language.PureScript.Constants.Prim qualified as C
 import Language.PureScript.Environment qualified as PEnv
-import           Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Types
 
 idePrimDeclarations :: ModuleMap [IdeDeclarationAnn]
 idePrimDeclarations = Map.fromList

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -9,16 +9,16 @@ module Language.PureScript.Ide.Rebuild
 import Protolude hiding (moduleName)
 
 import           "monad-logger" Control.Monad.Logger
-import Data.List qualified                       as List
-import Data.Map.Lazy qualified                   as M
+import Data.List qualified as List
+import Data.Map.Lazy qualified as M
 import Data.Maybe                      (fromJust)
-import Data.Set qualified                        as S
-import Data.Time qualified                       as Time
-import Data.Text qualified                       as Text
-import Language.PureScript qualified             as P
+import Data.Set qualified as S
+import Data.Time qualified as Time
+import Data.Text qualified as Text
+import Language.PureScript qualified as P
 import Language.PureScript.Make (ffiCodegen')
 import Language.PureScript.Make.Cache (CacheInfo(..), normaliseForCache)
-import Language.PureScript.CST qualified         as CST
+import Language.PureScript.CST qualified as CST
 
 import Language.PureScript.Ide.Error
 import Language.PureScript.Ide.Logging

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -8,7 +8,7 @@ module Language.PureScript.Ide.Rebuild
 
 import Protolude hiding (moduleName)
 
-import           "monad-logger" Control.Monad.Logger
+import "monad-logger" Control.Monad.Logger
 import Data.List qualified as List
 import Data.Map.Lazy qualified as M
 import Data.Maybe                      (fromJust)

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -11,7 +11,7 @@ import Protolude hiding (moduleName)
 import "monad-logger" Control.Monad.Logger
 import Data.List qualified as List
 import Data.Map.Lazy qualified as M
-import Data.Maybe                      (fromJust)
+import Data.Maybe (fromJust)
 import Data.Set qualified as S
 import Data.Time qualified as Time
 import Data.Text qualified as Text

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -9,16 +9,16 @@ module Language.PureScript.Ide.Rebuild
 import           Protolude hiding (moduleName)
 
 import           "monad-logger" Control.Monad.Logger
-import qualified Data.List                       as List
-import qualified Data.Map.Lazy                   as M
+import Data.List qualified                       as List
+import Data.Map.Lazy qualified                   as M
 import           Data.Maybe                      (fromJust)
-import qualified Data.Set                        as S
-import qualified Data.Time                       as Time
-import qualified Data.Text                       as Text
-import qualified Language.PureScript             as P
+import Data.Set qualified                        as S
+import Data.Time qualified                       as Time
+import Data.Text qualified                       as Text
+import Language.PureScript qualified             as P
 import           Language.PureScript.Make (ffiCodegen')
 import           Language.PureScript.Make.Cache (CacheInfo(..), normaliseForCache)
-import qualified Language.PureScript.CST         as CST
+import Language.PureScript.CST qualified         as CST
 
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Logging

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -6,26 +6,26 @@ module Language.PureScript.Ide.Rebuild
   , rebuildFile
   ) where
 
-import           Protolude hiding (moduleName)
+import Protolude hiding (moduleName)
 
 import           "monad-logger" Control.Monad.Logger
 import Data.List qualified                       as List
 import Data.Map.Lazy qualified                   as M
-import           Data.Maybe                      (fromJust)
+import Data.Maybe                      (fromJust)
 import Data.Set qualified                        as S
 import Data.Time qualified                       as Time
 import Data.Text qualified                       as Text
 import Language.PureScript qualified             as P
-import           Language.PureScript.Make (ffiCodegen')
-import           Language.PureScript.Make.Cache (CacheInfo(..), normaliseForCache)
+import Language.PureScript.Make (ffiCodegen')
+import Language.PureScript.Make.Cache (CacheInfo(..), normaliseForCache)
 import Language.PureScript.CST qualified         as CST
 
-import           Language.PureScript.Ide.Error
-import           Language.PureScript.Ide.Logging
-import           Language.PureScript.Ide.State
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util
-import           System.Directory (getCurrentDirectory)
+import Language.PureScript.Ide.Error
+import Language.PureScript.Ide.Logging
+import Language.PureScript.Ide.State
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Util
+import System.Directory (getCurrentDirectory)
 
 -- | Given a filepath performs the following steps:
 --

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -25,8 +25,8 @@ module Language.PureScript.Ide.Reexports
 import Protolude hiding (moduleName)
 
 import Control.Lens                  hiding (anyOf, (&))
-import Data.Map qualified                      as Map
-import Language.PureScript qualified           as P
+import Data.Map qualified as Map
+import Language.PureScript qualified as P
 import Language.PureScript.Ide.Types
 import Language.PureScript.Ide.Util
 

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -25,8 +25,8 @@ module Language.PureScript.Ide.Reexports
 import           Protolude hiding (moduleName)
 
 import           Control.Lens                  hiding (anyOf, (&))
-import qualified Data.Map                      as Map
-import qualified Language.PureScript           as P
+import Data.Map qualified                      as Map
+import Language.PureScript qualified           as P
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util
 

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -22,13 +22,13 @@ module Language.PureScript.Ide.Reexports
   , resolveReexports'
   ) where
 
-import           Protolude hiding (moduleName)
+import Protolude hiding (moduleName)
 
-import           Control.Lens                  hiding (anyOf, (&))
+import Control.Lens                  hiding (anyOf, (&))
 import Data.Map qualified                      as Map
 import Language.PureScript qualified           as P
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Util
 
 -- | Contains the module with resolved reexports, and possible failures
 data ReexportResult a

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -20,15 +20,15 @@ module Language.PureScript.Ide.SourceFile
   , extractTypeAnnotations
   ) where
 
-import           Protolude
+import Protolude
 
-import           Control.Parallel.Strategies (withStrategy, parList, rseq)
+import Control.Parallel.Strategies (withStrategy, parList, rseq)
 import Data.Map qualified                      as Map
 import Language.PureScript qualified           as P
 import Language.PureScript.CST qualified       as CST
-import           Language.PureScript.Ide.Error
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Error
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Util
 
 parseModule :: FilePath -> Text -> Either FilePath (FilePath, P.Module)
 parseModule path file =

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -23,9 +23,9 @@ module Language.PureScript.Ide.SourceFile
 import           Protolude
 
 import           Control.Parallel.Strategies (withStrategy, parList, rseq)
-import qualified Data.Map                      as Map
-import qualified Language.PureScript           as P
-import qualified Language.PureScript.CST       as CST
+import Data.Map qualified                      as Map
+import Language.PureScript qualified           as P
+import Language.PureScript.CST qualified       as CST
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -23,9 +23,9 @@ module Language.PureScript.Ide.SourceFile
 import Protolude
 
 import Control.Parallel.Strategies (withStrategy, parList, rseq)
-import Data.Map qualified                      as Map
-import Language.PureScript qualified           as P
-import Language.PureScript.CST qualified       as CST
+import Data.Map qualified as Map
+import Language.PureScript qualified as P
+import Language.PureScript.CST qualified as CST
 import Language.PureScript.Ide.Error
 import Language.PureScript.Ide.Types
 import Language.PureScript.Ide.Util

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -43,10 +43,10 @@ import           Control.Concurrent.STM
 import           Control.Lens                       hiding (anyOf, op, (&))
 import           "monad-logger" Control.Monad.Logger
 import           Data.IORef
-import qualified Data.Map.Lazy                      as Map
+import Data.Map.Lazy qualified                      as Map
 import           Data.Time.Clock (UTCTime)
 import           Data.Zip (unzip)
-import qualified Language.PureScript                as P
+import Language.PureScript qualified                as P
 import           Language.PureScript.Docs.Convert.Single (convertComments)
 import           Language.PureScript.Externs
 import           Language.PureScript.Make.Actions (cacheDbFile)

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -41,7 +41,7 @@ import Protolude hiding (moduleName, unzip)
 
 import Control.Concurrent.STM
 import Control.Lens                       hiding (anyOf, op, (&))
-import           "monad-logger" Control.Monad.Logger
+import "monad-logger" Control.Monad.Logger
 import Data.IORef
 import Data.Map.Lazy qualified as Map
 import Data.Time.Clock (UTCTime)

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -43,10 +43,10 @@ import Control.Concurrent.STM
 import Control.Lens                       hiding (anyOf, op, (&))
 import           "monad-logger" Control.Monad.Logger
 import Data.IORef
-import Data.Map.Lazy qualified                      as Map
+import Data.Map.Lazy qualified as Map
 import Data.Time.Clock (UTCTime)
 import Data.Zip (unzip)
-import Language.PureScript qualified                as P
+import Language.PureScript qualified as P
 import Language.PureScript.Docs.Convert.Single (convertComments)
 import Language.PureScript.Externs
 import Language.PureScript.Make.Actions (cacheDbFile)

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -37,25 +37,25 @@ module Language.PureScript.Ide.State
   , resolveDataConstructorsForModule
   ) where
 
-import           Protolude hiding (moduleName, unzip)
+import Protolude hiding (moduleName, unzip)
 
-import           Control.Concurrent.STM
-import           Control.Lens                       hiding (anyOf, op, (&))
+import Control.Concurrent.STM
+import Control.Lens                       hiding (anyOf, op, (&))
 import           "monad-logger" Control.Monad.Logger
-import           Data.IORef
+import Data.IORef
 import Data.Map.Lazy qualified                      as Map
-import           Data.Time.Clock (UTCTime)
-import           Data.Zip (unzip)
+import Data.Time.Clock (UTCTime)
+import Data.Zip (unzip)
 import Language.PureScript qualified                as P
-import           Language.PureScript.Docs.Convert.Single (convertComments)
-import           Language.PureScript.Externs
-import           Language.PureScript.Make.Actions (cacheDbFile)
-import           Language.PureScript.Ide.Externs
-import           Language.PureScript.Ide.Reexports
-import           Language.PureScript.Ide.SourceFile
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util
-import           System.Directory (getModificationTime)
+import Language.PureScript.Docs.Convert.Single (convertComments)
+import Language.PureScript.Externs
+import Language.PureScript.Make.Actions (cacheDbFile)
+import Language.PureScript.Ide.Externs
+import Language.PureScript.Ide.Reexports
+import Language.PureScript.Ide.SourceFile
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Util
+import System.Directory (getModificationTime)
 
 -- | Resets all State inside psc-ide
 resetIdeState :: Ide m => m ()

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -11,12 +11,12 @@ import           Control.Concurrent.STM (TVar)
 import           Control.Lens hiding (op, (.=))
 import           Control.Monad.Fail (fail)
 import           Data.Aeson (ToJSON, FromJSON, (.=))
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import           Data.IORef (IORef)
 import           Data.Time.Clock (UTCTime)
-import qualified Data.Map.Lazy as M
-import qualified Language.PureScript as P
-import qualified Language.PureScript.Errors.JSON as P
+import Data.Map.Lazy qualified as M
+import Language.PureScript qualified as P
+import Language.PureScript.Errors.JSON qualified as P
 import           Language.PureScript.Ide.Filter.Declaration (DeclarationType(..))
 
 type ModuleIdent = Text

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -5,19 +5,19 @@
 
 module Language.PureScript.Ide.Types where
 
-import           Protolude hiding (moduleName)
+import Protolude hiding (moduleName)
 
-import           Control.Concurrent.STM (TVar)
-import           Control.Lens hiding (op, (.=))
-import           Control.Monad.Fail (fail)
-import           Data.Aeson (ToJSON, FromJSON, (.=))
+import Control.Concurrent.STM (TVar)
+import Control.Lens hiding (op, (.=))
+import Control.Monad.Fail (fail)
+import Data.Aeson (ToJSON, FromJSON, (.=))
 import Data.Aeson qualified as Aeson
-import           Data.IORef (IORef)
-import           Data.Time.Clock (UTCTime)
+import Data.IORef (IORef)
+import Data.Time.Clock (UTCTime)
 import Data.Map.Lazy qualified as M
 import Language.PureScript qualified as P
 import Language.PureScript.Errors.JSON qualified as P
-import           Language.PureScript.Ide.Filter.Declaration (DeclarationType(..))
+import Language.PureScript.Ide.Filter.Declaration (DeclarationType(..))
 
 type ModuleIdent = Text
 type ModuleMap a = Map P.ModuleName a

--- a/src/Language/PureScript/Ide/Usage.hs
+++ b/src/Language/PureScript/Ide/Usage.hs
@@ -9,9 +9,9 @@ module Language.PureScript.Ide.Usage
 import           Protolude hiding (moduleName)
 
 import           Control.Lens (preview)
-import qualified Data.Map as Map
-import qualified Data.Set as Set
-import qualified Language.PureScript as P
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Language.PureScript qualified as P
 import           Language.PureScript.Ide.State (getAllModules, getFileState)
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util

--- a/src/Language/PureScript/Ide/Usage.hs
+++ b/src/Language/PureScript/Ide/Usage.hs
@@ -6,15 +6,15 @@ module Language.PureScript.Ide.Usage
   , findUsages
   ) where
 
-import           Protolude hiding (moduleName)
+import Protolude hiding (moduleName)
 
-import           Control.Lens (preview)
+import Control.Lens (preview)
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Language.PureScript qualified as P
-import           Language.PureScript.Ide.State (getAllModules, getFileState)
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util
+import Language.PureScript.Ide.State (getAllModules, getFileState)
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Util
 
 -- |
 -- How we find usages, given an IdeDeclaration and the module it was defined in:

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -34,10 +34,10 @@ import           Protolude                           hiding (decodeUtf8,
 
 import           Control.Lens                        hiding (op, (&))
 import           Data.Aeson
-import qualified Data.Text                           as T
-import qualified Data.Text.Lazy                      as TL
+import Data.Text qualified                           as T
+import Data.Text.Lazy qualified                      as TL
 import           Data.Text.Lazy.Encoding             as TLE
-import qualified Language.PureScript                 as P
+import Language.PureScript qualified                 as P
 import           Language.PureScript.Ide.Error       (IdeError(..))
 import           Language.PureScript.Ide.Logging
 import           Language.PureScript.Ide.Types

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -34,10 +34,10 @@ import Protolude                           hiding (decodeUtf8,
 
 import Control.Lens                        hiding (op, (&))
 import Data.Aeson
-import Data.Text qualified                           as T
-import Data.Text.Lazy qualified                      as TL
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding             as TLE
-import Language.PureScript qualified                 as P
+import Language.PureScript qualified as P
 import Language.PureScript.Ide.Error       (IdeError(..))
 import Language.PureScript.Ide.Logging
 import Language.PureScript.Ide.Types

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -38,11 +38,11 @@ import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding             as TLE
 import Language.PureScript qualified as P
-import Language.PureScript.Ide.Error       (IdeError(..))
+import Language.PureScript.Ide.Error (IdeError(..))
 import Language.PureScript.Ide.Logging
 import Language.PureScript.Ide.Types
-import System.IO.UTF8                      (readUTF8FileT)
-import System.Directory                    (makeAbsolute)
+import System.IO.UTF8 (readUTF8FileT)
+import System.Directory (makeAbsolute)
 
 identifierFromIdeDeclaration :: IdeDeclaration -> Text
 identifierFromIdeDeclaration d = case d of

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -29,20 +29,20 @@ module Language.PureScript.Ide.Util
   , module Language.PureScript.Ide.Logging
   ) where
 
-import           Protolude                           hiding (decodeUtf8,
+import Protolude                           hiding (decodeUtf8,
                                                       encodeUtf8, to)
 
-import           Control.Lens                        hiding (op, (&))
-import           Data.Aeson
+import Control.Lens                        hiding (op, (&))
+import Data.Aeson
 import Data.Text qualified                           as T
 import Data.Text.Lazy qualified                      as TL
-import           Data.Text.Lazy.Encoding             as TLE
+import Data.Text.Lazy.Encoding             as TLE
 import Language.PureScript qualified                 as P
-import           Language.PureScript.Ide.Error       (IdeError(..))
-import           Language.PureScript.Ide.Logging
-import           Language.PureScript.Ide.Types
-import           System.IO.UTF8                      (readUTF8FileT)
-import           System.Directory                    (makeAbsolute)
+import Language.PureScript.Ide.Error       (IdeError(..))
+import Language.PureScript.Ide.Logging
+import Language.PureScript.Ide.Types
+import System.IO.UTF8                      (readUTF8FileT)
+import System.Directory                    (makeAbsolute)
 
 identifierFromIdeDeclaration :: IdeDeclaration -> Text
 identifierFromIdeDeclaration d = case d of

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -14,10 +14,10 @@ import           Protolude (ordNub)
 
 import           Data.List (sort, find, foldl')
 import           Data.Maybe (fromMaybe, mapMaybe)
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.Map qualified as M
+import Data.Set qualified as S
 import           Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.State.Class
@@ -26,10 +26,10 @@ import           Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 import           Control.Monad.Trans.State.Strict (StateT, runStateT, evalStateT)
 import           Control.Monad.Writer.Strict (Writer(), runWriter)
 
-import qualified Language.PureScript as P
-import qualified Language.PureScript.CST as CST
-import qualified Language.PureScript.Names as N
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript qualified as P
+import Language.PureScript.CST qualified as CST
+import Language.PureScript.Names qualified as N
+import Language.PureScript.Constants.Prim qualified as C
 
 import           Language.PureScript.Interactive.Completion   as Interactive
 import           Language.PureScript.Interactive.IO           as Interactive

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -9,39 +9,39 @@ module Language.PureScript.Interactive
   , runMake
   ) where
 
-import           Prelude
-import           Protolude (ordNub)
+import Prelude
+import Protolude (ordNub)
 
-import           Data.List (sort, find, foldl')
-import           Data.Maybe (fromMaybe, mapMaybe)
+import Data.List (sort, find, foldl')
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Map qualified as M
 import Data.Set qualified as S
-import           Data.Text (Text)
+import Data.Text (Text)
 import Data.Text qualified as T
 
-import           Control.Monad.IO.Class (MonadIO, liftIO)
-import           Control.Monad.State.Class
-import           Control.Monad.Reader.Class
-import           Control.Monad.Trans.Except (ExceptT(..), runExceptT)
-import           Control.Monad.Trans.State.Strict (StateT, runStateT, evalStateT)
-import           Control.Monad.Writer.Strict (Writer(), runWriter)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.State.Class
+import Control.Monad.Reader.Class
+import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
+import Control.Monad.Trans.State.Strict (StateT, runStateT, evalStateT)
+import Control.Monad.Writer.Strict (Writer(), runWriter)
 
 import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
 import Language.PureScript.Names qualified as N
 import Language.PureScript.Constants.Prim qualified as C
 
-import           Language.PureScript.Interactive.Completion   as Interactive
-import           Language.PureScript.Interactive.IO           as Interactive
-import           Language.PureScript.Interactive.Message      as Interactive
-import           Language.PureScript.Interactive.Module       as Interactive
-import           Language.PureScript.Interactive.Parser       as Interactive
-import           Language.PureScript.Interactive.Printer      as Interactive
-import           Language.PureScript.Interactive.Types        as Interactive
+import Language.PureScript.Interactive.Completion   as Interactive
+import Language.PureScript.Interactive.IO           as Interactive
+import Language.PureScript.Interactive.Message      as Interactive
+import Language.PureScript.Interactive.Module       as Interactive
+import Language.PureScript.Interactive.Parser       as Interactive
+import Language.PureScript.Interactive.Printer      as Interactive
+import Language.PureScript.Interactive.Types        as Interactive
 
-import           System.Directory (getCurrentDirectory)
-import           System.FilePath ((</>))
-import           System.FilePath.Glob (glob)
+import System.Directory (getCurrentDirectory)
+import System.FilePath ((</>))
+import System.FilePath.Glob (glob)
 
 -- | Pretty-print errors
 printErrors :: MonadIO m => P.MultipleErrors -> m ()

--- a/src/Language/PureScript/Interactive/Completion.hs
+++ b/src/Language/PureScript/Interactive/Completion.hs
@@ -15,9 +15,9 @@ import           Control.Monad.Trans.Reader (asks, runReaderT, ReaderT)
 import           Data.List (nub, isPrefixOf, isInfixOf, isSuffixOf, sortBy, stripPrefix)
 import           Data.Map (keys)
 import           Data.Maybe (mapMaybe)
-import qualified Data.Text as T
-import qualified Language.PureScript as P
-import qualified Language.PureScript.Interactive.Directive as D
+import Data.Text qualified as T
+import Language.PureScript qualified as P
+import Language.PureScript.Interactive.Directive qualified as D
 import           Language.PureScript.Interactive.Types
 import           System.Console.Haskeline
 

--- a/src/Language/PureScript/Interactive/Completion.hs
+++ b/src/Language/PureScript/Interactive/Completion.hs
@@ -9,17 +9,17 @@ module Language.PureScript.Interactive.Completion
 import Prelude
 import Protolude (ordNub)
 
-import           Control.Monad.IO.Class (MonadIO(..))
-import           Control.Monad.State.Class (MonadState(..))
-import           Control.Monad.Trans.Reader (asks, runReaderT, ReaderT)
-import           Data.List (nub, isPrefixOf, isInfixOf, isSuffixOf, sortBy, stripPrefix)
-import           Data.Map (keys)
-import           Data.Maybe (mapMaybe)
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.State.Class (MonadState(..))
+import Control.Monad.Trans.Reader (asks, runReaderT, ReaderT)
+import Data.List (nub, isPrefixOf, isInfixOf, isSuffixOf, sortBy, stripPrefix)
+import Data.Map (keys)
+import Data.Maybe (mapMaybe)
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.Interactive.Directive qualified as D
-import           Language.PureScript.Interactive.Types
-import           System.Console.Haskeline
+import Language.PureScript.Interactive.Types
+import System.Console.Haskeline
 
 -- Completions may read the state, but not modify it.
 type CompletionM = ReaderT PSCiState IO

--- a/src/Language/PureScript/Interactive/Message.hs
+++ b/src/Language/PureScript/Interactive/Message.hs
@@ -4,7 +4,7 @@ import Prelude
 
 import Data.List (intercalate)
 import Data.Version (showVersion)
-import Paths qualified_purescript as Paths
+import Paths_purescript qualified as Paths
 import Language.PureScript.Interactive.Directive qualified as D
 import Language.PureScript.Interactive.Types
 

--- a/src/Language/PureScript/Interactive/Message.hs
+++ b/src/Language/PureScript/Interactive/Message.hs
@@ -4,7 +4,7 @@ import           Prelude
 
 import           Data.List (intercalate)
 import           Data.Version (showVersion)
-import qualified Paths_purescript as Paths
+import Paths qualified_purescript as Paths
 import Language.PureScript.Interactive.Directive qualified as D
 import           Language.PureScript.Interactive.Types
 

--- a/src/Language/PureScript/Interactive/Message.hs
+++ b/src/Language/PureScript/Interactive/Message.hs
@@ -1,12 +1,12 @@
 module Language.PureScript.Interactive.Message where
 
-import           Prelude
+import Prelude
 
-import           Data.List (intercalate)
-import           Data.Version (showVersion)
+import Data.List (intercalate)
+import Data.Version (showVersion)
 import Paths qualified_purescript as Paths
 import Language.PureScript.Interactive.Directive qualified as D
-import           Language.PureScript.Interactive.Types
+import Language.PureScript.Interactive.Types
 
 -- Messages
 

--- a/src/Language/PureScript/Interactive/Message.hs
+++ b/src/Language/PureScript/Interactive/Message.hs
@@ -5,7 +5,7 @@ import           Prelude
 import           Data.List (intercalate)
 import           Data.Version (showVersion)
 import qualified Paths_purescript as Paths
-import qualified Language.PureScript.Interactive.Directive as D
+import Language.PureScript.Interactive.Directive qualified as D
 import           Language.PureScript.Interactive.Types
 
 -- Messages

--- a/src/Language/PureScript/Interactive/Module.hs
+++ b/src/Language/PureScript/Interactive/Module.hs
@@ -2,8 +2,8 @@ module Language.PureScript.Interactive.Module where
 
 import           Prelude
 
-import qualified Language.PureScript as P
-import qualified Language.PureScript.CST as CST
+import Language.PureScript qualified as P
+import Language.PureScript.CST qualified as CST
 import           Language.PureScript.Interactive.Types
 import           System.Directory (getCurrentDirectory)
 import           System.FilePath (pathSeparator, makeRelative)

--- a/src/Language/PureScript/Interactive/Module.hs
+++ b/src/Language/PureScript/Interactive/Module.hs
@@ -1,13 +1,13 @@
 module Language.PureScript.Interactive.Module where
 
-import           Prelude
+import Prelude
 
 import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
-import           Language.PureScript.Interactive.Types
-import           System.Directory (getCurrentDirectory)
-import           System.FilePath (pathSeparator, makeRelative)
-import           System.IO.UTF8 (readUTF8FilesT)
+import Language.PureScript.Interactive.Types
+import System.Directory (getCurrentDirectory)
+import System.FilePath (pathSeparator, makeRelative)
+import System.IO.UTF8 (readUTF8FilesT)
 
 -- * Support Module
 

--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -12,12 +12,12 @@ import           Control.Monad (join)
 import           Data.Bifunctor (bimap)
 import           Data.Char (isSpace)
 import           Data.List (intercalate)
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Text as T
-import qualified Language.PureScript as P
-import qualified Language.PureScript.CST as CST
-import qualified Language.PureScript.CST.Monad as CSTM
-import qualified Language.PureScript.Interactive.Directive as D
+import Data.List.NonEmpty qualified as NE
+import Data.Text qualified as T
+import Language.PureScript qualified as P
+import Language.PureScript.CST qualified as CST
+import Language.PureScript.CST.Monad qualified as CSTM
+import Language.PureScript.Interactive.Directive qualified as D
 import           Language.PureScript.Interactive.Types
 
 -- |

--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -6,19 +6,19 @@ module Language.PureScript.Interactive.Parser
   , parseCommand
   ) where
 
-import           Prelude
+import Prelude
 
-import           Control.Monad (join)
-import           Data.Bifunctor (bimap)
-import           Data.Char (isSpace)
-import           Data.List (intercalate)
+import Control.Monad (join)
+import Data.Bifunctor (bimap)
+import Data.Char (isSpace)
+import Data.List (intercalate)
 import Data.List.NonEmpty qualified as NE
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
 import Language.PureScript.CST.Monad qualified as CSTM
 import Language.PureScript.Interactive.Directive qualified as D
-import           Language.PureScript.Interactive.Types
+import Language.PureScript.Interactive.Types
 
 -- |
 -- Parses a limited set of commands from from .purs-repl

--- a/src/Language/PureScript/Interactive/Printer.hs
+++ b/src/Language/PureScript/Interactive/Printer.hs
@@ -1,12 +1,12 @@
 module Language.PureScript.Interactive.Printer where
 
-import           Prelude
+import Prelude
 
-import           Data.List (intersperse)
+import Data.List (intersperse)
 import Data.Map qualified as M
-import           Data.Maybe (mapMaybe)
+import Data.Maybe (mapMaybe)
 import Data.Text qualified as T
-import           Data.Text (Text)
+import Data.Text (Text)
 import Language.PureScript qualified as P
 import Text.PrettyPrint.Boxes qualified as Box
 

--- a/src/Language/PureScript/Interactive/Printer.hs
+++ b/src/Language/PureScript/Interactive/Printer.hs
@@ -3,12 +3,12 @@ module Language.PureScript.Interactive.Printer where
 import           Prelude
 
 import           Data.List (intersperse)
-import qualified Data.Map as M
+import Data.Map qualified as M
 import           Data.Maybe (mapMaybe)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import           Data.Text (Text)
-import qualified Language.PureScript as P
-import qualified Text.PrettyPrint.Boxes as Box
+import Language.PureScript qualified as P
+import Text.PrettyPrint.Boxes qualified as Box
 
 -- TODO (Christoph): Text version of boxes
 textT :: Text -> Box.Box

--- a/src/Language/PureScript/Interactive/Types.hs
+++ b/src/Language/PureScript/Interactive/Types.hs
@@ -30,8 +30,8 @@ module Language.PureScript.Interactive.Types
 
 import Prelude
 
-import qualified Language.PureScript as P
-import qualified Data.Map as M
+import Language.PureScript qualified as P
+import Data.Map qualified as M
 import           Data.List (foldl')
 import           Language.PureScript.Sugar.Names.Env (nullImports, primExports)
 import           Control.Monad (foldM)

--- a/src/Language/PureScript/Interactive/Types.hs
+++ b/src/Language/PureScript/Interactive/Types.hs
@@ -32,12 +32,12 @@ import Prelude
 
 import Language.PureScript qualified as P
 import Data.Map qualified as M
-import           Data.List (foldl')
-import           Language.PureScript.Sugar.Names.Env (nullImports, primExports)
-import           Control.Monad (foldM)
-import           Control.Monad.Trans.Except (runExceptT)
-import           Control.Monad.Trans.State (execStateT)
-import           Control.Monad.Writer.Strict (runWriterT)
+import Data.List (foldl')
+import Language.PureScript.Sugar.Names.Env (nullImports, primExports)
+import Control.Monad (foldM)
+import Control.Monad.Trans.Except (runExceptT)
+import Control.Monad.Trans.State (execStateT)
+import Control.Monad.Writer.Strict (runWriterT)
 
 
 -- | The PSCI configuration.

--- a/src/Language/PureScript/Label.hs
+++ b/src/Language/PureScript/Label.hs
@@ -6,7 +6,7 @@ import Codec.Serialise (Serialise)
 import Control.DeepSeq (NFData)
 import Data.Monoid ()
 import Data.String (IsString(..))
-import qualified Data.Aeson as A
+import Data.Aeson qualified as A
 
 import Language.PureScript.PSString (PSString)
 

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -8,9 +8,9 @@ import Prelude
 import Control.Monad.Writer.Class
 
 import Data.Maybe (mapMaybe)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Control.Monad ((<=<))
 
 import Language.PureScript.AST
@@ -19,7 +19,7 @@ import Language.PureScript.Linter.Exhaustive as L
 import Language.PureScript.Linter.Imports as L
 import Language.PureScript.Names
 import Language.PureScript.Types
-import qualified Language.PureScript.Constants.Libs as C
+import Language.PureScript.Constants.Libs qualified as C
 
 -- | Lint the PureScript AST.
 -- |

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -18,8 +18,8 @@ import Control.Monad.Writer.Class
 
 import Data.List (foldl', sortOn)
 import Data.Maybe (fromMaybe)
-import qualified Data.Map as M
-import qualified Data.Text as T
+import Data.Map qualified as M
+import Data.Text qualified as T
 
 import Language.PureScript.AST.Binders
 import Language.PureScript.AST.Declarations
@@ -31,7 +31,7 @@ import Language.PureScript.Names as P
 import Language.PureScript.Pretty.Values (prettyPrintBinderAtom)
 import Language.PureScript.Traversals
 import Language.PureScript.Types as P
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Prim qualified as C
 
 -- | There are two modes of failure for the redundancy check:
 --

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -16,8 +16,8 @@ import Data.List (find, intersect, groupBy, sort, sortOn, (\\))
 import Data.Maybe (mapMaybe)
 import Data.Monoid (Sum(..))
 import Data.Traversable (forM)
-import qualified Data.Text as T
-import qualified Data.Map as M
+import Data.Text qualified as T
+import Data.Map qualified as M
 
 import Language.PureScript.AST.Declarations
 import Language.PureScript.AST.SourcePos
@@ -27,7 +27,7 @@ import Language.PureScript.Names
 import Language.PureScript.Sugar.Names.Common (warnDuplicateRefs)
 import Language.PureScript.Sugar.Names.Env
 import Language.PureScript.Sugar.Names.Imports
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Prim qualified as C
 
 -- |
 -- Map of module name to list of imported names from that module which have

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -9,47 +9,47 @@ module Language.PureScript.Make
   , module Actions
   ) where
 
-import           Prelude
+import Prelude
 
-import           Control.Concurrent.Lifted as C
-import           Control.Exception.Base (onException)
-import           Control.Monad hiding (sequence)
-import           Control.Monad.Error.Class (MonadError(..))
-import           Control.Monad.IO.Class
-import           Control.Monad.Supply
-import           Control.Monad.Trans.Control (MonadBaseControl(..), control)
-import           Control.Monad.Trans.State (runStateT)
-import           Control.Monad.Writer.Class (MonadWriter(..), censor)
-import           Control.Monad.Writer.Strict (runWriterT)
-import           Data.Function (on)
-import           Data.Foldable (fold, for_)
-import           Data.List (foldl', sortOn)
+import Control.Concurrent.Lifted as C
+import Control.Exception.Base (onException)
+import Control.Monad hiding (sequence)
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.IO.Class
+import Control.Monad.Supply
+import Control.Monad.Trans.Control (MonadBaseControl(..), control)
+import Control.Monad.Trans.State (runStateT)
+import Control.Monad.Writer.Class (MonadWriter(..), censor)
+import Control.Monad.Writer.Strict (runWriterT)
+import Data.Function (on)
+import Data.Foldable (fold, for_)
+import Data.List (foldl', sortOn)
 import Data.List.NonEmpty qualified as NEL
-import           Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe)
 import Data.Map qualified as M
 import Data.Set qualified as S
 import Data.Text qualified as T
-import           Language.PureScript.AST
-import           Language.PureScript.Crash
+import Language.PureScript.AST
+import Language.PureScript.Crash
 import Language.PureScript.CST qualified as CST
 import Language.PureScript.Docs.Convert qualified as Docs
-import           Language.PureScript.Environment
-import           Language.PureScript.Errors
-import           Language.PureScript.Externs
-import           Language.PureScript.Linter
-import           Language.PureScript.ModuleDependencies
-import           Language.PureScript.Names
-import           Language.PureScript.Renamer
-import           Language.PureScript.Sugar
-import           Language.PureScript.TypeChecker
-import           Language.PureScript.Make.BuildPlan
+import Language.PureScript.Environment
+import Language.PureScript.Errors
+import Language.PureScript.Externs
+import Language.PureScript.Linter
+import Language.PureScript.ModuleDependencies
+import Language.PureScript.Names
+import Language.PureScript.Renamer
+import Language.PureScript.Sugar
+import Language.PureScript.TypeChecker
+import Language.PureScript.Make.BuildPlan
 import Language.PureScript.Make.BuildPlan qualified as BuildPlan
 import Language.PureScript.Make.Cache qualified as Cache
-import           Language.PureScript.Make.Actions as Actions
-import           Language.PureScript.Make.Monad as Monad
+import Language.PureScript.Make.Actions as Actions
+import Language.PureScript.Make.Monad as Monad
 import Language.PureScript.CoreFn qualified as CF
-import           System.Directory (doesFileExist)
-import           System.FilePath (replaceExtension)
+import System.Directory (doesFileExist)
+import System.FilePath (replaceExtension)
 
 -- | Rebuild a single module.
 --

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -24,15 +24,15 @@ import           Control.Monad.Writer.Strict (runWriterT)
 import           Data.Function (on)
 import           Data.Foldable (fold, for_)
 import           Data.List (foldl', sortOn)
-import qualified Data.List.NonEmpty as NEL
+import Data.List.NonEmpty qualified as NEL
 import           Data.Maybe (fromMaybe)
-import qualified Data.Map as M
-import qualified Data.Set as S
-import qualified Data.Text as T
+import Data.Map qualified as M
+import Data.Set qualified as S
+import Data.Text qualified as T
 import           Language.PureScript.AST
 import           Language.PureScript.Crash
-import qualified Language.PureScript.CST as CST
-import qualified Language.PureScript.Docs.Convert as Docs
+import Language.PureScript.CST qualified as CST
+import Language.PureScript.Docs.Convert qualified as Docs
 import           Language.PureScript.Environment
 import           Language.PureScript.Errors
 import           Language.PureScript.Externs
@@ -43,11 +43,11 @@ import           Language.PureScript.Renamer
 import           Language.PureScript.Sugar
 import           Language.PureScript.TypeChecker
 import           Language.PureScript.Make.BuildPlan
-import qualified Language.PureScript.Make.BuildPlan as BuildPlan
-import qualified Language.PureScript.Make.Cache as Cache
+import Language.PureScript.Make.BuildPlan qualified as BuildPlan
+import Language.PureScript.Make.Cache qualified as Cache
 import           Language.PureScript.Make.Actions as Actions
 import           Language.PureScript.Make.Monad as Monad
-import qualified Language.PureScript.CoreFn as CF
+import Language.PureScript.CoreFn qualified as CF
 import           System.Directory (doesFileExist)
 import           System.FilePath (replaceExtension)
 

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -51,7 +51,7 @@ import           Language.PureScript.Make.Cache
 import           Language.PureScript.Names
 import           Language.PureScript.Options hiding (codegenTargets)
 import           Language.PureScript.Pretty.Common (SMap(..))
-import qualified Paths_purescript as Paths
+import Paths qualified_purescript as Paths
 import           SourceMap
 import           SourceMap.Types
 import           System.Directory (getCurrentDirectory)

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -24,26 +24,26 @@ import           Data.Aeson (Value(String), (.=), object)
 import           Data.Bifunctor (bimap, first)
 import           Data.Either (partitionEithers)
 import           Data.Foldable (for_)
-import qualified Data.List.NonEmpty as NEL
-import qualified Data.Map as M
+import Data.List.NonEmpty qualified as NEL
+import Data.Map qualified as M
 import           Data.Maybe (fromMaybe, maybeToList)
-import qualified Data.Set as S
-import qualified Data.Text as T
-import qualified Data.Text.IO as TIO
-import qualified Data.Text.Encoding as TE
+import Data.Set qualified as S
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+import Data.Text.Encoding qualified as TE
 import           Data.Time.Clock (UTCTime)
 import           Data.Version (showVersion)
-import qualified Language.JavaScript.Parser as JS
+import Language.JavaScript.Parser qualified as JS
 import           Language.PureScript.AST
-import qualified Language.PureScript.Bundle as Bundle
-import qualified Language.PureScript.CodeGen.JS as J
+import Language.PureScript.Bundle qualified as Bundle
+import Language.PureScript.CodeGen.JS qualified as J
 import           Language.PureScript.CodeGen.JS.Printer
-import qualified Language.PureScript.CoreFn as CF
-import qualified Language.PureScript.CoreFn.ToJSON as CFJ
+import Language.PureScript.CoreFn qualified as CF
+import Language.PureScript.CoreFn.ToJSON qualified as CFJ
 import           Language.PureScript.Crash
-import qualified Language.PureScript.CST as CST
-import qualified Language.PureScript.Docs.Prim as Docs.Prim
-import qualified Language.PureScript.Docs.Types as Docs
+import Language.PureScript.CST qualified as CST
+import Language.PureScript.Docs.Prim qualified as Docs.Prim
+import Language.PureScript.Docs.Types qualified as Docs
 import           Language.PureScript.Errors
 import           Language.PureScript.Externs (ExternsFile, externsFileName)
 import           Language.PureScript.Make.Monad
@@ -56,7 +56,7 @@ import           SourceMap
 import           SourceMap.Types
 import           System.Directory (getCurrentDirectory)
 import           System.FilePath ((</>), makeRelative, splitPath, normalise, splitDirectories)
-import qualified System.FilePath.Posix as Posix
+import System.FilePath.Posix qualified as Posix
 import           System.IO (stderr)
 
 -- | Determines when to rebuild a module

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -11,53 +11,53 @@ module Language.PureScript.Make.Actions
   , ffiCodegen'
   ) where
 
-import           Prelude
+import Prelude
 
-import           Control.Monad hiding (sequence)
-import           Control.Monad.Error.Class (MonadError(..))
-import           Control.Monad.IO.Class
-import           Control.Monad.Reader (asks)
-import           Control.Monad.Supply
-import           Control.Monad.Trans.Class (MonadTrans(..))
-import           Control.Monad.Writer.Class (MonadWriter(..))
-import           Data.Aeson (Value(String), (.=), object)
-import           Data.Bifunctor (bimap, first)
-import           Data.Either (partitionEithers)
-import           Data.Foldable (for_)
+import Control.Monad hiding (sequence)
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.IO.Class
+import Control.Monad.Reader (asks)
+import Control.Monad.Supply
+import Control.Monad.Trans.Class (MonadTrans(..))
+import Control.Monad.Writer.Class (MonadWriter(..))
+import Data.Aeson (Value(String), (.=), object)
+import Data.Bifunctor (bimap, first)
+import Data.Either (partitionEithers)
+import Data.Foldable (for_)
 import Data.List.NonEmpty qualified as NEL
 import Data.Map qualified as M
-import           Data.Maybe (fromMaybe, maybeToList)
+import Data.Maybe (fromMaybe, maybeToList)
 import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
 import Data.Text.Encoding qualified as TE
-import           Data.Time.Clock (UTCTime)
-import           Data.Version (showVersion)
+import Data.Time.Clock (UTCTime)
+import Data.Version (showVersion)
 import Language.JavaScript.Parser qualified as JS
-import           Language.PureScript.AST
+import Language.PureScript.AST
 import Language.PureScript.Bundle qualified as Bundle
 import Language.PureScript.CodeGen.JS qualified as J
-import           Language.PureScript.CodeGen.JS.Printer
+import Language.PureScript.CodeGen.JS.Printer
 import Language.PureScript.CoreFn qualified as CF
 import Language.PureScript.CoreFn.ToJSON qualified as CFJ
-import           Language.PureScript.Crash
+import Language.PureScript.Crash
 import Language.PureScript.CST qualified as CST
 import Language.PureScript.Docs.Prim qualified as Docs.Prim
 import Language.PureScript.Docs.Types qualified as Docs
-import           Language.PureScript.Errors
-import           Language.PureScript.Externs (ExternsFile, externsFileName)
-import           Language.PureScript.Make.Monad
-import           Language.PureScript.Make.Cache
-import           Language.PureScript.Names
-import           Language.PureScript.Options hiding (codegenTargets)
-import           Language.PureScript.Pretty.Common (SMap(..))
+import Language.PureScript.Errors
+import Language.PureScript.Externs (ExternsFile, externsFileName)
+import Language.PureScript.Make.Monad
+import Language.PureScript.Make.Cache
+import Language.PureScript.Names
+import Language.PureScript.Options hiding (codegenTargets)
+import Language.PureScript.Pretty.Common (SMap(..))
 import Paths qualified_purescript as Paths
-import           SourceMap
-import           SourceMap.Types
-import           System.Directory (getCurrentDirectory)
-import           System.FilePath ((</>), makeRelative, splitPath, normalise, splitDirectories)
+import SourceMap
+import SourceMap.Types
+import System.Directory (getCurrentDirectory)
+import System.FilePath ((</>), makeRelative, splitPath, normalise, splitDirectories)
 import System.FilePath.Posix qualified as Posix
-import           System.IO (stderr)
+import System.IO (stderr)
 
 -- | Determines when to rebuild a module
 data RebuildPolicy

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -51,7 +51,7 @@ import Language.PureScript.Make.Cache
 import Language.PureScript.Names
 import Language.PureScript.Options hiding (codegenTargets)
 import Language.PureScript.Pretty.Common (SMap(..))
-import Paths qualified_purescript as Paths
+import Paths_purescript qualified as Paths
 import SourceMap
 import SourceMap.Types
 import System.Directory (getCurrentDirectory)

--- a/src/Language/PureScript/Make/BuildPlan.hs
+++ b/src/Language/PureScript/Make/BuildPlan.hs
@@ -9,28 +9,28 @@ module Language.PureScript.Make.BuildPlan
   , needsRebuild
   ) where
 
-import           Prelude
+import Prelude
 
-import           Control.Concurrent.Async.Lifted as A
-import           Control.Concurrent.Lifted as C
-import           Control.Monad.Base (liftBase)
-import           Control.Monad hiding (sequence)
-import           Control.Monad.Trans.Control (MonadBaseControl(..))
-import           Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
-import           Data.Foldable (foldl')
+import Control.Concurrent.Async.Lifted as A
+import Control.Concurrent.Lifted as C
+import Control.Monad.Base (liftBase)
+import Control.Monad hiding (sequence)
+import Control.Monad.Trans.Control (MonadBaseControl(..))
+import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
+import Data.Foldable (foldl')
 import Data.Map qualified as M
-import           Data.Maybe (fromMaybe, mapMaybe)
-import           Data.Time.Clock (UTCTime)
-import           Language.PureScript.AST
-import           Language.PureScript.Crash
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Time.Clock (UTCTime)
+import Language.PureScript.AST
+import Language.PureScript.Crash
 import Language.PureScript.CST qualified as CST
-import           Language.PureScript.Errors
-import           Language.PureScript.Externs
-import           Language.PureScript.Make.Actions as Actions
-import           Language.PureScript.Make.Cache
-import           Language.PureScript.Names (ModuleName)
-import           Language.PureScript.Sugar.Names.Env
-import           System.Directory (getCurrentDirectory)
+import Language.PureScript.Errors
+import Language.PureScript.Externs
+import Language.PureScript.Make.Actions as Actions
+import Language.PureScript.Make.Cache
+import Language.PureScript.Names (ModuleName)
+import Language.PureScript.Sugar.Names.Env
+import System.Directory (getCurrentDirectory)
 
 -- | The BuildPlan tracks information about our build progress, and holds all
 -- prebuilt modules for incremental builds.

--- a/src/Language/PureScript/Make/BuildPlan.hs
+++ b/src/Language/PureScript/Make/BuildPlan.hs
@@ -18,12 +18,12 @@ import           Control.Monad hiding (sequence)
 import           Control.Monad.Trans.Control (MonadBaseControl(..))
 import           Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 import           Data.Foldable (foldl')
-import qualified Data.Map as M
+import Data.Map qualified as M
 import           Data.Maybe (fromMaybe, mapMaybe)
 import           Data.Time.Clock (UTCTime)
 import           Language.PureScript.AST
 import           Language.PureScript.Crash
-import qualified Language.PureScript.CST as CST
+import Language.PureScript.CST qualified as CST
 import           Language.PureScript.Errors
 import           Language.PureScript.Externs
 import           Language.PureScript.Make.Actions as Actions

--- a/src/Language/PureScript/Make/Cache.hs
+++ b/src/Language/PureScript/Make/Cache.hs
@@ -13,13 +13,13 @@ import Prelude
 import Control.Category ((>>>))
 import Control.Monad ((>=>))
 import Crypto.Hash (HashAlgorithm, Digest, SHA512)
-import qualified Crypto.Hash as Hash
-import qualified Data.Aeson as Aeson
+import Crypto.Hash qualified as Hash
+import Data.Aeson qualified as Aeson
 import Data.Align (align)
 import Data.ByteArray.Encoding (Base(Base16), convertToBase, convertFromBase)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Monoid (All(..))
 import Data.Set (Set)
@@ -28,7 +28,7 @@ import Data.Text.Encoding (encodeUtf8, decodeUtf8)
 import Data.These (These(..))
 import Data.Time.Clock (UTCTime)
 import Data.Traversable (for)
-import qualified System.FilePath as FilePath
+import System.FilePath qualified as FilePath
 
 import Language.PureScript.Names (ModuleName)
 

--- a/src/Language/PureScript/Make/Monad.hs
+++ b/src/Language/PureScript/Make/Monad.hs
@@ -19,34 +19,34 @@ module Language.PureScript.Make.Monad
   , copyFile
   ) where
 
-import           Prelude
+import Prelude
 
-import           Codec.Serialise (Serialise)
+import Codec.Serialise (Serialise)
 import Codec.Serialise qualified as Serialise
-import           Control.Exception (fromException, tryJust)
-import           Control.Monad (join, guard)
-import           Control.Monad.Base (MonadBase(..))
-import           Control.Monad.Error.Class (MonadError(..))
-import           Control.Monad.IO.Class
-import           Control.Monad.Logger
-import           Control.Monad.Reader (MonadReader(..), ReaderT(..))
-import           Control.Monad.Trans.Control (MonadBaseControl(..))
-import           Control.Monad.Trans.Except
-import           Control.Monad.Writer.Class (MonadWriter(..))
+import Control.Exception (fromException, tryJust)
+import Control.Monad (join, guard)
+import Control.Monad.Base (MonadBase(..))
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.IO.Class
+import Control.Monad.Logger
+import Control.Monad.Reader (MonadReader(..), ReaderT(..))
+import Control.Monad.Trans.Control (MonadBaseControl(..))
+import Control.Monad.Trans.Except
+import Control.Monad.Writer.Class (MonadWriter(..))
 import Data.Aeson qualified as Aeson
 import Data.ByteString qualified as B
-import           Data.Text (Text)
+import Data.Text (Text)
 import Data.Text qualified as Text
-import           Data.Time.Clock (UTCTime)
-import           Language.PureScript.Errors
-import           Language.PureScript.Externs (ExternsFile, externsIsCurrentVersion)
-import           Language.PureScript.Make.Cache (ContentHash, hash)
-import           Language.PureScript.Options
-import           System.Directory (createDirectoryIfMissing, getModificationTime)
+import Data.Time.Clock (UTCTime)
+import Language.PureScript.Errors
+import Language.PureScript.Externs (ExternsFile, externsIsCurrentVersion)
+import Language.PureScript.Make.Cache (ContentHash, hash)
+import Language.PureScript.Options
+import System.Directory (createDirectoryIfMissing, getModificationTime)
 import System.Directory qualified as Directory
-import           System.FilePath (takeDirectory)
-import           System.IO.Error (tryIOError, isDoesNotExistError)
-import           System.IO.UTF8 (readUTF8FileT)
+import System.FilePath (takeDirectory)
+import System.IO.Error (tryIOError, isDoesNotExistError)
+import System.IO.UTF8 (readUTF8FileT)
 
 -- | A monad for running make actions
 newtype Make a = Make

--- a/src/Language/PureScript/Make/Monad.hs
+++ b/src/Language/PureScript/Make/Monad.hs
@@ -22,7 +22,7 @@ module Language.PureScript.Make.Monad
 import           Prelude
 
 import           Codec.Serialise (Serialise)
-import qualified Codec.Serialise as Serialise
+import Codec.Serialise qualified as Serialise
 import           Control.Exception (fromException, tryJust)
 import           Control.Monad (join, guard)
 import           Control.Monad.Base (MonadBase(..))
@@ -33,17 +33,17 @@ import           Control.Monad.Reader (MonadReader(..), ReaderT(..))
 import           Control.Monad.Trans.Control (MonadBaseControl(..))
 import           Control.Monad.Trans.Except
 import           Control.Monad.Writer.Class (MonadWriter(..))
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as B
+import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as B
 import           Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import           Data.Time.Clock (UTCTime)
 import           Language.PureScript.Errors
 import           Language.PureScript.Externs (ExternsFile, externsIsCurrentVersion)
 import           Language.PureScript.Make.Cache (ContentHash, hash)
 import           Language.PureScript.Options
 import           System.Directory (createDirectoryIfMissing, getModificationTime)
-import qualified System.Directory as Directory
+import System.Directory qualified as Directory
 import           System.FilePath (takeDirectory)
 import           System.IO.Error (tryIOError, isDoesNotExistError)
 import           System.IO.UTF8 (readUTF8FileT)

--- a/src/Language/PureScript/ModuleDependencies.hs
+++ b/src/Language/PureScript/ModuleDependencies.hs
@@ -11,9 +11,9 @@ import           Protolude hiding (head)
 
 import           Data.Array ((!))
 import           Data.Graph
-import qualified Data.Set as S
+import Data.Set qualified as S
 import           Language.PureScript.AST
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Prim qualified as C
 import           Language.PureScript.Crash
 import           Language.PureScript.Errors hiding (nonEmpty)
 import           Language.PureScript.Names

--- a/src/Language/PureScript/ModuleDependencies.hs
+++ b/src/Language/PureScript/ModuleDependencies.hs
@@ -7,16 +7,16 @@ module Language.PureScript.ModuleDependencies
   , moduleSignature
   ) where
 
-import           Protolude hiding (head)
+import Protolude hiding (head)
 
-import           Data.Array ((!))
-import           Data.Graph
+import Data.Array ((!))
+import Data.Graph
 import Data.Set qualified as S
-import           Language.PureScript.AST
+import Language.PureScript.AST
 import Language.PureScript.Constants.Prim qualified as C
-import           Language.PureScript.Crash
-import           Language.PureScript.Errors hiding (nonEmpty)
-import           Language.PureScript.Names
+import Language.PureScript.Crash
+import Language.PureScript.Errors hiding (nonEmpty)
+import Language.PureScript.Names
 
 -- | A list of modules with their transitive dependencies
 type ModuleGraph = [(ModuleName, [ModuleName])]

--- a/src/Language/PureScript/Names.hs
+++ b/src/Language/PureScript/Names.hs
@@ -12,13 +12,13 @@ import Control.Applicative ((<|>))
 import Control.Monad.Supply.Class
 import Control.DeepSeq (NFData)
 import Data.Functor.Contravariant (contramap)
-import qualified Data.Vector as V
+import Data.Vector qualified as V
 
 import GHC.Generics (Generic)
 import Data.Aeson
 import Data.Aeson.TH
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Language.PureScript.AST.SourcePos (SourcePos, pattern SourcePos)
 

--- a/src/Language/PureScript/Options.hs
+++ b/src/Language/PureScript/Options.hs
@@ -2,9 +2,9 @@
 module Language.PureScript.Options where
 
 import Prelude
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 
 -- | The data type of compiler options
 data Options = Options

--- a/src/Language/PureScript/PSString.hs
+++ b/src/Language/PureScript/PSString.hs
@@ -15,24 +15,24 @@ import Codec.Serialise (Serialise)
 import Control.DeepSeq (NFData)
 import Control.Exception (try, evaluate)
 import Control.Applicative ((<|>))
-import qualified Data.Char as Char
+import Data.Char qualified as Char
 import Data.Bits (shiftR)
 import Data.Either (fromRight)
 import Data.List (unfoldr)
 import Data.Scientific (toBoundedInteger)
 import Data.String (IsString(..))
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf16BE)
 import Data.Text.Encoding.Error (UnicodeException)
-import qualified Data.Vector as V
+import Data.Vector qualified as V
 import Data.Word (Word16, Word8)
 import Numeric (showHex)
 import System.IO.Unsafe (unsafePerformIO)
-import qualified Data.Aeson as A
-import qualified Data.Aeson.Types as A
+import Data.Aeson qualified as A
+import Data.Aeson.Types qualified as A
 
 -- |
 -- Strings in PureScript are sequences of UTF-16 code units, which do not

--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -9,13 +9,13 @@ import Control.Monad.State (StateT, modify, get)
 
 import Data.List (elemIndices, intersperse)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Language.PureScript.AST (SourcePos(..), SourceSpan(..), nullSourceSpan)
 import Language.PureScript.CST.Lexer (isUnquotedKey)
 
 import Text.PrettyPrint.Boxes hiding ((<>))
-import qualified Text.PrettyPrint.Boxes as Box
+import Text.PrettyPrint.Boxes qualified as Box
 
 parensT :: Text -> Text
 parensT s = "(" <> s <> ")"

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -27,7 +27,7 @@ import Control.PatternArrows as PA
 import Data.Bifunctor (first)
 import Data.Maybe (fromMaybe, catMaybes)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Language.PureScript.Crash
 import Language.PureScript.Environment

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -12,9 +12,9 @@ import Prelude hiding ((<>))
 import Control.Arrow (second)
 
 import Data.Text (Text)
-import qualified Data.List.NonEmpty as NEL
-import qualified Data.Monoid as Monoid ((<>))
-import qualified Data.Text as T
+import Data.List.NonEmpty qualified as NEL
+import Data.Monoid qualified as Monoid ((<>))
+import Data.Text qualified as T
 
 import Language.PureScript.AST
 import Language.PureScript.Crash

--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -23,29 +23,29 @@ import Control.Arrow ((***))
 import Control.Category ((>>>))
 import Control.Monad.Writer.Strict (MonadWriter, WriterT, runWriterT, tell)
 
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString.Lazy qualified as BL
 import Data.String (String, lines)
 import Data.List (stripPrefix, (\\))
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Time.Clock (UTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Data.Version
-import qualified Distribution.SPDX as SPDX
-import qualified Distribution.Parsec as CabalParsec
+import Distribution.SPDX qualified as SPDX
+import Distribution.Parsec qualified as CabalParsec
 
 import System.Directory (doesFileExist)
 import System.FilePath.Glob (globDir1)
 import System.Process (readProcess)
 
 import Web.Bower.PackageMeta (PackageMeta(..), PackageName, Repository(..))
-import qualified Web.Bower.PackageMeta as Bower
+import Web.Bower.PackageMeta qualified as Bower
 
 import Language.PureScript.Publish.ErrorsWarnings
 import Language.PureScript.Publish.Registry.Compat
 import Language.PureScript.Publish.Utils
-import qualified Language.PureScript as P (version, ModuleName)
-import qualified Language.PureScript.CoreFn.FromJSON as P
-import qualified Language.PureScript.Docs as D
+import Language.PureScript qualified as P (version, ModuleName)
+import Language.PureScript.CoreFn.FromJSON qualified as P
+import Language.PureScript.Docs qualified as D
 import Data.Aeson.BetterErrors (Parse, withString, eachInObjectWithKey, asString, key, keyMay, parse, mapError)
 import Language.PureScript.Docs.Types (ManifestError(BowerManifest, PursManifest))
 

--- a/src/Language/PureScript/Publish/BoxesHelpers.hs
+++ b/src/Language/PureScript/Publish/BoxesHelpers.hs
@@ -7,10 +7,10 @@ module Language.PureScript.Publish.BoxesHelpers
 import Prelude
 
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import System.IO (hPutStr, stderr)
 
-import qualified Text.PrettyPrint.Boxes as Boxes
+import Text.PrettyPrint.Boxes qualified as Boxes
 
 width :: Int
 width = 79

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -22,16 +22,16 @@ import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe
 import Data.Monoid
 import Data.Version
-import qualified Data.List.NonEmpty as NonEmpty
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
-import qualified Language.PureScript.Docs.Types as D
-import qualified Language.PureScript as P
+import Language.PureScript.Docs.Types qualified as D
+import Language.PureScript qualified as P
 import Language.PureScript.Publish.BoxesHelpers
 
 import Web.Bower.PackageMeta (PackageName, runPackageName, showBowerError)
-import qualified Web.Bower.PackageMeta as Bower
+import Web.Bower.PackageMeta qualified as Bower
 import Language.PureScript.Docs.Types (showManifestError)
 
 -- | An error which meant that it was not possible to retrieve metadata for a

--- a/src/Language/PureScript/Publish/Registry/Compat.hs
+++ b/src/Language/PureScript/Publish/Registry/Compat.hs
@@ -8,8 +8,8 @@
 module Language.PureScript.Publish.Registry.Compat where
 
 import Protolude
-import qualified Data.Map as Map
-import qualified Web.Bower.PackageMeta as Bower
+import Data.Map qualified as Map
+import Web.Bower.PackageMeta qualified as Bower
 import Data.Bitraversable (Bitraversable(..))
 import Data.Aeson.BetterErrors (key, asText, keyMay, eachInObject, Parse, throwCustomError)
 

--- a/src/Language/PureScript/Renamer.hs
+++ b/src/Language/PureScript/Renamer.hs
@@ -10,9 +10,9 @@ import Control.Monad.State
 import Data.Functor ((<&>))
 import Data.List (find)
 import Data.Maybe (fromJust, fromMaybe)
-import qualified Data.Map as M
-import qualified Data.Set as S
-import qualified Data.Text as T
+import Data.Map qualified as M
+import Data.Set qualified as S
+import Data.Text qualified as T
 
 import Language.PureScript.CoreFn
 import Language.PureScript.Names

--- a/src/Language/PureScript/Roles.hs
+++ b/src/Language/PureScript/Roles.hs
@@ -12,8 +12,8 @@ import Prelude
 
 import Codec.Serialise (Serialise)
 import Control.DeepSeq (NFData)
-import qualified Data.Aeson as A
-import qualified Data.Aeson.TH as A
+import Data.Aeson qualified as A
+import Data.Aeson.TH qualified as A
 import Data.Text (Text)
 import GHC.Generics (Generic)
 

--- a/src/Language/PureScript/Sugar/AdoNotation.hs
+++ b/src/Language/PureScript/Sugar/AdoNotation.hs
@@ -3,15 +3,15 @@
 
 module Language.PureScript.Sugar.AdoNotation (desugarAdoModule) where
 
-import           Prelude hiding (abs)
+import Prelude hiding (abs)
 
-import           Control.Monad (foldM)
-import           Control.Monad.Error.Class (MonadError(..))
-import           Control.Monad.Supply.Class
-import           Data.List (foldl')
-import           Language.PureScript.AST
-import           Language.PureScript.Errors
-import           Language.PureScript.Names
+import Control.Monad (foldM)
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Supply.Class
+import Data.List (foldl')
+import Language.PureScript.AST
+import Language.PureScript.Errors
+import Language.PureScript.Names
 import Language.PureScript.Constants.Libs qualified as C
 
 -- | Replace all @AdoNotationBind@ and @AdoNotationValue@ constructors with

--- a/src/Language/PureScript/Sugar/AdoNotation.hs
+++ b/src/Language/PureScript/Sugar/AdoNotation.hs
@@ -12,7 +12,7 @@ import           Data.List (foldl')
 import           Language.PureScript.AST
 import           Language.PureScript.Errors
 import           Language.PureScript.Names
-import qualified Language.PureScript.Constants.Libs as C
+import Language.PureScript.Constants.Libs qualified as C
 
 -- | Replace all @AdoNotationBind@ and @AdoNotationValue@ constructors with
 -- applications of the pure and apply functions in scope, and all @AdoNotationLet@

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -20,9 +20,9 @@ import Data.List.NonEmpty (NonEmpty((:|)), nonEmpty)
 import Data.Foldable (find)
 import Data.Functor (($>))
 import Data.Maybe (isJust, mapMaybe)
-import qualified Data.List.NonEmpty as NEL
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.List.NonEmpty qualified as NEL
+import Data.Map qualified as M
+import Data.Set qualified as S
 
 import Language.PureScript.AST
 import Language.PureScript.Crash

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -14,7 +14,7 @@ import           Language.PureScript.AST
 import           Language.PureScript.Crash
 import           Language.PureScript.Errors
 import           Language.PureScript.Names
-import qualified Language.PureScript.Constants.Libs as C
+import Language.PureScript.Constants.Libs qualified as C
 
 -- | Replace all @DoNotationBind@ and @DoNotationValue@ constructors with
 -- applications of the bind function in scope, and all @DoNotationLet@

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -3,17 +3,17 @@
 
 module Language.PureScript.Sugar.DoNotation (desugarDoModule) where
 
-import           Prelude
+import Prelude
 
-import           Control.Applicative ((<|>))
-import           Control.Monad.Error.Class (MonadError(..))
-import           Control.Monad.Supply.Class
-import           Data.Maybe (fromMaybe)
-import           Data.Monoid (First(..))
-import           Language.PureScript.AST
-import           Language.PureScript.Crash
-import           Language.PureScript.Errors
-import           Language.PureScript.Names
+import Control.Applicative ((<|>))
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Supply.Class
+import Data.Maybe (fromMaybe)
+import Data.Monoid (First(..))
+import Language.PureScript.AST
+import Language.PureScript.Crash
+import Language.PureScript.Errors
+import Language.PureScript.Names
 import Language.PureScript.Constants.Libs qualified as C
 
 -- | Replace all @DoNotationBind@ and @DoNotationValue@ constructors with

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -18,10 +18,10 @@ import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Lazy
 import Control.Monad.Writer (MonadWriter(..))
 
-import qualified Data.List.NonEmpty as NEL
+import Data.List.NonEmpty qualified as NEL
 import Data.Maybe (fromMaybe, mapMaybe)
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.Map qualified as M
+import Data.Set qualified as S
 
 import Language.PureScript.AST
 import Language.PureScript.Crash

--- a/src/Language/PureScript/Sugar/Names/Env.hs
+++ b/src/Language/PureScript/Sugar/Names/Env.hs
@@ -29,10 +29,10 @@ import Data.Foldable (find)
 import Data.List (groupBy, sortOn, delete)
 import Data.Maybe (mapMaybe)
 import Safe (headMay)
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.Map qualified as M
+import Data.Set qualified as S
 
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Prim qualified as C
 import Language.PureScript.AST
 import Language.PureScript.Crash
 import Language.PureScript.Environment

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -13,7 +13,7 @@ import Data.Function (on)
 import Data.Foldable (traverse_)
 import Data.List (intersect, groupBy, sortOn)
 import Data.Maybe (fromMaybe, mapMaybe)
-import qualified Data.Map as M
+import Data.Map qualified as M
 
 import Language.PureScript.AST
 import Language.PureScript.Crash

--- a/src/Language/PureScript/Sugar/Names/Imports.hs
+++ b/src/Language/PureScript/Sugar/Names/Imports.hs
@@ -12,8 +12,8 @@ import Control.Monad.Error.Class (MonadError(..))
 
 import Data.Foldable (for_, traverse_)
 import Data.Maybe (fromMaybe)
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.Map qualified as M
+import Data.Set qualified as S
 
 import Language.PureScript.AST
 import Language.PureScript.Crash

--- a/src/Language/PureScript/Sugar/ObjectWildcards.hs
+++ b/src/Language/PureScript/Sugar/ObjectWildcards.hs
@@ -3,19 +3,19 @@ module Language.PureScript.Sugar.ObjectWildcards
   , desugarDecl
   ) where
 
-import           Prelude
+import Prelude
 
-import           Control.Monad (forM)
-import           Control.Monad.Error.Class (MonadError(..))
-import           Control.Monad.Supply.Class
-import           Data.Foldable (toList)
-import           Data.List (foldl')
-import           Data.Maybe (catMaybes)
-import           Language.PureScript.AST
-import           Language.PureScript.Environment (NameKind(..))
-import           Language.PureScript.Errors
-import           Language.PureScript.Names
-import           Language.PureScript.PSString (PSString)
+import Control.Monad (forM)
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Supply.Class
+import Data.Foldable (toList)
+import Data.List (foldl')
+import Data.Maybe (catMaybes)
+import Language.PureScript.AST
+import Language.PureScript.Environment (NameKind(..))
+import Language.PureScript.Errors
+import Language.PureScript.Names
+import Language.PureScript.PSString (PSString)
 
 
 desugarObjectConstructors

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -37,10 +37,10 @@ import Data.Functor (($>))
 import Data.Functor.Identity (Identity(..), runIdentity)
 import Data.List (groupBy, sortOn)
 import Data.Maybe (mapMaybe, listToMaybe)
-import qualified Data.Map as M
+import Data.Map qualified as M
 import Data.Ord (Down(..))
 
-import qualified Language.PureScript.Constants.Libs as C
+import Language.PureScript.Constants.Libs qualified as C
 
 -- |
 -- Removes unary negation operators and replaces them with calls to `negate`.

--- a/src/Language/PureScript/Sugar/Operators/Common.hs
+++ b/src/Language/PureScript/Sugar/Operators/Common.hs
@@ -9,12 +9,12 @@ import Data.Either (rights)
 import Data.Functor.Identity
 import Data.List (sortOn)
 import Data.Maybe (mapMaybe, fromJust)
-import qualified Data.List.NonEmpty as NEL
-import qualified Data.Map as M
+import Data.List.NonEmpty qualified as NEL
+import Data.Map qualified as M
 
-import qualified Text.Parsec as P
-import qualified Text.Parsec.Pos as P
-import qualified Text.Parsec.Expr as P
+import Text.Parsec qualified as P
+import Text.Parsec.Pos qualified as P
+import Text.Parsec.Expr qualified as P
 
 import Language.PureScript.AST
 import Language.PureScript.Crash

--- a/src/Language/PureScript/Sugar/Operators/Expr.hs
+++ b/src/Language/PureScript/Sugar/Operators/Expr.hs
@@ -5,8 +5,8 @@ import Prelude
 import Control.Monad.Except
 import Data.Functor.Identity
 
-import qualified Text.Parsec as P
-import qualified Text.Parsec.Expr as P
+import Text.Parsec qualified as P
+import Text.Parsec.Expr qualified as P
 
 import Language.PureScript.AST
 import Language.PureScript.Names

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -10,30 +10,30 @@ module Language.PureScript.Sugar.TypeClasses
 
 import Prelude
 
-import           Control.Arrow (first, second)
-import           Control.Monad.Error.Class (MonadError(..))
-import           Control.Monad.State
-import           Control.Monad.Supply.Class
-import           Data.Graph
-import           Data.List (find, partition)
-import           Data.List.NonEmpty (nonEmpty)
+import Control.Arrow (first, second)
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.State
+import Control.Monad.Supply.Class
+import Data.Graph
+import Data.List (find, partition)
+import Data.List.NonEmpty (nonEmpty)
 import Data.Map qualified as M
-import           Data.Maybe (catMaybes, mapMaybe, isJust)
+import Data.Maybe (catMaybes, mapMaybe, isJust)
 import Data.List.NonEmpty qualified as NEL
 import Data.Set qualified as S
-import           Data.Text (Text)
-import           Data.Traversable (for)
+import Data.Text (Text)
+import Data.Traversable (for)
 import Language.PureScript.Constants.Prim qualified as C
-import           Language.PureScript.Crash
-import           Language.PureScript.Environment
-import           Language.PureScript.Errors hiding (isExported, nonEmpty)
-import           Language.PureScript.Externs
-import           Language.PureScript.Label (Label(..))
-import           Language.PureScript.Names
-import           Language.PureScript.PSString (mkString)
-import           Language.PureScript.Sugar.CaseDeclarations
-import           Language.PureScript.TypeClassDictionaries (superclassName)
-import           Language.PureScript.Types
+import Language.PureScript.Crash
+import Language.PureScript.Environment
+import Language.PureScript.Errors hiding (isExported, nonEmpty)
+import Language.PureScript.Externs
+import Language.PureScript.Label (Label(..))
+import Language.PureScript.Names
+import Language.PureScript.PSString (mkString)
+import Language.PureScript.Sugar.CaseDeclarations
+import Language.PureScript.TypeClassDictionaries (superclassName)
+import Language.PureScript.Types
 
 type MemberMap = M.Map (ModuleName, ProperName 'ClassName) TypeClassData
 

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -17,13 +17,13 @@ import           Control.Monad.Supply.Class
 import           Data.Graph
 import           Data.List (find, partition)
 import           Data.List.NonEmpty (nonEmpty)
-import qualified Data.Map as M
+import Data.Map qualified as M
 import           Data.Maybe (catMaybes, mapMaybe, isJust)
-import qualified Data.List.NonEmpty as NEL
-import qualified Data.Set as S
+import Data.List.NonEmpty qualified as NEL
+import Data.Set qualified as S
 import           Data.Text (Text)
 import           Data.Traversable (for)
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Prim qualified as C
 import           Language.PureScript.Crash
 import           Language.PureScript.Environment
 import           Language.PureScript.Errors hiding (isExported, nonEmpty)

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -9,7 +9,7 @@ import           Control.Monad.Supply.Class (MonadSupply)
 import           Data.List (foldl', find, unzip5)
 import           Language.PureScript.AST
 import           Language.PureScript.AST.Utils
-import qualified Language.PureScript.Constants.Libs as Libs
+import Language.PureScript.Constants.Libs qualified as Libs
 import           Language.PureScript.Crash
 import           Language.PureScript.Environment
 import           Language.PureScript.Errors

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -1,22 +1,22 @@
 -- | This module implements the generic deriving elaboration that takes place during desugaring.
 module Language.PureScript.Sugar.TypeClasses.Deriving (deriveInstances) where
 
-import           Prelude
-import           Protolude (note)
+import Prelude
+import Protolude (note)
 
-import           Control.Monad.Error.Class (MonadError(..))
-import           Control.Monad.Supply.Class (MonadSupply)
-import           Data.List (foldl', find, unzip5)
-import           Language.PureScript.AST
-import           Language.PureScript.AST.Utils
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.Supply.Class (MonadSupply)
+import Data.List (foldl', find, unzip5)
+import Language.PureScript.AST
+import Language.PureScript.AST.Utils
 import Language.PureScript.Constants.Libs qualified as Libs
-import           Language.PureScript.Crash
-import           Language.PureScript.Environment
-import           Language.PureScript.Errors
-import           Language.PureScript.Names
-import           Language.PureScript.PSString (mkString)
-import           Language.PureScript.Types
-import           Language.PureScript.TypeChecker (checkNewtype)
+import Language.PureScript.Crash
+import Language.PureScript.Environment
+import Language.PureScript.Errors
+import Language.PureScript.Names
+import Language.PureScript.PSString (mkString)
+import Language.PureScript.Types
+import Language.PureScript.TypeChecker (checkNewtype)
 
 -- | Elaborates deriving instance declarations by code generation.
 deriveInstances

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -22,14 +22,14 @@ import Data.List (nub, nubBy, (\\), sort, group)
 import Data.Maybe
 import Data.Either (partitionEithers)
 import Data.Text (Text)
-import qualified Data.List.NonEmpty as NEL
-import qualified Data.Map as M
-import qualified Data.Set as S
-import qualified Data.Text as T
+import Data.List.NonEmpty qualified as NEL
+import Data.Map qualified as M
+import Data.Set qualified as S
+import Data.Text qualified as T
 
 import Language.PureScript.AST
 import Language.PureScript.AST.Declarations.ChainId (ChainId)
-import qualified Language.PureScript.Constants.Libs as Libs
+import Language.PureScript.Constants.Libs qualified as Libs
 import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Errors

--- a/src/Language/PureScript/TypeChecker/Deriving.hs
+++ b/src/Language/PureScript/TypeChecker/Deriving.hs
@@ -12,14 +12,14 @@ import Control.Monad.Writer.Class (MonadWriter(..))
 import Data.Align (align, unalign)
 import Data.Foldable (foldl1, foldr1)
 import Data.List (init, last, zipWith3, (!!))
-import qualified Data.Map as M
+import Data.Map qualified as M
 import Data.These (These(..), mergeTheseWith, these)
 
 import Control.Monad.Supply.Class
 import Language.PureScript.AST
 import Language.PureScript.AST.Utils
-import qualified Language.PureScript.Constants.Libs as Libs
-import qualified Language.PureScript.Constants.Prim as Prim
+import Language.PureScript.Constants.Libs qualified as Libs
+import Language.PureScript.Constants.Prim qualified as Prim
 import Language.PureScript.Crash
 import Language.PureScript.Environment
 import Language.PureScript.Errors hiding (nonEmpty)

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -25,13 +25,13 @@ import Data.Function (on)
 import Data.Functor (($>))
 import Data.List (delete, findIndices, minimumBy, nubBy, sortOn, tails)
 import Data.Maybe (catMaybes, fromMaybe, listToMaybe, mapMaybe)
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.Map qualified as M
+import Data.Set qualified as S
 import Data.Traversable (for)
 import Data.Text (Text, stripPrefix, stripSuffix)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.List.NonEmpty as NEL
+import Data.List.NonEmpty qualified as NEL
 
 import Language.PureScript.AST
 import Language.PureScript.Crash
@@ -48,8 +48,8 @@ import Language.PureScript.TypeClassDictionaries
 import Language.PureScript.Types
 import Language.PureScript.Label (Label(..))
 import Language.PureScript.PSString (PSString, mkString, decodeString)
-import qualified Language.PureScript.Constants.Libs as C
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Libs qualified as C
+import Language.PureScript.Constants.Prim qualified as C
 
 -- | Describes what sort of dictionary to generate for type class instances
 data Evidence

--- a/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
@@ -32,8 +32,8 @@ import Data.Maybe (fromMaybe, isJust)
 import Data.Monoid (Any(..))
 import Data.Text (Text)
 
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.Map qualified as M
+import Data.Set qualified as S
 
 import Language.PureScript.Crash
 import Language.PureScript.Environment
@@ -46,7 +46,7 @@ import Language.PureScript.TypeChecker.Synonyms
 import Language.PureScript.TypeChecker.Unify
 import Language.PureScript.Roles
 import Language.PureScript.Types
-import qualified Language.PureScript.Constants.Prim as Prim
+import Language.PureScript.Constants.Prim qualified as Prim
 
 -- | State of the given constraints solver.
 data GivenSolverState =

--- a/src/Language/PureScript/TypeChecker/Entailment/IntCompare.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment/IntCompare.hs
@@ -6,12 +6,12 @@ module Language.PureScript.TypeChecker.Entailment.IntCompare where
 
 import Protolude
 
-import qualified Data.Graph as G
-import qualified Data.Map as M
+import Data.Graph qualified as G
+import Data.Map qualified as M
 
-import qualified Language.PureScript.Names as P
-import qualified Language.PureScript.Types as P
-import qualified Language.PureScript.Constants.Prim as P
+import Language.PureScript.Names qualified as P
+import Language.PureScript.Types qualified as P
+import Language.PureScript.Constants.Prim qualified as P
 
 data Relation a
   = Equal a a

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -39,16 +39,16 @@ import Data.Bitraversable (bitraverse)
 import Data.Foldable (for_, traverse_)
 import Data.Function (on)
 import Data.Functor (($>))
-import qualified Data.IntSet as IS
+import Data.IntSet qualified as IS
 import Data.List (nubBy, sortOn, (\\))
-import qualified Data.Map as M
+import Data.Map qualified as M
 import Data.Maybe (fromJust, fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Traversable (for)
 
 import Language.PureScript.Crash
-import qualified Language.PureScript.Environment as E
+import Language.PureScript.Environment qualified as E
 import Language.PureScript.Errors
 import Language.PureScript.Names
 import Language.PureScript.TypeChecker.Monad

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -13,10 +13,10 @@ import Control.Monad.State
 import Control.Monad.Writer.Class (MonadWriter(..), censor)
 
 import Data.Maybe
-import qualified Data.Map as M
-import qualified Data.Set as S
+import Data.Map qualified as M
+import Data.Set qualified as S
 import Data.Text (Text, isPrefixOf, unpack)
-import qualified Data.List.NonEmpty as NEL
+import Data.List.NonEmpty qualified as NEL
 
 import Language.PureScript.Crash (internalError)
 import Language.PureScript.Environment

--- a/src/Language/PureScript/TypeChecker/Roles.hs
+++ b/src/Language/PureScript/TypeChecker/Roles.hs
@@ -18,9 +18,9 @@ import Control.Monad (unless, when, zipWithM_)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State (MonadState(..), runState, state)
 import Data.Coerce (coerce)
-import qualified Data.Map as M
+import Data.Map qualified as M
 import Data.Maybe (fromMaybe)
-import qualified Data.Set as S
+import Data.Set qualified as S
 import Data.Semigroup (Any(..))
 import Data.Text (Text)
 

--- a/src/Language/PureScript/TypeChecker/Synonyms.hs
+++ b/src/Language/PureScript/TypeChecker/Synonyms.hs
@@ -15,7 +15,7 @@ import           Prelude
 import           Control.Monad.Error.Class (MonadError(..))
 import           Control.Monad.State
 import           Data.Maybe (fromMaybe)
-import qualified Data.Map as M
+import Data.Map qualified as M
 import           Data.Text (Text)
 import           Language.PureScript.Environment
 import           Language.PureScript.Errors

--- a/src/Language/PureScript/TypeChecker/Synonyms.hs
+++ b/src/Language/PureScript/TypeChecker/Synonyms.hs
@@ -10,18 +10,18 @@ module Language.PureScript.TypeChecker.Synonyms
   , replaceAllTypeSynonymsM
   ) where
 
-import           Prelude
+import Prelude
 
-import           Control.Monad.Error.Class (MonadError(..))
-import           Control.Monad.State
-import           Data.Maybe (fromMaybe)
+import Control.Monad.Error.Class (MonadError(..))
+import Control.Monad.State
+import Data.Maybe (fromMaybe)
 import Data.Map qualified as M
-import           Data.Text (Text)
-import           Language.PureScript.Environment
-import           Language.PureScript.Errors
-import           Language.PureScript.Names
-import           Language.PureScript.TypeChecker.Monad
-import           Language.PureScript.Types
+import Data.Text (Text)
+import Language.PureScript.Environment
+import Language.PureScript.Errors
+import Language.PureScript.Names
+import Language.PureScript.TypeChecker.Monad
+import Language.PureScript.Types
 
 -- | Type synonym information (arguments with kinds, aliased type), indexed by name
 type SynonymMap = M.Map (Qualified (ProperName 'TypeName)) ([(Text, Maybe SourceType)], SourceType)

--- a/src/Language/PureScript/TypeChecker/TypeSearch.hs
+++ b/src/Language/PureScript/TypeChecker/TypeSearch.hs
@@ -2,26 +2,26 @@ module Language.PureScript.TypeChecker.TypeSearch
   ( typeSearch
   ) where
 
-import           Protolude
+import Protolude
 
-import           Control.Monad.Writer (WriterT, runWriterT)
+import Control.Monad.Writer (WriterT, runWriterT)
 import Data.Map qualified                                    as Map
 import Language.PureScript.TypeChecker.Entailment qualified  as Entailment
 
 import Language.PureScript.TypeChecker.Monad qualified       as TC
-import           Language.PureScript.TypeChecker.Subsumption
-import           Language.PureScript.TypeChecker.Unify       as P
+import Language.PureScript.TypeChecker.Subsumption
+import Language.PureScript.TypeChecker.Unify       as P
 
-import           Control.Monad.Supply                        as P
-import           Language.PureScript.AST                     as P
-import           Language.PureScript.Environment             as P
-import           Language.PureScript.Errors                  as P
-import           Language.PureScript.Label
-import           Language.PureScript.Names                   as P
-import           Language.PureScript.Pretty.Types            as P
-import           Language.PureScript.TypeChecker.Skolems     as Skolem
-import           Language.PureScript.TypeChecker.Synonyms    as P
-import           Language.PureScript.Types                   as P
+import Control.Monad.Supply                        as P
+import Language.PureScript.AST                     as P
+import Language.PureScript.Environment             as P
+import Language.PureScript.Errors                  as P
+import Language.PureScript.Label
+import Language.PureScript.Names                   as P
+import Language.PureScript.Pretty.Types            as P
+import Language.PureScript.TypeChecker.Skolems     as Skolem
+import Language.PureScript.TypeChecker.Synonyms    as P
+import Language.PureScript.Types                   as P
 
 checkInEnvironment
   :: Environment

--- a/src/Language/PureScript/TypeChecker/TypeSearch.hs
+++ b/src/Language/PureScript/TypeChecker/TypeSearch.hs
@@ -5,10 +5,10 @@ module Language.PureScript.TypeChecker.TypeSearch
 import           Protolude
 
 import           Control.Monad.Writer (WriterT, runWriterT)
-import qualified Data.Map                                    as Map
-import qualified Language.PureScript.TypeChecker.Entailment  as Entailment
+import Data.Map qualified                                    as Map
+import Language.PureScript.TypeChecker.Entailment qualified  as Entailment
 
-import qualified Language.PureScript.TypeChecker.Monad       as TC
+import Language.PureScript.TypeChecker.Monad qualified       as TC
 import           Language.PureScript.TypeChecker.Subsumption
 import           Language.PureScript.TypeChecker.Unify       as P
 

--- a/src/Language/PureScript/TypeChecker/TypeSearch.hs
+++ b/src/Language/PureScript/TypeChecker/TypeSearch.hs
@@ -5,10 +5,10 @@ module Language.PureScript.TypeChecker.TypeSearch
 import Protolude
 
 import Control.Monad.Writer (WriterT, runWriterT)
-import Data.Map qualified                                    as Map
-import Language.PureScript.TypeChecker.Entailment qualified  as Entailment
+import Data.Map qualified as Map
+import Language.PureScript.TypeChecker.Entailment qualified as Entailment
 
-import Language.PureScript.TypeChecker.Monad qualified       as TC
+import Language.PureScript.TypeChecker.Monad qualified as TC
 import Language.PureScript.TypeChecker.Subsumption
 import Language.PureScript.TypeChecker.Unify       as P
 

--- a/src/Language/PureScript/TypeChecker/Types.hs
+++ b/src/Language/PureScript/TypeChecker/Types.hs
@@ -40,10 +40,10 @@ import Data.List (transpose, (\\), partition, delete)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Traversable (for)
-import qualified Data.List.NonEmpty as NEL
-import qualified Data.Map as M
-import qualified Data.Set as S
-import qualified Data.IntSet as IS
+import Data.List.NonEmpty qualified as NEL
+import Data.Map qualified as M
+import Data.Set qualified as S
+import Data.IntSet qualified as IS
 
 import Language.PureScript.AST
 import Language.PureScript.Crash

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -23,11 +23,11 @@ import Control.Monad.Writer.Class (MonadWriter(..))
 
 import Data.Foldable (traverse_)
 import Data.Maybe (fromMaybe)
-import qualified Data.Map as M
-import qualified Data.Text as T
+import Data.Map qualified as M
+import Data.Text qualified as T
 
 import Language.PureScript.Crash
-import qualified Language.PureScript.Environment as E
+import Language.PureScript.Environment qualified as E
 import Language.PureScript.Errors
 import Language.PureScript.TypeChecker.Kinds (elaborateKind, instantiateKind, unifyKinds')
 import Language.PureScript.TypeChecker.Monad

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -13,18 +13,18 @@ import Control.DeepSeq (NFData)
 import Control.Lens (Lens', (^.), set)
 import Control.Monad ((<=<), (>=>))
 import Data.Aeson ((.:), (.:?), (.!=), (.=))
-import qualified Data.Aeson as A
-import qualified Data.Aeson.Types as A
+import Data.Aeson qualified as A
+import Data.Aeson.Types qualified as A
 import Data.Foldable (fold, foldl')
-import qualified Data.IntSet as IS
+import Data.IntSet qualified as IS
 import Data.List (sortOn)
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import GHC.Generics (Generic)
 
 import Language.PureScript.AST.SourcePos
-import qualified Language.PureScript.Constants.Prim as C
+import Language.PureScript.Constants.Prim qualified as C
 import Language.PureScript.Names
 import Language.PureScript.Label (Label)
 import Language.PureScript.PSString (PSString)

--- a/src/System/IO/UTF8.hs
+++ b/src/System/IO/UTF8.hs
@@ -6,9 +6,9 @@ import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.ByteString.Search qualified as BSS
 import Data.ByteString.UTF8 qualified as UTF8
-import           Data.Text (Text)
+import Data.Text (Text)
 import Data.Text.Encoding qualified as TE
-import           Protolude (ordNub)
+import Protolude (ordNub)
 
 -- | Unfortunately ByteString's readFile does not convert line endings on
 -- Windows, so we have to do it ourselves

--- a/src/System/IO/UTF8.hs
+++ b/src/System/IO/UTF8.hs
@@ -2,12 +2,12 @@ module System.IO.UTF8 where
 
 import Prelude
 
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString.Search as BSS
-import qualified Data.ByteString.UTF8 as UTF8
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Search qualified as BSS
+import Data.ByteString.UTF8 qualified as UTF8
 import           Data.Text (Text)
-import qualified Data.Text.Encoding as TE
+import Data.Text.Encoding qualified as TE
 import           Protolude (ordNub)
 
 -- | Unfortunately ByteString's readFile does not convert line endings on

--- a/tests/Language/PureScript/Ide/CompletionSpec.hs
+++ b/tests/Language/PureScript/Ide/CompletionSpec.hs
@@ -2,11 +2,11 @@ module Language.PureScript.Ide.CompletionSpec where
 
 import Protolude
 
-import qualified Language.PureScript as P
+import Language.PureScript qualified as P
 import Language.PureScript.Ide.Test as Test
 import Language.PureScript.Ide.Command as Command
 import Language.PureScript.Ide.Completion
-import qualified Language.PureScript.Ide.Filter.Declaration as DeclarationType
+import Language.PureScript.Ide.Filter.Declaration qualified as DeclarationType
 import Language.PureScript.Ide.Types
 import Test.Hspec
 

--- a/tests/Language/PureScript/Ide/FilterSpec.hs
+++ b/tests/Language/PureScript/Ide/FilterSpec.hs
@@ -1,14 +1,14 @@
 module Language.PureScript.Ide.FilterSpec where
 
 import           Protolude
-import qualified Data.Map as Map
-import qualified Data.Set as Set
+import Data.Map qualified as Map
+import Data.Set qualified as Set
 import           Language.PureScript.Ide.Filter
 import           Language.PureScript.Ide.Filter.Declaration as D
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Imports
 import           Language.PureScript.Ide.Test as T
-import qualified Language.PureScript as P
+import Language.PureScript qualified as P
 import           Test.Hspec
 
 type Module = (P.ModuleName, [IdeDeclarationAnn])

--- a/tests/Language/PureScript/Ide/FilterSpec.hs
+++ b/tests/Language/PureScript/Ide/FilterSpec.hs
@@ -1,15 +1,15 @@
 module Language.PureScript.Ide.FilterSpec where
 
-import           Protolude
+import Protolude
 import Data.Map qualified as Map
 import Data.Set qualified as Set
-import           Language.PureScript.Ide.Filter
-import           Language.PureScript.Ide.Filter.Declaration as D
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Imports
-import           Language.PureScript.Ide.Test as T
+import Language.PureScript.Ide.Filter
+import Language.PureScript.Ide.Filter.Declaration as D
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Imports
+import Language.PureScript.Ide.Test as T
 import Language.PureScript qualified as P
-import           Test.Hspec
+import Test.Hspec
 
 type Module = (P.ModuleName, [IdeDeclarationAnn])
 

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -2,15 +2,15 @@ module Language.PureScript.Ide.ImportsSpec where
 
 import           Protolude hiding (moduleName)
 import           Data.Maybe (fromJust)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 
-import qualified Language.PureScript as P
+import Language.PureScript qualified as P
 import           Language.PureScript.Ide.Command as Command
 import           Language.PureScript.Ide.Error
 import           Language.PureScript.Ide.Imports
 import           Language.PureScript.Ide.Imports.Actions
 import           Language.PureScript.Ide.Filter (moduleFilter)
-import qualified Language.PureScript.Ide.Test as Test
+import Language.PureScript.Ide.Test qualified as Test
 import           Language.PureScript.Ide.Types
 import           System.FilePath
 import           Test.Hspec

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -1,19 +1,19 @@
 module Language.PureScript.Ide.ImportsSpec where
 
-import           Protolude hiding (moduleName)
-import           Data.Maybe (fromJust)
+import Protolude hiding (moduleName)
+import Data.Maybe (fromJust)
 import Data.Set qualified as Set
 
 import Language.PureScript qualified as P
-import           Language.PureScript.Ide.Command as Command
-import           Language.PureScript.Ide.Error
-import           Language.PureScript.Ide.Imports
-import           Language.PureScript.Ide.Imports.Actions
-import           Language.PureScript.Ide.Filter (moduleFilter)
+import Language.PureScript.Ide.Command as Command
+import Language.PureScript.Ide.Error
+import Language.PureScript.Ide.Imports
+import Language.PureScript.Ide.Imports.Actions
+import Language.PureScript.Ide.Filter (moduleFilter)
 import Language.PureScript.Ide.Test qualified as Test
-import           Language.PureScript.Ide.Types
-import           System.FilePath
-import           Test.Hspec
+import Language.PureScript.Ide.Types
+import System.FilePath
+import Test.Hspec
 
 noImportsFile :: [Text]
 noImportsFile =

--- a/tests/Language/PureScript/Ide/MatcherSpec.hs
+++ b/tests/Language/PureScript/Ide/MatcherSpec.hs
@@ -1,12 +1,12 @@
 module Language.PureScript.Ide.MatcherSpec where
 
-import           Protolude
+import Protolude
 
 import Language.PureScript qualified as P
-import           Language.PureScript.Ide.Matcher
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Util
-import           Test.Hspec
+import Language.PureScript.Ide.Matcher
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Util
+import Test.Hspec
 
 value :: Text -> IdeDeclarationAnn
 value s = withEmptyAnn (IdeDeclValue (IdeValue (P.Ident (toS s)) P.srcREmpty))

--- a/tests/Language/PureScript/Ide/MatcherSpec.hs
+++ b/tests/Language/PureScript/Ide/MatcherSpec.hs
@@ -2,7 +2,7 @@ module Language.PureScript.Ide.MatcherSpec where
 
 import           Protolude
 
-import qualified Language.PureScript                 as P
+import Language.PureScript qualified as P
 import           Language.PureScript.Ide.Matcher
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Util

--- a/tests/Language/PureScript/Ide/RebuildSpec.hs
+++ b/tests/Language/PureScript/Ide/RebuildSpec.hs
@@ -2,14 +2,14 @@ module Language.PureScript.Ide.RebuildSpec where
 
 import           Protolude
 
-import qualified Data.Set as Set
-import qualified Language.PureScript as P
+import Data.Set qualified as Set
+import Language.PureScript qualified as P
 import           Language.PureScript.AST.SourcePos (spanName)
 import           Language.PureScript.Ide.Command
 import           Language.PureScript.Ide.Completion
 import           Language.PureScript.Ide.Matcher
 import           Language.PureScript.Ide.Types
-import qualified Language.PureScript.Ide.Test as Test
+import Language.PureScript.Ide.Test qualified as Test
 import           System.FilePath
 import           System.Directory (doesFileExist, removePathForcibly)
 import           Test.Hspec

--- a/tests/Language/PureScript/Ide/RebuildSpec.hs
+++ b/tests/Language/PureScript/Ide/RebuildSpec.hs
@@ -1,18 +1,18 @@
 module Language.PureScript.Ide.RebuildSpec where
 
-import           Protolude
+import Protolude
 
 import Data.Set qualified as Set
 import Language.PureScript qualified as P
-import           Language.PureScript.AST.SourcePos (spanName)
-import           Language.PureScript.Ide.Command
-import           Language.PureScript.Ide.Completion
-import           Language.PureScript.Ide.Matcher
-import           Language.PureScript.Ide.Types
+import Language.PureScript.AST.SourcePos (spanName)
+import Language.PureScript.Ide.Command
+import Language.PureScript.Ide.Completion
+import Language.PureScript.Ide.Matcher
+import Language.PureScript.Ide.Types
 import Language.PureScript.Ide.Test qualified as Test
-import           System.FilePath
-import           System.Directory (doesFileExist, removePathForcibly)
-import           Test.Hspec
+import System.FilePath
+import System.Directory (doesFileExist, removePathForcibly)
+import Test.Hspec
 
 defaultTarget :: Set P.CodegenTarget
 defaultTarget = Set.singleton P.JS

--- a/tests/Language/PureScript/Ide/ReexportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ReexportsSpec.hs
@@ -2,11 +2,11 @@ module Language.PureScript.Ide.ReexportsSpec where
 
 import           Protolude
 
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import           Language.PureScript.Ide.Reexports
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.Test
-import qualified Language.PureScript as P
+import Language.PureScript qualified as P
 import           Test.Hspec
 
 valueA, typeA, synonymA, classA, dtorA1, dtorA2, kindA :: IdeDeclarationAnn

--- a/tests/Language/PureScript/Ide/ReexportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ReexportsSpec.hs
@@ -1,13 +1,13 @@
 module Language.PureScript.Ide.ReexportsSpec where
 
-import           Protolude
+import Protolude
 
 import Data.Map qualified as Map
-import           Language.PureScript.Ide.Reexports
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Test
+import Language.PureScript.Ide.Reexports
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Test
 import Language.PureScript qualified as P
-import           Test.Hspec
+import Test.Hspec
 
 valueA, typeA, synonymA, classA, dtorA1, dtorA2, kindA :: IdeDeclarationAnn
 valueA = ideValue "valueA" Nothing

--- a/tests/Language/PureScript/Ide/SourceFileSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFileSpec.hs
@@ -1,13 +1,13 @@
 module Language.PureScript.Ide.SourceFileSpec where
 
-import           Protolude
+import Protolude
 
 import Language.PureScript qualified as P
-import           Language.PureScript.Ide.Command
-import           Language.PureScript.Ide.SourceFile
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.Test
-import           Test.Hspec
+import Language.PureScript.Ide.Command
+import Language.PureScript.Ide.SourceFile
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Test
+import Test.Hspec
 
 span1, span2 :: P.SourceSpan
 span1 = P.SourceSpan "" (P.SourcePos 1 1) (P.SourcePos 2 2)

--- a/tests/Language/PureScript/Ide/SourceFileSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFileSpec.hs
@@ -2,7 +2,7 @@ module Language.PureScript.Ide.SourceFileSpec where
 
 import           Protolude
 
-import qualified Language.PureScript as P
+import Language.PureScript qualified as P
 import           Language.PureScript.Ide.Command
 import           Language.PureScript.Ide.SourceFile
 import           Language.PureScript.Ide.Types

--- a/tests/Language/PureScript/Ide/StateSpec.hs
+++ b/tests/Language/PureScript/Ide/StateSpec.hs
@@ -5,9 +5,9 @@ import           Control.Lens hiding (anyOf, (&))
 import           Language.PureScript.Ide.Types
 import           Language.PureScript.Ide.State
 import           Language.PureScript.Ide.Test
-import qualified Language.PureScript as P
+import Language.PureScript qualified as P
 import           Test.Hspec
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 
 valueOperator :: Maybe P.SourceType -> IdeDeclarationAnn
 valueOperator =

--- a/tests/Language/PureScript/Ide/StateSpec.hs
+++ b/tests/Language/PureScript/Ide/StateSpec.hs
@@ -1,12 +1,12 @@
 module Language.PureScript.Ide.StateSpec where
 
-import           Protolude
-import           Control.Lens hiding (anyOf, (&))
-import           Language.PureScript.Ide.Types
-import           Language.PureScript.Ide.State
-import           Language.PureScript.Ide.Test
+import Protolude
+import Control.Lens hiding (anyOf, (&))
+import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.State
+import Language.PureScript.Ide.Test
 import Language.PureScript qualified as P
-import           Test.Hspec
+import Test.Hspec
 import Data.Map qualified as Map
 
 valueOperator :: Maybe P.SourceType -> IdeDeclarationAnn

--- a/tests/Language/PureScript/Ide/Test.hs
+++ b/tests/Language/PureScript/Ide/Test.hs
@@ -4,7 +4,7 @@ module Language.PureScript.Ide.Test where
 import           Control.Concurrent.STM
 import           "monad-logger" Control.Monad.Logger
 import           Data.IORef
-import qualified Data.Map                        as Map
+import Data.Map qualified as Map
 import           Language.PureScript.Ide
 import           Language.PureScript.Ide.Command
 import           Language.PureScript.Ide.Error
@@ -14,7 +14,7 @@ import           System.Directory
 import           System.FilePath
 import           System.Process
 
-import qualified Language.PureScript             as P
+import Language.PureScript qualified as P
 
 defConfig :: IdeConfiguration
 defConfig =

--- a/tests/Language/PureScript/Ide/Test.hs
+++ b/tests/Language/PureScript/Ide/Test.hs
@@ -2,7 +2,7 @@
 module Language.PureScript.Ide.Test where
 
 import Control.Concurrent.STM
-import           "monad-logger" Control.Monad.Logger
+import "monad-logger" Control.Monad.Logger
 import Data.IORef
 import Data.Map qualified as Map
 import Language.PureScript.Ide

--- a/tests/Language/PureScript/Ide/Test.hs
+++ b/tests/Language/PureScript/Ide/Test.hs
@@ -1,18 +1,18 @@
 {-# LANGUAGE PackageImports    #-}
 module Language.PureScript.Ide.Test where
 
-import           Control.Concurrent.STM
+import Control.Concurrent.STM
 import           "monad-logger" Control.Monad.Logger
-import           Data.IORef
+import Data.IORef
 import Data.Map qualified as Map
-import           Language.PureScript.Ide
-import           Language.PureScript.Ide.Command
-import           Language.PureScript.Ide.Error
-import           Language.PureScript.Ide.Types
-import           Protolude
-import           System.Directory
-import           System.FilePath
-import           System.Process
+import Language.PureScript.Ide
+import Language.PureScript.Ide.Command
+import Language.PureScript.Ide.Error
+import Language.PureScript.Ide.Types
+import Protolude
+import System.Directory
+import System.FilePath
+import System.Process
 
 import Language.PureScript qualified as P
 

--- a/tests/Language/PureScript/Ide/UsageSpec.hs
+++ b/tests/Language/PureScript/Ide/UsageSpec.hs
@@ -2,11 +2,11 @@ module Language.PureScript.Ide.UsageSpec where
 
 import           Protolude
 
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import           Language.PureScript.Ide.Command
 import           Language.PureScript.Ide.Types
-import qualified Language.PureScript.Ide.Test as Test
-import qualified Language.PureScript as P
+import Language.PureScript.Ide.Test qualified as Test
+import Language.PureScript qualified as P
 import           Test.Hspec
 import           Data.Text.Read (decimal)
 import           System.FilePath

--- a/tests/Language/PureScript/Ide/UsageSpec.hs
+++ b/tests/Language/PureScript/Ide/UsageSpec.hs
@@ -1,15 +1,15 @@
 module Language.PureScript.Ide.UsageSpec where
 
-import           Protolude
+import Protolude
 
 import Data.Text qualified as Text
-import           Language.PureScript.Ide.Command
-import           Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Command
+import Language.PureScript.Ide.Types
 import Language.PureScript.Ide.Test qualified as Test
 import Language.PureScript qualified as P
-import           Test.Hspec
-import           Data.Text.Read (decimal)
-import           System.FilePath
+import Test.Hspec
+import Data.Text.Read (decimal)
+import System.FilePath
 
 load :: [Text] -> Command
 load = LoadSync . map Test.mn

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -6,21 +6,21 @@ import Prelude
 
 import Test.Hspec
 
-import qualified TestAst
-import qualified TestCompiler
-import qualified TestCoreFn
-import qualified TestCst
-import qualified TestDocs
-import qualified TestHierarchy
-import qualified TestPrimDocs
-import qualified TestPsci
-import qualified TestIde
-import qualified TestPscPublish
-import qualified TestSourceMaps
--- import qualified TestBundle
-import qualified TestMake
-import qualified TestUtils
-import qualified TestGraph
+import TestAst qualified
+import TestCompiler qualified
+import TestCoreFn qualified
+import TestCst qualified
+import TestDocs qualified
+import TestHierarchy qualified
+import TestPrimDocs qualified
+import TestPsci qualified
+import TestIde qualified
+import TestPscPublish qualified
+import TestSourceMaps qualified
+-- import TestBundle qualified
+import TestMake qualified
+import TestUtils qualified
+import TestGraph qualified
 
 import System.IO (hSetEncoding, stdout, stderr, utf8)
 

--- a/tests/TestCompiler.hs
+++ b/tests/TestCompiler.hs
@@ -24,16 +24,16 @@ module TestCompiler where
 
 import Prelude
 
-import qualified Language.PureScript as P
+import Language.PureScript qualified as P
 import Language.PureScript.Interactive.IO (readNodeProcessWithExitCode)
 
 import Control.Arrow ((>>>))
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Function (on)
 import Data.List (sort, stripPrefix, minimumBy)
 import Data.Maybe (mapMaybe)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
 
 
 import Control.Monad

--- a/tests/TestCst.hs
+++ b/tests/TestCst.hs
@@ -5,9 +5,9 @@ import Prelude
 import Control.Monad (when, forM_)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import qualified Data.Text.IO as Text
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Data.Text.IO qualified as Text
 import Test.Hspec
 import Test.QuickCheck
 import TestUtils

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -6,17 +6,17 @@ import Data.Bifunctor (first)
 import Data.List (findIndex)
 import Data.Foldable
 import Safe (headMay)
-import qualified Data.Map as Map
+import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, isNothing, mapMaybe)
 import Data.Monoid
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Text.PrettyPrint.Boxes as Boxes
+import Data.Text qualified as T
+import Text.PrettyPrint.Boxes qualified as Boxes
 
-import qualified Language.PureScript as P
-import qualified Language.PureScript.Docs as Docs
+import Language.PureScript qualified as P
+import Language.PureScript.Docs qualified as Docs
 import Language.PureScript.Docs.AsMarkdown (codeToString)
-import qualified Language.PureScript.Publish.ErrorsWarnings as Publish
+import Language.PureScript.Publish.ErrorsWarnings qualified as Publish
 
 import Web.Bower.PackageMeta (parsePackageName, runPackageName)
 

--- a/tests/TestGraph.hs
+++ b/tests/TestGraph.hs
@@ -5,8 +5,8 @@ import Prelude
 import Test.Hspec
 import Data.Either (isLeft)
 
-import qualified Data.Aeson as Json
-import qualified Language.PureScript as P
+import Data.Aeson qualified as Json
+import Language.PureScript qualified as P
 
 spec :: Spec
 spec = do

--- a/tests/TestHierarchy.hs
+++ b/tests/TestHierarchy.hs
@@ -3,7 +3,7 @@ module TestHierarchy where
 import Prelude
 
 import Language.PureScript.Hierarchy
-import qualified Language.PureScript as P
+import Language.PureScript qualified as P
 
 import Test.Hspec
 

--- a/tests/TestIde.hs
+++ b/tests/TestIde.hs
@@ -4,7 +4,7 @@ import Prelude
 
 import Control.Monad (unless)
 import Language.PureScript.Ide.Test
-import qualified PscIdeSpec
+import PscIdeSpec qualified
 import Test.Hspec
 
 spec :: Spec

--- a/tests/TestIde.hs
+++ b/tests/TestIde.hs
@@ -1,11 +1,11 @@
 module TestIde where
 
-import           Prelude
+import Prelude
 
-import           Control.Monad (unless)
-import           Language.PureScript.Ide.Test
+import Control.Monad (unless)
+import Language.PureScript.Ide.Test
 import qualified PscIdeSpec
-import           Test.Hspec
+import Test.Hspec
 
 spec :: Spec
 spec =

--- a/tests/TestMake.hs
+++ b/tests/TestMake.hs
@@ -5,8 +5,8 @@ module TestMake where
 
 import Prelude
 
-import qualified Language.PureScript as P
-import qualified Language.PureScript.CST as CST
+import Language.PureScript qualified as P
+import Language.PureScript.CST qualified as CST
 
 import Control.Concurrent (threadDelay)
 import Control.Monad
@@ -15,10 +15,10 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Concurrent.MVar (readMVar, newMVar, modifyMVar_)
 import Data.Time.Calendar
 import Data.Time.Clock
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Set (Set)
-import qualified Data.Set as Set
-import qualified Data.Map as M
+import Data.Set qualified as Set
+import Data.Map qualified as M
 
 import System.FilePath
 import System.Directory

--- a/tests/TestPrimDocs.hs
+++ b/tests/TestPrimDocs.hs
@@ -5,10 +5,10 @@ import Prelude
 import Data.List (sort)
 import Control.Exception (evaluate)
 import Control.DeepSeq (force)
-import qualified Data.Map as Map
-import qualified Data.Text as Text
-import qualified Language.PureScript as P
-import qualified Language.PureScript.Docs as D
+import Data.Map qualified as Map
+import Data.Text qualified as Text
+import Language.PureScript qualified as P
+import Language.PureScript.Docs qualified as D
 
 import Test.Hspec
 

--- a/tests/TestPscPublish.hs
+++ b/tests/TestPscPublish.hs
@@ -7,18 +7,18 @@ import Control.Monad (void, guard)
 import Control.Monad.IO.Class (liftIO)
 import Data.ByteString.Lazy (ByteString)
 import Data.Time.Clock (getCurrentTime)
-import qualified Data.Aeson as A
+import Data.Aeson qualified as A
 import Data.Version
 import Data.Foldable (forM_)
-import qualified Text.PrettyPrint.Boxes as Boxes
+import Text.PrettyPrint.Boxes qualified as Boxes
 import System.Directory (listDirectory, removeDirectoryRecursive)
 import System.FilePath ((</>))
 import System.IO.Error (isDoesNotExistError)
 
 import Language.PureScript.Docs
 import Language.PureScript.Publish (PublishOptions(..), defaultPublishOptions)
-import qualified Language.PureScript.Publish as Publish
-import qualified Language.PureScript.Publish.ErrorsWarnings as Publish
+import Language.PureScript.Publish qualified as Publish
+import Language.PureScript.Publish.ErrorsWarnings qualified as Publish
 
 import Test.Hspec
 import TestUtils hiding (inferForeignModules, makeActions)

--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -7,8 +7,8 @@ import Test.Hspec
 import           Control.Monad.Trans.State.Strict (evalStateT)
 import           Data.Functor ((<&>))
 import           Data.List (sort)
-import qualified Data.Text as T
-import qualified Language.PureScript as P
+import Data.Text qualified as T
+import Language.PureScript qualified as P
 import           Language.PureScript.Interactive
 import           TestPsci.TestEnv (initTestPSCiEnv)
 import           TestUtils (getSupportModuleNames)

--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -4,14 +4,14 @@ import Prelude
 
 import Test.Hspec
 
-import           Control.Monad.Trans.State.Strict (evalStateT)
-import           Data.Functor ((<&>))
-import           Data.List (sort)
+import Control.Monad.Trans.State.Strict (evalStateT)
+import Data.Functor ((<&>))
+import Data.List (sort)
 import Data.Text qualified as T
 import Language.PureScript qualified as P
-import           Language.PureScript.Interactive
-import           TestPsci.TestEnv (initTestPSCiEnv)
-import           TestUtils (getSupportModuleNames)
+import Language.PureScript.Interactive
+import TestPsci.TestEnv (initTestPSCiEnv)
+import TestUtils (getSupportModuleNames)
 
 completionTests :: Spec
 completionTests = context "completionTests" $

--- a/tests/TestPsci/EvalTest.hs
+++ b/tests/TestPsci/EvalTest.hs
@@ -2,17 +2,17 @@ module TestPsci.EvalTest where
 
 import Prelude
 
-import           Control.Monad (forM_, foldM_)
-import           Control.Monad.IO.Class (liftIO)
-import           Data.List (stripPrefix, intercalate)
-import           Data.List.Split (splitOn)
-import           System.Directory (getCurrentDirectory)
-import           System.Exit (exitFailure)
-import           System.FilePath ((</>), takeFileName)
+import Control.Monad (forM_, foldM_)
+import Control.Monad.IO.Class (liftIO)
+import Data.List (stripPrefix, intercalate)
+import Data.List.Split (splitOn)
+import System.Directory (getCurrentDirectory)
+import System.Exit (exitFailure)
+import System.FilePath ((</>), takeFileName)
 import System.FilePath.Glob qualified as Glob
-import           System.IO.UTF8 (readUTF8File)
-import           Test.Hspec
-import           TestPsci.TestEnv
+import System.IO.UTF8 (readUTF8File)
+import Test.Hspec
+import TestPsci.TestEnv
 
 evalTests :: Spec
 evalTests = context "evalTests" $ do

--- a/tests/TestPsci/EvalTest.hs
+++ b/tests/TestPsci/EvalTest.hs
@@ -9,7 +9,7 @@ import           Data.List.Split (splitOn)
 import           System.Directory (getCurrentDirectory)
 import           System.Exit (exitFailure)
 import           System.FilePath ((</>), takeFileName)
-import qualified System.FilePath.Glob as Glob
+import System.FilePath.Glob qualified as Glob
 import           System.IO.UTF8 (readUTF8File)
 import           Test.Hspec
 import           TestPsci.TestEnv

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -8,14 +8,14 @@ import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad.Trans.RWS.Strict (evalRWST, asks, local, RWST)
 import           Data.Foldable (traverse_)
 import           Data.List (isSuffixOf)
-import qualified Data.Text as T
-import qualified Language.PureScript as P
-import qualified Language.PureScript.CST as CST
+import Data.Text qualified as T
+import Language.PureScript qualified as P
+import Language.PureScript.CST qualified as CST
 import           Language.PureScript.Interactive
 import           System.Directory (getCurrentDirectory, doesPathExist, removeFile)
 import           System.Exit
 import           System.FilePath ((</>), pathSeparator)
-import qualified System.FilePath.Glob as Glob
+import System.FilePath.Glob qualified as Glob
 import           Test.Hspec (shouldBe, Expectation)
 
 -- | A monad transformer for handle PSCi actions in tests

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -2,21 +2,21 @@ module TestPsci.TestEnv where
 
 import Prelude
 
-import           Control.Exception.Lifted (bracket_)
-import           Control.Monad (void, when)
-import           Control.Monad.IO.Class (liftIO)
-import           Control.Monad.Trans.RWS.Strict (evalRWST, asks, local, RWST)
-import           Data.Foldable (traverse_)
-import           Data.List (isSuffixOf)
+import Control.Exception.Lifted (bracket_)
+import Control.Monad (void, when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.RWS.Strict (evalRWST, asks, local, RWST)
+import Data.Foldable (traverse_)
+import Data.List (isSuffixOf)
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
-import           Language.PureScript.Interactive
-import           System.Directory (getCurrentDirectory, doesPathExist, removeFile)
-import           System.Exit
-import           System.FilePath ((</>), pathSeparator)
+import Language.PureScript.Interactive
+import System.Directory (getCurrentDirectory, doesPathExist, removeFile)
+import System.Exit
+import System.FilePath ((</>), pathSeparator)
 import System.FilePath.Glob qualified as Glob
-import           Test.Hspec (shouldBe, Expectation)
+import Test.Hspec (shouldBe, Expectation)
 
 -- | A monad transformer for handle PSCi actions in tests
 type TestPSCi a = RWST PSCiConfig () PSCiState IO a

--- a/tests/TestSourceMaps.hs
+++ b/tests/TestSourceMaps.hs
@@ -6,12 +6,12 @@ import Control.Monad (void, forM_)
 import Data.Aeson as Json
 import Test.Hspec
 import System.FilePath (replaceExtension, takeFileName, (</>), (<.>))
-import qualified Language.PureScript as P
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
+import Language.PureScript qualified as P
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
 import Data.Foldable (fold)
 import TestUtils (getTestFiles, SupportModules (..), compile', ExpectedModuleName (IsSourceMap))
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import TestCompiler (getTestMain)
 import System.Process.Typed (proc, readProcess_)
 

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -2,10 +2,10 @@ module TestUtils where
 
 import Prelude
 
-import qualified Language.PureScript as P
-import qualified Language.PureScript.CST as CST
-import qualified Language.PureScript.AST as AST
-import qualified Language.PureScript.Names as N
+import Language.PureScript qualified as P
+import Language.PureScript.CST qualified as CST
+import Language.PureScript.AST qualified as AST
+import Language.PureScript.Names qualified as N
 import Language.PureScript.Interactive.IO (findNodeProcess)
 
 import Control.Arrow ((***), (>>>))
@@ -16,14 +16,14 @@ import Control.Monad.Trans.Maybe
 import Control.Monad.Writer.Class (tell)
 import Control.Exception
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Char (isSpace)
 import Data.Function (on)
 import Data.List (sort, sortBy, stripPrefix, groupBy, find)
-import qualified Data.Map as M
+import Data.Map qualified as M
 import Data.Maybe (isJust)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
 import Data.Time.Clock (UTCTime(), diffUTCTime, getCurrentTime, nominalDay)
 import Data.Tuple (swap)
 import System.Directory
@@ -33,7 +33,7 @@ import System.FilePath
 import System.IO.Error (isDoesNotExistError)
 import System.IO.UTF8 (readUTF8FileT)
 import System.Process hiding (cwd)
-import qualified System.FilePath.Glob as Glob
+import System.FilePath.Glob qualified as Glob
 import System.IO
 import Test.Hspec
 


### PR DESCRIPTION
**Description of the change**

First part of #4450. I'm breaking this up over multiple PRs because of how many files this will touch.

Changes made across `app`, `src`, and `tests`:
```diff
-import qualified Foo
+import Foo qualified
-import qualified Foo as F
+import Foo qualified as F
-import qualified Foo    as F
+import Foo qualified as F
-import           Foo
+import Foo
-import           Foo         (bar)
+import Foo (bar)
-import           "monad-logger" Foo
+import "monad-logger" Foo
```

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
