### PR TITLE
Add ARM64 builds/releases for Linux and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone
         # if the Git version is less than 2.18.
         name: "(Linux only) Install a newer version of Git"
-        if: "${{ matrix.os == ['ubuntu-latest'] }}"
+        if: contains(matrix.os, 'ubuntu-latest')
         run: |
           . /etc/os-release
           echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
@@ -71,7 +71,7 @@ jobs:
         # Note: here we exclude the self-hosted runners because this action does not work on ARM
         # and their Haskell environment is instead provided by a nix-shell
         # See https://github.com/purescript/purescript/pulls/4455
-        if: "${{ matrix.os != ['ubuntu-latest'] && !contains(matrix.os, 'self-hosted') }}"
+        if: "!contains(matrix.os, 'ubuntu-latest') && !contains(matrix.os, 'self-hosted')"
         uses: "haskell/actions/setup@v1"
         with:
           enable-stack: true
@@ -79,7 +79,7 @@ jobs:
           stack-no-global: true
 
       - name: "(Linux only) Check Stack version and fix working directory ownership"
-        if: "${{ matrix.os == ['ubuntu-latest'] }}"
+        if: contains(matrix.os, 'ubuntu-latest')
         run: |
           [ "$(stack --numeric-version)" = "$STACK_VERSION" ]
           chown root:root .
@@ -104,7 +104,7 @@ jobs:
         run: "ci/fix-home ci/build.sh"
 
       - name: "(Linux only) Build the entire package set"
-        if: "${{ matrix.os == ['ubuntu-latest'] }}"
+        if: contains(matrix.os, 'ubuntu-latest')
         # We build in this directory in build.sh, so this is where we need to
         # launch `stack exec`. The actual package-set building happens in a
         # temporary directory.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           - os: ["self-hosted", "macos", "ARM64"]
           - os: ["self-hosted", "Linux", "ARM64"]
 
-    runs-on: ${{ matrix.os }}
+    runs-on: "${{ matrix.os }}"
     container: "${{ matrix.image }}"
 
     outputs:
@@ -55,13 +55,12 @@ jobs:
       - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone
         # if the Git version is less than 2.18.
         name: "(Linux only) Install a newer version of Git"
-        if: contains(matrix.os, 'ubuntu-latest')
+        if: "contains(matrix.os, 'ubuntu-latest')"
         run: |
           . /etc/os-release
           echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
           apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
       - uses: "actions/checkout@v2"
-
       - uses: "actions/setup-node@v2"
         with:
           node-version: "16"
@@ -79,7 +78,7 @@ jobs:
           stack-no-global: true
 
       - name: "(Linux only) Check Stack version and fix working directory ownership"
-        if: contains(matrix.os, 'ubuntu-latest')
+        if: "contains(matrix.os, 'ubuntu-latest')"
         run: |
           [ "$(stack --numeric-version)" = "$STACK_VERSION" ]
           chown root:root .
@@ -104,7 +103,7 @@ jobs:
         run: "ci/fix-home ci/build.sh"
 
       - name: "(Linux only) Build the entire package set"
-        if: contains(matrix.os, 'ubuntu-latest')
+        if: "contains(matrix.os, 'ubuntu-latest')"
         # We build in this directory in build.sh, so this is where we need to
         # launch `stack exec`. The actual package-set building happens in a
         # temporary directory.
@@ -121,7 +120,7 @@ jobs:
           ../ci/fix-home stack --haddock exec ../ci/build-package-set.sh
 
       - name: Verify that 'libtinfo' isn't in binary
-        if: runner.os == 'Linux'
+        if: "runner.os == 'Linux'"
         working-directory: "sdist-test"
         run: |
           if [ $(ldd $(../ci/fix-home stack path --local-doc-root)/../bin/purs | grep 'libtinfo' | wc -l) -ge 1 ]; then
@@ -131,7 +130,7 @@ jobs:
           fi
 
       - name: "(Self-hosted Linux ARM64 only) Patch the binary to work on non-Nix systems"
-        if: runner.os == 'Linux' && runner.arch == 'ARM64'
+        if: "runner.os == 'Linux' && runner.arch == 'ARM64'"
         working-directory: "sdist-test"
         # The self-hosted build happens inside a nix-shell that provides a working stack binary
         # on ARM systems, and while the macOS binary is fine - because macOS binaries are almost
@@ -153,14 +152,14 @@ jobs:
                   bundle_os=linux-arm64;;
                 *)
                   bundle_os=linux64;;
-              esac
+              esac;;
             macOS)
               case "$os_arch" in
                 ARM64)
                   bundle_os=macos-arm64;;
                 *)
                   bundle_os=macos;;
-              esac
+              esac;;
             Windows)
               bundle_os=win64;;
             *)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           # - os: ["macOS-11"]
           # - os: ["windows-2019"]
           - os: ["self-hosted", "macos", "ARM64"]
+          - os: ["self-hosted", "Linux", "ARM64"]
 
     runs-on: ${{ matrix.os }}
     container: "${{ matrix.image }}"
@@ -54,7 +55,7 @@ jobs:
       - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone
         # if the Git version is less than 2.18.
         name: "(Linux only) Install a newer version of Git"
-        if: "${{ runner.os == 'Linux' }}"
+        if: "${{ matrix.os == 'ubuntu-latest' }}"
         run: |
           . /etc/os-release
           echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
@@ -66,7 +67,7 @@ jobs:
 
       - id: "haskell"
         name: "(Non-Linux only) Install Haskell"
-        if: "${{ runner.os != 'Linux' && !contains(matrix.os, 'self-hosted') }}"
+        if: "${{ matrix.os != 'ubuntu-latest' && !contains(matrix.os, 'self-hosted') }}"
         uses: "haskell/actions/setup@v1"
         with:
           enable-stack: true
@@ -74,7 +75,7 @@ jobs:
           stack-no-global: true
 
       - name: "(Linux only) Check Stack version and fix working directory ownership"
-        if: "${{ runner.os == 'Linux' }}"
+        if: "${{ matrix.os == 'ubuntu-latest' }}"
         run: |
           [ "$(stack --numeric-version)" = "$STACK_VERSION" ]
           chown root:root .
@@ -99,7 +100,7 @@ jobs:
         run: "ci/fix-home ci/build.sh"
 
       - name: "(Linux only) Build the entire package set"
-        if: "${{ runner.os == 'Linux' }}"
+        if: "${{ matrix.os == 'ubuntu-latest' }}"
         # We build in this directory in build.sh, so this is where we need to
         # launch `stack exec`. The actual package-set building happens in a
         # temporary directory.
@@ -132,7 +133,12 @@ jobs:
           os_arch="${{ runner.arch }}"
           case "$os_name" in
             Linux)
-              bundle_os=linux64;;
+              case "$os_arch" in
+                ARM64)
+                  bundle_os=linux-arm64;;
+                *)
+                  bundle_os=linux64;;
+              esac
             macOS)
               case "$os_arch" in
                 ARM64)
@@ -153,7 +159,7 @@ jobs:
         if: "${{ env.CI_PRERELEASE == 'true' && steps.build.outputs.do-not-prerelease != 'true' }}"
         uses: "actions/upload-artifact@v3"
         with:
-          name: "${{ runner.os }}-bundle"
+          name: "${{ runner.os }}-${{ runner.arch }}-bundle"
           path: |
             sdist-test/bundle/*.sha
             sdist-test/bundle/*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,14 @@ jobs:
           node-version: "16"
 
       - name: "(macOS ARM64 only) Install Haskell, but not stack"
-        if: "${{ runner.os == 'self-hosted' }}"
+        if: "${{ matrix.os == 'self-hosted' }}"
         uses: "haskell/actions/setup@v1"
         with:
           enable-stack: false
 
       - id: "haskell"
         name: "(Non-Linux only) Install Haskell"
-        if: "${{ runner.os != 'Linux' && runner.os != 'self-hosted' }}"
+        if: "${{ runner.os != 'Linux' && matrix.os != 'self-hosted' }}"
         uses: "haskell/actions/setup@v1"
         with:
           enable-stack: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,6 @@ jobs:
         with:
           node-version: "16"
 
-      - name: "(macOS ARM64 only) Install Haskell, but not stack"
-        if: "${{ matrix.os == 'self-hosted' }}"
-        uses: "haskell/actions/setup@v1"
-        with:
-          enable-stack: false
-
       - id: "haskell"
         name: "(Non-Linux only) Install Haskell"
         if: "${{ runner.os != 'Linux' && matrix.os != 'self-hosted' }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ defaults:
     shell: "bash"
 
 env:
-  CI_PRERELEASE: "${{ github.event_name == 'push' }}"
+  CI_PRERELEASE: "${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}"
   CI_RELEASE: "${{ github.event_name == 'release' }}"
   STACK_VERSION: "2.9.3"
 
@@ -36,11 +36,11 @@ jobs:
       fail-fast: false # do not cancel builds for other OSes if one fails
       matrix:
         include:
-          - # If upgrading the Haskell image, also upgrade it in the lint job below
-            os: "ubuntu-latest"
-            image: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
-          - os: "macOS-11"
-          - os: "windows-2019"
+          # - # If upgrading the Haskell image, also upgrade it in the lint job below
+          #   os: "ubuntu-latest"
+          #   image: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
+          # - os: "macOS-11"
+          # - os: "windows-2019"
           - os: "self-hosted"
 
     runs-on: "${{ matrix.os }}"
@@ -62,7 +62,7 @@ jobs:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-node@v2"
         with:
-          node-version: "14"
+          node-version: "16"
 
       - id: "haskell"
         name: "(Non-Linux only) Install Haskell"
@@ -171,68 +171,68 @@ jobs:
           files: "sdist-test/bundle/*.{tar.gz,sha}"
 
   lint:
-    runs-on: "ubuntu-latest"
+    runs-on: "self-hosted" # "ubuntu-latest"
     # At the moment, this is a different image from the image used for
     # compilation, though the GHC versions match. This is because the
     # compilation image uses an old version of glibc, which we want because it
     # means our published binaries will work on the widest number of platforms.
     # But the HLint binary downloaded by this job requires a newer glibc
     # version.
-    container: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
+    # container: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
 
     steps:
-      - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone
-        # if the Git version is less than 2.18.
-        name: "Install a newer version of Git"
-        run: |
-          . /etc/os-release
-          echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
-          apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
+      # - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone
+      #   # if the Git version is less than 2.18.
+      #   name: "Install a newer version of Git"
+      #   run: |
+      #     . /etc/os-release
+      #     echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
+      #     apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
       - uses: "actions/checkout@v2"
-      - name: "Fix working directory ownership"
-        run: |
-          chown root:root .
+      # - name: "Fix working directory ownership"
+      #   run: |
+      #     chown root:root .
 
-      - uses: "actions/cache@v2"
-        with:
-          path: |
-            /root/.stack
-          key: "${{ runner.os }}-${{ job.container.id }}-UnWw0N-lint-${{ hashFiles('stack.yaml') }}"
+      # - uses: "actions/cache@v2"
+      #   with:
+      #     path: |
+      #       /root/.stack
+      #     key: "${{ runner.os }}-${{ job.container.id }}-UnWw0N-lint-${{ hashFiles('stack.yaml') }}"
 
-      - run: "ci/fix-home ci/run-hlint.sh --git"
-        env:
-          VERSION: "3.5"
+      # - run: "ci/fix-home ci/run-hlint.sh --git"
+      #   env:
+      #     VERSION: "3.5"
 
-      # Note: the weeder version will need to be updated when we next update our version
-      # of GHC.
-      #
-      # weeder-2.2.0 has somewhat strange version deps. It doesn't appear to
-      # support the exact versions of dhall and generic-lens in LTS-18.
-      # However, forcing it to use the versions of dhall and generic-lens in
-      # LTS-18 doesn't cause any problems when building, so the following
-      # commands build weeder while ignoring version constraints.
-      - name: Install weeder
-        run: |
-          # The `stack.yaml` file is copied to a separate file so that
-          # adding `allow-newer: true` doesn't affect any subsequant
-          # calls to `stack`.
-          cp stack.yaml stack-weeder.yaml
-          # `allow-newer: true` is needed so that weeder-2.2.0 can be
-          # installed with the dependencies present in LTS-18.
-          echo 'allow-newer: true' >> stack-weeder.yaml
-          ci/fix-home stack --no-terminal --jobs=2 build --copy-compiler-tool --stack-yaml ./stack-weeder.yaml weeder-2.4.0
+      # # Note: the weeder version will need to be updated when we next update our version
+      # # of GHC.
+      # #
+      # # weeder-2.2.0 has somewhat strange version deps. It doesn't appear to
+      # # support the exact versions of dhall and generic-lens in LTS-18.
+      # # However, forcing it to use the versions of dhall and generic-lens in
+      # # LTS-18 doesn't cause any problems when building, so the following
+      # # commands build weeder while ignoring version constraints.
+      # - name: Install weeder
+      #   run: |
+      #     # The `stack.yaml` file is copied to a separate file so that
+      #     # adding `allow-newer: true` doesn't affect any subsequant
+      #     # calls to `stack`.
+      #     cp stack.yaml stack-weeder.yaml
+      #     # `allow-newer: true` is needed so that weeder-2.2.0 can be
+      #     # installed with the dependencies present in LTS-18.
+      #     echo 'allow-newer: true' >> stack-weeder.yaml
+      #     ci/fix-home stack --no-terminal --jobs=2 build --copy-compiler-tool --stack-yaml ./stack-weeder.yaml weeder-2.4.0
 
-      - run: "ci/fix-home stack --no-terminal --jobs=2 build --fast --ghc-options -fwrite-ide-info"
+      # - run: "ci/fix-home stack --no-terminal --jobs=2 build --fast --ghc-options -fwrite-ide-info"
 
-      - run: "ci/fix-home stack exec weeder"
+      # - run: "ci/fix-home stack exec weeder"
 
-      # Now do it again, with the test suite included. We don't want a
-      # reference from our test suite to count in the above check; the fact
-      # that a function is tested is not evidence that it's needed. But we also
-      # don't want to leave weeds lying around in our test suite either.
-      - run: "ci/fix-home stack --no-terminal --jobs=2 build --fast --test --no-run-tests --ghc-options -fwrite-ide-info"
+      # # Now do it again, with the test suite included. We don't want a
+      # # reference from our test suite to count in the above check; the fact
+      # # that a function is tested is not evidence that it's needed. But we also
+      # # don't want to leave weeds lying around in our test suite either.
+      # - run: "ci/fix-home stack --no-terminal --jobs=2 build --fast --test --no-run-tests --ghc-options -fwrite-ide-info"
 
-      - run: "ci/fix-home stack exec weeder"
+      # - run: "ci/fix-home stack exec weeder"
 
   make-prerelease:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: "CI"
 
 on:
   push:
-    branches: ["master", "f-f/arm64-runner"]
+    branches: [ "master" ]
   pull_request:
-    branches: ["master"]
+    branches: [ "master" ]
   release:
-    types: ["published"]
+    types: [ "published" ]
 
 defaults:
   run:
@@ -36,11 +36,11 @@ jobs:
       fail-fast: false # do not cancel builds for other OSes if one fails
       matrix:
         include:
-          # - # If upgrading the Haskell image, also upgrade it in the lint job below
-          #   os: ["ubuntu-latest"]
-          #   image: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
-          # - os: ["macOS-11"]
-          # - os: ["windows-2019"]
+          - # If upgrading the Haskell image, also upgrade it in the lint job below
+            os: ["ubuntu-latest"]
+            image: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
+          - os: ["macOS-11"]
+          - os: ["windows-2019"]
           - os: ["self-hosted", "macos", "ARM64"]
           - os: ["self-hosted", "Linux", "ARM64"]
 
@@ -55,19 +55,23 @@ jobs:
       - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone
         # if the Git version is less than 2.18.
         name: "(Linux only) Install a newer version of Git"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
+        if: "${{ matrix.os == ['ubuntu-latest'] }}"
         run: |
           . /etc/os-release
           echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
           apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
       - uses: "actions/checkout@v2"
+
       - uses: "actions/setup-node@v2"
         with:
           node-version: "16"
 
       - id: "haskell"
         name: "(Non-Linux only) Install Haskell"
-        if: "${{ matrix.os != 'ubuntu-latest' && !contains(matrix.os, 'self-hosted') }}"
+        # Note: here we exclude the self-hosted runners because this action does not work on ARM
+        # and their Haskell environment is instead provided by a nix-shell
+        # See https://github.com/purescript/purescript/pulls/4455
+        if: "${{ matrix.os != ['ubuntu-latest'] && !contains(matrix.os, 'self-hosted') }}"
         uses: "haskell/actions/setup@v1"
         with:
           enable-stack: true
@@ -75,7 +79,7 @@ jobs:
           stack-no-global: true
 
       - name: "(Linux only) Check Stack version and fix working directory ownership"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
+        if: "${{ matrix.os == ['ubuntu-latest'] }}"
         run: |
           [ "$(stack --numeric-version)" = "$STACK_VERSION" ]
           chown root:root .
@@ -100,7 +104,7 @@ jobs:
         run: "ci/fix-home ci/build.sh"
 
       - name: "(Linux only) Build the entire package set"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
+        if: "${{ matrix.os == ['ubuntu-latest'] }}"
         # We build in this directory in build.sh, so this is where we need to
         # launch `stack exec`. The actual package-set building happens in a
         # temporary directory.
@@ -189,95 +193,96 @@ jobs:
           files: "sdist-test/bundle/*.{tar.gz,sha}"
 
   lint:
-    runs-on: "self-hosted" # "ubuntu-latest"
+    runs-on: "ubuntu-latest"
     # At the moment, this is a different image from the image used for
     # compilation, though the GHC versions match. This is because the
     # compilation image uses an old version of glibc, which we want because it
     # means our published binaries will work on the widest number of platforms.
     # But the HLint binary downloaded by this job requires a newer glibc
     # version.
-    # container: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
+    container: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
 
     steps:
-      # - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone
-      #   # if the Git version is less than 2.18.
-      #   name: "Install a newer version of Git"
-      #   run: |
-      #     . /etc/os-release
-      #     echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
-      #     apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
+      - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone
+        # if the Git version is less than 2.18.
+        name: "Install a newer version of Git"
+        run: |
+          . /etc/os-release
+          echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
+          apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
       - uses: "actions/checkout@v2"
-      # - name: "Fix working directory ownership"
-      #   run: |
-      #     chown root:root .
 
-      # - uses: "actions/cache@v2"
-      #   with:
-      #     path: |
-      #       /root/.stack
-      #     key: "${{ runner.os }}-${{ job.container.id }}-UnWw0N-lint-${{ hashFiles('stack.yaml') }}"
+      - name: "Fix working directory ownership"
+        run: |
+          chown root:root .
 
-      # - run: "ci/fix-home ci/run-hlint.sh --git"
-      #   env:
-      #     VERSION: "3.5"
+      - uses: "actions/cache@v2"
+        with:
+          path: |
+            /root/.stack
+          key: "${{ runner.os }}-${{ job.container.id }}-UnWw0N-lint-${{ hashFiles('stack.yaml') }}"
 
-      # # Note: the weeder version will need to be updated when we next update our version
-      # # of GHC.
-      # #
-      # # weeder-2.2.0 has somewhat strange version deps. It doesn't appear to
-      # # support the exact versions of dhall and generic-lens in LTS-18.
-      # # However, forcing it to use the versions of dhall and generic-lens in
-      # # LTS-18 doesn't cause any problems when building, so the following
-      # # commands build weeder while ignoring version constraints.
-      # - name: Install weeder
-      #   run: |
-      #     # The `stack.yaml` file is copied to a separate file so that
-      #     # adding `allow-newer: true` doesn't affect any subsequant
-      #     # calls to `stack`.
-      #     cp stack.yaml stack-weeder.yaml
-      #     # `allow-newer: true` is needed so that weeder-2.2.0 can be
-      #     # installed with the dependencies present in LTS-18.
-      #     echo 'allow-newer: true' >> stack-weeder.yaml
-      #     ci/fix-home stack --no-terminal --jobs=2 build --copy-compiler-tool --stack-yaml ./stack-weeder.yaml weeder-2.4.0
+      - run: "ci/fix-home ci/run-hlint.sh --git"
+        env:
+          VERSION: "3.5"
 
-      # - run: "ci/fix-home stack --no-terminal --jobs=2 build --fast --ghc-options -fwrite-ide-info"
+      # Note: the weeder version will need to be updated when we next update our version
+      # of GHC.
+      #
+      # weeder-2.2.0 has somewhat strange version deps. It doesn't appear to
+      # support the exact versions of dhall and generic-lens in LTS-18.
+      # However, forcing it to use the versions of dhall and generic-lens in
+      # LTS-18 doesn't cause any problems when building, so the following
+      # commands build weeder while ignoring version constraints.
+      - name: Install weeder
+        run: |
+          # The `stack.yaml` file is copied to a separate file so that
+          # adding `allow-newer: true` doesn't affect any subsequant
+          # calls to `stack`.
+          cp stack.yaml stack-weeder.yaml
+          # `allow-newer: true` is needed so that weeder-2.2.0 can be
+          # installed with the dependencies present in LTS-18.
+          echo 'allow-newer: true' >> stack-weeder.yaml
+          ci/fix-home stack --no-terminal --jobs=2 build --copy-compiler-tool --stack-yaml ./stack-weeder.yaml weeder-2.4.0
 
-      # - run: "ci/fix-home stack exec weeder"
+      - run: "ci/fix-home stack --no-terminal --jobs=2 build --fast --ghc-options -fwrite-ide-info"
 
-      # # Now do it again, with the test suite included. We don't want a
-      # # reference from our test suite to count in the above check; the fact
-      # # that a function is tested is not evidence that it's needed. But we also
-      # # don't want to leave weeds lying around in our test suite either.
-      # - run: "ci/fix-home stack --no-terminal --jobs=2 build --fast --test --no-run-tests --ghc-options -fwrite-ide-info"
+      - run: "ci/fix-home stack exec weeder"
 
-      # - run: "ci/fix-home stack exec weeder"
+      # Now do it again, with the test suite included. We don't want a
+      # reference from our test suite to count in the above check; the fact
+      # that a function is tested is not evidence that it's needed. But we also
+      # don't want to leave weeds lying around in our test suite either.
+      - run: "ci/fix-home stack --no-terminal --jobs=2 build --fast --test --no-run-tests --ghc-options -fwrite-ide-info"
 
-  # make-prerelease:
-  #   runs-on: "ubuntu-latest"
-  #   needs:
-  #     - "build"
-  #     - "lint"
-  #   if: "${{ github.event_name == 'push' && needs.build.outputs.do-not-prerelease != 'true' }}"
-  #   steps:
-  #     - uses: "actions/download-artifact@v3"
-  #     - uses: "ncipollo/release-action@v1.10.0"
-  #       with:
-  #         tag: "v${{ needs.build.outputs.version }}"
-  #         artifacts: "*-bundle/*"
-  #         prerelease: true
-  #         body: "This is an automated preview release. Get the latest stable release [here](https://github.com/purescript/purescript/releases/latest)."
-  #     - uses: "actions/checkout@v3"
-  #     - uses: "actions/setup-node@v3"
-  #       with:
-  #         node-version: "16.x"
-  #         registry-url: "https://registry.npmjs.org"
-  #     - name: "Publish npm package"
-  #       working-directory: "npm-package"
-  #       env:
-  #         BUILD_VERSION: "${{ needs.build.outputs.version }}"
-  #         NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}"
-  #       run: |
-  #         src_version=$(node -pe 'require("./package.json").version')
-  #         npm version --allow-same-version "$BUILD_VERSION"
-  #         sed -i -e "s/--purs-ver=${src_version//./\\.}/--purs-ver=$BUILD_VERSION/" package.json
-  #         npm publish --tag next
+      - run: "ci/fix-home stack exec weeder"
+
+  make-prerelease:
+    runs-on: "ubuntu-latest"
+    needs:
+      - "build"
+      - "lint"
+    if: "${{ github.event_name == 'push' && needs.build.outputs.do-not-prerelease != 'true' }}"
+    steps:
+      - uses: "actions/download-artifact@v3"
+      - uses: "ncipollo/release-action@v1.10.0"
+        with:
+          tag: "v${{ needs.build.outputs.version }}"
+          artifacts: "*-bundle/*"
+          prerelease: true
+          body: "This is an automated preview release. Get the latest stable release [here](https://github.com/purescript/purescript/releases/latest)."
+      - uses: "actions/checkout@v3"
+      - uses: "actions/setup-node@v3"
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: "Publish npm package"
+        working-directory: "npm-package"
+        env:
+          BUILD_VERSION: "${{ needs.build.outputs.version }}"
+          NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}"
+        run: |
+          src_version=$(node -pe 'require("./package.json").version')
+          npm version --allow-same-version "$BUILD_VERSION"
+          sed -i -e "s/--purs-ver=${src_version//./\\.}/--purs-ver=$BUILD_VERSION/" package.json
+          npm publish --tag next

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           # - os: ["windows-2019"]
           - os: ["self-hosted", "macos", "ARM64"]
 
-    runs-on: ${{ [matrix.os] }}
+    runs-on: ${{ matrix.os }}
     container: "${{ matrix.image }}"
 
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,15 @@ jobs:
         with:
           node-version: "16"
 
+      - name: "(macOS ARM64 only) Install Haskell, but not stack"
+        if: "${{ runner.os == 'self-hosted' }}"
+        uses: "haskell/actions/setup@v1"
+        with:
+          enable-stack: false
+
       - id: "haskell"
         name: "(Non-Linux only) Install Haskell"
-        if: "${{ runner.os != 'Linux' }}"
+        if: "${{ runner.os != 'Linux' && runner.os != 'self-hosted' }}"
         uses: "haskell/actions/setup@v1"
         with:
           enable-stack: true
@@ -234,32 +240,32 @@ jobs:
 
       # - run: "ci/fix-home stack exec weeder"
 
-  make-prerelease:
-    runs-on: "ubuntu-latest"
-    needs:
-      - "build"
-      - "lint"
-    if: "${{ github.event_name == 'push' && needs.build.outputs.do-not-prerelease != 'true' }}"
-    steps:
-      - uses: "actions/download-artifact@v3"
-      - uses: "ncipollo/release-action@v1.10.0"
-        with:
-          tag: "v${{ needs.build.outputs.version }}"
-          artifacts: "*-bundle/*"
-          prerelease: true
-          body: "This is an automated preview release. Get the latest stable release [here](https://github.com/purescript/purescript/releases/latest)."
-      - uses: "actions/checkout@v3"
-      - uses: "actions/setup-node@v3"
-        with:
-          node-version: "16.x"
-          registry-url: "https://registry.npmjs.org"
-      - name: "Publish npm package"
-        working-directory: "npm-package"
-        env:
-          BUILD_VERSION: "${{ needs.build.outputs.version }}"
-          NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}"
-        run: |
-          src_version=$(node -pe 'require("./package.json").version')
-          npm version --allow-same-version "$BUILD_VERSION"
-          sed -i -e "s/--purs-ver=${src_version//./\\.}/--purs-ver=$BUILD_VERSION/" package.json
-          npm publish --tag next
+  # make-prerelease:
+  #   runs-on: "ubuntu-latest"
+  #   needs:
+  #     - "build"
+  #     - "lint"
+  #   if: "${{ github.event_name == 'push' && needs.build.outputs.do-not-prerelease != 'true' }}"
+  #   steps:
+  #     - uses: "actions/download-artifact@v3"
+  #     - uses: "ncipollo/release-action@v1.10.0"
+  #       with:
+  #         tag: "v${{ needs.build.outputs.version }}"
+  #         artifacts: "*-bundle/*"
+  #         prerelease: true
+  #         body: "This is an automated preview release. Get the latest stable release [here](https://github.com/purescript/purescript/releases/latest)."
+  #     - uses: "actions/checkout@v3"
+  #     - uses: "actions/setup-node@v3"
+  #       with:
+  #         node-version: "16.x"
+  #         registry-url: "https://registry.npmjs.org"
+  #     - name: "Publish npm package"
+  #       working-directory: "npm-package"
+  #       env:
+  #         BUILD_VERSION: "${{ needs.build.outputs.version }}"
+  #         NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}"
+  #       run: |
+  #         src_version=$(node -pe 'require("./package.json").version')
+  #         npm version --allow-same-version "$BUILD_VERSION"
+  #         sed -i -e "s/--purs-ver=${src_version//./\\.}/--purs-ver=$BUILD_VERSION/" package.json
+  #         npm publish --tag next

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         # So here we first point the binary to the right linker that should work on a generic linux,
         # and then fix the RUNPATH with the right location to load the shared libraries from
         run: |
-          ldd /usr/lib/ld-linux-aarch64.so.1 $(stack path --local-doc-root)/../bin/purs
+          patchelf --set-interpreter /usr/lib/ld-linux-aarch64.so.1 $(stack path --local-doc-root)/../bin/purs
           patchelf --set-rpath /usr/lib/aarch64-linux-gnu $(stack path --local-doc-root)/../bin/purs
 
       - name: "(Release/prerelease only) Create bundle"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
       matrix:
         include:
           # - # If upgrading the Haskell image, also upgrade it in the lint job below
-          #   os: "ubuntu-latest"
+          #   os: ["ubuntu-latest"]
           #   image: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
-          # - os: "macOS-11"
-          # - os: "windows-2019"
-          - os: "self-hosted"
+          # - os: ["macOS-11"]
+          # - os: ["windows-2019"]
+          - os: ["self-hosted", "macos", "ARM64"]
 
-    runs-on: "${{ matrix.os }}"
+    runs-on: ${{ [matrix.os] }}
     container: "${{ matrix.image }}"
 
     outputs:
@@ -66,7 +66,7 @@ jobs:
 
       - id: "haskell"
         name: "(Non-Linux only) Install Haskell"
-        if: "${{ runner.os != 'Linux' && matrix.os != 'self-hosted' }}"
+        if: "${{ runner.os != 'Linux' && !contains(matrix.os, 'self-hosted') }}"
         uses: "haskell/actions/setup@v1"
         with:
           enable-stack: true
@@ -136,7 +136,7 @@ jobs:
             macOS)
               case "$os_arch" in
                 ARM64)
-                  bundle_os=macos64;;
+                  bundle_os=macos-arm64;;
                 *)
                   bundle_os=macos;;
               esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,7 @@ jobs:
         # So here we first point the binary to the right linker that should work on a generic linux,
         # and then fix the RUNPATH with the right location to load the shared libraries from
         run: |
-          patchelf --set-interpreter /usr/lib/ld-linux-aarch64.so.1 $(stack path --local-doc-root)/../bin/purs
-          patchelf --set-rpath /usr/lib/aarch64-linux-gnu $(stack path --local-doc-root)/../bin/purs
+          patchelf --set-interpreter /usr/lib/ld-linux-aarch64.so.1 --set-rpath /usr/lib/aarch64-linux-gnu $(stack path --local-doc-root)/../bin/purs
 
       - name: "(Release/prerelease only) Create bundle"
         if: "${{ env.CI_RELEASE == 'true' || env.CI_PRERELEASE == 'true' && steps.build.outputs.do-not-prerelease != 'true' }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: "CI"
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "f-f/arm64-runner"]
   pull_request:
     branches: ["master"]
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: "CI"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
   release:
-    types: [ "published" ]
+    types: ["published"]
 
 defaults:
   run:
@@ -41,6 +41,7 @@ jobs:
             image: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
           - os: "macOS-11"
           - os: "windows-2019"
+          - os: "self-hosted"
 
     runs-on: "${{ matrix.os }}"
     container: "${{ matrix.image }}"
@@ -59,7 +60,6 @@ jobs:
           echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
           apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
       - uses: "actions/checkout@v2"
-
       - uses: "actions/setup-node@v2"
         with:
           node-version: "14"
@@ -129,11 +129,17 @@ jobs:
         if: "${{ env.CI_RELEASE == 'true' || env.CI_PRERELEASE == 'true' && steps.build.outputs.do-not-prerelease != 'true' }}"
         run: |
           os_name="${{ runner.os }}"
+          os_arch="${{ runner.arch }}"
           case "$os_name" in
             Linux)
               bundle_os=linux64;;
             macOS)
-              bundle_os=macos;;
+              case "$os_arch" in
+                ARM64)
+                  bundle_os=macos64;;
+                *)
+                  bundle_os=macos;;
+              esac
             Windows)
               bundle_os=win64;;
             *)
@@ -183,7 +189,6 @@ jobs:
           echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
           apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
       - uses: "actions/checkout@v2"
-
       - name: "Fix working directory ownership"
         run: |
           chown root:root .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,18 @@ jobs:
             exit 1
           fi
 
+      - name: "(Self-hosted Linux ARM64 only) Patch the binary to work on non-Nix systems"
+        if: runner.os == 'Linux' && runner.arch == 'ARM64'
+        working-directory: "sdist-test"
+        # The self-hosted build happens inside a nix-shell that provides a working stack binary
+        # on ARM systems, and while the macOS binary is fine - because macOS binaries are almost
+        # statically linked), the linux ones are all pointing at the nix store.
+        # So here we first point the binary to the right linker that should work on a generic linux,
+        # and then fix the RUNPATH with the right location to load the shared libraries from
+        run: |
+          ldd /usr/lib/ld-linux-aarch64.so.1 $(stack path --local-doc-root)/../bin/purs
+          patchelf --set-rpath /usr/lib/aarch64-linux-gnu $(stack path --local-doc-root)/../bin/purs
+
       - name: "(Release/prerelease only) Create bundle"
         if: "${{ env.CI_RELEASE == 'true' || env.CI_PRERELEASE == 'true' && steps.build.outputs.do-not-prerelease != 'true' }}"
         run: |

--- a/CHANGELOG.d/feature_arm_builds.md
+++ b/CHANGELOG.d/feature_arm_builds.md
@@ -1,0 +1,1 @@
+* Add release artifacts for Linux and macOS running on the ARM64 architecture.


### PR DESCRIPTION
**Description of the change**

This PR adds support for building and releasing ARM64 binaries for Linux and macOS.
Since GitHub Actions' Runners do not yet support the ARM64 architecture, these builds are running on [self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners), deployed on VMs on a M2 server in our office at @id3as.

The binaries build fine (see the latest run for [macOS](https://github.com/purescript/purescript/actions/runs/4447472842/jobs/7809285949) and [Linux](https://github.com/purescript/purescript/actions/runs/4447472842/jobs/7809286094)) and I have tested them on a few environments and they seem to work, but we won't know how compatible they are with the rest of the world until we have at least some prereleases out in the wild - I expect there will be a few follow-up PRs as people start to use them.

A few highlights of the patch:
- the `runs-on` is now an array, so we can precisely match on the self-hosted runners when needed, as quite a few steps in the workflow only run on the Ubuntu container
- the GH Action for setting up the Haskell environment does not work on ARM64 systems. Building stack from scratch is also somewhat broken on ARM, so the Runners are running inside a `nix-shell` that contains a properly-built `stack`. For posterity and replicability, this is the `shell.nix` file:
  ```nix
  let
    pinnedNixHash = "7c3d4d3af8e9319ccd2a74c31cf247b0fcd08bc2";
  
    pinnedNix =
      builtins.fetchGit {
        name = "nixpkgs-pinned";
        url = "https://github.com/NixOS/nixpkgs.git";
        rev = "${pinnedNixHash}";
      };
  
    nixpkgs = import pinnedNix {};
  
  in nixpkgs.mkShell {
    buildInputs = [
      nixpkgs.bash
      nixpkgs.stack
      nixpkgs.nodejs-18_x
      nixpkgs.gmp
      nixpkgs.zlib
    ];
    # This is because otherwise GHC will throw
    # "commitAndReleaseBuffer: invalid argument (invalid character)"
    shellHook = with nixpkgs; if stdenv.isLinux then ''
      export LANG=C.UTF-8
      export LC_ALL=C.UTF-8
    '' else "";
  }
  ```
- Because of the above, the binary built on Linux ARM will have its dynamic links all pointing to the nix store, so the Linux ARM build has an additional step that runs `patchelf` to make the binary compatible with the "normal" linux systems.
  Most of the build is contained in the `build.sh` file, but I didn't want to handle this situation there, as this is quite specific to our current build environment, and might change in the future.
- Nomenclature: the new release artifacts simply add an `-arm64` suffix to the OS name. Things might be cleaner overall by also adding the architecture suffix to the artifacts that we already release - especially because we have `linux64`, which sorta does that already - but I instead kept them as they were for backwards compatibility.