### PR TITLE
Replace copying foreign js with writing (avoid permissions denied error)

### DIFF
--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -46,7 +46,7 @@ import Language.PureScript.Docs.Prim qualified as Docs.Prim
 import Language.PureScript.Docs.Types qualified as Docs
 import Language.PureScript.Errors (MultipleErrors, SimpleErrorMessage(..), errorMessage, errorMessage')
 import Language.PureScript.Externs (ExternsFile, externsFileName)
-import Language.PureScript.Make.Monad (Make, copyFile, getTimestamp, getTimestampMaybe, hashFile, makeIO, readExternsFile, readJSONFile, readTextFile, writeCborFile, writeJSONFile, writeTextFile)
+import Language.PureScript.Make.Monad (Make, getTimestamp, getTimestampMaybe, hashFile, makeIO, readExternsFile, readJSONFile, writeCborFile, writeJSONFile, writeTextFile, readTextFile')
 import Language.PureScript.Make.Cache (CacheDb, ContentHash, normaliseForCache)
 import Language.PureScript.Names (Ident(..), ModuleName, runModuleName)
 import Language.PureScript.Options (CodegenTarget(..), Options(..))
@@ -329,11 +329,10 @@ data ForeignModuleType = ESModule | CJSModule deriving (Show)
 
 -- | Check that the declarations in a given PureScript module match with those
 -- in its corresponding foreign module.
-checkForeignDecls :: CF.Module ann -> FilePath -> Make (Either MultipleErrors (ForeignModuleType, S.Set Ident))
-checkForeignDecls m path = do
-  jsStr <- T.unpack <$> readTextFile path
-
+checkForeignDecls :: CF.Module ann -> T.Text -> FilePath -> Make (Either MultipleErrors (ForeignModuleType, S.Set Ident))
+checkForeignDecls m jsText path = do
   let
+    jsStr = T.unpack jsText
     parseResult :: Either MultipleErrors JS.JSAST
     parseResult = first (errorParsingModule . Bundle.UnableToParseModule) $ JS.parseModule jsStr path
   traverse checkFFI parseResult
@@ -440,10 +439,11 @@ ffiCodegen' foreigns codegenTargets makeOutputPath m = do
         | not $ requiresForeign m ->
             tell $ errorMessage' (CF.moduleSourceSpan m) $ UnnecessaryFFIModule mn path
         | otherwise -> do
-            checkResult <- checkForeignDecls m path
+            (bs, jsText) <- readTextFile' path
+            checkResult <- checkForeignDecls m jsText path
             case checkResult of
-              Left _ -> copyForeign path mn
-              Right (ESModule, _) -> copyForeign path mn
+              Left _ -> writeForeign bs mn
+              Right (ESModule, _) -> writeForeign bs mn
               Right (CJSModule, _) -> do
                 throwError $ errorMessage' (CF.moduleSourceSpan m) $ DeprecatedFFICommonJSModule mn path
       Nothing | requiresForeign m -> throwError . errorMessage' (CF.moduleSourceSpan m) $ MissingFFIModule mn
@@ -451,5 +451,5 @@ ffiCodegen' foreigns codegenTargets makeOutputPath m = do
   where
   requiresForeign = not . null . CF.moduleForeign
 
-  copyForeign path mn =
-    for_ makeOutputPath (\outputFilename -> copyFile path (outputFilename mn "foreign.js"))
+  writeForeign bs mn =
+    for_ makeOutputPath (\outputFilename -> writeTextFile (outputFilename mn "foreign.js") bs)

--- a/src/Language/PureScript/Make/Monad.hs
+++ b/src/Language/PureScript/Make/Monad.hs
@@ -6,6 +6,7 @@ module Language.PureScript.Make.Monad
   , getTimestamp
   , getTimestampMaybe
   , readTextFile
+  , readTextFile'
   , readJSONFile
   , readJSONFileIO
   , readCborFile
@@ -46,7 +47,7 @@ import System.Directory (createDirectoryIfMissing, getModificationTime)
 import System.Directory qualified as Directory
 import System.FilePath (takeDirectory)
 import System.IO.Error (tryIOError, isDoesNotExistError)
-import System.IO.UTF8 (readUTF8FileT)
+import System.IO.UTF8 (readUTF8FileT, readUTF8FileT')
 
 -- | A monad for running make actions
 newtype Make a = Make
@@ -91,6 +92,12 @@ readTextFile :: (MonadIO m, MonadError MultipleErrors m) => FilePath -> m Text
 readTextFile path =
   makeIO ("read file: " <> Text.pack path) $
     readUTF8FileT path
+
+-- | Read a text file version that returns byte string along with decoded text data.
+readTextFile' :: (MonadIO m, MonadError MultipleErrors m) => FilePath -> m (B.ByteString, Text)
+readTextFile' path =
+  makeIO ("read file: " <> Text.pack path) $
+    readUTF8FileT' path
 
 -- | Read a JSON file in the 'Make' monad, returning 'Nothing' if the file does
 -- not exist or could not be parsed. Errors are captured using the 'MonadError'

--- a/src/System/IO/UTF8.hs
+++ b/src/System/IO/UTF8.hs
@@ -23,6 +23,10 @@ readUTF8FileT :: FilePath -> IO Text
 readUTF8FileT inFile =
   fmap (TE.decodeUtf8 . fixCRLF) (BS.readFile inFile)
 
+readUTF8FileT' :: FilePath -> IO (BS.ByteString, Text)
+readUTF8FileT' inFile =
+  fmap ((,) <*> TE.decodeUtf8 . fixCRLF) (BS.readFile inFile)
+
 writeUTF8FileT :: FilePath -> Text -> IO ()
 writeUTF8FileT inFile text =
   BS.writeFile inFile (TE.encodeUtf8 text)


### PR DESCRIPTION
It allows to avoid permission denied errors while copying files on Windows (because of file watchers).

**Description of the change**

When a file watcher is working over the `output` folder during a compilation (`spago build`) when a large number of modules is compiled I usually get such an error on some of the "unlucky" files:

```bash
I/O error while trying to copy file: ...\project\My\Module.js -> output\My.Module\foreign.js

    output\My.Module\.coFFF.tmp: copyFile:atomicCopyFileContents:withReplacementFile:renameFile:renamePath:MoveFileEx "\\\\...output\My.Module\.coFFF.tmp" Just "\\\\?\\...output\My.Module\foreign.js": permission denied (Access is denied.)
```
As the error clearly points to the `copyFile` as the source of the problem, I tried to replace it with writing, and now build works without the aforementioned flaw.

I've added a new version function of `readTextFile` that returns original `ByteString` along with `Text` data, to avoid unnecessary encoding.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
