### PR TITLE
Moving closedRecordUpdate optimization to codegen side

### DIFF
--- a/purescript.cabal
+++ b/purescript.cabal
@@ -232,8 +232,8 @@ library
     Language.PureScript.CodeGen
     Language.PureScript.CodeGen.JS
     Language.PureScript.CodeGen.JS.Common
-    Language.PureScript.CodeGen.JS.Printer
     Language.PureScript.CodeGen.JS.CoreFnOptimizer
+    Language.PureScript.CodeGen.JS.Printer
     Language.PureScript.Constants.Libs
     Language.PureScript.CoreFn
     Language.PureScript.CoreFn.Ann

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -233,6 +233,7 @@ library
     Language.PureScript.CodeGen.JS
     Language.PureScript.CodeGen.JS.Common
     Language.PureScript.CodeGen.JS.Printer
+    Language.PureScript.CodeGen.JS.CoreFnOptimizer
     Language.PureScript.Constants.Libs
     Language.PureScript.CoreFn
     Language.PureScript.CoreFn.Ann

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -3,6 +3,7 @@
 module Language.PureScript.CodeGen.JS
   ( module AST
   , module Common
+  , module Optimizer
   , moduleToJs
   ) where
 
@@ -45,6 +46,7 @@ import Language.PureScript.Options (CodegenTarget(..), Options(..))
 import Language.PureScript.PSString (PSString, mkString)
 import Language.PureScript.Traversals (sndM)
 import Language.PureScript.Constants.Prim qualified as C
+import  Language.PureScript.CodeGen.JS.CoreFnOptimizer as Optimizer
 
 import System.FilePath.Posix ((</>))
 

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -46,7 +46,7 @@ import Language.PureScript.Options (CodegenTarget(..), Options(..))
 import Language.PureScript.PSString (PSString, mkString)
 import Language.PureScript.Traversals (sndM)
 import Language.PureScript.Constants.Prim qualified as C
-import  Language.PureScript.CodeGen.JS.CoreFnOptimizer as Optimizer
+import Language.PureScript.CodeGen.JS.CoreFnOptimizer as Optimizer
 
 import System.FilePath.Posix ((</>))
 

--- a/src/Language/PureScript/CodeGen/JS/CoreFnOptimizer.hs
+++ b/src/Language/PureScript/CodeGen/JS/CoreFnOptimizer.hs
@@ -1,24 +1,21 @@
-module  Language.PureScript.CodeGen.JS.CoreFnOptimizer (optimizeCoreFn) where
+module Language.PureScript.CodeGen.JS.CoreFnOptimizer (optimizeCoreFn) where
 
-import Protolude ( Maybe(..), (<$>), identity, map )
+import Protolude (Maybe (..), identity, map, (<$>))
 
 import Data.List (lookup)
-import Language.PureScript.AST.Literals (Literal(..))
+import Language.PureScript.AST.Literals (Literal (..))
 import Language.PureScript.AST.SourcePos (nullSourceSpan)
-import Language.PureScript.CoreFn.Ann (Ann)
-import Language.PureScript.CoreFn.Expr ( Bind, Expr(Literal, ObjectUpdate, Accessor) )
-import Language.PureScript.Label (Label(..))
-import Language.PureScript.Types (pattern REmptyKinded, Type(..))
 import Language.PureScript.Constants.Prim qualified as C
-import Language.PureScript.CoreFn.Module (Module(..))
+import Language.PureScript.CoreFn.Ann (Ann)
+import Language.PureScript.CoreFn.Expr (Bind, Expr (Accessor, Literal, ObjectUpdate))
+import Language.PureScript.CoreFn.Module (Module (..))
 import Language.PureScript.CoreFn.Traversals (everywhereOnValues)
+import Language.PureScript.Label (Label (..))
+import Language.PureScript.Types (Type (..), pattern REmptyKinded)
 
-------
--- CoreFn Optimization for JS Codegen
---
---
+-- CoreFn optimizations that are getting used at the JS codegen level
 optimizeCoreFn :: Module Ann -> Module Ann
-optimizeCoreFn m = m { moduleDecls = optimizeModuleDecls m.moduleDecls}
+optimizeCoreFn m = m {moduleDecls = optimizeModuleDecls m.moduleDecls}
 
 optimizeModuleDecls :: [Bind Ann] -> [Bind Ann]
 optimizeModuleDecls = map transformBinds

--- a/src/Language/PureScript/CodeGen/JS/CoreFnOptimizer.hs
+++ b/src/Language/PureScript/CodeGen/JS/CoreFnOptimizer.hs
@@ -1,0 +1,49 @@
+module  Language.PureScript.CodeGen.JS.CoreFnOptimizer (optimizeCoreFn) where
+
+import Protolude ( Maybe(..), (<$>), identity, map )
+
+import Data.List (lookup)
+import Language.PureScript.AST.Literals (Literal(..))
+import Language.PureScript.AST.SourcePos (nullSourceSpan)
+import Language.PureScript.CoreFn.Ann (Ann)
+import Language.PureScript.CoreFn.Expr ( Bind, Expr(Literal, ObjectUpdate, Accessor) )
+import Language.PureScript.Label (Label(..))
+import Language.PureScript.Types (pattern REmptyKinded, Type(..))
+import Language.PureScript.Constants.Prim qualified as C
+import Language.PureScript.CoreFn.Module (Module(..))
+import Language.PureScript.CoreFn.Traversals (everywhereOnValues)
+
+------
+-- CoreFn Optimization for JS Codegen
+--
+--
+optimizeCoreFn :: Module Ann -> Module Ann
+optimizeCoreFn m = m { moduleDecls = optimizeModuleDecls m.moduleDecls}
+
+optimizeModuleDecls :: [Bind Ann] -> [Bind Ann]
+optimizeModuleDecls = map transformBinds
+  where
+  (transformBinds, _, _) = everywhereOnValues identity transformExprs identity
+  transformExprs
+    = optimizeClosedRecordUpdate 
+
+optimizeClosedRecordUpdate :: Expr Ann -> Expr Ann
+optimizeClosedRecordUpdate ou@(ObjectUpdate a@(_, _, Just t, _) r updatedFields) =
+  case closedRecordFields t of
+    Nothing -> ou
+    Just allFields -> Literal a (ObjectLiteral (map f allFields))
+      where f (Label l) = case lookup l updatedFields of
+              Nothing -> (l, Accessor (nullSourceSpan, [], Nothing, Nothing) l r)
+              Just e -> (l, e)
+optimizeClosedRecordUpdate e = e
+
+-- | Return the labels of a closed record, or Nothing for other types or open records.
+closedRecordFields :: Type a -> Maybe [Label]
+closedRecordFields (TypeApp _ (TypeConstructor _ C.Record) row) =
+  collect row
+  where
+    collect :: Type a -> Maybe [Label]
+    collect (REmptyKinded _ _) = Just []
+    collect (RCons _ l _ r) = (l :) <$> collect r
+    collect _ = Nothing
+closedRecordFields _ = Nothing

--- a/src/Language/PureScript/CoreFn/Optimizer.hs
+++ b/src/Language/PureScript/CoreFn/Optimizer.hs
@@ -3,18 +3,12 @@ module Language.PureScript.CoreFn.Optimizer (optimizeCoreFn) where
 import Protolude hiding (Type, moduleName)
 
 import Control.Monad.Supply (Supply)
-import Data.List (lookup)
-import Language.PureScript.AST.Literals (Literal(..))
-import Language.PureScript.AST.SourcePos (nullSourceSpan)
 import Language.PureScript.CoreFn.Ann (Ann)
 import Language.PureScript.CoreFn.CSE (optimizeCommonSubexpressions)
 import Language.PureScript.CoreFn.Expr (Bind, Expr(..))
 import Language.PureScript.CoreFn.Module (Module(..))
 import Language.PureScript.CoreFn.Traversals (everywhereOnValues)
-import Language.PureScript.Label (Label(..))
-import Language.PureScript.Types (pattern REmptyKinded, Type(..))
 import Language.PureScript.Constants.Libs qualified as C
-import Language.PureScript.Constants.Prim qualified as C
 
 -- |
 -- CoreFn optimization pass.
@@ -27,29 +21,7 @@ optimizeModuleDecls = map transformBinds
   where
   (transformBinds, _, _) = everywhereOnValues identity transformExprs identity
   transformExprs
-    = optimizeClosedRecordUpdate
-    . optimizeDataFunctionApply
-
-optimizeClosedRecordUpdate :: Expr Ann -> Expr Ann
-optimizeClosedRecordUpdate ou@(ObjectUpdate a@(_, _, Just t, _) r updatedFields) =
-  case closedRecordFields t of
-    Nothing -> ou
-    Just allFields -> Literal a (ObjectLiteral (map f allFields))
-      where f (Label l) = case lookup l updatedFields of
-              Nothing -> (l, Accessor (nullSourceSpan, [], Nothing, Nothing) l r)
-              Just e -> (l, e)
-optimizeClosedRecordUpdate e = e
-
--- | Return the labels of a closed record, or Nothing for other types or open records.
-closedRecordFields :: Type a -> Maybe [Label]
-closedRecordFields (TypeApp _ (TypeConstructor _ C.Record) row) =
-  collect row
-  where
-    collect :: Type a -> Maybe [Label]
-    collect (REmptyKinded _ _) = Just []
-    collect (RCons _ l _ r) = (l :) <$> collect r
-    collect _ = Nothing
-closedRecordFields _ = Nothing
+    = optimizeDataFunctionApply
 
 optimizeDataFunctionApply :: Expr a -> Expr a
 optimizeDataFunctionApply e = case e of

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -263,7 +263,7 @@ buildMakeActions outputDir filePathMap foreigns usePrefix =
               return $ Just "./foreign.js"
         Nothing | requiresForeign m -> throwError . errorMessage' (CF.moduleSourceSpan m) $ MissingFFIModule mn
                 | otherwise -> return Nothing
-      rawJs <- J.moduleToJs m foreignInclude
+      rawJs <- J.moduleToJs (J.optimizeCoreFn m) foreignInclude
       dir <- lift $ makeIO "get the current directory" getCurrentDirectory
       let sourceMaps = S.member JSSourceMap codegenTargets
           (pjs, mappings) = if sourceMaps then prettyPrintJSWithSourceMaps rawJs else (prettyPrintJS rawJs, [])


### PR DESCRIPTION

Moving the closedRecord Optimization to JS CodeGen side.

when we are using purescript compiler to generate JS files. we use closedRecord optimization to optimise the the js code in terms of speed. But, this optimization was placed at coreFn level. so, we cannot properly infer difference between objectupdate and objectliteral at corefn level. 

### **Changes**
- Created a new module `CoreFnOptimizer.hs` in `src/Language/PureScript/CodeGen/JS `
- Moved the closedRecordOptimization to this new module.
- Applied the closedRecordOptimization at Action.hs


> You can read more about this issue here : https://github.com/purescript/purescript/issues/4473

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
