### PR TITLE
Add option to exclude globs from given input

### DIFF
--- a/CHANGELOG.d/feature_exclude_files_from_compile_input.md
+++ b/CHANGELOG.d/feature_exclude_files_from_compile_input.md
@@ -1,0 +1,45 @@
+* Exclude files from compiler input
+
+  The compiler now supports excluding files from the globs given to it as input.
+  This means there's now a new option for `purs compile`, namely
+  `--exclude-files` (or the short version `-x`):
+
+```sh
+> purs compile --help
+Usage: purs compile [FILE] [-x|--exclude-files ARG] [-o|--output ARG] ...
+
+  Compile PureScript source files
+
+Available options:
+  -h,--help                Show this help text
+  FILE                     The input .purs file(s).
+  -x,--exclude-files ARG   Glob of .purs files to exclude from the supplied
+                           files.
+  ...
+```
+
+This allows you to keep related files closer together (that is, [colocate](https://kentcdodds.com/blog/colocation) them).
+
+Consider a setup like the following:
+
+```sh
+src/
+    Main.purs
+    View/
+        LoginPage.purs
+        LoginPageTest.purs
+        LoginPageStories.purs
+```
+
+In order to exclude the files in the example above you can now invoke `purs`
+like this and it will only compile `LoginPage.purs`:
+
+```sh
+purs compile "src/**/*.purs" --exclude-files "src/**/*Stories.purs" -x "src/**/*Test.purs"
+```
+
+With `spago`, the equivalent command is:
+
+```sh
+spago build --purs-args '-x "src/**/*Test.purs" -x "src/**/*Stories.purs"'
+```


### PR DESCRIPTION
### Adds the possibility to remove files from the globs passed to the compiler

[Colocation](https://kentcdodds.com/blog/colocation) means that we can keep related files close together in our file system.
So instead of recreating the whole module tree in a `test` folder it'd be possible to structure the project as such:

```
src/
  Foo/
    Bar.purs
    BarTest.purs
```

The motivation for supporting colocation can be followed [here](https://github.com/purescript/registry-dev/issues/602).

However, it's currently not possible to exclude globs from publishing. I've opened PRs to add this functionality to the new [registry](https://github.com/purescript/registry-dev/pull/613) and [spago](https://github.com/purescript/spago/pull/967).

Verity [raised a good point](https://github.com/purescript/registry-dev/issues/602#issuecomment-1593816461), however, in that it should also be easy to pass only the files that shall be published to the compiler (for example to not include test dependencies).
This PR adds this possibility.

Note that this does not add a way to exclude globs from the IDE or PSCI, because I don't see the use case for it and wanted to keep the change small. It could also be added later.
---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
