### PR TITLE
Make unqualified imports explicit

### DIFF
--- a/app/Command/Compile.hs
+++ b/app/Command/Compile.hs
@@ -2,8 +2,8 @@ module Command.Compile (command) where
 
 import Prelude
 
-import Control.Applicative
-import Control.Monad
+import Control.Applicative (Alternative(..))
+import Control.Monad (when)
 import Data.Aeson qualified as A
 import Data.Bool (bool)
 import Data.ByteString.Lazy.UTF8 qualified as LBU8
@@ -14,8 +14,8 @@ import Data.Text qualified as T
 import Data.Traversable (for)
 import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
-import Language.PureScript.Errors.JSON
-import Language.PureScript.Make
+import Language.PureScript.Errors.JSON (JSONResult(..), toJSONErrors)
+import Language.PureScript.Make (buildMakeActions, inferForeignModules, runMake)
 import Options.Applicative qualified as Opts
 import System.Console.ANSI qualified as ANSI
 import System.Exit (exitSuccess, exitFailure)

--- a/app/Command/Docs.hs
+++ b/app/Command/Docs.hs
@@ -3,10 +3,10 @@ module Command.Docs (command, infoModList) where
 
 import Prelude
 
-import Command.Docs.Html
-import Command.Docs.Markdown
-import Control.Applicative
-import Control.Monad.Writer
+import Command.Docs.Html (asHtml, writeHtmlModules)
+import Command.Docs.Markdown (asMarkdown, writeMarkdownModules)
+import Control.Applicative (Alternative(..), optional)
+import Control.Monad.Writer (when)
 import Control.Monad.Trans.Except (runExceptT)
 import Data.Maybe (fromMaybe)
 import Data.Text qualified as T

--- a/app/Command/Docs/Html.hs
+++ b/app/Command/Docs/Html.hs
@@ -7,9 +7,9 @@ module Command.Docs.Html
 
 import Prelude
 
-import Control.Applicative
+import Control.Applicative (Alternative(..))
 import Control.Arrow ((&&&))
-import Control.Monad.Writer
+import Control.Monad.Writer (guard)
 import Data.List (sort)
 import Data.Text (Text)
 import Data.Text.Lazy (toStrict)

--- a/app/Command/Graph.hs
+++ b/app/Command/Graph.hs
@@ -9,7 +9,7 @@ import Data.Bool (bool)
 import Data.ByteString.Lazy qualified as LB
 import Data.ByteString.Lazy.UTF8 qualified as LBU8
 import Language.PureScript qualified as P
-import Language.PureScript.Errors.JSON
+import Language.PureScript.Errors.JSON (JSONResult(..), toJSONErrors)
 import Options.Applicative qualified as Opts
 import System.Console.ANSI qualified as ANSI
 import System.Exit (exitFailure)

--- a/app/Command/Ide.hs
+++ b/app/Command/Ide.hs
@@ -20,24 +20,24 @@ module Command.Ide (command) where
 import Protolude
 
 import Data.Aeson qualified as Aeson
-import Control.Concurrent.STM
-import "monad-logger" Control.Monad.Logger
-import Data.IORef
+import Control.Concurrent.STM (newTVarIO)
+import "monad-logger" Control.Monad.Logger (MonadLogger, logDebug, logError, logInfo)
+import Data.IORef (newIORef)
 import Data.Text.IO qualified as T
 import Data.ByteString.Char8 qualified as BS8
 import Data.ByteString.Lazy.Char8 qualified as BSL8
 import GHC.IO.Exception (IOErrorType(..), IOException(..))
-import Language.PureScript.Ide
-import Language.PureScript.Ide.Command
-import Language.PureScript.Ide.Util
-import Language.PureScript.Ide.Error
+import Language.PureScript.Ide (handleCommand)
+import Language.PureScript.Ide.Command (Command(..), commandName)
+import Language.PureScript.Ide.Util (decodeT, displayTimeSpec, encodeT, logPerf, runLogger)
+import Language.PureScript.Ide.Error (IdeError(..))
 import Language.PureScript.Ide.State (updateCacheTimestamp)
-import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Types (Ide, IdeConfiguration(..), IdeEnvironment(..), IdeLogLevel(..), emptyIdeState)
 import Network.Socket qualified as Network
 import Options.Applicative qualified as Opts
-import System.Directory
-import System.FilePath
-import System.IO hiding (putStrLn, print)
+import System.Directory (doesDirectoryExist, getCurrentDirectory, setCurrentDirectory)
+import System.FilePath ((</>))
+import System.IO (BufferMode(..), hClose, hFlush, hSetBuffering, hSetEncoding, utf8)
 import System.IO.Error (isEOFError)
 
 listenOnLocalhost :: Network.PortNumber -> IO Network.Socket

--- a/app/Command/Publish.hs
+++ b/app/Command/Publish.hs
@@ -7,8 +7,8 @@ import Data.Aeson qualified as A
 import Data.ByteString.Lazy.Char8 qualified as BL
 import Data.Time.Clock (getCurrentTime)
 import Data.Version (Version(..))
-import Language.PureScript.Publish
-import Language.PureScript.Publish.ErrorsWarnings
+import Language.PureScript.Publish (PublishOptions(..), defaultPublishOptions, unsafePreparePackage, warn)
+import Language.PureScript.Publish.ErrorsWarnings (PackageWarning(..))
 import Options.Applicative (Parser)
 import Options.Applicative qualified as Opts
 

--- a/app/Command/REPL.hs
+++ b/app/Command/REPL.hs
@@ -5,10 +5,10 @@ module Command.REPL (command) where
 
 import Prelude
 import Control.Applicative (many, (<|>))
-import Control.Monad
+import Control.Monad (unless, when)
 import Control.Monad.Catch (MonadMask)
 import Control.Monad.IO.Class (liftIO, MonadIO)
-import Control.Monad.Trans.Class
+import Control.Monad.Trans.Class (MonadTrans(..))
 import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 import Control.Monad.Trans.State.Strict (StateT, evalStateT)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT)
@@ -17,9 +17,9 @@ import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
 import Language.PureScript.Interactive
 import Options.Applicative qualified as Opts
-import System.Console.Haskeline
+import System.Console.Haskeline (InputT, Settings(..), defaultSettings, getInputLine, handleInterrupt, outputStrLn, runInputT, setComplete, withInterrupt)
 import System.IO.UTF8 (readUTF8File)
-import System.Exit
+import System.Exit (ExitCode(..), exitFailure)
 import System.Directory (doesFileExist, getCurrentDirectory)
 import System.FilePath ((</>))
 import System.FilePath.Glob qualified as Glob

--- a/src/Control/Monad/Logger.hs
+++ b/src/Control/Monad/Logger.hs
@@ -7,11 +7,11 @@ import Prelude
 
 import Control.Monad (ap)
 import Control.Monad.Base (MonadBase(..))
-import Control.Monad.IO.Class
+import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Trans.Control (MonadBaseControl(..))
-import Control.Monad.Writer.Class
+import Control.Monad.Writer.Class (MonadWriter(..))
 
-import Data.IORef
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 
 -- | A replacement for WriterT IO which uses mutable references.
 newtype Logger w a = Logger { runLogger :: IORef w -> IO a }

--- a/src/Control/Monad/Supply.hs
+++ b/src/Control/Monad/Supply.hs
@@ -5,13 +5,13 @@ module Control.Monad.Supply where
 
 import Prelude
 
-import Control.Applicative
+import Control.Applicative (Alternative)
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Reader
-import Control.Monad.State
-import Control.Monad.Writer
+import Control.Monad.Reader (MonadPlus, MonadReader, MonadTrans)
+import Control.Monad.State (StateT(..))
+import Control.Monad.Writer (MonadWriter)
 
-import Data.Functor.Identity
+import Data.Functor.Identity (Identity(..))
 
 newtype SupplyT m a = SupplyT { unSupplyT :: StateT Integer m a }
   deriving (Functor, Applicative, Monad, MonadTrans, MonadError e, MonadWriter w, MonadReader r, Alternative, MonadPlus)

--- a/src/Control/Monad/Supply/Class.hs
+++ b/src/Control/Monad/Supply/Class.hs
@@ -6,10 +6,10 @@ module Control.Monad.Supply.Class where
 
 import Prelude
 
-import Control.Monad.RWS
-import Control.Monad.State
-import Control.Monad.Supply
-import Control.Monad.Writer
+import Control.Monad.RWS (MonadState(..), MonadTrans(..), RWST)
+import Control.Monad.State (StateT)
+import Control.Monad.Supply (SupplyT(..))
+import Control.Monad.Writer (WriterT)
 import Data.Text (Text, pack)
 
 class Monad m => MonadSupply m where

--- a/src/Language/PureScript/AST/Binders.hs
+++ b/src/Language/PureScript/AST/Binders.hs
@@ -5,11 +5,11 @@ module Language.PureScript.AST.Binders where
 
 import Prelude
 
-import Language.PureScript.AST.SourcePos
-import Language.PureScript.AST.Literals
-import Language.PureScript.Names
-import Language.PureScript.Comments
-import Language.PureScript.Types
+import Language.PureScript.AST.SourcePos (SourceSpan)
+import Language.PureScript.AST.Literals (Literal(..))
+import Language.PureScript.Names (Ident, OpName, OpNameType(..), ProperName, ProperNameType(..), Qualified)
+import Language.PureScript.Comments (Comment)
+import Language.PureScript.Types (SourceType)
 
 -- |
 -- Data type for binders

--- a/src/Language/PureScript/AST/Declarations.hs
+++ b/src/Language/PureScript/AST/Declarations.hs
@@ -11,27 +11,27 @@ import Protolude.Exceptions (hush)
 
 import Codec.Serialise (Serialise)
 import Control.DeepSeq (NFData)
-import Data.Functor.Identity
+import Data.Functor.Identity (Identity(..))
 
-import Data.Aeson.TH
+import Data.Aeson.TH (Options(..), SumEncoding(..), defaultOptions, deriveJSON)
 import Data.Map qualified as M
 import Data.Text (Text)
 import Data.List.NonEmpty qualified as NEL
 import GHC.Generics (Generic)
 
-import Language.PureScript.AST.Binders
-import Language.PureScript.AST.Literals
-import Language.PureScript.AST.Operators
-import Language.PureScript.AST.SourcePos
+import Language.PureScript.AST.Binders (Binder)
+import Language.PureScript.AST.Literals (Literal(..))
+import Language.PureScript.AST.Operators (Fixity)
+import Language.PureScript.AST.SourcePos (SourceAnn, SourceSpan)
 import Language.PureScript.AST.Declarations.ChainId (ChainId)
-import Language.PureScript.Types
+import Language.PureScript.Types (SourceConstraint, SourceType)
 import Language.PureScript.PSString (PSString)
 import Language.PureScript.Label (Label)
-import Language.PureScript.Names
-import Language.PureScript.Roles
-import Language.PureScript.TypeClassDictionaries
-import Language.PureScript.Comments
-import Language.PureScript.Environment
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident(..), ModuleName(..), Name(..), OpName, OpNameType(..), ProperName, ProperNameType(..), Qualified(..), QualifiedBy(..), toMaybeModuleName)
+import Language.PureScript.Roles (Role)
+import Language.PureScript.TypeClassDictionaries (NamedDict)
+import Language.PureScript.Comments (Comment)
+import Language.PureScript.Environment (DataDeclType, Environment, FunctionalDependency, NameKind)
 import Language.PureScript.Constants.Prim qualified as C
 
 -- | A map of locally-bound names in scope.

--- a/src/Language/PureScript/AST/Exported.hs
+++ b/src/Language/PureScript/AST/Exported.hs
@@ -12,9 +12,9 @@ import Control.Applicative ((<|>))
 import Data.Maybe (mapMaybe)
 import Data.Map qualified as M
 
-import Language.PureScript.AST.Declarations
-import Language.PureScript.Types
-import Language.PureScript.Names
+import Language.PureScript.AST.Declarations (DataConstructorDeclaration(..), Declaration(..), DeclarationRef(..), Module(..), declName, declRefName, flattenDecls)
+import Language.PureScript.Types (Constraint(..), Type(..), everythingOnTypes)
+import Language.PureScript.Names (ModuleName, Name(..), ProperName, ProperNameType(..), Qualified, coerceProperName, disqualify, isQualified, isQualifiedWith)
 
 -- |
 -- Return a list of all declarations which are exported from a module.

--- a/src/Language/PureScript/AST/Operators.hs
+++ b/src/Language/PureScript/AST/Operators.hs
@@ -11,7 +11,7 @@ import Control.DeepSeq (NFData)
 import Data.Aeson ((.=))
 import Data.Aeson qualified as A
 
-import Language.PureScript.Crash
+import Language.PureScript.Crash (internalError)
 
 -- |
 -- A precedence level for an infix operator

--- a/src/Language/PureScript/AST/SourcePos.hs
+++ b/src/Language/PureScript/AST/SourcePos.hs
@@ -11,7 +11,7 @@ import Control.DeepSeq (NFData)
 import Data.Aeson ((.=), (.:))
 import Data.Text (Text)
 import GHC.Generics (Generic)
-import Language.PureScript.Comments
+import Language.PureScript.Comments (Comment)
 import Data.Aeson qualified as A
 import Data.Text qualified as T
 import System.FilePath (makeRelative)

--- a/src/Language/PureScript/AST/Traversals.hs
+++ b/src/Language/PureScript/AST/Traversals.hs
@@ -6,8 +6,8 @@ module Language.PureScript.AST.Traversals where
 import Prelude
 import Protolude (swap)
 
-import Control.Monad
-import Control.Monad.Trans.State
+import Control.Monad ((<=<), (>=>))
+import Control.Monad.Trans.State (StateT(..))
 
 import Data.Foldable (fold)
 import Data.Functor.Identity (runIdentity)
@@ -17,13 +17,13 @@ import Data.List.NonEmpty qualified as NEL
 import Data.Map qualified as M
 import Data.Set qualified as S
 
-import Language.PureScript.AST.Binders
-import Language.PureScript.AST.Declarations
-import Language.PureScript.AST.Literals
-import Language.PureScript.Names
-import Language.PureScript.Traversals
+import Language.PureScript.AST.Binders (Binder(..), binderNames)
+import Language.PureScript.AST.Declarations (CaseAlternative(..), DataConstructorDeclaration(..), Declaration(..), DoNotationElement(..), Expr(..), Guard(..), GuardedExpr(..), TypeDeclarationData(..), TypeInstanceBody(..), pattern ValueDecl, ValueDeclarationData(..), mapTypeInstanceBody, traverseTypeInstanceBody)
+import Language.PureScript.AST.Literals (Literal(..))
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident)
+import Language.PureScript.Traversals (sndM, sndM', thirdM)
 import Language.PureScript.TypeClassDictionaries (TypeClassDictionaryInScope(..))
-import Language.PureScript.Types
+import Language.PureScript.Types (Constraint(..), SourceType, mapConstraintArgs)
 
 guardedExprM :: Applicative m
              => (Guard -> m Guard)

--- a/src/Language/PureScript/AST/Utils.hs
+++ b/src/Language/PureScript/AST/Utils.hs
@@ -2,9 +2,9 @@ module Language.PureScript.AST.Utils where
 
 import Protolude
 
-import Language.PureScript.AST
-import Language.PureScript.Names
-import Language.PureScript.Types
+import Language.PureScript.AST (Binder(..), CaseAlternative, Expr(..), GuardedExpr, Literal, pattern MkUnguarded, nullSourceSpan)
+import Language.PureScript.Names (Ident, ModuleName, ProperName, ProperNameType(..), Qualified(..), QualifiedBy(..), byMaybeModuleName)
+import Language.PureScript.Types (SourceType, Type(..))
 
 lam :: Ident -> Expr -> Expr
 lam = Abs . mkBinder

--- a/src/Language/PureScript/Bundle.hs
+++ b/src/Language/PureScript/Bundle.hs
@@ -18,7 +18,7 @@ module Language.PureScript.Bundle
 
 import Prelude
 
-import Control.Monad.Error.Class
+import Control.Monad.Error.Class (MonadError(..))
 
 import Data.Aeson ((.=))
 import Data.Char (chr, digitToInt)
@@ -27,9 +27,9 @@ import Data.Maybe (mapMaybe, maybeToList)
 import Data.Aeson qualified as A
 import Data.Text.Lazy qualified as LT
 
-import Language.JavaScript.Parser
-import Language.JavaScript.Parser.AST
-import Language.JavaScript.Process.Minify
+import Language.JavaScript.Parser (JSAST(..), JSAnnot(..), JSAssignOp(..), JSExpression(..), JSStatement(..), renderToText)
+import Language.JavaScript.Parser.AST (JSCommaList(..), JSCommaTrailingList(..), JSExportClause(..), JSExportDeclaration(..), JSExportSpecifier(..), JSFromClause(..), JSIdent(..), JSImportDeclaration(..), JSModuleItem(..), JSObjectProperty(..), JSObjectPropertyList, JSPropertyName(..), JSVarInitializer(..))
+import Language.JavaScript.Process.Minify (minifyJS)
 
 -- | The type of error messages. We separate generation and rendering of errors using a data
 -- type, in case we need to match on error types later.

--- a/src/Language/PureScript/CST/Errors.hs
+++ b/src/Language/PureScript/CST/Errors.hs
@@ -13,9 +13,9 @@ import Prelude
 
 import Data.Text qualified as Text
 import Data.Char (isSpace, toUpper)
-import Language.PureScript.CST.Layout
-import Language.PureScript.CST.Print
-import Language.PureScript.CST.Types
+import Language.PureScript.CST.Layout (LayoutStack)
+import Language.PureScript.CST.Print (printToken)
+import Language.PureScript.CST.Types (SourcePos(..), SourceRange(..), SourceToken(..), Token(..))
 import Text.Printf (printf)
 
 data ParserErrorType

--- a/src/Language/PureScript/CST/Flatten.hs
+++ b/src/Language/PureScript/CST/Flatten.hs
@@ -4,7 +4,7 @@ import Prelude
 
 import Data.DList (DList)
 import Language.PureScript.CST.Types
-import Language.PureScript.CST.Positions
+import Language.PureScript.CST.Positions (advanceLeading, moduleRange, srcRange)
 
 flattenModule :: Module a -> DList SourceToken
 flattenModule m@(Module _ a b c d e f g) =

--- a/src/Language/PureScript/CST/Layout.hs
+++ b/src/Language/PureScript/CST/Layout.hs
@@ -174,7 +174,7 @@ import Data.DList (snoc)
 import Data.DList qualified as DList
 import Data.Foldable (find)
 import Data.Function ((&))
-import Language.PureScript.CST.Types
+import Language.PureScript.CST.Types (Comment, LineFeed, SourcePos(..), SourceRange(..), SourceToken(..), Token(..), TokenAnn(..))
 
 type LayoutStack = [(SourcePos, LayoutDelim)]
 

--- a/src/Language/PureScript/CST/Lexer.hs
+++ b/src/Language/PureScript/CST/Lexer.hs
@@ -19,11 +19,11 @@ import Data.String (fromString)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.PureScript qualified as Text
-import Language.PureScript.CST.Errors
-import Language.PureScript.CST.Monad hiding (token)
-import Language.PureScript.CST.Layout
-import Language.PureScript.CST.Positions
-import Language.PureScript.CST.Types
+import Language.PureScript.CST.Errors (ParserErrorInfo(..), ParserErrorType(..))
+import Language.PureScript.CST.Monad (LexResult, LexState(..), ParserM(..), throw)
+import Language.PureScript.CST.Layout (LayoutDelim(..), insertLayout, lytToken, unwindLayout)
+import Language.PureScript.CST.Positions (advanceLeading, advanceToken, advanceTrailing, applyDelta, textDelta)
+import Language.PureScript.CST.Types (Comment(..), LineFeed(..), SourcePos(..), SourceRange(..), SourceStyle(..), SourceToken(..), Token(..), TokenAnn(..))
 
 -- | Stops at the first lexing error and replaces it with TokEof. Otherwise,
 -- the parser will fail when it attempts to draw a lookahead token.

--- a/src/Language/PureScript/CST/Monad.hs
+++ b/src/Language/PureScript/CST/Monad.hs
@@ -6,10 +6,10 @@ import Data.List (sortOn)
 import Data.List.NonEmpty qualified as NE
 import Data.Ord (comparing)
 import Data.Text (Text)
-import Language.PureScript.CST.Errors
-import Language.PureScript.CST.Layout
-import Language.PureScript.CST.Positions
-import Language.PureScript.CST.Types
+import Language.PureScript.CST.Errors (ParserError, ParserErrorInfo(..), ParserErrorType(..), ParserWarning, ParserWarningType)
+import Language.PureScript.CST.Layout (LayoutStack)
+import Language.PureScript.CST.Positions (widen)
+import Language.PureScript.CST.Types (Comment, LineFeed, SourcePos(..), SourceRange(..), SourceToken(..), Token, TokenAnn(..))
 
 type LexResult = Either (LexState, ParserError) SourceToken
 

--- a/src/Language/PureScript/CST/Print.hs
+++ b/src/Language/PureScript/CST/Print.hs
@@ -15,7 +15,7 @@ import Prelude
 import Data.DList qualified as DList
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Language.PureScript.CST.Types
+import Language.PureScript.CST.Types (Comment(..), LineFeed(..), Module, SourceStyle(..), SourceToken(..), Token(..), TokenAnn(..))
 import Language.PureScript.CST.Flatten (flattenModule)
 
 printToken :: Token -> Text

--- a/src/Language/PureScript/CST/Traversals.hs
+++ b/src/Language/PureScript/CST/Traversals.hs
@@ -2,7 +2,7 @@ module Language.PureScript.CST.Traversals where
 
 import Prelude
 
-import Language.PureScript.CST.Types
+import Language.PureScript.CST.Types (Separated(..))
 
 everythingOnSeparated :: (r -> r -> r) -> (a -> r) -> Separated a -> r
 everythingOnSeparated op k (Separated hd tl) = go hd tl

--- a/src/Language/PureScript/CST/Traversals/Type.hs
+++ b/src/Language/PureScript/CST/Traversals/Type.hs
@@ -2,8 +2,8 @@ module Language.PureScript.CST.Traversals.Type where
 
 import Prelude
 
-import Language.PureScript.CST.Types
-import Language.PureScript.CST.Traversals
+import Language.PureScript.CST.Types (Constraint(..), Labeled(..), Row(..), Type(..), Wrapped(..))
+import Language.PureScript.CST.Traversals (everythingOnSeparated)
 
 everythingOnTypes :: (r -> r -> r) -> (Type a -> r) -> Type a -> r
 everythingOnTypes op k = goTy

--- a/src/Language/PureScript/CST/Utils.hs
+++ b/src/Language/PureScript/CST/Utils.hs
@@ -11,10 +11,10 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Language.PureScript.CST.Errors
-import Language.PureScript.CST.Monad
-import Language.PureScript.CST.Positions
-import Language.PureScript.CST.Traversals.Type
+import Language.PureScript.CST.Errors (ParserErrorType(..))
+import Language.PureScript.CST.Monad (Parser, addFailure, parseFail, pushBack)
+import Language.PureScript.CST.Positions (TokenRange, binderRange, importDeclRange, recordUpdateRange, typeRange)
+import Language.PureScript.CST.Traversals.Type (everythingOnTypes)
 import Language.PureScript.CST.Types
 import Language.PureScript.Names qualified as N
 import Language.PureScript.PSString (PSString, mkString)

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -13,7 +13,7 @@ import Control.Applicative (liftA2)
 import Control.Monad (forM, replicateM, void)
 import Control.Monad.Except (MonadError, throwError)
 import Control.Monad.Reader (MonadReader, asks)
-import Control.Monad.Supply.Class
+import Control.Monad.Supply.Class (MonadSupply, freshName)
 import Control.Monad.Writer (MonadWriter, runWriterT, writer)
 
 import Data.Bifunctor (first)
@@ -28,20 +28,20 @@ import Data.String (fromString)
 import Data.Text (Text)
 import Data.Text qualified as T
 
-import Language.PureScript.AST.SourcePos
+import Language.PureScript.AST.SourcePos (SourceSpan, displayStartEndPos)
 import Language.PureScript.CodeGen.JS.Common as Common
 import Language.PureScript.CoreImp.AST (AST, InitializerEffects(..), everywhere, everywhereTopDownM, withSourceSpan)
 import Language.PureScript.CoreImp.AST qualified as AST
 import Language.PureScript.CoreImp.Module qualified as AST
-import Language.PureScript.CoreImp.Optimizer
-import Language.PureScript.CoreFn
+import Language.PureScript.CoreImp.Optimizer (optimize)
+import Language.PureScript.CoreFn (Ann, Bind(..), Binder(..), CaseAlternative(..), ConstructorType(..), Expr(..), Guard, Literal(..), Meta(..), Module(..), extractAnn, extractBinderAnn, modifyAnn, removeComments)
 import Language.PureScript.CoreFn.Laziness (applyLazinessTransform)
-import Language.PureScript.Crash
+import Language.PureScript.Crash (internalError)
 import Language.PureScript.Errors (ErrorMessageHint(..), SimpleErrorMessage(..),
                                    MultipleErrors(..), rethrow, errorMessage,
                                    errorMessage', rethrowWithPosition, addHint)
-import Language.PureScript.Names
-import Language.PureScript.Options
+import Language.PureScript.Names (Ident(..), ModuleName, ProperName(..), Qualified(..), QualifiedBy(..), runIdent, runModuleName, showIdent, showQualified)
+import Language.PureScript.Options (CodegenTarget(..), Options(..))
 import Language.PureScript.PSString (PSString, mkString)
 import Language.PureScript.Traversals (sndM)
 import Language.PureScript.Constants.Prim qualified as C

--- a/src/Language/PureScript/CodeGen/JS/Common.hs
+++ b/src/Language/PureScript/CodeGen/JS/Common.hs
@@ -3,12 +3,12 @@ module Language.PureScript.CodeGen.JS.Common where
 
 import Prelude
 
-import Data.Char
+import Data.Char (isAlpha, isAlphaNum, isDigit, ord)
 import Data.Text (Text)
 import Data.Text qualified as T
 
-import Language.PureScript.Crash
-import Language.PureScript.Names
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Names (Ident(..), InternalIdentData(..), ModuleName(..), ProperName(..), unusedIdent)
 
 moduleNameToJs :: ModuleName -> Text
 moduleNameToJs (ModuleName mn) =

--- a/src/Language/PureScript/CodeGen/JS/Printer.hs
+++ b/src/Language/PureScript/CodeGen/JS/Printer.hs
@@ -9,7 +9,7 @@ import Prelude
 import Control.Arrow ((<+>))
 import Control.Monad (forM, mzero)
 import Control.Monad.State (StateT, evalStateT)
-import Control.PatternArrows
+import Control.PatternArrows (Operator(..), OperatorTable(..), Pattern(..), buildPrettyPrinter, mkPattern, mkPattern')
 import Control.Arrow qualified as A
 
 import Data.Maybe (fromMaybe)
@@ -18,12 +18,12 @@ import Data.Text qualified as T
 import Data.List.NonEmpty qualified as NEL (toList)
 
 import Language.PureScript.AST (SourceSpan(..))
-import Language.PureScript.CodeGen.JS.Common
-import Language.PureScript.CoreImp.AST
-import Language.PureScript.CoreImp.Module
-import Language.PureScript.Comments
-import Language.PureScript.Crash
-import Language.PureScript.Pretty.Common
+import Language.PureScript.CodeGen.JS.Common (identCharToText, isValidJsIdentifier, nameIsJsBuiltIn, nameIsJsReserved)
+import Language.PureScript.CoreImp.AST (AST(..), BinaryOperator(..), CIComments(..), UnaryOperator(..), getSourceSpan)
+import Language.PureScript.CoreImp.Module (Export(..), Import(..), Module(..))
+import Language.PureScript.Comments (Comment(..))
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Pretty.Common (Emit(..), PrinterState(..), SMap, StrPos(..), addMapping', currentIndent, intercalate, parensPos, runPlainString, withIndent)
 import Language.PureScript.PSString (PSString, decodeString, prettyPrintStringJS)
 
 -- TODO (Christoph): Get rid of T.unpack / pack

--- a/src/Language/PureScript/Comments.hs
+++ b/src/Language/PureScript/Comments.hs
@@ -11,7 +11,7 @@ import Control.DeepSeq (NFData)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
-import Data.Aeson.TH
+import Data.Aeson.TH (Options(..), SumEncoding(..), defaultOptions, deriveJSON)
 
 data Comment
   = LineComment Text

--- a/src/Language/PureScript/Constants/Prim.hs
+++ b/src/Language/PureScript/Constants/Prim.hs
@@ -3,7 +3,7 @@
 -- | Various constants which refer to things in Prim
 module Language.PureScript.Constants.Prim where
 
-import Language.PureScript.Names
+import Language.PureScript.Names (ModuleName)
 import Language.PureScript.Constants.TH qualified as TH
 
 $(TH.declare do

--- a/src/Language/PureScript/Constants/TH.hs
+++ b/src/Language/PureScript/Constants/TH.hs
@@ -74,8 +74,8 @@ import Control.Monad.Trans.RWS (RWS, execRWS)
 import Control.Monad.Trans.Writer (Writer, execWriter)
 import Control.Monad.Writer.Class (tell)
 import Data.String (String)
-import Language.Haskell.TH
-import Language.PureScript.Names hiding (Name)
+import Language.Haskell.TH (Dec, Name, Pat, Q, Type, conP, implBidir, litP, mkName, patSynD, patSynSigD, prefixPatSyn, stringL)
+import Language.PureScript.Names (Ident(..), ModuleName(..), ProperName(..), ProperNameType(..), Qualified(..), QualifiedBy(..))
 
 -- | Generate pattern synonyms corresponding to the provided PureScript
 -- declarations.

--- a/src/Language/PureScript/CoreFn/Ann.hs
+++ b/src/Language/PureScript/CoreFn/Ann.hs
@@ -2,10 +2,10 @@ module Language.PureScript.CoreFn.Ann where
 
 import Prelude
 
-import Language.PureScript.AST.SourcePos
-import Language.PureScript.Comments
-import Language.PureScript.CoreFn.Meta
-import Language.PureScript.Types
+import Language.PureScript.AST.SourcePos (SourceSpan)
+import Language.PureScript.Comments (Comment)
+import Language.PureScript.CoreFn.Meta (Meta)
+import Language.PureScript.Types (SourceType)
 
 -- |
 -- Type alias for basic annotations

--- a/src/Language/PureScript/CoreFn/Binders.hs
+++ b/src/Language/PureScript/CoreFn/Binders.hs
@@ -5,8 +5,8 @@ module Language.PureScript.CoreFn.Binders where
 
 import Prelude
 
-import Language.PureScript.AST.Literals
-import Language.PureScript.Names
+import Language.PureScript.AST.Literals (Literal)
+import Language.PureScript.Names (Ident, ProperName, ProperNameType(..), Qualified)
 
 -- |
 -- Data type for binders

--- a/src/Language/PureScript/CoreFn/CSE.hs
+++ b/src/Language/PureScript/CoreFn/CSE.hs
@@ -4,7 +4,7 @@ module Language.PureScript.CoreFn.CSE (optimizeCommonSubexpressions) where
 
 import Protolude hiding (pass)
 
-import Control.Lens
+import Control.Lens (At(..), makeLenses, non, view, (%~), (.=), (.~), (<>~), (^.))
 import Control.Monad.Supply (Supply)
 import Control.Monad.Supply.Class (MonadSupply)
 import Control.Monad.RWS (MonadWriter, RWST, censor, evalRWST, listen, pass, tell)
@@ -17,16 +17,16 @@ import Data.Maybe (fromJust)
 import Data.Semigroup (Min(..))
 import Data.Semigroup.Generic (GenericSemigroupMonoid(..))
 
-import Language.PureScript.AST.Literals
+import Language.PureScript.AST.Literals (Literal(..))
 import Language.PureScript.AST.SourcePos (nullSourceSpan)
 import Language.PureScript.Constants.Libs qualified as C
 import Language.PureScript.CoreFn.Ann (Ann)
-import Language.PureScript.CoreFn.Binders
-import Language.PureScript.CoreFn.Expr
+import Language.PureScript.CoreFn.Binders (Binder(..))
+import Language.PureScript.CoreFn.Expr (Bind(..), CaseAlternative(..), Expr(..))
 import Language.PureScript.CoreFn.Meta (Meta(IsSyntheticApp))
-import Language.PureScript.CoreFn.Traversals
+import Language.PureScript.CoreFn.Traversals (everywhereOnValues, traverseCoreFn)
 import Language.PureScript.Environment (dictTypeName)
-import Language.PureScript.Names
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident(..), ModuleName, ProperName(..), Qualified(..), QualifiedBy(..), freshIdent, runIdent, toMaybeModuleName)
 import Language.PureScript.PSString (decodeString)
 
 -- |

--- a/src/Language/PureScript/CoreFn/Desugar.hs
+++ b/src/Language/PureScript/CoreFn/Desugar.hs
@@ -11,19 +11,19 @@ import Data.Tuple (swap)
 import Data.List.NonEmpty qualified as NEL
 import Data.Map qualified as M
 
-import Language.PureScript.AST.Literals
-import Language.PureScript.AST.SourcePos
-import Language.PureScript.AST.Traversals
-import Language.PureScript.Comments
-import Language.PureScript.CoreFn.Ann
-import Language.PureScript.CoreFn.Binders
-import Language.PureScript.CoreFn.Expr
-import Language.PureScript.CoreFn.Meta
-import Language.PureScript.CoreFn.Module
-import Language.PureScript.Crash
-import Language.PureScript.Environment
-import Language.PureScript.Names
-import Language.PureScript.Types
+import Language.PureScript.AST.Literals (Literal(..))
+import Language.PureScript.AST.SourcePos (pattern NullSourceSpan, SourceSpan(..))
+import Language.PureScript.AST.Traversals (everythingOnValues)
+import Language.PureScript.Comments (Comment)
+import Language.PureScript.CoreFn.Ann (Ann, ssAnn)
+import Language.PureScript.CoreFn.Binders (Binder(..))
+import Language.PureScript.CoreFn.Expr (Bind(..), CaseAlternative(..), Expr(..), Guard)
+import Language.PureScript.CoreFn.Meta (ConstructorType(..), Meta(..))
+import Language.PureScript.CoreFn.Module (Module(..))
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Environment (DataDeclType(..), Environment(..), NameKind(..), isDictTypeName, lookupConstructor, lookupValue)
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident(..), ModuleName, ProperName(..), ProperNameType(..), Qualified(..), QualifiedBy(..), getQual)
+import Language.PureScript.Types (SourceType)
 import Language.PureScript.AST qualified as A
 import Language.PureScript.Constants.Prim qualified as C
 

--- a/src/Language/PureScript/CoreFn/Expr.hs
+++ b/src/Language/PureScript/CoreFn/Expr.hs
@@ -7,9 +7,9 @@ import Prelude
 
 import Control.Arrow ((***))
 
-import Language.PureScript.AST.Literals
-import Language.PureScript.CoreFn.Binders
-import Language.PureScript.Names
+import Language.PureScript.AST.Literals (Literal)
+import Language.PureScript.CoreFn.Binders (Binder)
+import Language.PureScript.Names (Ident, ProperName, ProperNameType(..), Qualified)
 import Language.PureScript.PSString (PSString)
 
 -- |

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -11,7 +11,7 @@ import Prelude
 
 import Control.Applicative ((<|>))
 
-import Data.Aeson
+import Data.Aeson (FromJSON(..), Object, Value(..), withObject, withText, (.:))
 import Data.Aeson.Types (Parser, listParser)
 import Data.Map.Strict qualified as M
 import Data.Text (Text)
@@ -20,10 +20,10 @@ import Data.Vector qualified as V
 import Data.Version (Version, parseVersion)
 
 import Language.PureScript.AST.SourcePos (SourceSpan(..))
-import Language.PureScript.AST.Literals
-import Language.PureScript.CoreFn.Ann
-import Language.PureScript.CoreFn
-import Language.PureScript.Names
+import Language.PureScript.AST.Literals (Literal(..))
+import Language.PureScript.CoreFn.Ann (Ann)
+import Language.PureScript.CoreFn (Bind(..), Binder(..), CaseAlternative(..), ConstructorType(..), Expr(..), Guard, Meta(..), Module(..))
+import Language.PureScript.Names (Ident(..), ModuleName(..), ProperName(..), Qualified(..), QualifiedBy(..), unusedIdent)
 import Language.PureScript.PSString (PSString)
 
 import Text.ParserCombinators.ReadP (readP_to_S)

--- a/src/Language/PureScript/CoreFn/Laziness.hs
+++ b/src/Language/PureScript/CoreFn/Laziness.hs
@@ -16,11 +16,11 @@ import Data.Map.Monoidal qualified as M
 import Data.Semigroup (Max(..))
 import Data.Set qualified as S
 
-import Language.PureScript.AST.SourcePos
+import Language.PureScript.AST.SourcePos (SourcePos(..), SourceSpan(..), nullSourceSpan)
 import Language.PureScript.Constants.Libs qualified as C
-import Language.PureScript.CoreFn
-import Language.PureScript.Crash
-import Language.PureScript.Names
+import Language.PureScript.CoreFn (Ann, Bind, Expr(..), Literal(..), Meta(..), ssAnn, traverseCoreFn)
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident(..), InternalIdentData(..), ModuleName, Qualified(..), QualifiedBy(..), runIdent, runModuleName, toMaybeModuleName)
 import Language.PureScript.PSString (mkString)
 
 -- This module is responsible for ensuring that the bindings in recursive

--- a/src/Language/PureScript/CoreFn/Meta.hs
+++ b/src/Language/PureScript/CoreFn/Meta.hs
@@ -5,7 +5,7 @@ module Language.PureScript.CoreFn.Meta where
 
 import Prelude
 
-import Language.PureScript.Names
+import Language.PureScript.Names (Ident)
 
 -- |
 -- Metadata annotations

--- a/src/Language/PureScript/CoreFn/Module.hs
+++ b/src/Language/PureScript/CoreFn/Module.hs
@@ -4,10 +4,10 @@ import Prelude
 
 import Data.Map.Strict (Map)
 
-import Language.PureScript.AST.SourcePos
-import Language.PureScript.Comments
-import Language.PureScript.CoreFn.Expr
-import Language.PureScript.Names
+import Language.PureScript.AST.SourcePos (SourceSpan)
+import Language.PureScript.Comments (Comment)
+import Language.PureScript.CoreFn.Expr (Bind)
+import Language.PureScript.Names (Ident, ModuleName)
 
 -- |
 -- The CoreFn module representation

--- a/src/Language/PureScript/CoreFn/Optimizer.hs
+++ b/src/Language/PureScript/CoreFn/Optimizer.hs
@@ -4,15 +4,15 @@ import Protolude hiding (Type, moduleName)
 
 import Control.Monad.Supply (Supply)
 import Data.List (lookup)
-import Language.PureScript.AST.Literals
-import Language.PureScript.AST.SourcePos
-import Language.PureScript.CoreFn.Ann
-import Language.PureScript.CoreFn.CSE
-import Language.PureScript.CoreFn.Expr
-import Language.PureScript.CoreFn.Module
-import Language.PureScript.CoreFn.Traversals
-import Language.PureScript.Label
-import Language.PureScript.Types
+import Language.PureScript.AST.Literals (Literal(..))
+import Language.PureScript.AST.SourcePos (nullSourceSpan)
+import Language.PureScript.CoreFn.Ann (Ann)
+import Language.PureScript.CoreFn.CSE (optimizeCommonSubexpressions)
+import Language.PureScript.CoreFn.Expr (Bind, Expr(..))
+import Language.PureScript.CoreFn.Module (Module(..))
+import Language.PureScript.CoreFn.Traversals (everywhereOnValues)
+import Language.PureScript.Label (Label(..))
+import Language.PureScript.Types (pattern REmptyKinded, Type(..))
 import Language.PureScript.Constants.Libs qualified as C
 import Language.PureScript.Constants.Prim qualified as C
 

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -12,7 +12,7 @@ import Prelude
 import Control.Arrow ((***))
 import Data.Either (isLeft)
 import Data.Map.Strict qualified as M
-import Data.Aeson hiding ((.=))
+import Data.Aeson (ToJSON(..), Value(..), object)
 import Data.Aeson qualified
 import Data.Aeson.Key qualified
 import Data.Aeson.Types (Pair)
@@ -20,10 +20,10 @@ import Data.Version (Version, showVersion)
 import Data.Text (Text)
 import Data.Text qualified as T
 
-import Language.PureScript.AST.Literals
+import Language.PureScript.AST.Literals (Literal(..))
 import Language.PureScript.AST.SourcePos (SourceSpan(..))
-import Language.PureScript.CoreFn
-import Language.PureScript.Names
+import Language.PureScript.CoreFn (Ann, Bind(..), Binder(..), CaseAlternative(..), ConstructorType(..), Expr(..), Meta(..), Module(..))
+import Language.PureScript.Names (Ident, ModuleName(..), ProperName(..), Qualified(..), QualifiedBy(..), runIdent)
 import Language.PureScript.PSString (PSString)
 
 constructorTypeToJSON :: ConstructorType -> Value

--- a/src/Language/PureScript/CoreFn/Traversals.hs
+++ b/src/Language/PureScript/CoreFn/Traversals.hs
@@ -8,9 +8,9 @@ import Prelude
 import Control.Arrow (second, (***), (+++))
 import Data.Bitraversable (bitraverse)
 
-import Language.PureScript.AST.Literals
-import Language.PureScript.CoreFn.Binders
-import Language.PureScript.CoreFn.Expr
+import Language.PureScript.AST.Literals (Literal(..))
+import Language.PureScript.CoreFn.Binders (Binder(..))
+import Language.PureScript.CoreFn.Expr (Bind(..), CaseAlternative(..), Expr(..))
 
 everywhereOnValues :: (Bind a -> Bind a) ->
                       (Expr a -> Expr a) ->

--- a/src/Language/PureScript/CoreImp/AST.hs
+++ b/src/Language/PureScript/CoreImp/AST.hs
@@ -8,10 +8,10 @@ import Control.Monad.Identity (Identity(..), runIdentity)
 import Data.Text (Text)
 
 import Language.PureScript.AST (SourceSpan(..))
-import Language.PureScript.Comments
+import Language.PureScript.Comments (Comment)
 import Language.PureScript.Names (ModuleName)
 import Language.PureScript.PSString (PSString)
-import Language.PureScript.Traversals
+import Language.PureScript.Traversals (sndM)
 
 -- | Built-in unary operators
 data UnaryOperator

--- a/src/Language/PureScript/CoreImp/Module.hs
+++ b/src/Language/PureScript/CoreImp/Module.hs
@@ -3,8 +3,8 @@ module Language.PureScript.CoreImp.Module where
 import Protolude
 import Data.List.NonEmpty qualified as NEL (NonEmpty)
 
-import Language.PureScript.Comments
-import Language.PureScript.CoreImp.AST
+import Language.PureScript.Comments (Comment)
+import Language.PureScript.CoreImp.AST (AST)
 import Language.PureScript.PSString (PSString)
 
 data Module = Module

--- a/src/Language/PureScript/CoreImp/Optimizer.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer.hs
@@ -24,13 +24,13 @@ import Prelude
 import Data.Text (Text)
 
 import Control.Monad.Supply.Class (MonadSupply)
-import Language.PureScript.CoreImp.AST
-import Language.PureScript.CoreImp.Optimizer.Blocks
-import Language.PureScript.CoreImp.Optimizer.Common
-import Language.PureScript.CoreImp.Optimizer.Inliner
-import Language.PureScript.CoreImp.Optimizer.MagicDo
-import Language.PureScript.CoreImp.Optimizer.TCO
-import Language.PureScript.CoreImp.Optimizer.Unused
+import Language.PureScript.CoreImp.AST (AST(..), InitializerEffects(..))
+import Language.PureScript.CoreImp.Optimizer.Blocks (collapseNestedBlocks, collapseNestedIfs)
+import Language.PureScript.CoreImp.Optimizer.Common (applyAll, replaceIdents)
+import Language.PureScript.CoreImp.Optimizer.Inliner (etaConvert, evaluateIifes, inlineCommonOperators, inlineCommonValues, inlineFnComposition, inlineFnIdentity, inlineUnsafeCoerce, inlineUnsafePartial, inlineVariables, unThunk)
+import Language.PureScript.CoreImp.Optimizer.MagicDo (inlineST, magicDoEff, magicDoEffect, magicDoST)
+import Language.PureScript.CoreImp.Optimizer.TCO (tco)
+import Language.PureScript.CoreImp.Optimizer.Unused (removeCodeAfterReturnStatements, removeUndefinedApp, removeUnusedEffectFreeVars)
 
 -- | Apply a series of optimizer passes to simplified JavaScript code
 optimize :: forall m. MonadSupply m => [Text] -> [[AST]] -> m [[AST]]

--- a/src/Language/PureScript/CoreImp/Optimizer/Blocks.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Blocks.hs
@@ -6,7 +6,7 @@ module Language.PureScript.CoreImp.Optimizer.Blocks
 
 import Prelude
 
-import Language.PureScript.CoreImp.AST
+import Language.PureScript.CoreImp.AST (AST(..), BinaryOperator(..), everywhere)
 
 -- | Collapse blocks which appear nested directly below another block
 collapseNestedBlocks :: AST -> AST

--- a/src/Language/PureScript/CoreImp/Optimizer/Common.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Common.hs
@@ -7,8 +7,8 @@ import Data.Text (Text)
 import Data.List (foldl')
 import Data.Maybe (fromMaybe)
 
-import Language.PureScript.Crash
-import Language.PureScript.CoreImp.AST
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.CoreImp.AST (AST(..), everything, everywhere)
 import Language.PureScript.Names (ModuleName)
 import Language.PureScript.PSString (PSString)
 

--- a/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Inliner.hs
@@ -23,8 +23,8 @@ import Data.Text qualified as T
 
 import Language.PureScript.Names (ModuleName)
 import Language.PureScript.PSString (PSString, mkString)
-import Language.PureScript.CoreImp.AST
-import Language.PureScript.CoreImp.Optimizer.Common
+import Language.PureScript.CoreImp.AST (AST(..), BinaryOperator(..), InitializerEffects(..), UnaryOperator(..), everywhere, everywhereTopDown, everywhereTopDownM, getSourceSpan)
+import Language.PureScript.CoreImp.Optimizer.Common (pattern Ref, applyAll, isReassigned, isRebound, isUpdated, removeFromBlock, replaceIdent, replaceIdents)
 import Language.PureScript.AST (SourceSpan(..))
 import Language.PureScript.Constants.Libs qualified as C
 import Language.PureScript.Constants.Prim qualified as C

--- a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs
@@ -7,8 +7,8 @@ import Protolude (ordNub)
 
 import Data.Maybe (fromJust, isJust)
 
-import Language.PureScript.CoreImp.AST
-import Language.PureScript.CoreImp.Optimizer.Common
+import Language.PureScript.CoreImp.AST (AST(..), InitializerEffects(..), UnaryOperator(..), everything, everywhere, everywhereTopDown)
+import Language.PureScript.CoreImp.Optimizer.Common (pattern Ref)
 import Language.PureScript.Names (ModuleName)
 import Language.PureScript.PSString (mkString)
 import Language.PureScript.Constants.Libs qualified as C

--- a/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/TCO.hs
@@ -9,7 +9,7 @@ import Control.Monad.State (State, evalState, get, modify)
 import Data.Functor (($>), (<&>))
 import Data.Set qualified as S
 import Data.Text (Text, pack)
-import Language.PureScript.CoreImp.AST
+import Language.PureScript.CoreImp.AST (AST(..), InitializerEffects(..), UnaryOperator(..), everything, everywhereTopDownM)
 import Language.PureScript.AST.SourcePos (SourceSpan)
 import Safe (headDef, tailSafe)
 

--- a/src/Language/PureScript/CoreImp/Optimizer/Unused.hs
+++ b/src/Language/PureScript/CoreImp/Optimizer/Unused.hs
@@ -12,8 +12,8 @@ import Data.Monoid (Any(..))
 import Data.Set qualified as S
 import Data.Text (Text)
 
-import Language.PureScript.CoreImp.AST
-import Language.PureScript.CoreImp.Optimizer.Common
+import Language.PureScript.CoreImp.AST (AST(..), InitializerEffects(..), everything, everywhere)
+import Language.PureScript.CoreImp.Optimizer.Common (removeFromBlock)
 import Language.PureScript.Constants.Prim qualified as C
 
 removeCodeAfterReturnStatements :: AST -> AST

--- a/src/Language/PureScript/Docs/AsHtml.hs
+++ b/src/Language/PureScript/Docs/AsHtml.hs
@@ -34,7 +34,7 @@ import Cheapskate qualified
 import Language.PureScript qualified as P
 
 import Language.PureScript.Docs.Types
-import Language.PureScript.Docs.RenderedCode hiding (sp)
+import Language.PureScript.Docs.RenderedCode (Link(..), outputWith)
 import Language.PureScript.Docs.Render qualified as Render
 import Language.PureScript.CST qualified as CST
 

--- a/src/Language/PureScript/Docs/AsMarkdown.hs
+++ b/src/Language/PureScript/Docs/AsMarkdown.hs
@@ -15,8 +15,8 @@ import Data.List (partition)
 import Data.Text (Text)
 import Data.Text qualified as T
 
-import Language.PureScript.Docs.RenderedCode
-import Language.PureScript.Docs.Types
+import Language.PureScript.Docs.RenderedCode (RenderedCode, RenderedCodeElement(..), outputWith)
+import Language.PureScript.Docs.Types (ChildDeclaration(..), ChildDeclarationInfo(..), Declaration(..), Module(..), ignorePackage)
 import Language.PureScript qualified as P
 import Language.PureScript.Docs.Render qualified as Render
 

--- a/src/Language/PureScript/Docs/Collect.hs
+++ b/src/Language/PureScript/Docs/Collect.hs
@@ -17,7 +17,7 @@ import System.IO.UTF8 (readUTF8FileT, readUTF8FilesT)
 
 import Language.PureScript.Docs.Convert.ReExports (updateReExports)
 import Language.PureScript.Docs.Prim (primModules)
-import Language.PureScript.Docs.Types
+import Language.PureScript.Docs.Types (InPackage(..), Module(..), asModule, displayPackageError, ignorePackage)
 
 import Language.PureScript.AST qualified as P
 import Language.PureScript.CST qualified as P

--- a/src/Language/PureScript/Docs/Convert.hs
+++ b/src/Language/PureScript/Docs/Convert.hs
@@ -16,7 +16,7 @@ import Data.String (String)
 import Data.Text qualified as T
 
 import Language.PureScript.Docs.Convert.Single (convertSingleModule)
-import Language.PureScript.Docs.Types
+import Language.PureScript.Docs.Types (Declaration(..), DeclarationInfo(..), KindInfo(..), Module(..), Type')
 import Language.PureScript.CST qualified as CST
 import Language.PureScript.AST qualified as P
 import Language.PureScript.Crash qualified as P

--- a/src/Language/PureScript/Docs/Convert/ReExports.hs
+++ b/src/Language/PureScript/Docs/Convert/ReExports.hs
@@ -5,13 +5,13 @@ module Language.PureScript.Docs.Convert.ReExports
 import Prelude
 
 import Control.Arrow ((&&&), first, second)
-import Control.Monad
+import Control.Monad (foldM, (<=<))
 import Control.Monad.Reader.Class (MonadReader, ask)
 import Control.Monad.State.Class (MonadState, gets, modify)
 import Control.Monad.Trans.Reader (runReaderT)
 import Control.Monad.Trans.State.Strict (execState)
 
-import Data.Either
+import Data.Either (partitionEithers)
 import Data.Foldable (fold, traverse_)
 import Data.Map (Map)
 import Data.Maybe (mapMaybe)

--- a/src/Language/PureScript/Docs/Convert/Single.hs
+++ b/src/Language/PureScript/Docs/Convert/Single.hs
@@ -9,7 +9,7 @@ import Control.Category ((>>>))
 
 import Data.Text qualified as T
 
-import Language.PureScript.Docs.Types
+import Language.PureScript.Docs.Types (ChildDeclaration(..), ChildDeclarationInfo(..), Declaration(..), DeclarationInfo(..), KindInfo(..), Module(..), Type', convertFundepsToStrings, isType, isTypeClass)
 
 import Language.PureScript.AST qualified as P
 import Language.PureScript.Comments qualified as P

--- a/src/Language/PureScript/Docs/Prim.hs
+++ b/src/Language/PureScript/Docs/Prim.hs
@@ -11,7 +11,7 @@ import Data.Functor (($>))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Map qualified as Map
-import Language.PureScript.Docs.Types
+import Language.PureScript.Docs.Types (Declaration(..), DeclarationInfo(..), Module(..), Type', convertFundepsToStrings)
 
 import Language.PureScript.Constants.Prim qualified as P
 import Language.PureScript.Crash qualified as P

--- a/src/Language/PureScript/Docs/Render.hs
+++ b/src/Language/PureScript/Docs/Render.hs
@@ -16,8 +16,8 @@ import Data.Text (Text)
 import Data.Text qualified as T
 
 import Language.PureScript.Docs.RenderedCode
-import Language.PureScript.Docs.Types
-import Language.PureScript.Docs.Utils.MonoidExtras
+import Language.PureScript.Docs.Types (ChildDeclaration(..), ChildDeclarationInfo(..), Constraint', Declaration(..), DeclarationInfo(..), KindInfo(..), Type', isTypeClassMember, kindSignatureForKeyword)
+import Language.PureScript.Docs.Utils.MonoidExtras (mintersperse)
 
 import Language.PureScript.AST qualified as P
 import Language.PureScript.Environment qualified as P

--- a/src/Language/PureScript/Docs/RenderedCode/RenderType.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/RenderType.hs
@@ -21,16 +21,16 @@ import Data.List (uncons)
 import Control.Arrow ((<+>))
 import Control.PatternArrows as PA
 
-import Language.PureScript.Crash
-import Language.PureScript.Label
-import Language.PureScript.Names
-import Language.PureScript.Pretty.Types
-import Language.PureScript.Roles
-import Language.PureScript.Types
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Label (Label)
+import Language.PureScript.Names (coerceProperName)
+import Language.PureScript.Pretty.Types (PrettyPrintConstraint, PrettyPrintType(..), convertPrettyPrintType, prettyPrintLabel)
+import Language.PureScript.Roles (Role, displayRole)
+import Language.PureScript.Types (Type)
 import Language.PureScript.PSString (prettyPrintString)
 
-import Language.PureScript.Docs.RenderedCode.Types
-import Language.PureScript.Docs.Utils.MonoidExtras
+import Language.PureScript.Docs.RenderedCode.Types (RenderedCode, keywordForall, roleAnn, sp, syntax, typeCtor, typeOp, typeVar)
+import Language.PureScript.Docs.Utils.MonoidExtras (mintersperse)
 
 typeLiterals :: Pattern () PrettyPrintType RenderedCode
 typeLiterals = mkPattern match

--- a/src/Language/PureScript/Docs/RenderedCode/Types.hs
+++ b/src/Language/PureScript/Docs/RenderedCode/Types.hs
@@ -45,7 +45,7 @@ import Data.Text qualified as T
 import Data.ByteString.Lazy qualified as BS
 import Data.Text.Encoding qualified as TE
 
-import Language.PureScript.Names
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident(..), ModuleName, OpName(..), OpNameType(..), ProperName(..), ProperNameType(..), Qualified(..), QualifiedBy(..), moduleNameFromString, runIdent, runModuleName)
 import Language.PureScript.AST (Associativity(..))
 
 -- | Given a list of actions, attempt them all, returning the first success.

--- a/src/Language/PureScript/Docs/Tags.hs
+++ b/src/Language/PureScript/Docs/Tags.hs
@@ -11,7 +11,7 @@ import Data.List (sort)
 import Data.Maybe (mapMaybe)
 import Data.Text qualified as T
 import Language.PureScript.AST (SourceSpan, sourcePosLine, spanStart)
-import Language.PureScript.Docs.Types
+import Language.PureScript.Docs.Types (ChildDeclaration(..), Declaration(..), Module(..))
 
 tags :: Module -> [(String, Int)]
 tags = map (first T.unpack) . concatMap dtags . modDeclarations

--- a/src/Language/PureScript/Docs/Types.hs
+++ b/src/Language/PureScript/Docs/Types.hs
@@ -19,7 +19,7 @@ import Data.Aeson.BetterErrors
 import Data.Map qualified as Map
 import Data.Time.Clock (UTCTime)
 import Data.Time.Format qualified as TimeFormat
-import Data.Version
+import Data.Version (Version(..), showVersion)
 import Data.Aeson qualified as A
 import Data.Text qualified as T
 import Data.Vector qualified as V
@@ -33,7 +33,7 @@ import Language.PureScript.Roles qualified as P
 import Language.PureScript.Types qualified as P
 import Paths_purescript qualified as Paths
 
-import Web.Bower.PackageMeta hiding (Version, displayError)
+import Web.Bower.PackageMeta (BowerError, PackageMeta(..), PackageName, asPackageMeta, parsePackageName, runPackageName, showBowerError)
 
 import Language.PureScript.Docs.RenderedCode as ReExports
   (RenderedCode,

--- a/src/Language/PureScript/Docs/Utils/MonoidExtras.hs
+++ b/src/Language/PureScript/Docs/Utils/MonoidExtras.hs
@@ -1,6 +1,6 @@
 module Language.PureScript.Docs.Utils.MonoidExtras where
 
-import Data.Monoid
+import Data.Monoid (Monoid(..), (<>))
 
 mintersperse :: (Monoid m) => m -> [m] -> m
 mintersperse _ []       = mempty

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -20,12 +20,12 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.List.NonEmpty qualified as NEL
 
-import Language.PureScript.AST.SourcePos
-import Language.PureScript.Crash
-import Language.PureScript.Names
-import Language.PureScript.Roles
-import Language.PureScript.TypeClassDictionaries
-import Language.PureScript.Types
+import Language.PureScript.AST.SourcePos (nullSourceAnn)
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Names (Ident, ProperName(..), ProperNameType(..), Qualified, QualifiedBy, coerceProperName)
+import Language.PureScript.Roles (Role(..))
+import Language.PureScript.TypeClassDictionaries (NamedDict)
+import Language.PureScript.Types (SourceConstraint, SourceType, Type(..), eqType, srcTypeConstructor)
 import Language.PureScript.Constants.Prim qualified as C
 
 -- | The @Environment@ defines all values and types which are currently in scope:

--- a/src/Language/PureScript/Errors.hs
+++ b/src/Language/PureScript/Errors.hs
@@ -9,10 +9,10 @@ import Protolude (unsnoc)
 import Control.Arrow ((&&&))
 import Control.Exception (displayException)
 import Control.Lens (both, head1, over)
-import Control.Monad
+import Control.Monad (forM, unless)
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Trans.State.Lazy
-import Control.Monad.Writer
+import Control.Monad.Trans.State.Lazy (State, evalState, get, put)
+import Control.Monad.Writer (Last(..), MonadWriter(..), censor)
 import Data.Bifunctor (first, second)
 import Data.Bitraversable (bitraverse)
 import Data.Char (isSpace)
@@ -37,17 +37,17 @@ import Language.PureScript.AST
 import Language.PureScript.Bundle qualified as Bundle
 import Language.PureScript.Constants.Libs qualified as C
 import Language.PureScript.Constants.Prim qualified as C
-import Language.PureScript.Crash
+import Language.PureScript.Crash (internalError)
 import Language.PureScript.CST.Errors qualified as CST
 import Language.PureScript.CST.Print qualified as CST
 import Language.PureScript.Label (Label(..))
 import Language.PureScript.Names
-import Language.PureScript.Pretty
+import Language.PureScript.Pretty (prettyPrintBinderAtom, prettyPrintLabel, prettyPrintObjectKey, prettyPrintSuggestedType, prettyPrintValue, typeAsBox, typeAtomAsBox, typeDiffAsBox)
 import Language.PureScript.Pretty.Common (endWith)
 import Language.PureScript.PSString (decodeStringWithReplacement)
-import Language.PureScript.Roles
-import Language.PureScript.Traversals
-import Language.PureScript.Types
+import Language.PureScript.Roles (Role, displayRole)
+import Language.PureScript.Traversals (sndM)
+import Language.PureScript.Types (Constraint(..), ConstraintData(..), RowListItem(..), SourceConstraint, SourceType, Type(..), eraseForAllKindAnnotations, eraseKindApps, everywhereOnTypesTopDownM, getAnnForType, overConstraintArgs, rowFromList, rowToList, srcTUnknown)
 import Language.PureScript.Publish.BoxesHelpers qualified as BoxHelpers
 import System.Console.ANSI qualified as ANSI
 import System.FilePath (makeRelative)

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -28,13 +28,13 @@ import Data.Version (showVersion)
 import Data.Map qualified as M
 import Data.List.NonEmpty qualified as NEL
 
-import Language.PureScript.AST
+import Language.PureScript.AST (Associativity, Declaration(..), DeclarationRef(..), Fixity(..), ImportDeclarationType, Module(..), NameSource(..), Precedence, SourceSpan, pattern TypeFixityDeclaration, pattern ValueFixityDeclaration, getTypeOpRef, getValueOpRef)
 import Language.PureScript.AST.Declarations.ChainId (ChainId)
-import Language.PureScript.Crash
-import Language.PureScript.Environment
-import Language.PureScript.Names
-import Language.PureScript.TypeClassDictionaries
-import Language.PureScript.Types
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Environment (DataDeclType, Environment(..), FunctionalDependency, NameKind(..), NameVisibility(..), TypeClassData(..), TypeKind(..), dictTypeName, makeTypeClassData)
+import Language.PureScript.Names (Ident, ModuleName, OpName, OpNameType(..), ProperName, ProperNameType(..), Qualified(..), QualifiedBy(..), coerceProperName, isPlainIdent)
+import Language.PureScript.TypeClassDictionaries (NamedDict, TypeClassDictionaryInScope(..))
+import Language.PureScript.Types (SourceConstraint, SourceType, srcInstanceType)
 
 import Paths_purescript as Paths
 

--- a/src/Language/PureScript/Ide.hs
+++ b/src/Language/PureScript/Ide.hs
@@ -20,25 +20,25 @@ module Language.PureScript.Ide
 
 import Protolude hiding (moduleName)
 
-import "monad-logger" Control.Monad.Logger
+import "monad-logger" Control.Monad.Logger (MonadLogger, logWarnN)
 import Data.Map qualified as Map
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.Ide.CaseSplit qualified as CS
-import Language.PureScript.Ide.Command
-import Language.PureScript.Ide.Completion
-import Language.PureScript.Ide.Error
-import Language.PureScript.Ide.Externs
-import Language.PureScript.Ide.Filter
-import Language.PureScript.Ide.Imports hiding (Import)
-import Language.PureScript.Ide.Imports.Actions
-import Language.PureScript.Ide.Matcher
-import Language.PureScript.Ide.Prim
-import Language.PureScript.Ide.Rebuild
-import Language.PureScript.Ide.SourceFile
-import Language.PureScript.Ide.State
-import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Command (Command(..), ImportCommand(..), ListType(..))
+import Language.PureScript.Ide.Completion (CompletionOptions, completionFromMatch, getCompletions, getExactCompletions, simpleExport)
+import Language.PureScript.Ide.Error (IdeError(..))
+import Language.PureScript.Ide.Externs (readExternFile)
+import Language.PureScript.Ide.Filter (Filter)
+import Language.PureScript.Ide.Imports (parseImportsFromFile)
+import Language.PureScript.Ide.Imports.Actions (addImplicitImport, addImportForIdentifier, addQualifiedImport, answerRequest)
+import Language.PureScript.Ide.Matcher (Matcher)
+import Language.PureScript.Ide.Prim (idePrimDeclarations)
+import Language.PureScript.Ide.Rebuild (rebuildFileAsync, rebuildFileSync)
+import Language.PureScript.Ide.SourceFile (parseModulesFromFiles)
+import Language.PureScript.Ide.State (getAllModules, getLoadedModulenames, insertExterns, insertModule, populateVolatileState, populateVolatileStateSync, resetIdeState)
+import Language.PureScript.Ide.Types (Annotation(..), Ide, IdeConfiguration(..), IdeDeclarationAnn(..), IdeEnvironment(..), Success(..))
+import Language.PureScript.Ide.Util (discardAnn, identifierFromIdeDeclaration, namespaceForDeclaration, withEmptyAnn)
 import Language.PureScript.Ide.Usage (findUsages)
 import System.Directory (getCurrentDirectory, getDirectoryContents, doesDirectoryExist, doesFileExist)
 import System.FilePath ((</>), normalise)

--- a/src/Language/PureScript/Ide/CaseSplit.hs
+++ b/src/Language/PureScript/Ide/CaseSplit.hs
@@ -29,10 +29,10 @@ import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
 
-import Language.PureScript.Externs
-import Language.PureScript.Ide.Error
-import Language.PureScript.Ide.State
-import Language.PureScript.Ide.Types
+import Language.PureScript.Externs (ExternsDeclaration(..), ExternsFile(..))
+import Language.PureScript.Ide.Error (IdeError(..))
+import Language.PureScript.Ide.State (cachedRebuild, getExternFiles)
+import Language.PureScript.Ide.Types (Ide)
 
 type Constructor = (P.ProperName 'P.ConstructorName, [P.SourceType])
 

--- a/src/Language/PureScript/Ide/Command.hs
+++ b/src/Language/PureScript/Ide/Command.hs
@@ -17,15 +17,15 @@ module Language.PureScript.Ide.Command where
 import Protolude
 
 import Control.Monad.Fail (fail)
-import Data.Aeson
+import Data.Aeson (FromJSON(..), withObject, (.!=), (.:), (.:?))
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Language.PureScript qualified as P
-import Language.PureScript.Ide.CaseSplit
-import Language.PureScript.Ide.Completion
-import Language.PureScript.Ide.Filter
-import Language.PureScript.Ide.Matcher
-import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.CaseSplit (WildcardAnnotations, explicitAnnotations, noAnnotations)
+import Language.PureScript.Ide.Completion (CompletionOptions, defaultCompletionOptions)
+import Language.PureScript.Ide.Filter (Filter)
+import Language.PureScript.Ide.Matcher (Matcher)
+import Language.PureScript.Ide.Types (IdeDeclarationAnn, IdeNamespace)
 
 data Command
     = Load [P.ModuleName]

--- a/src/Language/PureScript/Ide/Completion.hs
+++ b/src/Language/PureScript/Ide/Completion.hs
@@ -11,16 +11,16 @@ module Language.PureScript.Ide.Completion
 
 import Protolude hiding ((<&>), moduleName)
 
-import Control.Lens hiding (op, (&))
-import Data.Aeson
+import Control.Lens ((.~), (<&>), (^.))
+import Data.Aeson (FromJSON(..), withObject, (.!=), (.:?))
 import Data.Map qualified as Map
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.Ide.Error (prettyPrintTypeSingleLine)
-import Language.PureScript.Ide.Filter
-import Language.PureScript.Ide.Matcher
+import Language.PureScript.Ide.Filter (Filter, applyFilters, exactFilter)
+import Language.PureScript.Ide.Matcher (Matcher, runMatcher)
 import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Util (identT, identifierFromIdeDeclaration, namespaceForDeclaration, properNameT, typeOperatorAliasT, valueOperatorAliasT)
 
 -- | Applies the CompletionFilters and the Matcher to the given Modules
 --   and sorts the found Completions according to the Matching Score

--- a/src/Language/PureScript/Ide/Error.hs
+++ b/src/Language/PureScript/Ide/Error.hs
@@ -17,12 +17,12 @@ module Language.PureScript.Ide.Error
        , prettyPrintTypeSingleLine
        ) where
 
-import Data.Aeson
+import Data.Aeson (KeyValue(..), ToJSON(..), Value, object)
 import Data.Aeson.Types qualified as Aeson
 import Data.Aeson.KeyMap qualified as KM
 import Data.Text qualified as T
 import Language.PureScript qualified as P
-import Language.PureScript.Errors.JSON
+import Language.PureScript.Errors.JSON (toJSONError)
 import Language.PureScript.Ide.Types (ModuleIdent, Completion(..))
 import Protolude
 

--- a/src/Language/PureScript/Ide/Externs.hs
+++ b/src/Language/PureScript/Ide/Externs.hs
@@ -8,14 +8,14 @@ module Language.PureScript.Ide.Externs
 import Protolude hiding (to, from, (&))
 
 import Codec.CBOR.Term as Term
-import Control.Lens hiding (anyOf)
-import "monad-logger" Control.Monad.Logger
+import Control.Lens (preview, view, (&), (^.))
+import "monad-logger" Control.Monad.Logger (MonadLogger, logErrorN)
 import Data.Version (showVersion)
 import Data.Text qualified as Text
 import Language.PureScript qualified as P
 import Language.PureScript.Make.Monad qualified as Make
 import Language.PureScript.Ide.Error (IdeError (..))
-import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Types (IdeDataConstructor(..), IdeDeclaration(..), IdeDeclarationAnn(..), IdeType(..), IdeTypeClass(..), IdeTypeOperator(..), IdeTypeSynonym(..), IdeValue(..), IdeValueOperator(..), _IdeDeclType, anyOf, emptyAnn, ideTypeKind, ideTypeName)
 import Language.PureScript.Ide.Util (properNameT)
 
 readExternFile

--- a/src/Language/PureScript/Ide/Filter.hs
+++ b/src/Language/PureScript/Ide/Filter.hs
@@ -26,19 +26,19 @@ module Language.PureScript.Ide.Filter
 import Protolude                     hiding (isPrefixOf, Prefix)
 
 import Control.Monad.Fail (fail)
-import Data.Aeson
+import Data.Aeson (FromJSON(..), withObject, (.:), (.:?))
 import Data.Text (isPrefixOf)
 import Data.Set qualified as Set
 import Data.Map qualified as Map
 import Language.PureScript.Ide.Filter.Declaration (DeclarationType)
-import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Imports
-import Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Types (IdeDeclarationAnn, IdeNamespace, ModuleMap, declarationType)
+import Language.PureScript.Ide.Imports (Import, sliceImportSection)
+import Language.PureScript.Ide.Util (discardAnn, identifierFromIdeDeclaration, namespaceForDeclaration)
 
 import Language.PureScript qualified as P
 import Data.Text qualified as T
 
-import Language.PureScript.Ide.Filter.Imports 
+import Language.PureScript.Ide.Filter.Imports (matchImport)
 
 newtype Filter = Filter (Either (Set P.ModuleName) DeclarationFilter)
   deriving Show

--- a/src/Language/PureScript/Ide/Filter/Declaration.hs
+++ b/src/Language/PureScript/Ide/Filter/Declaration.hs
@@ -5,7 +5,7 @@ module Language.PureScript.Ide.Filter.Declaration
 import Protolude                     hiding (isPrefixOf)
 
 import Control.Monad.Fail (fail)
-import Data.Aeson
+import Data.Aeson (FromJSON(..), ToJSON(..), withText)
 
 data DeclarationType
   = Value

--- a/src/Language/PureScript/Ide/Filter/Imports.hs
+++ b/src/Language/PureScript/Ide/Filter/Imports.hs
@@ -3,8 +3,8 @@ module Language.PureScript.Ide.Filter.Imports where
 
 import Protolude                     hiding (isPrefixOf)
 
-import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Imports
+import Language.PureScript.Ide.Types (IdeDataConstructor(..), IdeDeclaration(..), IdeDeclarationAnn(..), IdeType(..), IdeTypeClass(..), IdeTypeOperator(..), IdeTypeSynonym(..), IdeValue(..), IdeValueOperator(..))
+import Language.PureScript.Ide.Imports (Import(..))
 
 import Language.PureScript qualified as P
 

--- a/src/Language/PureScript/Ide/Imports.hs
+++ b/src/Language/PureScript/Ide/Imports.hs
@@ -32,8 +32,8 @@ import Data.List.NonEmpty qualified as NE
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
-import Language.PureScript.Ide.Error
-import Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Error (IdeError(..))
+import Language.PureScript.Ide.Util (ideReadFile)
 
 data Import = Import P.ModuleName P.ImportDeclarationType (Maybe P.ModuleName)
               deriving (Eq, Show)

--- a/src/Language/PureScript/Ide/Imports/Actions.hs
+++ b/src/Language/PureScript/Ide/Imports/Actions.hs
@@ -19,14 +19,14 @@ import Data.Map qualified as Map
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.Constants.Prim qualified as C
-import Language.PureScript.Ide.Completion
-import Language.PureScript.Ide.Error
-import Language.PureScript.Ide.Filter
-import Language.PureScript.Ide.Imports
-import Language.PureScript.Ide.State
-import Language.PureScript.Ide.Prim
-import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Completion (getExactMatches)
+import Language.PureScript.Ide.Error (IdeError(..))
+import Language.PureScript.Ide.Filter (Filter)
+import Language.PureScript.Ide.Imports (Import(..), parseImportsFromFile', prettyPrintImportSection)
+import Language.PureScript.Ide.State (getAllModules)
+import Language.PureScript.Ide.Prim (idePrimDeclarations)
+import Language.PureScript.Ide.Types (Ide, IdeDeclaration(..), IdeType(..), Match(..), Success(..), _IdeDeclModule, ideDtorName, ideDtorTypeName, ideTCName, ideTypeName, ideTypeOpName, ideValueOpName)
+import Language.PureScript.Ide.Util (discardAnn, identifierFromIdeDeclaration)
 import System.IO.UTF8 (writeUTF8FileT)
 
 -- | Adds an implicit import like @import Prelude@ to a Sourcefile.

--- a/src/Language/PureScript/Ide/Logging.hs
+++ b/src/Language/PureScript/Ide/Logging.hs
@@ -9,11 +9,11 @@ module Language.PureScript.Ide.Logging
 
 import Protolude
 
-import "monad-logger" Control.Monad.Logger
+import "monad-logger" Control.Monad.Logger (LogLevel(..), LoggingT, MonadLogger, filterLogger, logOtherN, runStdoutLoggingT)
 import Data.Text qualified as T
-import Language.PureScript.Ide.Types
-import System.Clock
-import Text.Printf
+import Language.PureScript.Ide.Types (IdeLogLevel(..))
+import System.Clock (Clock(..), TimeSpec, diffTimeSpec, getTime, toNanoSecs)
+import Text.Printf (printf)
 
 runLogger :: MonadIO m => IdeLogLevel -> LoggingT m a -> m a
 runLogger logLevel' =

--- a/src/Language/PureScript/Ide/Matcher.hs
+++ b/src/Language/PureScript/Ide/Matcher.hs
@@ -22,12 +22,12 @@ module Language.PureScript.Ide.Matcher
 import Protolude
 
 import Control.Monad.Fail (fail)
-import Data.Aeson
+import Data.Aeson (FromJSON(..), withObject, (.:), (.:?))
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
-import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Util
-import Text.EditDistance
+import Language.PureScript.Ide.Types (IdeDeclarationAnn, Match)
+import Language.PureScript.Ide.Util (discardAnn, identifierFromIdeDeclaration, unwrapMatch)
+import Text.EditDistance (defaultEditCosts, levenshteinDistance)
 import Text.Regex.TDFA ((=~))
 
 

--- a/src/Language/PureScript/Ide/Prim.hs
+++ b/src/Language/PureScript/Ide/Prim.hs
@@ -7,7 +7,7 @@ import Data.Map qualified as Map
 import Language.PureScript qualified as P
 import Language.PureScript.Constants.Prim qualified as C
 import Language.PureScript.Environment qualified as PEnv
-import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Types (IdeDeclaration(..), IdeDeclarationAnn(..), IdeType(..), IdeTypeClass(..), ModuleMap, emptyAnn)
 
 idePrimDeclarations :: ModuleMap [IdeDeclarationAnn]
 idePrimDeclarations = Map.fromList

--- a/src/Language/PureScript/Ide/Rebuild.hs
+++ b/src/Language/PureScript/Ide/Rebuild.hs
@@ -8,7 +8,7 @@ module Language.PureScript.Ide.Rebuild
 
 import Protolude hiding (moduleName)
 
-import "monad-logger" Control.Monad.Logger
+import "monad-logger" Control.Monad.Logger (LoggingT, MonadLogger, logDebug)
 import Data.List qualified as List
 import Data.Map.Lazy qualified as M
 import Data.Maybe (fromJust)
@@ -20,11 +20,11 @@ import Language.PureScript.Make (ffiCodegen')
 import Language.PureScript.Make.Cache (CacheInfo(..), normaliseForCache)
 import Language.PureScript.CST qualified as CST
 
-import Language.PureScript.Ide.Error
-import Language.PureScript.Ide.Logging
-import Language.PureScript.Ide.State
-import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Error (IdeError(..))
+import Language.PureScript.Ide.Logging (labelTimespec, logPerf, runLogger)
+import Language.PureScript.Ide.State (cacheRebuild, getExternFiles, insertExterns, insertModule, populateVolatileState, updateCacheTimestamp)
+import Language.PureScript.Ide.Types (Ide, IdeConfiguration(..), IdeEnvironment(..), ModuleMap, Success(..))
+import Language.PureScript.Ide.Util (ideReadFile)
 import System.Directory (getCurrentDirectory)
 
 -- | Given a filepath performs the following steps:

--- a/src/Language/PureScript/Ide/Reexports.hs
+++ b/src/Language/PureScript/Ide/Reexports.hs
@@ -24,11 +24,11 @@ module Language.PureScript.Ide.Reexports
 
 import Protolude hiding (moduleName)
 
-import Control.Lens                  hiding (anyOf, (&))
+import Control.Lens (set)
 import Data.Map qualified as Map
 import Language.PureScript qualified as P
 import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Util (discardAnn)
 
 -- | Contains the module with resolved reexports, and possible failures
 data ReexportResult a

--- a/src/Language/PureScript/Ide/SourceFile.hs
+++ b/src/Language/PureScript/Ide/SourceFile.hs
@@ -26,9 +26,9 @@ import Control.Parallel.Strategies (withStrategy, parList, rseq)
 import Data.Map qualified as Map
 import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
-import Language.PureScript.Ide.Error
-import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Error (IdeError)
+import Language.PureScript.Ide.Types (DefinitionSites, IdeNamespace(..), IdeNamespaced(..), TypeAnnotations)
+import Language.PureScript.Ide.Util (ideReadFile)
 
 parseModule :: FilePath -> Text -> Either FilePath (FilePath, P.Module)
 parseModule path file =

--- a/src/Language/PureScript/Ide/State.hs
+++ b/src/Language/PureScript/Ide/State.hs
@@ -39,22 +39,22 @@ module Language.PureScript.Ide.State
 
 import Protolude hiding (moduleName, unzip)
 
-import Control.Concurrent.STM
-import Control.Lens                       hiding (anyOf, op, (&))
-import "monad-logger" Control.Monad.Logger
-import Data.IORef
+import Control.Concurrent.STM (TVar, modifyTVar, readTVar, readTVarIO, writeTVar)
+import Control.Lens (Ixed(..), preview, view, (%~), (.~), (^.))
+import "monad-logger" Control.Monad.Logger (MonadLogger, logWarnN)
+import Data.IORef (readIORef, writeIORef)
 import Data.Map.Lazy qualified as Map
 import Data.Time.Clock (UTCTime)
 import Data.Zip (unzip)
 import Language.PureScript qualified as P
 import Language.PureScript.Docs.Convert.Single (convertComments)
-import Language.PureScript.Externs
+import Language.PureScript.Externs (ExternsDeclaration(..), ExternsFile(..))
 import Language.PureScript.Make.Actions (cacheDbFile)
-import Language.PureScript.Ide.Externs
-import Language.PureScript.Ide.Reexports
-import Language.PureScript.Ide.SourceFile
+import Language.PureScript.Ide.Externs (convertExterns)
+import Language.PureScript.Ide.Reexports (ReexportResult(..), prettyPrintReexportResult, reexportHasFailures, resolveReexports)
+import Language.PureScript.Ide.SourceFile (extractAstInformation)
 import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Util (discardAnn, displayTimeSpec, logPerf, opNameT, properNameT, runLogger)
 import System.Directory (getModificationTime)
 
 -- | Resets all State inside psc-ide

--- a/src/Language/PureScript/Ide/Types.hs
+++ b/src/Language/PureScript/Ide/Types.hs
@@ -8,7 +8,7 @@ module Language.PureScript.Ide.Types where
 import Protolude hiding (moduleName)
 
 import Control.Concurrent.STM (TVar)
-import Control.Lens hiding (op, (.=))
+import Control.Lens (Getting, Traversal', makeLenses)
 import Control.Monad.Fail (fail)
 import Data.Aeson (ToJSON, FromJSON, (.=))
 import Data.Aeson qualified as Aeson

--- a/src/Language/PureScript/Ide/Usage.hs
+++ b/src/Language/PureScript/Ide/Usage.hs
@@ -14,7 +14,7 @@ import Data.Set qualified as Set
 import Language.PureScript qualified as P
 import Language.PureScript.Ide.State (getAllModules, getFileState)
 import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Util
+import Language.PureScript.Ide.Util (identifierFromIdeDeclaration, namespaceForDeclaration)
 
 -- |
 -- How we find usages, given an IdeDeclaration and the module it was defined in:

--- a/src/Language/PureScript/Ide/Util.hs
+++ b/src/Language/PureScript/Ide/Util.hs
@@ -32,15 +32,15 @@ module Language.PureScript.Ide.Util
 import Protolude                           hiding (decodeUtf8,
                                                       encodeUtf8, to)
 
-import Control.Lens                        hiding (op, (&))
-import Data.Aeson
+import Control.Lens (Getting, to, (^.))
+import Data.Aeson (FromJSON, ToJSON, eitherDecode, encode)
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Encoding             as TLE
 import Language.PureScript qualified as P
 import Language.PureScript.Ide.Error (IdeError(..))
 import Language.PureScript.Ide.Logging
-import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Types (IdeDeclaration(..), IdeDeclarationAnn(..), IdeNamespace(..), Match(..), emptyAnn, ideDtorName, ideSynonymName, ideTCName, ideTypeName, ideTypeOpName, ideValueIdent, ideValueOpName)
 import System.IO.UTF8 (readUTF8FileT)
 import System.Directory (makeAbsolute)
 

--- a/src/Language/PureScript/Interactive.hs
+++ b/src/Language/PureScript/Interactive.hs
@@ -20,8 +20,8 @@ import Data.Text (Text)
 import Data.Text qualified as T
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.State.Class
-import Control.Monad.Reader.Class
+import Control.Monad.State.Class (MonadState(..), gets, modify)
+import Control.Monad.Reader.Class (MonadReader, asks)
 import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 import Control.Monad.Trans.State.Strict (StateT, runStateT, evalStateT)
 import Control.Monad.Writer.Strict (Writer(), runWriter)

--- a/src/Language/PureScript/Interactive/Completion.hs
+++ b/src/Language/PureScript/Interactive/Completion.hs
@@ -18,8 +18,8 @@ import Data.Maybe (mapMaybe)
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.Interactive.Directive qualified as D
-import Language.PureScript.Interactive.Types
-import System.Console.Haskeline
+import Language.PureScript.Interactive.Types (Directive(..), PSCiState, psciExports, psciImports, psciLoadedExterns, replQueryStrings)
+import System.Console.Haskeline (Completion(..), CompletionFunc, completeWordWithPrev, listFiles, simpleCompletion)
 
 -- Completions may read the state, but not modify it.
 type CompletionM = ReaderT PSCiState IO

--- a/src/Language/PureScript/Interactive/Directive.hs
+++ b/src/Language/PureScript/Interactive/Directive.hs
@@ -9,7 +9,7 @@ import Data.Maybe (fromJust)
 import Data.List (isPrefixOf)
 import Data.Tuple (swap)
 
-import Language.PureScript.Interactive.Types
+import Language.PureScript.Interactive.Types (Directive(..))
 
 -- |
 -- A mapping of directives to the different strings that can be used to invoke

--- a/src/Language/PureScript/Interactive/Message.hs
+++ b/src/Language/PureScript/Interactive/Message.hs
@@ -6,7 +6,7 @@ import Data.List (intercalate)
 import Data.Version (showVersion)
 import Paths_purescript qualified as Paths
 import Language.PureScript.Interactive.Directive qualified as D
-import Language.PureScript.Interactive.Types
+import Language.PureScript.Interactive.Types (Directive)
 
 -- Messages
 

--- a/src/Language/PureScript/Interactive/Module.hs
+++ b/src/Language/PureScript/Interactive/Module.hs
@@ -4,7 +4,7 @@ import Prelude
 
 import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
-import Language.PureScript.Interactive.Types
+import Language.PureScript.Interactive.Types (ImportedModule, PSCiState, initialInteractivePrint, psciImportedModules, psciInteractivePrint, psciLetBindings)
 import System.Directory (getCurrentDirectory)
 import System.FilePath (pathSeparator, makeRelative)
 import System.IO.UTF8 (readUTF8FilesT)

--- a/src/Language/PureScript/Interactive/Parser.hs
+++ b/src/Language/PureScript/Interactive/Parser.hs
@@ -18,7 +18,7 @@ import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
 import Language.PureScript.CST.Monad qualified as CSTM
 import Language.PureScript.Interactive.Directive qualified as D
-import Language.PureScript.Interactive.Types
+import Language.PureScript.Interactive.Types (Command(..), Directive(..), ReplQuery(..), parseReplQuery, replQueryStrings)
 
 -- |
 -- Parses a limited set of commands from from .purs-repl

--- a/src/Language/PureScript/Linter.hs
+++ b/src/Language/PureScript/Linter.hs
@@ -5,7 +5,7 @@ module Language.PureScript.Linter (lint, module L) where
 
 import Prelude
 
-import Control.Monad.Writer.Class
+import Control.Monad.Writer.Class (MonadWriter(..), censor)
 
 import Data.Maybe (mapMaybe)
 import Data.Set qualified as S
@@ -14,11 +14,11 @@ import Data.Text qualified as Text
 import Control.Monad ((<=<))
 
 import Language.PureScript.AST
-import Language.PureScript.Errors
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), addHint, errorMessage')
 import Language.PureScript.Linter.Exhaustive as L
 import Language.PureScript.Linter.Imports as L
-import Language.PureScript.Names
-import Language.PureScript.Types
+import Language.PureScript.Names (Ident(..), Qualified(..), QualifiedBy(..), getIdentName, runIdent)
+import Language.PureScript.Types (Constraint(..), SourceType, Type(..), everythingWithContextOnTypes)
 import Language.PureScript.Constants.Libs qualified as C
 
 -- | Lint the PureScript AST.

--- a/src/Language/PureScript/Linter/Exhaustive.hs
+++ b/src/Language/PureScript/Linter/Exhaustive.hs
@@ -11,25 +11,25 @@ module Language.PureScript.Linter.Exhaustive
 import Prelude
 import Protolude (ordNub)
 
-import Control.Applicative
+import Control.Applicative (Applicative(..))
 import Control.Arrow (first, second)
 import Control.Monad (unless)
-import Control.Monad.Writer.Class
+import Control.Monad.Writer.Class (MonadWriter(..), censor)
 
 import Data.List (foldl', sortOn)
 import Data.Maybe (fromMaybe)
 import Data.Map qualified as M
 import Data.Text qualified as T
 
-import Language.PureScript.AST.Binders
-import Language.PureScript.AST.Declarations
-import Language.PureScript.AST.Literals
-import Language.PureScript.Crash
-import Language.PureScript.Environment hiding (tyVar)
-import Language.PureScript.Errors
+import Language.PureScript.AST.Binders (Binder(..))
+import Language.PureScript.AST.Declarations (CaseAlternative(..), Declaration(..), ErrorMessageHint(..), Expr(..), Guard(..), GuardedExpr(..), pattern MkUnguarded, pattern ValueDecl, isTrueExpr)
+import Language.PureScript.AST.Literals (Literal(..))
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Environment (DataDeclType, Environment(..), TypeKind(..))
+import Language.PureScript.Errors (MultipleErrors, pattern NullSourceAnn, SimpleErrorMessage(..), SourceSpan, addHint, errorMessage')
 import Language.PureScript.Names as P
 import Language.PureScript.Pretty.Values (prettyPrintBinderAtom)
-import Language.PureScript.Traversals
+import Language.PureScript.Traversals (sndM)
 import Language.PureScript.Types as P
 import Language.PureScript.Constants.Prim qualified as C
 

--- a/src/Language/PureScript/Linter/Imports.hs
+++ b/src/Language/PureScript/Linter/Imports.hs
@@ -8,7 +8,7 @@ import Prelude
 import Protolude (ordNub)
 
 import Control.Monad (join, unless, foldM, (<=<))
-import Control.Monad.Writer.Class
+import Control.Monad.Writer.Class (MonadWriter(..))
 
 import Data.Function (on)
 import Data.Foldable (for_)
@@ -19,14 +19,14 @@ import Data.Traversable (forM)
 import Data.Text qualified as T
 import Data.Map qualified as M
 
-import Language.PureScript.AST.Declarations
-import Language.PureScript.AST.SourcePos
-import Language.PureScript.Crash
-import Language.PureScript.Errors
+import Language.PureScript.AST.Declarations (Declaration(..), DeclarationRef(..), ExportSource, ImportDeclarationType(..), Module(..), getTypeRef, isExplicit)
+import Language.PureScript.AST.SourcePos (SourceSpan)
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), errorMessage')
 import Language.PureScript.Names
 import Language.PureScript.Sugar.Names.Common (warnDuplicateRefs)
-import Language.PureScript.Sugar.Names.Env
-import Language.PureScript.Sugar.Names.Imports
+import Language.PureScript.Sugar.Names.Env (Env, Exports(..), ImportRecord(..), Imports(..), envModuleExports, nullImports)
+import Language.PureScript.Sugar.Names.Imports (ImportDef, findImports)
 import Language.PureScript.Constants.Prim qualified as C
 
 -- |

--- a/src/Language/PureScript/Linter/Wildcards.hs
+++ b/src/Language/PureScript/Linter/Wildcards.hs
@@ -4,8 +4,8 @@ module Language.PureScript.Linter.Wildcards
 
 import Protolude hiding (Type)
 
-import Language.PureScript.AST
-import Language.PureScript.Types
+import Language.PureScript.AST (Binder(..), Declaration, Expr(..), everywhereWithContextOnValues)
+import Language.PureScript.Types (Type(..), WildcardData(..), everythingOnTypes, everywhereOnTypes)
 
 -- |
 -- Replaces `TypeWildcard _ UnnamedWildcard` with

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -13,11 +13,11 @@ module Language.PureScript.Make.Actions
 
 import Prelude
 
-import Control.Monad hiding (sequence)
+import Control.Monad (unless, when)
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.IO.Class
+import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Reader (asks)
-import Control.Monad.Supply
+import Control.Monad.Supply (SupplyT)
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Control.Monad.Writer.Class (MonadWriter(..))
 import Data.Aeson (Value(String), (.=), object)
@@ -34,26 +34,26 @@ import Data.Text.Encoding qualified as TE
 import Data.Time.Clock (UTCTime)
 import Data.Version (showVersion)
 import Language.JavaScript.Parser qualified as JS
-import Language.PureScript.AST
+import Language.PureScript.AST (SourcePos(..))
 import Language.PureScript.Bundle qualified as Bundle
 import Language.PureScript.CodeGen.JS qualified as J
-import Language.PureScript.CodeGen.JS.Printer
+import Language.PureScript.CodeGen.JS.Printer (prettyPrintJS, prettyPrintJSWithSourceMaps)
 import Language.PureScript.CoreFn qualified as CF
 import Language.PureScript.CoreFn.ToJSON qualified as CFJ
-import Language.PureScript.Crash
+import Language.PureScript.Crash (internalError)
 import Language.PureScript.CST qualified as CST
 import Language.PureScript.Docs.Prim qualified as Docs.Prim
 import Language.PureScript.Docs.Types qualified as Docs
-import Language.PureScript.Errors
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), errorMessage, errorMessage')
 import Language.PureScript.Externs (ExternsFile, externsFileName)
-import Language.PureScript.Make.Monad
-import Language.PureScript.Make.Cache
-import Language.PureScript.Names
-import Language.PureScript.Options hiding (codegenTargets)
+import Language.PureScript.Make.Monad (Make, copyFile, getTimestamp, getTimestampMaybe, hashFile, makeIO, readExternsFile, readJSONFile, readTextFile, writeCborFile, writeJSONFile, writeTextFile)
+import Language.PureScript.Make.Cache (CacheDb, ContentHash, normaliseForCache)
+import Language.PureScript.Names (Ident(..), ModuleName, runModuleName)
+import Language.PureScript.Options (CodegenTarget(..), Options(..))
 import Language.PureScript.Pretty.Common (SMap(..))
 import Paths_purescript qualified as Paths
-import SourceMap
-import SourceMap.Types
+import SourceMap (generate)
+import SourceMap.Types (Mapping(..), Pos(..), SourceMapping(..))
 import System.Directory (getCurrentDirectory)
 import System.FilePath ((</>), makeRelative, splitPath, normalise, splitDirectories)
 import System.FilePath.Posix qualified as Posix

--- a/src/Language/PureScript/Make/BuildPlan.hs
+++ b/src/Language/PureScript/Make/BuildPlan.hs
@@ -14,22 +14,22 @@ import Prelude
 import Control.Concurrent.Async.Lifted as A
 import Control.Concurrent.Lifted as C
 import Control.Monad.Base (liftBase)
-import Control.Monad hiding (sequence)
+import Control.Monad (foldM)
 import Control.Monad.Trans.Control (MonadBaseControl(..))
 import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 import Data.Foldable (foldl')
 import Data.Map qualified as M
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Time.Clock (UTCTime)
-import Language.PureScript.AST
-import Language.PureScript.Crash
+import Language.PureScript.AST (Module, getModuleName)
+import Language.PureScript.Crash (internalError)
 import Language.PureScript.CST qualified as CST
-import Language.PureScript.Errors
-import Language.PureScript.Externs
+import Language.PureScript.Errors (MultipleErrors(..))
+import Language.PureScript.Externs (ExternsFile)
 import Language.PureScript.Make.Actions as Actions
-import Language.PureScript.Make.Cache
+import Language.PureScript.Make.Cache (CacheDb, CacheInfo, checkChanged)
 import Language.PureScript.Names (ModuleName)
-import Language.PureScript.Sugar.Names.Env
+import Language.PureScript.Sugar.Names.Env (Env, primEnv)
 import System.Directory (getCurrentDirectory)
 
 -- | The BuildPlan tracks information about our build progress, and holds all

--- a/src/Language/PureScript/Make/Monad.hs
+++ b/src/Language/PureScript/Make/Monad.hs
@@ -27,21 +27,21 @@ import Control.Exception (fromException, tryJust)
 import Control.Monad (join, guard)
 import Control.Monad.Base (MonadBase(..))
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.IO.Class
-import Control.Monad.Logger
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.Logger (Logger, runLogger')
 import Control.Monad.Reader (MonadReader(..), ReaderT(..))
 import Control.Monad.Trans.Control (MonadBaseControl(..))
-import Control.Monad.Trans.Except
+import Control.Monad.Trans.Except (ExceptT, runExceptT)
 import Control.Monad.Writer.Class (MonadWriter(..))
 import Data.Aeson qualified as Aeson
 import Data.ByteString qualified as B
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Time.Clock (UTCTime)
-import Language.PureScript.Errors
+import Language.PureScript.Errors (ErrorMessage(..), MultipleErrors, SimpleErrorMessage(..), singleError)
 import Language.PureScript.Externs (ExternsFile, externsIsCurrentVersion)
 import Language.PureScript.Make.Cache (ContentHash, hash)
-import Language.PureScript.Options
+import Language.PureScript.Options (Options)
 import System.Directory (createDirectoryIfMissing, getModificationTime)
 import System.Directory qualified as Directory
 import System.FilePath (takeDirectory)

--- a/src/Language/PureScript/ModuleDependencies.hs
+++ b/src/Language/PureScript/ModuleDependencies.hs
@@ -10,13 +10,13 @@ module Language.PureScript.ModuleDependencies
 import Protolude hiding (head)
 
 import Data.Array ((!))
-import Data.Graph
+import Data.Graph (SCC(..), graphFromEdges, reachable, stronglyConnComp)
 import Data.Set qualified as S
-import Language.PureScript.AST
+import Language.PureScript.AST (Declaration(..), ErrorMessageHint(..), Module(..), SourceSpan)
 import Language.PureScript.Constants.Prim qualified as C
-import Language.PureScript.Crash
-import Language.PureScript.Errors hiding (nonEmpty)
-import Language.PureScript.Names
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), addHint, errorMessage', errorMessage'', parU)
+import Language.PureScript.Names (ModuleName)
 
 -- | A list of modules with their transitive dependencies
 type ModuleGraph = [(ModuleName, [ModuleName])]

--- a/src/Language/PureScript/Names.hs
+++ b/src/Language/PureScript/Names.hs
@@ -9,14 +9,14 @@ import Prelude
 
 import Codec.Serialise (Serialise)
 import Control.Applicative ((<|>))
-import Control.Monad.Supply.Class
+import Control.Monad.Supply.Class (MonadSupply(..))
 import Control.DeepSeq (NFData)
 import Data.Functor.Contravariant (contramap)
 import Data.Vector qualified as V
 
 import GHC.Generics (Generic)
-import Data.Aeson
-import Data.Aeson.TH
+import Data.Aeson (FromJSON(..), FromJSONKey(..), Options(..), SumEncoding(..), ToJSON(..), ToJSONKey(..), defaultOptions, parseJSON2, toJSON2, withArray)
+import Data.Aeson.TH (deriveJSON)
 import Data.Text (Text)
 import Data.Text qualified as T
 

--- a/src/Language/PureScript/Pretty/Common.hs
+++ b/src/Language/PureScript/Pretty/Common.hs
@@ -14,7 +14,7 @@ import Data.Text qualified as T
 import Language.PureScript.AST (SourcePos(..), SourceSpan(..), nullSourceSpan)
 import Language.PureScript.CST.Lexer (isUnquotedKey)
 
-import Text.PrettyPrint.Boxes hiding ((<>))
+import Text.PrettyPrint.Boxes (Box(..), emptyBox, text, top, vcat, (//))
 import Text.PrettyPrint.Boxes qualified as Box
 
 parensT :: Text -> Text

--- a/src/Language/PureScript/Pretty/Types.hs
+++ b/src/Language/PureScript/Pretty/Types.hs
@@ -1,6 +1,3 @@
--- HLint is confused by the identifier `pattern` if PatternSynonyms is enabled.
-{-# LANGUAGE NoPatternSynonyms #-}
-
 -- |
 -- Pretty printer for Types
 --
@@ -29,15 +26,15 @@ import Data.Maybe (fromMaybe, catMaybes)
 import Data.Text (Text)
 import Data.Text qualified as T
 
-import Language.PureScript.Crash
-import Language.PureScript.Environment
-import Language.PureScript.Names
-import Language.PureScript.Pretty.Common
-import Language.PureScript.Types
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Environment (tyFunction, tyRecord)
+import Language.PureScript.Names (OpName(..), OpNameType(..), ProperName(..), ProperNameType(..), Qualified, coerceProperName, disqualify, showQualified)
+import Language.PureScript.Pretty.Common (before, objectKeyRequiresQuoting)
+import Language.PureScript.Types (Constraint(..), pattern REmptyKinded, RowListItem(..), Type(..), WildcardData(..), eqType, rowToSortedList)
 import Language.PureScript.PSString (PSString, prettyPrintString, decodeString)
 import Language.PureScript.Label (Label(..))
 
-import Text.PrettyPrint.Boxes hiding ((<+>))
+import Text.PrettyPrint.Boxes (Box(..), hcat, hsep, left, moveRight, nullBox, render, text, top, vcat, (<>))
 
 data PrettyPrintType
   = PPTUnknown Int

--- a/src/Language/PureScript/Pretty/Values.hs
+++ b/src/Language/PureScript/Pretty/Values.hs
@@ -16,15 +16,15 @@ import Data.List.NonEmpty qualified as NEL
 import Data.Monoid qualified as Monoid ((<>))
 import Data.Text qualified as T
 
-import Language.PureScript.AST
-import Language.PureScript.Crash
-import Language.PureScript.Names
-import Language.PureScript.Pretty.Common
+import Language.PureScript.AST (AssocList(..), Binder(..), CaseAlternative(..), Declaration(..), DoNotationElement(..), Expr(..), Guard(..), GuardedExpr(..), Literal(..), PathNode(..), PathTree(..), TypeDeclarationData(..), pattern ValueDecl, WhereProvenance(..))
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Names (OpName(..), ProperName(..), Qualified(..), disqualify, runModuleName, showIdent)
+import Language.PureScript.Pretty.Common (before, beforeWithSpace, parensT)
 import Language.PureScript.Pretty.Types (typeAsBox, typeAtomAsBox, prettyPrintObjectKey)
 import Language.PureScript.Types (Constraint(..))
 import Language.PureScript.PSString (PSString, prettyPrintString)
 
-import Text.PrettyPrint.Boxes
+import Text.PrettyPrint.Boxes (Box, left, moveRight, text, vcat, vsep, (//), (<>))
 
 -- TODO(Christoph): remove T.unpack s
 

--- a/src/Language/PureScript/Publish.hs
+++ b/src/Language/PureScript/Publish.hs
@@ -29,7 +29,7 @@ import Data.List (stripPrefix, (\\))
 import Data.Text qualified as T
 import Data.Time.Clock (UTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import Data.Version
+import Data.Version (Version)
 import Distribution.SPDX qualified as SPDX
 import Distribution.Parsec qualified as CabalParsec
 
@@ -40,9 +40,9 @@ import System.Process (readProcess)
 import Web.Bower.PackageMeta (PackageMeta(..), PackageName, Repository(..))
 import Web.Bower.PackageMeta qualified as Bower
 
-import Language.PureScript.Publish.ErrorsWarnings
-import Language.PureScript.Publish.Registry.Compat
-import Language.PureScript.Publish.Utils
+import Language.PureScript.Publish.ErrorsWarnings (InternalError(..), OtherError(..), PackageError(..), PackageWarning(..), RepositoryFieldError(..), UserError(..), printError, printWarnings)
+import Language.PureScript.Publish.Registry.Compat (asPursJson, toBowerPackage)
+import Language.PureScript.Publish.Utils (globRelative, purescriptSourceFiles)
 import Language.PureScript qualified as P (version, ModuleName)
 import Language.PureScript.CoreFn.FromJSON qualified as P
 import Language.PureScript.Docs qualified as D

--- a/src/Language/PureScript/Publish/ErrorsWarnings.hs
+++ b/src/Language/PureScript/Publish/ErrorsWarnings.hs
@@ -19,16 +19,16 @@ import Control.Exception (IOException)
 import Data.Aeson.BetterErrors (ParseError, displayError)
 import Data.List (intersperse)
 import Data.List.NonEmpty (NonEmpty(..))
-import Data.Maybe
-import Data.Monoid
-import Data.Version
+import Data.Maybe (catMaybes, fromMaybe)
+import Data.Monoid (Any(..))
+import Data.Version (Version, showVersion)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Text (Text)
 import Data.Text qualified as T
 
 import Language.PureScript.Docs.Types qualified as D
 import Language.PureScript qualified as P
-import Language.PureScript.Publish.BoxesHelpers
+import Language.PureScript.Publish.BoxesHelpers (Box, bulletedList, bulletedListT, indented, nullBox, para, printToStderr, spacer, successivelyIndented, vcat)
 
 import Web.Bower.PackageMeta (PackageName, runPackageName, showBowerError)
 import Web.Bower.PackageMeta qualified as Bower

--- a/src/Language/PureScript/Publish/Utils.hs
+++ b/src/Language/PureScript/Publish/Utils.hs
@@ -2,7 +2,7 @@ module Language.PureScript.Publish.Utils where
 
 import Prelude
 
-import System.Directory
+import System.Directory (getCurrentDirectory)
 import System.FilePath.Glob (Pattern, compile, globDir1)
 
 -- | Glob relative to the current directory, and produce relative pathnames.

--- a/src/Language/PureScript/Renamer.hs
+++ b/src/Language/PureScript/Renamer.hs
@@ -5,7 +5,7 @@ module Language.PureScript.Renamer (renameInModule) where
 
 import Prelude
 
-import Control.Monad.State
+import Control.Monad.State (MonadState(..), State, gets, modify, runState, (>=>))
 
 import Data.Functor ((<&>))
 import Data.List (find)
@@ -14,9 +14,9 @@ import Data.Map qualified as M
 import Data.Set qualified as S
 import Data.Text qualified as T
 
-import Language.PureScript.CoreFn
-import Language.PureScript.Names
-import Language.PureScript.Traversals
+import Language.PureScript.CoreFn (Ann, Bind(..), Binder(..), CaseAlternative(..), Expr(..), Literal(..), Module(..))
+import Language.PureScript.Names (Ident(..), Qualified(..), isBySourcePos, isPlainIdent, runIdent, showIdent)
+import Language.PureScript.Traversals (eitherM, pairM, sndM)
 
 -- |
 -- The state object used in this module

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -4,16 +4,16 @@
 module Language.PureScript.Sugar (desugar, module S) where
 
 import Control.Category ((>>>))
-import Control.Monad
+import Control.Monad ((>=>))
 import Control.Monad.Error.Class (MonadError)
 import Control.Monad.Supply.Class (MonadSupply)
 import Control.Monad.State.Class (MonadState)
 import Control.Monad.Writer.Class (MonadWriter)
 
-import Language.PureScript.AST
-import Language.PureScript.Errors
-import Language.PureScript.Externs
-import Language.PureScript.Linter.Imports
+import Language.PureScript.AST (Module)
+import Language.PureScript.Errors (MultipleErrors)
+import Language.PureScript.Externs (ExternsFile)
+import Language.PureScript.Linter.Imports (UsedImports)
 import Language.PureScript.Sugar.BindingGroups as S
 import Language.PureScript.Sugar.CaseDeclarations as S
 import Language.PureScript.Sugar.DoNotation as S

--- a/src/Language/PureScript/Sugar/AdoNotation.hs
+++ b/src/Language/PureScript/Sugar/AdoNotation.hs
@@ -7,11 +7,11 @@ import Prelude hiding (abs)
 
 import Control.Monad (foldM)
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Supply.Class
+import Control.Monad.Supply.Class (MonadSupply)
 import Data.List (foldl')
-import Language.PureScript.AST
-import Language.PureScript.Errors
-import Language.PureScript.Names
+import Language.PureScript.AST (Binder(..), CaseAlternative(..), Declaration, DoNotationElement(..), Expr(..), pattern MkUnguarded, Module(..), SourceSpan, WhereProvenance(..), declSourceSpan, everywhereOnValuesM)
+import Language.PureScript.Errors (MultipleErrors, parU, rethrowWithPosition)
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident(..), ModuleName, Qualified(..), byMaybeModuleName, freshIdent')
 import Language.PureScript.Constants.Libs qualified as C
 
 -- | Replace all @AdoNotationBind@ and @AdoNotationValue@ constructors with

--- a/src/Language/PureScript/Sugar/BindingGroups.hs
+++ b/src/Language/PureScript/Sugar/BindingGroups.hs
@@ -14,7 +14,7 @@ import Protolude (ordNub, swap)
 import Control.Monad ((<=<), guard)
 import Control.Monad.Error.Class (MonadError(..))
 
-import Data.Graph
+import Data.Graph (SCC(..), stronglyConnComp, stronglyConnCompR)
 import Data.List (intersect, (\\))
 import Data.List.NonEmpty (NonEmpty((:|)), nonEmpty)
 import Data.Foldable (find)
@@ -25,11 +25,11 @@ import Data.Map qualified as M
 import Data.Set qualified as S
 
 import Language.PureScript.AST
-import Language.PureScript.Crash
-import Language.PureScript.Environment
-import Language.PureScript.Errors hiding (nonEmpty)
-import Language.PureScript.Names
-import Language.PureScript.Types
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Environment (NameKind)
+import Language.PureScript.Errors (ErrorMessage(..), MultipleErrors(..), SimpleErrorMessage(..), errorMessage', parU, positionedError)
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident, ModuleName, ProperName, ProperNameType(..), Qualified(..), QualifiedBy(..), coerceProperName)
+import Language.PureScript.Types (Constraint(..), SourceConstraint, SourceType, Type(..), everythingOnTypes)
 
 data VertexType
   = VertexDefinition

--- a/src/Language/PureScript/Sugar/CaseDeclarations.hs
+++ b/src/Language/PureScript/Sugar/CaseDeclarations.hs
@@ -16,13 +16,13 @@ import Data.Maybe (catMaybes, mapMaybe)
 
 import Control.Monad ((<=<), forM, replicateM, join, unless)
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Supply.Class
+import Control.Monad.Supply.Class (MonadSupply)
 
 import Language.PureScript.AST
-import Language.PureScript.Crash
-import Language.PureScript.Environment
-import Language.PureScript.Errors
-import Language.PureScript.Names
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Environment (NameKind(..))
+import Language.PureScript.Errors (ErrorMessage(..), MultipleErrors(..), SimpleErrorMessage(..), addHint, errorMessage', parU, rethrow, withPosition)
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident, Qualified(..), freshIdent')
 import Language.PureScript.TypeChecker.Monad (guardWith)
 
 -- |

--- a/src/Language/PureScript/Sugar/DoNotation.hs
+++ b/src/Language/PureScript/Sugar/DoNotation.hs
@@ -7,13 +7,13 @@ import Prelude
 
 import Control.Applicative ((<|>))
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Supply.Class
+import Control.Monad.Supply.Class (MonadSupply)
 import Data.Maybe (fromMaybe)
 import Data.Monoid (First(..))
-import Language.PureScript.AST
-import Language.PureScript.Crash
-import Language.PureScript.Errors
-import Language.PureScript.Names
+import Language.PureScript.AST (Binder(..), CaseAlternative(..), Declaration, DoNotationElement(..), Expr(..), pattern MkUnguarded, Module(..), SourceSpan, pattern ValueDecl, WhereProvenance(..), binderNames, declSourceSpan, everywhereOnValuesM)
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), errorMessage, errorMessage', parU, rethrowWithPosition)
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident(..), ModuleName, Qualified(..), byMaybeModuleName, freshIdent')
 import Language.PureScript.Constants.Libs qualified as C
 
 -- | Replace all @DoNotationBind@ and @DoNotationValue@ constructors with

--- a/src/Language/PureScript/Sugar/LetPattern.hs
+++ b/src/Language/PureScript/Sugar/LetPattern.hs
@@ -9,8 +9,8 @@ import Prelude
 import Data.List (groupBy)
 import Data.Function (on)
 
-import Language.PureScript.AST
-import Language.PureScript.Crash
+import Language.PureScript.AST (Binder, CaseAlternative(..), Declaration(..), Expr(..), pattern MkUnguarded, Module(..), SourceAnn, WhereProvenance, everywhereOnValues)
+import Language.PureScript.Crash (internalError)
 
 -- | Replace every @BoundValueDeclaration@ in @Let@ expressions with @Case@
 -- expressions.

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -13,9 +13,9 @@ import Prelude
 import Protolude (sortOn, swap, foldl')
 
 import Control.Arrow (first, second, (&&&))
-import Control.Monad
+import Control.Monad (foldM, when, (>=>))
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.State.Lazy
+import Control.Monad.State.Lazy (MonadState, StateT(..), gets, modify)
 import Control.Monad.Writer (MonadWriter(..))
 
 import Data.List.NonEmpty qualified as NEL
@@ -24,16 +24,16 @@ import Data.Map qualified as M
 import Data.Set qualified as S
 
 import Language.PureScript.AST
-import Language.PureScript.Crash
-import Language.PureScript.Errors
-import Language.PureScript.Externs
-import Language.PureScript.Linter.Imports
-import Language.PureScript.Names
-import Language.PureScript.Sugar.Names.Env
-import Language.PureScript.Sugar.Names.Exports
-import Language.PureScript.Sugar.Names.Imports
-import Language.PureScript.Traversals
-import Language.PureScript.Types
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), addHint, errorMessage, errorMessage'', nonEmpty, parU, warnAndRethrow, warnAndRethrowWithPosition)
+import Language.PureScript.Externs (ExternsDeclaration(..), ExternsFile(..), ExternsImport(..))
+import Language.PureScript.Linter.Imports (Name(..), UsedImports)
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident, OpName, OpNameType(..), ProperName, ProperNameType(..), Qualified(..), QualifiedBy(..))
+import Language.PureScript.Sugar.Names.Env (Env, Exports(..), ImportProvenance(..), ImportRecord(..), Imports(..), checkImportConflicts, nullImports, primEnv)
+import Language.PureScript.Sugar.Names.Exports (findExportable, resolveExports)
+import Language.PureScript.Sugar.Names.Imports (resolveImports, resolveModuleImport)
+import Language.PureScript.Traversals (defS, sndM)
+import Language.PureScript.Types (Constraint(..), SourceConstraint, SourceType, Type(..), everywhereOnTypesM)
 
 -- |
 -- Replaces all local names with qualified names.

--- a/src/Language/PureScript/Sugar/Names/Common.hs
+++ b/src/Language/PureScript/Sugar/Names/Common.hs
@@ -9,9 +9,9 @@ import Data.Foldable (for_)
 import Data.List (group, sort, (\\))
 import Data.Maybe (mapMaybe)
 
-import Language.PureScript.AST
-import Language.PureScript.Errors
-import Language.PureScript.Names
+import Language.PureScript.AST (DeclarationRef(..), SourceSpan)
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage, errorMessage, warnWithPosition)
+import Language.PureScript.Names (Name(..))
 
 -- |
 -- Warns about duplicate values in a list of declaration refs.

--- a/src/Language/PureScript/Sugar/Names/Env.hs
+++ b/src/Language/PureScript/Sugar/Names/Env.hs
@@ -20,7 +20,7 @@ module Language.PureScript.Sugar.Names.Env
 
 import Prelude
 
-import Control.Monad
+import Control.Monad (forM_, when)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Writer.Class (MonadWriter(..))
 
@@ -33,11 +33,11 @@ import Data.Map qualified as M
 import Data.Set qualified as S
 
 import Language.PureScript.Constants.Prim qualified as C
-import Language.PureScript.AST
-import Language.PureScript.Crash
+import Language.PureScript.AST (ExportSource(..), SourceSpan, internalModuleSourceSpan, nullSourceSpan)
+import Language.PureScript.Crash (internalError)
 import Language.PureScript.Environment
-import Language.PureScript.Errors
-import Language.PureScript.Names
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), errorMessage, errorMessage')
+import Language.PureScript.Names (Ident, ModuleName, Name(..), OpName, OpNameType(..), ProperName, ProperNameType(..), Qualified(..), QualifiedBy(..), coerceProperName, disqualify, getQual)
 
 -- |
 -- The details for an import: the name of the thing that is being imported

--- a/src/Language/PureScript/Sugar/Names/Exports.hs
+++ b/src/Language/PureScript/Sugar/Names/Exports.hs
@@ -5,7 +5,7 @@ module Language.PureScript.Sugar.Names.Exports
 
 import Prelude
 
-import Control.Monad
+import Control.Monad (filterM, foldM, liftM2, unless, void, when)
 import Control.Monad.Writer.Class (MonadWriter(..))
 import Control.Monad.Error.Class (MonadError(..))
 
@@ -16,10 +16,10 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Map qualified as M
 
 import Language.PureScript.AST
-import Language.PureScript.Crash
-import Language.PureScript.Errors
-import Language.PureScript.Names
-import Language.PureScript.Sugar.Names.Env
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), addHint, errorMessage', rethrow, rethrowWithPosition, warnAndRethrow)
+import Language.PureScript.Names (Ident, ModuleName, Name(..), OpName, OpNameType(..), ProperName, ProperNameType(..), Qualified(..), QualifiedBy(..), disqualifyFor, isQualifiedWith, isUnqualified)
+import Language.PureScript.Sugar.Names.Env (Env, ExportMode(..), Exports(..), ImportRecord(..), Imports(..), checkImportConflicts, envModuleExports, exportType, exportTypeClass, exportTypeOp, exportValue, exportValueOp, nullExports)
 import Language.PureScript.Sugar.Names.Common (warnDuplicateRefs)
 
 -- |

--- a/src/Language/PureScript/Sugar/Names/Imports.hs
+++ b/src/Language/PureScript/Sugar/Names/Imports.hs
@@ -7,7 +7,7 @@ module Language.PureScript.Sugar.Names.Imports
 
 import Prelude
 
-import Control.Monad
+import Control.Monad (foldM, when)
 import Control.Monad.Error.Class (MonadError(..))
 
 import Data.Foldable (for_, traverse_)
@@ -15,11 +15,11 @@ import Data.Maybe (fromMaybe)
 import Data.Map qualified as M
 import Data.Set qualified as S
 
-import Language.PureScript.AST
-import Language.PureScript.Crash
-import Language.PureScript.Errors
-import Language.PureScript.Names
-import Language.PureScript.Sugar.Names.Env
+import Language.PureScript.AST (Declaration(..), DeclarationRef(..), ErrorMessageHint(..), ExportSource(..), ImportDeclarationType(..), Module(..), SourceSpan, internalModuleSourceSpan)
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), addHint, errorMessage', rethrow)
+import Language.PureScript.Names (pattern ByNullSourcePos, ModuleName, Name(..), ProperName, ProperNameType(..), Qualified(..), QualifiedBy(..), byMaybeModuleName)
+import Language.PureScript.Sugar.Names.Env (Env, Exports(..), ImportProvenance(..), ImportRecord(..), Imports(..), envModuleExports, nullImports)
 
 type ImportDef = (SourceSpan, ImportDeclarationType, Maybe ModuleName)
 

--- a/src/Language/PureScript/Sugar/ObjectWildcards.hs
+++ b/src/Language/PureScript/Sugar/ObjectWildcards.hs
@@ -7,14 +7,14 @@ import Prelude
 
 import Control.Monad (forM)
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.Supply.Class
+import Control.Monad.Supply.Class (MonadSupply)
 import Data.Foldable (toList)
 import Data.List (foldl')
 import Data.Maybe (catMaybes)
 import Language.PureScript.AST
 import Language.PureScript.Environment (NameKind(..))
-import Language.PureScript.Errors
-import Language.PureScript.Names
+import Language.PureScript.Errors (MultipleErrors, rethrowWithPosition)
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident, Qualified(..), freshIdent')
 import Language.PureScript.PSString (PSString)
 
 

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -16,15 +16,15 @@ module Language.PureScript.Sugar.Operators
 import Prelude
 
 import Language.PureScript.AST
-import Language.PureScript.Crash
-import Language.PureScript.Errors
-import Language.PureScript.Externs
-import Language.PureScript.Names
-import Language.PureScript.Sugar.Operators.Binders
-import Language.PureScript.Sugar.Operators.Expr
-import Language.PureScript.Sugar.Operators.Types
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), addHint, errorMessage, errorMessage', parU, rethrow, rethrowWithPosition)
+import Language.PureScript.Externs (ExternsFile(..), ExternsFixity(..), ExternsTypeFixity(..))
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident(..), Name(..), OpName, OpNameType(..), ProperName, ProperNameType(..), Qualified(..), QualifiedBy(..), freshIdent')
+import Language.PureScript.Sugar.Operators.Binders (matchBinderOperators)
+import Language.PureScript.Sugar.Operators.Expr (matchExprOperators)
+import Language.PureScript.Sugar.Operators.Types (matchTypeOperators)
 import Language.PureScript.Traversals (defS, sndM)
-import Language.PureScript.Types
+import Language.PureScript.Types (Constraint(..), SourceType, Type(..), everywhereOnTypesTopDownM, overConstraintArgs)
 
 import Control.Monad (unless, (<=<))
 import Control.Monad.Error.Class (MonadError(..))

--- a/src/Language/PureScript/Sugar/Operators/Binders.hs
+++ b/src/Language/PureScript/Sugar/Operators/Binders.hs
@@ -2,12 +2,12 @@ module Language.PureScript.Sugar.Operators.Binders where
 
 import Prelude
 
-import Control.Monad.Except
+import Control.Monad.Except (MonadError)
 
-import Language.PureScript.AST
-import Language.PureScript.Errors
-import Language.PureScript.Names
-import Language.PureScript.Sugar.Operators.Common
+import Language.PureScript.AST (Associativity, Binder(..), SourceSpan)
+import Language.PureScript.Errors (MultipleErrors)
+import Language.PureScript.Names (OpName(..), OpNameType(..), Qualified(..))
+import Language.PureScript.Sugar.Operators.Common (matchOperators)
 
 matchBinderOperators
   :: MonadError MultipleErrors m

--- a/src/Language/PureScript/Sugar/Operators/Common.hs
+++ b/src/Language/PureScript/Sugar/Operators/Common.hs
@@ -2,11 +2,11 @@ module Language.PureScript.Sugar.Operators.Common where
 
 import Prelude
 
-import Control.Monad.State
-import Control.Monad.Except
+import Control.Monad.State (guard, join)
+import Control.Monad.Except (MonadError(..))
 
 import Data.Either (rights)
-import Data.Functor.Identity
+import Data.Functor.Identity (Identity)
 import Data.List (sortOn)
 import Data.Maybe (mapMaybe, fromJust)
 import Data.List.NonEmpty qualified as NEL
@@ -16,10 +16,10 @@ import Text.Parsec qualified as P
 import Text.Parsec.Pos qualified as P
 import Text.Parsec.Expr qualified as P
 
-import Language.PureScript.AST
-import Language.PureScript.Crash
-import Language.PureScript.Errors
-import Language.PureScript.Names
+import Language.PureScript.AST (Associativity(..), ErrorMessageHint(..), SourceSpan)
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Errors (ErrorMessage(..), MultipleErrors(..), SimpleErrorMessage(..))
+import Language.PureScript.Names (OpName, Qualified, eraseOpName)
 
 type Chain a = [Either a a]
 

--- a/src/Language/PureScript/Sugar/Operators/Expr.hs
+++ b/src/Language/PureScript/Sugar/Operators/Expr.hs
@@ -2,16 +2,16 @@ module Language.PureScript.Sugar.Operators.Expr where
 
 import Prelude
 
-import Control.Monad.Except
-import Data.Functor.Identity
+import Control.Monad.Except (MonadError)
+import Data.Functor.Identity (Identity)
 
 import Text.Parsec qualified as P
 import Text.Parsec.Expr qualified as P
 
-import Language.PureScript.AST
-import Language.PureScript.Names
-import Language.PureScript.Sugar.Operators.Common
-import Language.PureScript.Errors
+import Language.PureScript.AST (Associativity, Expr(..), SourceSpan)
+import Language.PureScript.Names (OpName(..), OpNameType(..), Qualified(..))
+import Language.PureScript.Sugar.Operators.Common (Chain, matchOperators, token)
+import Language.PureScript.Errors (MultipleErrors)
 
 matchExprOperators
   :: MonadError MultipleErrors m

--- a/src/Language/PureScript/Sugar/Operators/Types.hs
+++ b/src/Language/PureScript/Sugar/Operators/Types.hs
@@ -2,12 +2,12 @@ module Language.PureScript.Sugar.Operators.Types where
 
 import Prelude
 
-import Control.Monad.Except
-import Language.PureScript.AST
-import Language.PureScript.Errors
-import Language.PureScript.Names
-import Language.PureScript.Sugar.Operators.Common
-import Language.PureScript.Types
+import Control.Monad.Except (MonadError)
+import Language.PureScript.AST (Associativity, SourceSpan)
+import Language.PureScript.Errors (MultipleErrors)
+import Language.PureScript.Names (OpName(..), OpNameType(..), Qualified(..))
+import Language.PureScript.Sugar.Operators.Common (matchOperators)
+import Language.PureScript.Types (SourceType, Type(..), srcTypeApp)
 
 matchTypeOperators
   :: MonadError MultipleErrors m

--- a/src/Language/PureScript/Sugar/TypeClasses.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses.hs
@@ -12,9 +12,9 @@ import Prelude
 
 import Control.Arrow (first, second)
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.State
-import Control.Monad.Supply.Class
-import Data.Graph
+import Control.Monad.State (MonadState(..), StateT, evalStateT, modify)
+import Control.Monad.Supply.Class (MonadSupply)
+import Data.Graph (SCC(..), stronglyConnComp)
 import Data.List (find, partition)
 import Data.List.NonEmpty (nonEmpty)
 import Data.Map qualified as M
@@ -24,14 +24,14 @@ import Data.Set qualified as S
 import Data.Text (Text)
 import Data.Traversable (for)
 import Language.PureScript.Constants.Prim qualified as C
-import Language.PureScript.Crash
-import Language.PureScript.Environment
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Environment (DataDeclType(..), NameKind(..), TypeClassData(..), dictTypeName, function, makeTypeClassData, primClasses, primCoerceClasses, primIntClasses, primRowClasses, primRowListClasses, primSymbolClasses, primTypeErrorClasses, tyRecord)
 import Language.PureScript.Errors hiding (isExported, nonEmpty)
-import Language.PureScript.Externs
+import Language.PureScript.Externs (ExternsDeclaration(..), ExternsFile(..))
 import Language.PureScript.Label (Label(..))
-import Language.PureScript.Names
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident(..), ModuleName, Name(..), ProperName, ProperNameType(..), Qualified(..), QualifiedBy(..), coerceProperName, freshIdent, qualify, runIdent)
 import Language.PureScript.PSString (mkString)
-import Language.PureScript.Sugar.CaseDeclarations
+import Language.PureScript.Sugar.CaseDeclarations (desugarCases)
 import Language.PureScript.TypeClassDictionaries (superclassName)
 import Language.PureScript.Types
 

--- a/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
+++ b/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs
@@ -7,15 +7,15 @@ import Protolude (note)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Supply.Class (MonadSupply)
 import Data.List (foldl', find, unzip5)
-import Language.PureScript.AST
-import Language.PureScript.AST.Utils
+import Language.PureScript.AST (Binder(..), CaseAlternative(..), DataConstructorDeclaration(..), Declaration(..), Expr(..), pattern MkUnguarded, Module(..), SourceSpan(..), TypeInstanceBody(..), pattern ValueDecl)
+import Language.PureScript.AST.Utils (UnwrappedTypeConstructor(..), lamCase, unguarded, unwrapTypeConstructor)
 import Language.PureScript.Constants.Libs qualified as Libs
-import Language.PureScript.Crash
-import Language.PureScript.Environment
-import Language.PureScript.Errors
-import Language.PureScript.Names
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Environment (DataDeclType(..), NameKind(..))
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), errorMessage')
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident(..), ModuleName, ProperName(..), ProperNameType(..), Qualified(..), QualifiedBy(..), freshIdent)
 import Language.PureScript.PSString (mkString)
-import Language.PureScript.Types
+import Language.PureScript.Types (SourceType, Type(..), WildcardData(..), replaceAllTypeVars, srcTypeApp, srcTypeConstructor, srcTypeLevelString)
 import Language.PureScript.TypeChecker (checkNewtype)
 
 -- | Elaborates deriving instance declarations by code generation.

--- a/src/Language/PureScript/Sugar/TypeDeclarations.hs
+++ b/src/Language/PureScript/Sugar/TypeDeclarations.hs
@@ -11,10 +11,10 @@ import Prelude
 import Control.Monad (unless)
 import Control.Monad.Error.Class (MonadError(..))
 
-import Language.PureScript.AST
-import Language.PureScript.Names
-import Language.PureScript.Environment
-import Language.PureScript.Errors
+import Language.PureScript.AST (Declaration(..), ErrorMessageHint(..), Expr(..), GuardedExpr(..), KindSignatureFor(..), pattern MkUnguarded, Module(..), RoleDeclarationData(..), TypeDeclarationData(..), TypeInstanceBody(..), pattern ValueDecl, declSourceSpan, everywhereOnValuesTopDownM)
+import Language.PureScript.Names (Ident, coerceProperName)
+import Language.PureScript.Environment (DataDeclType(..), NameKind)
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), addHint, errorMessage', rethrow)
 
 -- |
 -- Replace all top level type declarations in a module with type annotations

--- a/src/Language/PureScript/TypeChecker.hs
+++ b/src/Language/PureScript/TypeChecker.hs
@@ -19,7 +19,7 @@ import Control.Monad.Writer.Class (MonadWriter, tell)
 
 import Data.Foldable (for_, traverse_, toList)
 import Data.List (nub, nubBy, (\\), sort, group)
-import Data.Maybe
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Either (partitionEithers)
 import Data.Text (Text)
 import Data.List.NonEmpty qualified as NEL
@@ -30,13 +30,13 @@ import Data.Text qualified as T
 import Language.PureScript.AST
 import Language.PureScript.AST.Declarations.ChainId (ChainId)
 import Language.PureScript.Constants.Libs qualified as Libs
-import Language.PureScript.Crash
-import Language.PureScript.Environment
-import Language.PureScript.Errors
-import Language.PureScript.Linter
-import Language.PureScript.Linter.Wildcards
-import Language.PureScript.Names
-import Language.PureScript.Roles
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Environment (DataDeclType(..), Environment(..), FunctionalDependency, NameKind(..), NameVisibility(..), TypeClassData(..), TypeKind(..), isDictTypeName, kindArity, makeTypeClassData, nominalRolesForKind, tyFunction)
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), addHint, errorMessage, errorMessage', positionedError, rethrow, warnAndRethrow)
+import Language.PureScript.Linter (checkExhaustiveExpr)
+import Language.PureScript.Linter.Wildcards (ignoreWildcardsUnderCompleteTypeSignatures)
+import Language.PureScript.Names (Ident, ModuleName, ProperName, ProperNameType(..), Qualified(..), QualifiedBy(..), coerceProperName, disqualify, isPlainIdent, mkQualified)
+import Language.PureScript.Roles (Role)
 import Language.PureScript.Sugar.Names.Env (Exports(..))
 import Language.PureScript.TypeChecker.Kinds as T
 import Language.PureScript.TypeChecker.Monad as T
@@ -44,8 +44,8 @@ import Language.PureScript.TypeChecker.Roles as T
 import Language.PureScript.TypeChecker.Synonyms as T
 import Language.PureScript.TypeChecker.Types as T
 import Language.PureScript.TypeChecker.Unify (varIfUnknown)
-import Language.PureScript.TypeClassDictionaries
-import Language.PureScript.Types
+import Language.PureScript.TypeClassDictionaries (NamedDict, TypeClassDictionaryInScope(..))
+import Language.PureScript.Types (Constraint(..), SourceConstraint, SourceType, Type(..), containsForAll, eqType, everythingOnTypes, freeTypeVariables, overConstraintArgs, srcInstanceType, unapplyTypes)
 
 addDataType
   :: (MonadState CheckState m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)

--- a/src/Language/PureScript/TypeChecker/Deriving.hs
+++ b/src/Language/PureScript/TypeChecker/Deriving.hs
@@ -15,23 +15,23 @@ import Data.List (init, last, zipWith3, (!!))
 import Data.Map qualified as M
 import Data.These (These(..), mergeTheseWith, these)
 
-import Control.Monad.Supply.Class
-import Language.PureScript.AST
-import Language.PureScript.AST.Utils
+import Control.Monad.Supply.Class (MonadSupply)
+import Language.PureScript.AST (Binder(..), CaseAlternative(..), ErrorMessageHint(..), Expr(..), InstanceDerivationStrategy(..), Literal(..), SourceSpan, nullSourceSpan)
+import Language.PureScript.AST.Utils (UnwrappedTypeConstructor(..), lam, lamCase, lamCase2, mkBinder, mkCtor, mkCtorBinder, mkLit, mkRef, mkVar, unguarded, unwrapTypeConstructor, utcQTyCon)
 import Language.PureScript.Constants.Libs qualified as Libs
 import Language.PureScript.Constants.Prim qualified as Prim
-import Language.PureScript.Crash
-import Language.PureScript.Environment
-import Language.PureScript.Errors hiding (nonEmpty)
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Environment (DataDeclType(..), Environment(..), FunctionalDependency(..), TypeClassData(..), TypeKind(..), kindType, (-:>))
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), addHint, errorMessage, internalCompilerError)
 import Language.PureScript.Label (Label(..))
-import Language.PureScript.Names
-import Language.PureScript.PSString
-import Language.PureScript.Sugar.TypeClasses
-import Language.PureScript.TypeChecker.Entailment
-import Language.PureScript.TypeChecker.Monad
-import Language.PureScript.TypeChecker.Synonyms
-import Language.PureScript.TypeClassDictionaries
-import Language.PureScript.Types
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident(..), ModuleName(..), Name(..), ProperName(..), ProperNameType(..), Qualified(..), QualifiedBy(..), coerceProperName, freshIdent, qualify)
+import Language.PureScript.PSString (PSString, mkString)
+import Language.PureScript.Sugar.TypeClasses (superClassDictionaryNames)
+import Language.PureScript.TypeChecker.Entailment (InstanceContext, findDicts)
+import Language.PureScript.TypeChecker.Monad (CheckState, getEnv, getTypeClassDictionaries, unsafeCheckCurrentModule)
+import Language.PureScript.TypeChecker.Synonyms (replaceAllTypeSynonyms)
+import Language.PureScript.TypeClassDictionaries (TypeClassDictionaryInScope(..))
+import Language.PureScript.Types (Constraint(..), pattern REmptyKinded, SourceType, Type(..), completeBinderList, eqType, everythingOnTypes, replaceAllTypeVars, srcTypeVar, usedTypeVariables)
 
 -- | Extract the name of the newtype appearing in the last type argument of
 -- a derived newtype instance.

--- a/src/Language/PureScript/TypeChecker/Entailment.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment.hs
@@ -15,9 +15,9 @@ import Protolude (ordNub)
 
 import Control.Arrow (second, (&&&))
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.State
+import Control.Monad.State (MonadState(..), MonadTrans(..), StateT(..), evalStateT, execStateT, foldM, gets, guard, join, modify, zipWithM, zipWithM_, (<=<))
 import Control.Monad.Supply.Class (MonadSupply(..))
-import Control.Monad.Writer
+import Control.Monad.Writer (Any(..), MonadWriter(..), WriterT(..))
 
 import Data.Either (lefts, partitionEithers)
 import Data.Foldable (for_, fold, toList)
@@ -33,18 +33,18 @@ import Data.Text qualified as T
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.List.NonEmpty qualified as NEL
 
-import Language.PureScript.AST
-import Language.PureScript.Crash
-import Language.PureScript.Environment
-import Language.PureScript.Errors
-import Language.PureScript.Names
-import Language.PureScript.TypeChecker.Entailment.Coercible
-import Language.PureScript.TypeChecker.Entailment.IntCompare
+import Language.PureScript.AST (Binder(..), ErrorMessageHint(..), Expr(..), Literal(..), pattern NullSourceSpan, everywhereOnValuesTopDownM, nullSourceSpan)
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Environment (Environment(..), FunctionalDependency(..), TypeClassData(..), dictTypeName, kindRow, tyBoolean, tyInt, tyString)
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), addHint, addHints, errorMessage, rethrow)
+import Language.PureScript.Names (pattern ByNullSourcePos, Ident(..), ModuleName, ProperName(..), ProperNameType(..), Qualified(..), QualifiedBy(..), byMaybeModuleName, coerceProperName, disqualify, freshIdent, getQual)
+import Language.PureScript.TypeChecker.Entailment.Coercible (GivenSolverState(..), WantedSolverState(..), initialGivenSolverState, initialWantedSolverState, insoluble, solveGivens, solveWanteds)
+import Language.PureScript.TypeChecker.Entailment.IntCompare (mkFacts, mkRelation, solveRelation)
 import Language.PureScript.TypeChecker.Kinds (elaborateKind, unifyKinds')
-import Language.PureScript.TypeChecker.Monad
+import Language.PureScript.TypeChecker.Monad (CheckState(..), withErrorMessageHint)
 import Language.PureScript.TypeChecker.Synonyms (replaceAllTypeSynonyms)
-import Language.PureScript.TypeChecker.Unify
-import Language.PureScript.TypeClassDictionaries
+import Language.PureScript.TypeChecker.Unify (freshTypeWithKind, substituteType, unifyTypes)
+import Language.PureScript.TypeClassDictionaries (NamedDict, TypeClassDictionaryInScope(..), superclassName)
 import Language.PureScript.Types
 import Language.PureScript.Label (Label(..))
 import Language.PureScript.PSString (PSString, mkString, decodeString)

--- a/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
+++ b/src/Language/PureScript/TypeChecker/Entailment/Coercible.hs
@@ -35,17 +35,17 @@ import Data.Text (Text)
 import Data.Map qualified as M
 import Data.Set qualified as S
 
-import Language.PureScript.Crash
-import Language.PureScript.Environment
-import Language.PureScript.Errors hiding (inScope)
-import Language.PureScript.Names
-import Language.PureScript.TypeChecker.Kinds hiding (kindOf)
-import Language.PureScript.TypeChecker.Monad
-import Language.PureScript.TypeChecker.Roles
-import Language.PureScript.TypeChecker.Synonyms
-import Language.PureScript.TypeChecker.Unify
-import Language.PureScript.Roles
-import Language.PureScript.Types
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Environment (DataDeclType(..), Environment(..), TypeKind(..), unapplyKinds)
+import Language.PureScript.Errors (DeclarationRef(..), ErrorMessageHint(..), ExportSource, ImportDeclarationType(..), MultipleErrors, SimpleErrorMessage(..), SourceAnn, errorMessage)
+import Language.PureScript.Names (ModuleName, ProperName, ProperNameType(..), Qualified(..), byMaybeModuleName, toMaybeModuleName)
+import Language.PureScript.TypeChecker.Kinds (elaborateKind, freshKindWithKind, unifyKinds')
+import Language.PureScript.TypeChecker.Monad (CheckState(..))
+import Language.PureScript.TypeChecker.Roles (lookupRoles)
+import Language.PureScript.TypeChecker.Synonyms (replaceAllTypeSynonyms)
+import Language.PureScript.TypeChecker.Unify (alignRowsWith, freshTypeWithKind, substituteType)
+import Language.PureScript.Roles (Role(..))
+import Language.PureScript.Types (Constraint(..), SourceType, Type(..), completeBinderList, containsUnknowns, everythingOnTypes, isMonoType, replaceAllTypeVars, rowFromList, srcConstraint, srcTypeApp, unapplyTypes)
 import Language.PureScript.Constants.Prim qualified as Prim
 
 -- | State of the given constraints solver.

--- a/src/Language/PureScript/TypeChecker/Kinds.hs
+++ b/src/Language/PureScript/TypeChecker/Kinds.hs
@@ -29,10 +29,10 @@ import Prelude
 
 import Control.Arrow ((***))
 import Control.Lens ((^.), _1, _2, _3)
-import Control.Monad
+import Control.Monad (join, unless, void, when, (<=<))
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.State
-import Control.Monad.Supply.Class
+import Control.Monad.State (MonadState, gets, modify)
+import Control.Monad.Supply.Class (MonadSupply(..))
 
 import Data.Bifunctor (first)
 import Data.Bitraversable (bitraverse)
@@ -47,15 +47,15 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Traversable (for)
 
-import Language.PureScript.Crash
+import Language.PureScript.Crash (HasCallStack, internalError)
 import Language.PureScript.Environment qualified as E
 import Language.PureScript.Errors
-import Language.PureScript.Names
-import Language.PureScript.TypeChecker.Monad
+import Language.PureScript.Names (pattern ByNullSourcePos, ModuleName, Name(..), ProperName(..), ProperNameType(..), Qualified(..), QualifiedBy(..), coerceProperName, mkQualified)
+import Language.PureScript.TypeChecker.Monad (CheckState(..), Substitution(..), UnkLevel(..), Unknown, bindLocalTypeVariables, debugType, getEnv, lookupTypeVariable, unsafeCheckCurrentModule, withErrorMessageHint, withFreshSubstitution)
 import Language.PureScript.TypeChecker.Skolems (newSkolemConstant, newSkolemScope, skolemize)
-import Language.PureScript.TypeChecker.Synonyms
+import Language.PureScript.TypeChecker.Synonyms (replaceAllTypeSynonyms)
 import Language.PureScript.Types
-import Language.PureScript.Pretty.Types
+import Language.PureScript.Pretty.Types (prettyPrintType)
 
 generalizeUnknowns :: [(Unknown, SourceType)] -> SourceType -> SourceType
 generalizeUnknowns unks ty =

--- a/src/Language/PureScript/TypeChecker/Monad.hs
+++ b/src/Language/PureScript/TypeChecker/Monad.hs
@@ -9,23 +9,23 @@ import Prelude
 
 import Control.Arrow (second)
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.State
+import Control.Monad.State (MonadState(..), StateT(..), forM_, gets, guard, join, modify, when, (<=<))
 import Control.Monad.Writer.Class (MonadWriter(..), censor)
 
-import Data.Maybe
+import Data.Maybe (fromMaybe)
 import Data.Map qualified as M
 import Data.Set qualified as S
 import Data.Text (Text, isPrefixOf, unpack)
 import Data.List.NonEmpty qualified as NEL
 
 import Language.PureScript.Crash (internalError)
-import Language.PureScript.Environment
-import Language.PureScript.Errors
-import Language.PureScript.Names
-import Language.PureScript.Pretty.Types
-import Language.PureScript.Pretty.Values
-import Language.PureScript.TypeClassDictionaries
-import Language.PureScript.Types
+import Language.PureScript.Environment (Environment(..), NameKind(..), NameVisibility(..), TypeClassData(..), TypeKind(..))
+import Language.PureScript.Errors (Context, ErrorMessageHint, ExportSource, Expr, ImportDeclarationType, MultipleErrors, SimpleErrorMessage(..), SourceAnn, SourceSpan(..), addHint, errorMessage, positionedError, rethrow, warnWithPosition)
+import Language.PureScript.Names (Ident(..), ModuleName, ProperName(..), ProperNameType(..), Qualified(..), QualifiedBy(..), coerceProperName, disqualify, runIdent, runModuleName, showQualified, toMaybeModuleName)
+import Language.PureScript.Pretty.Types (prettyPrintType)
+import Language.PureScript.Pretty.Values (prettyPrintValue)
+import Language.PureScript.TypeClassDictionaries (NamedDict, TypeClassDictionaryInScope(..))
+import Language.PureScript.Types (Constraint(..), SourceType, Type(..), srcKindedType, srcTypeVar)
 import Text.PrettyPrint.Boxes (render)
 
 newtype UnkLevel = UnkLevel (NEL.NonEmpty Unknown)

--- a/src/Language/PureScript/TypeChecker/Roles.hs
+++ b/src/Language/PureScript/TypeChecker/Roles.hs
@@ -24,11 +24,11 @@ import Data.Set qualified as S
 import Data.Semigroup (Any(..))
 import Data.Text (Text)
 
-import Language.PureScript.Environment
-import Language.PureScript.Errors
-import Language.PureScript.Names
-import Language.PureScript.Roles
-import Language.PureScript.Types
+import Language.PureScript.Environment (Environment(..), TypeKind(..))
+import Language.PureScript.Errors (DataConstructorDeclaration(..), MultipleErrors, RoleDeclarationData(..), SimpleErrorMessage(..), errorMessage)
+import Language.PureScript.Names (ModuleName, ProperName, ProperNameType(..), Qualified(..), QualifiedBy(..))
+import Language.PureScript.Roles (Role(..))
+import Language.PureScript.Types (Constraint(..), SourceType, Type(..), freeTypeVariables, unapplyTypes)
 
 -- |
 -- A map of a type's formal parameter names to their roles. This type's

--- a/src/Language/PureScript/TypeChecker/Skolems.hs
+++ b/src/Language/PureScript/TypeChecker/Skolems.hs
@@ -16,12 +16,12 @@ import Data.Foldable (traverse_)
 import Data.Functor.Identity (Identity(), runIdentity)
 import Data.Set (Set, fromList, notMember)
 import Data.Text (Text)
-import Language.PureScript.AST
-import Language.PureScript.Crash
-import Language.PureScript.Errors
+import Language.PureScript.AST (Binder(..), ErrorMessageHint(..), Expr(..), SourceAnn, SourceSpan, everythingWithContextOnValues, everywhereWithContextOnValuesM, nonEmptySpan)
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Errors (ErrorMessage(..), MultipleErrors, SimpleErrorMessage(..), positionedError, singleError)
 import Language.PureScript.Traversals (defS)
-import Language.PureScript.TypeChecker.Monad
-import Language.PureScript.Types
+import Language.PureScript.TypeChecker.Monad (CheckState(..))
+import Language.PureScript.Types (SkolemScope(..), SourceType, Type(..), everythingOnTypes, everywhereOnTypesM, replaceTypeVars)
 
 -- | Generate a new skolem constant
 newSkolemConstant :: MonadState CheckState m => m Int

--- a/src/Language/PureScript/TypeChecker/Subsumption.hs
+++ b/src/Language/PureScript/TypeChecker/Subsumption.hs
@@ -16,14 +16,14 @@ import Data.List (uncons)
 import Data.List.Ordered (minusBy')
 import Data.Ord (comparing)
 
-import Language.PureScript.AST
-import Language.PureScript.Crash
-import Language.PureScript.Environment
-import Language.PureScript.Errors
-import Language.PureScript.TypeChecker.Monad
-import Language.PureScript.TypeChecker.Skolems
-import Language.PureScript.TypeChecker.Unify
-import Language.PureScript.Types
+import Language.PureScript.AST (ErrorMessageHint(..), Expr(..), pattern NullSourceAnn)
+import Language.PureScript.Crash (internalError)
+import Language.PureScript.Environment (tyFunction, tyRecord)
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), errorMessage, internalCompilerError)
+import Language.PureScript.TypeChecker.Monad (CheckState, getHints, getTypeClassDictionaries, withErrorMessageHint)
+import Language.PureScript.TypeChecker.Skolems (newSkolemConstant, skolemize)
+import Language.PureScript.TypeChecker.Unify (alignRowsWith, freshTypeWithKind, unifyTypes)
+import Language.PureScript.Types (RowListItem(..), SourceType, Type(..), eqType, isREmpty, replaceTypeVars, rowFromList)
 
 -- | Subsumption can operate in two modes:
 --

--- a/src/Language/PureScript/TypeChecker/Synonyms.hs
+++ b/src/Language/PureScript/TypeChecker/Synonyms.hs
@@ -13,15 +13,15 @@ module Language.PureScript.TypeChecker.Synonyms
 import Prelude
 
 import Control.Monad.Error.Class (MonadError(..))
-import Control.Monad.State
+import Control.Monad.State (MonadState)
 import Data.Maybe (fromMaybe)
 import Data.Map qualified as M
 import Data.Text (Text)
-import Language.PureScript.Environment
-import Language.PureScript.Errors
-import Language.PureScript.Names
-import Language.PureScript.TypeChecker.Monad
-import Language.PureScript.Types
+import Language.PureScript.Environment (Environment(..), TypeKind)
+import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), SourceSpan, errorMessage')
+import Language.PureScript.Names (ProperName, ProperNameType(..), Qualified)
+import Language.PureScript.TypeChecker.Monad (CheckState, getEnv)
+import Language.PureScript.Types (SourceType, Type(..), completeBinderList, everywhereOnTypesTopDownM, getAnnForType, replaceAllTypeVars)
 
 -- | Type synonym information (arguments with kinds, aliased type), indexed by name
 type SynonymMap = M.Map (Qualified (ProperName 'TypeName)) ([(Text, Maybe SourceType)], SourceType)

--- a/src/Language/PureScript/TypeChecker/TypeSearch.hs
+++ b/src/Language/PureScript/TypeChecker/TypeSearch.hs
@@ -9,14 +9,14 @@ import Data.Map qualified as Map
 import Language.PureScript.TypeChecker.Entailment qualified as Entailment
 
 import Language.PureScript.TypeChecker.Monad qualified as TC
-import Language.PureScript.TypeChecker.Subsumption
+import Language.PureScript.TypeChecker.Subsumption (subsumes)
 import Language.PureScript.TypeChecker.Unify       as P
 
 import Control.Monad.Supply                        as P
 import Language.PureScript.AST                     as P
 import Language.PureScript.Environment             as P
 import Language.PureScript.Errors                  as P
-import Language.PureScript.Label
+import Language.PureScript.Label (Label)
 import Language.PureScript.Names                   as P
 import Language.PureScript.Pretty.Types            as P
 import Language.PureScript.TypeChecker.Skolems     as Skolem

--- a/src/Language/PureScript/TypeChecker/Unify.hs
+++ b/src/Language/PureScript/TypeChecker/Unify.hs
@@ -16,7 +16,7 @@ module Language.PureScript.TypeChecker.Unify
 
 import Prelude
 
-import Control.Monad
+import Control.Monad (forM_, void)
 import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.State.Class (MonadState(..), gets, modify, state)
 import Control.Monad.Writer.Class (MonadWriter(..))
@@ -26,13 +26,13 @@ import Data.Maybe (fromMaybe)
 import Data.Map qualified as M
 import Data.Text qualified as T
 
-import Language.PureScript.Crash
+import Language.PureScript.Crash (internalError)
 import Language.PureScript.Environment qualified as E
-import Language.PureScript.Errors
+import Language.PureScript.Errors (ErrorMessageHint(..), MultipleErrors, SimpleErrorMessage(..), SourceAnn, errorMessage, internalCompilerError, onErrorMessages, rethrow, warnWithPosition, withoutPosition)
 import Language.PureScript.TypeChecker.Kinds (elaborateKind, instantiateKind, unifyKinds')
-import Language.PureScript.TypeChecker.Monad
-import Language.PureScript.TypeChecker.Skolems
-import Language.PureScript.Types
+import Language.PureScript.TypeChecker.Monad (CheckState(..), Substitution(..), UnkLevel(..), Unknown, getLocalContext, guardWith, lookupUnkName, withErrorMessageHint)
+import Language.PureScript.TypeChecker.Skolems (newSkolemConstant, skolemize)
+import Language.PureScript.Types (Constraint(..), pattern REmptyKinded, RowListItem(..), SourceType, Type(..), WildcardData(..), alignRowsWith, everythingOnTypes, everywhereOnTypes, everywhereOnTypesM, getAnnForType, mkForAll, rowFromList, srcTUnknown)
 
 -- | Generate a fresh type variable with an unknown kind. Avoid this if at all possible.
 freshType :: (MonadState CheckState m) => m SourceType

--- a/src/Language/PureScript/TypeClassDictionaries.hs
+++ b/src/Language/PureScript/TypeClassDictionaries.hs
@@ -7,8 +7,8 @@ import Control.DeepSeq (NFData)
 import Data.Text (Text, pack)
 
 import Language.PureScript.AST.Declarations.ChainId (ChainId)
-import Language.PureScript.Names
-import Language.PureScript.Types
+import Language.PureScript.Names (Ident, ProperName(..), ProperNameType(..), Qualified, disqualify)
+import Language.PureScript.Types (SourceConstraint, SourceType)
 
 --
 -- Data representing a type class dictionary which is in scope

--- a/src/Language/PureScript/Types.hs
+++ b/src/Language/PureScript/Types.hs
@@ -23,9 +23,9 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
 
-import Language.PureScript.AST.SourcePos
+import Language.PureScript.AST.SourcePos (pattern NullSourceAnn, SourceAnn, SourceSpan)
 import Language.PureScript.Constants.Prim qualified as C
-import Language.PureScript.Names
+import Language.PureScript.Names (OpName, OpNameType(..), ProperName, ProperNameType(..), Qualified, coerceProperName)
 import Language.PureScript.Label (Label)
 import Language.PureScript.PSString (PSString)
 

--- a/tests/Language/PureScript/Ide/CompletionSpec.hs
+++ b/tests/Language/PureScript/Ide/CompletionSpec.hs
@@ -5,10 +5,10 @@ import Protolude
 import Language.PureScript qualified as P
 import Language.PureScript.Ide.Test as Test
 import Language.PureScript.Ide.Command as Command
-import Language.PureScript.Ide.Completion
+import Language.PureScript.Ide.Completion (CompletionOptions(..), applyCompletionOptions, defaultCompletionOptions)
 import Language.PureScript.Ide.Filter.Declaration qualified as DeclarationType
-import Language.PureScript.Ide.Types
-import Test.Hspec
+import Language.PureScript.Ide.Types (Completion(..), IdeDeclarationAnn, Match(..), Success(..))
+import Test.Hspec (Spec, describe, it, shouldBe, shouldMatchList, shouldSatisfy)
 
 reexportMatches :: [Match IdeDeclarationAnn]
 reexportMatches =

--- a/tests/Language/PureScript/Ide/FilterSpec.hs
+++ b/tests/Language/PureScript/Ide/FilterSpec.hs
@@ -3,13 +3,13 @@ module Language.PureScript.Ide.FilterSpec where
 import Protolude
 import Data.Map qualified as Map
 import Data.Set qualified as Set
-import Language.PureScript.Ide.Filter
+import Language.PureScript.Ide.Filter (applyFilters, declarationTypeFilter, dependencyFilter, exactFilter, moduleFilter, namespaceFilter, prefixFilter)
 import Language.PureScript.Ide.Filter.Declaration as D
-import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Imports
+import Language.PureScript.Ide.Types (IdeDeclarationAnn, IdeNamespace(..), ModuleMap)
+import Language.PureScript.Ide.Imports (Import, sliceImportSection)
 import Language.PureScript.Ide.Test as T
 import Language.PureScript qualified as P
-import Test.Hspec
+import Test.Hspec (Spec, describe, it, shouldBe)
 
 type Module = (P.ModuleName, [IdeDeclarationAnn])
 

--- a/tests/Language/PureScript/Ide/ImportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ImportsSpec.hs
@@ -6,14 +6,14 @@ import Data.Set qualified as Set
 
 import Language.PureScript qualified as P
 import Language.PureScript.Ide.Command as Command
-import Language.PureScript.Ide.Error
-import Language.PureScript.Ide.Imports
-import Language.PureScript.Ide.Imports.Actions
+import Language.PureScript.Ide.Error (IdeError)
+import Language.PureScript.Ide.Imports (Import, parseImport, prettyPrintImport', prettyPrintImportSection, sliceImportSection)
+import Language.PureScript.Ide.Imports.Actions (addExplicitImport', addImplicitImport', addQualifiedImport')
 import Language.PureScript.Ide.Filter (moduleFilter)
 import Language.PureScript.Ide.Test qualified as Test
-import Language.PureScript.Ide.Types
-import System.FilePath
-import Test.Hspec
+import Language.PureScript.Ide.Types (IdeDeclarationAnn(..), Success(..))
+import System.FilePath ((</>))
+import Test.Hspec (Expectation, Spec, describe, it, shouldBe, shouldSatisfy)
 
 noImportsFile :: [Text]
 noImportsFile =

--- a/tests/Language/PureScript/Ide/MatcherSpec.hs
+++ b/tests/Language/PureScript/Ide/MatcherSpec.hs
@@ -3,10 +3,10 @@ module Language.PureScript.Ide.MatcherSpec where
 import Protolude
 
 import Language.PureScript qualified as P
-import Language.PureScript.Ide.Matcher
-import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Util
-import Test.Hspec
+import Language.PureScript.Ide.Matcher (flexMatcher, runMatcher)
+import Language.PureScript.Ide.Types (IdeDeclaration(..), IdeDeclarationAnn, IdeValue(..), Match(..))
+import Language.PureScript.Ide.Util (withEmptyAnn)
+import Test.Hspec (Spec, describe, it, shouldBe)
 
 value :: Text -> IdeDeclarationAnn
 value s = withEmptyAnn (IdeDeclValue (IdeValue (P.Ident (toS s)) P.srcREmpty))

--- a/tests/Language/PureScript/Ide/RebuildSpec.hs
+++ b/tests/Language/PureScript/Ide/RebuildSpec.hs
@@ -5,14 +5,14 @@ import Protolude
 import Data.Set qualified as Set
 import Language.PureScript qualified as P
 import Language.PureScript.AST.SourcePos (spanName)
-import Language.PureScript.Ide.Command
-import Language.PureScript.Ide.Completion
-import Language.PureScript.Ide.Matcher
-import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Command (Command(..))
+import Language.PureScript.Ide.Completion (defaultCompletionOptions)
+import Language.PureScript.Ide.Matcher (flexMatcher)
+import Language.PureScript.Ide.Types (Completion(..), Success(..), emptyIdeState)
 import Language.PureScript.Ide.Test qualified as Test
-import System.FilePath
+import System.FilePath ((</>))
 import System.Directory (doesFileExist, removePathForcibly)
-import Test.Hspec
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 
 defaultTarget :: Set P.CodegenTarget
 defaultTarget = Set.singleton P.JS

--- a/tests/Language/PureScript/Ide/ReexportsSpec.hs
+++ b/tests/Language/PureScript/Ide/ReexportsSpec.hs
@@ -3,11 +3,11 @@ module Language.PureScript.Ide.ReexportsSpec where
 import Protolude
 
 import Data.Map qualified as Map
-import Language.PureScript.Ide.Reexports
-import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.Test
+import Language.PureScript.Ide.Reexports (ReexportResult(..), reexportHasFailures, resolveReexports')
+import Language.PureScript.Ide.Types (IdeDeclarationAnn, ModuleMap)
+import Language.PureScript.Ide.Test (annExp, ideDtor, ideKind, ideSynonym, ideType, ideTypeClass, ideValue, mn)
 import Language.PureScript qualified as P
-import Test.Hspec
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 
 valueA, typeA, synonymA, classA, dtorA1, dtorA2, kindA :: IdeDeclarationAnn
 valueA = ideValue "valueA" Nothing

--- a/tests/Language/PureScript/Ide/SourceFileSpec.hs
+++ b/tests/Language/PureScript/Ide/SourceFileSpec.hs
@@ -3,11 +3,11 @@ module Language.PureScript.Ide.SourceFileSpec where
 import Protolude
 
 import Language.PureScript qualified as P
-import Language.PureScript.Ide.Command
-import Language.PureScript.Ide.SourceFile
-import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Command (Command(..))
+import Language.PureScript.Ide.SourceFile (extractSpans, extractTypeAnnotations)
+import Language.PureScript.Ide.Types (Completion(..), IdeNamespace(..), IdeNamespaced(..), Success(..), emptyIdeState)
 import Language.PureScript.Ide.Test
-import Test.Hspec
+import Test.Hspec (Spec, describe, it, shouldBe)
 
 span1, span2 :: P.SourceSpan
 span1 = P.SourceSpan "" (P.SourcePos 1 1) (P.SourcePos 2 2)

--- a/tests/Language/PureScript/Ide/StateSpec.hs
+++ b/tests/Language/PureScript/Ide/StateSpec.hs
@@ -1,12 +1,12 @@
 module Language.PureScript.Ide.StateSpec where
 
 import Protolude
-import Control.Lens hiding (anyOf, (&))
-import Language.PureScript.Ide.Types
-import Language.PureScript.Ide.State
-import Language.PureScript.Ide.Test
+import Control.Lens (Ixed(..), folded)
+import Language.PureScript.Ide.Types (IdeDeclarationAnn, IdeInstance(..), ModuleMap, _IdeDeclTypeClass, anyOf, idaDeclaration, ideTCInstances)
+import Language.PureScript.Ide.State (resolveDataConstructorsForModule, resolveInstances, resolveOperatorsForModule)
+import Language.PureScript.Ide.Test (ideDtor, ideType, ideTypeClass, ideTypeOp, ideValue, ideValueOp, mn)
 import Language.PureScript qualified as P
-import Test.Hspec
+import Test.Hspec (Spec, describe, it, shouldSatisfy)
 import Data.Map qualified as Map
 
 valueOperator :: Maybe P.SourceType -> IdeDeclarationAnn

--- a/tests/Language/PureScript/Ide/Test.hs
+++ b/tests/Language/PureScript/Ide/Test.hs
@@ -1,18 +1,18 @@
 {-# LANGUAGE PackageImports    #-}
 module Language.PureScript.Ide.Test where
 
-import Control.Concurrent.STM
-import "monad-logger" Control.Monad.Logger
-import Data.IORef
+import Control.Concurrent.STM (newTVarIO, readTVarIO)
+import "monad-logger" Control.Monad.Logger (NoLoggingT(..))
+import Data.IORef (newIORef)
 import Data.Map qualified as Map
-import Language.PureScript.Ide
-import Language.PureScript.Ide.Command
-import Language.PureScript.Ide.Error
+import Language.PureScript.Ide (handleCommand)
+import Language.PureScript.Ide.Command (Command)
+import Language.PureScript.Ide.Error (IdeError)
 import Language.PureScript.Ide.Types
 import Protolude
-import System.Directory
-import System.FilePath
-import System.Process
+import System.Directory (doesDirectoryExist, getCurrentDirectory, makeAbsolute, removeDirectoryRecursive, setCurrentDirectory)
+import System.FilePath ((</>))
+import System.Process (createProcess, getProcessExitCode, shell)
 
 import Language.PureScript qualified as P
 

--- a/tests/Language/PureScript/Ide/UsageSpec.hs
+++ b/tests/Language/PureScript/Ide/UsageSpec.hs
@@ -3,13 +3,13 @@ module Language.PureScript.Ide.UsageSpec where
 import Protolude
 
 import Data.Text qualified as Text
-import Language.PureScript.Ide.Command
-import Language.PureScript.Ide.Types
+import Language.PureScript.Ide.Command (Command(..))
+import Language.PureScript.Ide.Types (IdeNamespace(..), Success(..))
 import Language.PureScript.Ide.Test qualified as Test
 import Language.PureScript qualified as P
-import Test.Hspec
+import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
 import Data.Text.Read (decimal)
-import System.FilePath
+import System.FilePath ((</>))
 
 load :: [Text] -> Command
 load = LoadSync . map Test.mn

--- a/tests/TestAst.hs
+++ b/tests/TestAst.hs
@@ -5,14 +5,14 @@ import Protolude hiding (Constraint, Type, (:+))
 
 import Control.Lens ((+~))
 import Control.Newtype (ala')
-import Generic.Random
-import Test.Hspec
-import Test.QuickCheck
+import Generic.Random (genericArbitraryRecG, genericArbitraryUG, listOf', uniform, withBaseCase, (:+)(..))
+import Test.Hspec (Spec, describe, it)
+import Test.QuickCheck (Arbitrary(..), Gen, Property, Testable, counterexample, forAllShrink, subterms, (===))
 
-import Language.PureScript.Label
-import Language.PureScript.Names
-import Language.PureScript.PSString
-import Language.PureScript.Types
+import Language.PureScript.Label (Label(..))
+import Language.PureScript.Names (pattern ByNullSourcePos, OpName(..), OpNameType(..), ProperName(..), ProperNameType(..), Qualified(..))
+import Language.PureScript.PSString (PSString)
+import Language.PureScript.Types (Constraint, ConstraintData, SkolemScope(..), Type(..), WildcardData, annForType, everythingOnTypes, everythingWithContextOnTypes, everywhereOnTypes, everywhereOnTypesM, everywhereOnTypesTopDownM, getAnnForType)
 
 spec :: Spec
 spec = do

--- a/tests/TestCompiler.hs
+++ b/tests/TestCompiler.hs
@@ -36,18 +36,18 @@ import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 
 
-import Control.Monad
+import Control.Monad (forM_, when)
 
-import System.Exit
-import System.FilePath
-import System.IO
+import System.Exit (ExitCode(..))
+import System.FilePath (pathSeparator, replaceExtension, takeFileName, (</>))
+import System.IO (Handle, hPutStr, hPutStrLn)
 import System.IO.UTF8 (readUTF8File)
 
-import Text.Regex.Base
+import Text.Regex.Base (RegexContext(..), RegexMaker(..))
 import Text.Regex.TDFA (Regex)
 
-import TestUtils
-import Test.Hspec
+import TestUtils (ExpectedModuleName(..), SupportModules, compile, createOutputFile, getTestFiles, goldenVsString, modulesDir, trim)
+import Test.Hspec (Expectation, SpecWith, beforeAllWith, describe, expectationFailure, it, runIO)
 
 spec :: SpecWith SupportModules
 spec = do

--- a/tests/TestCst.hs
+++ b/tests/TestCst.hs
@@ -8,14 +8,14 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Text.IO qualified as Text
-import Test.Hspec
-import Test.QuickCheck
-import TestUtils
+import Test.Hspec (Spec, describe, it, runIO, specify)
+import Test.QuickCheck (Arbitrary(..), Gen, Testable(..), arbitrarySizedNatural, arbitraryUnicodeChar, discard, elements, frequency, listOf, listOf1, oneof, resize)
+import TestUtils (getTestFiles, goldenVsString)
 import Text.Read (readMaybe)
 import Language.PureScript.CST.Errors as CST
 import Language.PureScript.CST.Lexer as CST
 import Language.PureScript.CST.Print as CST
-import Language.PureScript.CST.Types
+import Language.PureScript.CST.Types (SourceToken(..), Token(..))
 import System.FilePath (takeBaseName, replaceExtension)
 
 spec :: Spec

--- a/tests/TestDocs.hs
+++ b/tests/TestDocs.hs
@@ -4,11 +4,11 @@ import Prelude
 
 import Data.Bifunctor (first)
 import Data.List (findIndex)
-import Data.Foldable
+import Data.Foldable (find, forM_)
 import Safe (headMay)
 import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, isNothing, mapMaybe)
-import Data.Monoid
+import Data.Monoid (Any(..), First(..))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Text.PrettyPrint.Boxes qualified as Boxes
@@ -22,7 +22,7 @@ import Web.Bower.PackageMeta (parsePackageName, runPackageName)
 
 import TestPscPublish (preparePackage)
 
-import Test.Hspec
+import Test.Hspec (Spec, beforeAll, context, expectationFailure, it)
 
 spec :: Spec
 spec = beforeAll (handleDocPrepFailure <$> preparePackage "tests/purs/docs" "purs.json" "resolutions.json") $

--- a/tests/TestGraph.hs
+++ b/tests/TestGraph.hs
@@ -2,7 +2,7 @@ module TestGraph where
 
 import Prelude
 
-import Test.Hspec
+import Test.Hspec (Spec, it, shouldBe, shouldSatisfy)
 import Data.Either (isLeft)
 
 import Data.Aeson qualified as Json

--- a/tests/TestHierarchy.hs
+++ b/tests/TestHierarchy.hs
@@ -2,10 +2,10 @@ module TestHierarchy where
 
 import Prelude
 
-import Language.PureScript.Hierarchy
+import Language.PureScript.Hierarchy (Digraph(..), Graph(..), GraphName(..), SuperMap(..), prettyPrint, typeClassGraph)
 import Language.PureScript qualified as P
 
-import Test.Hspec
+import Test.Hspec (Spec, describe, it, shouldBe)
 
 spec :: Spec
 spec = describe "hierarchy" $ do

--- a/tests/TestMake.hs
+++ b/tests/TestMake.hs
@@ -9,23 +9,23 @@ import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
 
 import Control.Concurrent (threadDelay)
-import Control.Monad
+import Control.Monad (guard, void)
 import Control.Exception (tryJust)
 import Control.Monad.IO.Class (liftIO)
 import Control.Concurrent.MVar (readMVar, newMVar, modifyMVar_)
-import Data.Time.Calendar
-import Data.Time.Clock
+import Data.Time.Calendar (fromGregorian)
+import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
 import Data.Text qualified as T
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Map qualified as M
 
-import System.FilePath
-import System.Directory
+import System.FilePath ((</>))
+import System.Directory (createDirectory, removeDirectoryRecursive, removeFile, setModificationTime)
 import System.IO.Error (isDoesNotExistError)
 import System.IO.UTF8 (readUTF8FilesT, writeUTF8FileT)
 
-import Test.Hspec
+import Test.Hspec (Spec, before_, it, shouldReturn)
 
 utcMidnightOnDate :: Integer -> Int -> Int -> UTCTime
 utcMidnightOnDate year month day = UTCTime (fromGregorian year month day) (secondsToDiffTime 0)

--- a/tests/TestPrimDocs.hs
+++ b/tests/TestPrimDocs.hs
@@ -10,7 +10,7 @@ import Data.Text qualified as Text
 import Language.PureScript qualified as P
 import Language.PureScript.Docs qualified as D
 
-import Test.Hspec
+import Test.Hspec (Spec, it, shouldBe)
 
 spec :: Spec
 spec = do

--- a/tests/TestPscPublish.hs
+++ b/tests/TestPscPublish.hs
@@ -8,20 +8,20 @@ import Control.Monad.IO.Class (liftIO)
 import Data.ByteString.Lazy (ByteString)
 import Data.Time.Clock (getCurrentTime)
 import Data.Aeson qualified as A
-import Data.Version
+import Data.Version (Version(..))
 import Data.Foldable (forM_)
 import Text.PrettyPrint.Boxes qualified as Boxes
 import System.Directory (listDirectory, removeDirectoryRecursive)
 import System.FilePath ((</>))
 import System.IO.Error (isDoesNotExistError)
 
-import Language.PureScript.Docs
+import Language.PureScript.Docs (UploadedPackage, VerifiedPackage)
 import Language.PureScript.Publish (PublishOptions(..), defaultPublishOptions)
 import Language.PureScript.Publish qualified as Publish
 import Language.PureScript.Publish.ErrorsWarnings qualified as Publish
 
-import Test.Hspec
-import TestUtils hiding (inferForeignModules, makeActions)
+import Test.Hspec (Expectation, Spec, context, expectationFailure, it, runIO)
+import TestUtils (pushd)
 
 spec :: Spec
 spec = do

--- a/tests/TestPsci.hs
+++ b/tests/TestPsci.hs
@@ -5,7 +5,7 @@ import TestPsci.CommandTest (commandTests)
 import TestPsci.CompletionTest (completionTests)
 import TestPsci.EvalTest (evalTests)
 
-import Test.Hspec
+import Test.Hspec (Spec)
 
 spec :: Spec
 spec = do

--- a/tests/TestPsci/CommandTest.hs
+++ b/tests/TestPsci/CommandTest.hs
@@ -5,11 +5,11 @@ import Prelude
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.RWS.Strict (get)
 import Language.PureScript (moduleNameFromString)
-import Language.PureScript.Interactive
+import Language.PureScript.Interactive (psciImportedModules, psciInteractivePrint)
 import System.FilePath ((</>))
 import System.Directory (getCurrentDirectory)
-import Test.Hspec
-import TestPsci.TestEnv
+import Test.Hspec (Spec, context, shouldContain, shouldNotContain, specify)
+import TestPsci.TestEnv (TestPSCi, equalsTo, execTestPSCi, printed, prints, run, simulateModuleEdit)
 
 specPSCi :: String -> TestPSCi () -> Spec
 specPSCi label = specify label . execTestPSCi

--- a/tests/TestPsci/CompletionTest.hs
+++ b/tests/TestPsci/CompletionTest.hs
@@ -2,14 +2,14 @@ module TestPsci.CompletionTest where
 
 import Prelude
 
-import Test.Hspec
+import Test.Hspec (Spec, SpecWith, beforeAll, context, shouldBe, specify)
 
 import Control.Monad.Trans.State.Strict (evalStateT)
 import Data.Functor ((<&>))
 import Data.List (sort)
 import Data.Text qualified as T
 import Language.PureScript qualified as P
-import Language.PureScript.Interactive
+import Language.PureScript.Interactive (CompletionM, PSCiState, completion', formatCompletions, liftCompletionM, updateImportedModules)
 import TestPsci.TestEnv (initTestPSCiEnv)
 import TestUtils (getSupportModuleNames)
 

--- a/tests/TestPsci/EvalTest.hs
+++ b/tests/TestPsci/EvalTest.hs
@@ -11,8 +11,8 @@ import System.Exit (exitFailure)
 import System.FilePath ((</>), takeFileName)
 import System.FilePath.Glob qualified as Glob
 import System.IO.UTF8 (readUTF8File)
-import Test.Hspec
-import TestPsci.TestEnv
+import Test.Hspec (Spec, context, runIO, specify)
+import TestPsci.TestEnv (TestPSCi, evaluatesTo, execTestPSCi, run)
 
 evalTests :: Spec
 evalTests = context "evalTests" $ do

--- a/tests/TestPsci/TestEnv.hs
+++ b/tests/TestPsci/TestEnv.hs
@@ -11,7 +11,7 @@ import Data.List (isSuffixOf)
 import Data.Text qualified as T
 import Language.PureScript qualified as P
 import Language.PureScript.CST qualified as CST
-import Language.PureScript.Interactive
+import Language.PureScript.Interactive (Command(..), PSCiConfig(..), PSCiState, handleCommand, indexFile, initialPSCiState, loadAllModules, make, modulesDir, parseCommand, readNodeProcessWithExitCode, runMake, updateLoadedExterns)
 import System.Directory (getCurrentDirectory, doesPathExist, removeFile)
 import System.Exit
 import System.FilePath ((</>), pathSeparator)

--- a/tests/TestSourceMaps.hs
+++ b/tests/TestSourceMaps.hs
@@ -4,7 +4,7 @@ import Prelude
 
 import Control.Monad (void, forM_)
 import Data.Aeson as Json
-import Test.Hspec
+import Test.Hspec (Expectation, SpecWith, describe, expectationFailure, it, runIO, shouldBe)
 import System.FilePath (replaceExtension, takeFileName, (</>), (<.>))
 import Language.PureScript qualified as P
 import Data.ByteString qualified as BS

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -9,12 +9,12 @@ import Language.PureScript.Names qualified as N
 import Language.PureScript.Interactive.IO (findNodeProcess)
 
 import Control.Arrow ((***), (>>>))
-import Control.Monad
-import Control.Monad.Reader
-import Control.Monad.Trans.Except
-import Control.Monad.Trans.Maybe
+import Control.Monad (forM, guard, unless)
+import Control.Monad.Reader (MonadIO(..), MonadTrans(..))
+import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
+import Control.Monad.Trans.Maybe (MaybeT(..))
 import Control.Monad.Writer.Class (tell)
-import Control.Exception
+import Control.Exception (IOException, catch, throw, throwIO, try, tryJust)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.Char (isSpace)
@@ -26,16 +26,16 @@ import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Data.Time.Clock (UTCTime(), diffUTCTime, getCurrentTime, nominalDay)
 import Data.Tuple (swap)
-import System.Directory
+import System.Directory (createDirectoryIfMissing, doesDirectoryExist, getCurrentDirectory, getModificationTime, getTemporaryDirectory, listDirectory, setCurrentDirectory, withCurrentDirectory)
 import System.Exit (exitFailure)
 import System.Environment (lookupEnv)
-import System.FilePath
+import System.FilePath (dropExtensions, makeRelative, takeDirectory, takeExtensions, takeFileName, (</>))
 import System.IO.Error (isDoesNotExistError)
 import System.IO.UTF8 (readUTF8FileT)
-import System.Process hiding (cwd)
+import System.Process (callCommand, callProcess)
 import System.FilePath.Glob qualified as Glob
-import System.IO
-import Test.Hspec
+import System.IO (Handle, IOMode(..), hPutStrLn, openFile, stderr)
+import Test.Hspec (Expectation, HasCallStack, expectationFailure, pendingWith)
 
 -- |
 -- Fetches code necessary to run the tests with. The resulting support code


### PR DESCRIPTION
This skips imports that have any `as` clause whatsoever, some of which still introduce implicit identifiers into the namespace.

**Description of the change**

The relatively uncontroversial part of #4452. Hopefully this is useful as a starting point to discuss the thornier problems.

Note that some of these explicit import lists are quite long, and maybe we should consider redoing this PR to have some sort of threshold on the size of the import list above which we switch to a qualified syntax. I did this 98% with an automated script and adding such a threshold would be trivial.

Some statistics:

* Import statements modified: 809
* ... with at least 10 imported names: 84
* ... at least 15 imported names: 35
* ... at least 20 imported names: 19
* ... at least 30 imported names: 4
* Longest import statement: 53 imports in [src/Language/PureScript/CST/Convert.hs](https://github.com/purescript/purescript/compare/master...rhendric:purescript:rhendric/make-imports-explicit?expand=1#diff-95781674f96d06e494074fdaeca6a234d04680c6cf460eeba40072dc4dc76a77)

Two files received manual attention:
* [src/Language/PureScript/Pretty/Types.hs](https://github.com/purescript/purescript/compare/master...rhendric:purescript:rhendric/make-imports-explicit?expand=1#diff-0a17e0bce61f890eac2ab371044bd20f6813fd4dc86c4befccef74c85a9c6669) had its `NoPatternSynonyms` pragma removed, as this no longer confuses HLint and is required for one of the imports.
* [tests/TestCoreFn.hs](https://github.com/purescript/purescript/compare/master...rhendric:purescript:rhendric/make-imports-explicit?expand=1#diff-aae152207e87b02ce20d39d1374595d0f0bad85fa9d350f33d1a9c50ee414487) was lightly rewritten because `Result` and `Value` were accessible from both `Data.Aeson` and `Data.Aeson.Types`, and the way we were using the qualified `Aeson` prefix was inconsistent.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
