### PR TITLE
Move the closed record update optimization

### DIFF
--- a/CHANGELOG.d/feature_closed-record-update.md
+++ b/CHANGELOG.d/feature_closed-record-update.md
@@ -1,0 +1,7 @@
+* Move the closed record update optimization
+
+  For consumers of CoreFn like alternate backends, the optimization of
+  replacing a closed record update with an object literal has now been moved to
+  the point of desugaring CoreFn into JS. The `ObjectUpdate` expression
+  constructor now contains a `Maybe` field holding a list of record labels to
+  be copied as-is, for backends that want to perform this optimization also.

--- a/src/Language/PureScript/CoreFn/Ann.hs
+++ b/src/Language/PureScript/CoreFn/Ann.hs
@@ -5,21 +5,20 @@ import Prelude
 import Language.PureScript.AST.SourcePos (SourceSpan)
 import Language.PureScript.Comments (Comment)
 import Language.PureScript.CoreFn.Meta (Meta)
-import Language.PureScript.Types (SourceType)
 
 -- |
 -- Type alias for basic annotations
 --
-type Ann = (SourceSpan, [Comment], Maybe SourceType, Maybe Meta)
+type Ann = (SourceSpan, [Comment], Maybe Meta)
 
 -- |
 -- An annotation empty of metadata aside from a source span.
 --
 ssAnn :: SourceSpan -> Ann
-ssAnn ss = (ss, [], Nothing, Nothing)
+ssAnn ss = (ss, [], Nothing)
 
 -- |
 -- Remove the comments from an annotation
 --
 removeComments :: Ann -> Ann
-removeComments (ss, _, ty, meta) = (ss, [], ty, meta)
+removeComments (ss, _, meta) = (ss, [], meta)

--- a/src/Language/PureScript/CoreFn/CSE.hs
+++ b/src/Language/PureScript/CoreFn/CSE.hs
@@ -262,7 +262,7 @@ generateIdentFor d e = at d . non mempty . at e %%<~ \case
     _ -> "ref"
 
 nullAnn :: Ann
-nullAnn = (nullSourceSpan, [], Nothing, Nothing)
+nullAnn = (nullSourceSpan, [], Nothing)
 
 -- |
 -- Use a map to substitute local Vars in a list of Binds.
@@ -386,8 +386,8 @@ optimizeCommonSubexpressions mn
   -- common subexpression elimination pass.
   shouldFloatExpr :: Expr Ann -> Bool
   shouldFloatExpr = \case
-    App (_, _, _, Just IsSyntheticApp) e _ -> isSimple e
-    _                                      -> False
+    App (_, _, Just IsSyntheticApp) e _ -> isSimple e
+    _                                   -> False
 
   isSimple :: Expr Ann -> Bool
   isSimple = \case

--- a/src/Language/PureScript/CoreFn/Expr.hs
+++ b/src/Language/PureScript/CoreFn/Expr.hs
@@ -29,9 +29,9 @@ data Expr a
   --
   | Accessor a PSString (Expr a)
   -- |
-  -- Partial record update
+  -- Partial record update (original value, fields to copy (if known), fields to update)
   --
-  | ObjectUpdate a (Expr a) [(PSString, Expr a)]
+  | ObjectUpdate a (Expr a) (Maybe [PSString]) [(PSString, Expr a)]
   -- |
   -- Function introduction
   --
@@ -99,7 +99,7 @@ extractAnn :: Expr a -> a
 extractAnn (Literal a _) = a
 extractAnn (Constructor a _ _ _) = a
 extractAnn (Accessor a _ _) = a
-extractAnn (ObjectUpdate a _ _) = a
+extractAnn (ObjectUpdate a _ _ _) = a
 extractAnn (Abs a _ _) = a
 extractAnn (App a _ _) = a
 extractAnn (Var a _) = a
@@ -111,12 +111,12 @@ extractAnn (Let a _ _) = a
 -- Modify the annotation on a term
 --
 modifyAnn :: (a -> a) -> Expr a -> Expr a
-modifyAnn f (Literal a b)         = Literal (f a) b
-modifyAnn f (Constructor a b c d) = Constructor (f a) b c d
-modifyAnn f (Accessor a b c)      = Accessor (f a) b c
-modifyAnn f (ObjectUpdate a b c)  = ObjectUpdate (f a) b c
-modifyAnn f (Abs a b c)           = Abs (f a) b c
-modifyAnn f (App a b c)           = App (f a) b c
-modifyAnn f (Var a b)             = Var (f a) b
-modifyAnn f (Case a b c)          = Case (f a) b c
-modifyAnn f (Let a b c)           = Let (f a) b c
+modifyAnn f (Literal a b)          = Literal (f a) b
+modifyAnn f (Constructor a b c d)  = Constructor (f a) b c d
+modifyAnn f (Accessor a b c)       = Accessor (f a) b c
+modifyAnn f (ObjectUpdate a b c d) = ObjectUpdate (f a) b c d
+modifyAnn f (Abs a b c)            = Abs (f a) b c
+modifyAnn f (App a b c)            = App (f a) b c
+modifyAnn f (Var a b)              = Var (f a) b
+modifyAnn f (Case a b c)           = Case (f a) b c
+modifyAnn f (Let a b c)            = Let (f a) b c

--- a/src/Language/PureScript/CoreFn/FromJSON.hs
+++ b/src/Language/PureScript/CoreFn/FromJSON.hs
@@ -70,7 +70,7 @@ annFromJSON modulePath = withObject "Ann" annFromObj
   annFromObj o = do
     ss <- o .: "sourceSpan" >>= sourceSpanFromJSON modulePath
     mm <- o .: "meta" >>= metaFromJSON
-    return (ss, [], Nothing, mm)
+    return (ss, [], mm)
 
 sourceSpanFromJSON :: FilePath -> Value -> Parser SourceSpan
 sourceSpanFromJSON modulePath = withObject "SourceSpan" $ \o ->
@@ -228,8 +228,9 @@ exprFromJSON modulePath = withObject "Expr" exprFromObj
   objectUpdateFromObj o = do
     ann <- o .: "annotation" >>= annFromJSON modulePath
     e   <- o .: "expression" >>= exprFromJSON modulePath
+    copy <- o .: "copy" >>= parseJSON
     us  <- o .: "updates" >>= recordFromJSON (exprFromJSON modulePath)
-    return $ ObjectUpdate ann e us
+    return $ ObjectUpdate ann e copy us
 
   absFromObj o = do
     ann <- o .: "annotation" >>= annFromJSON modulePath

--- a/src/Language/PureScript/CoreFn/Laziness.hs
+++ b/src/Language/PureScript/CoreFn/Laziness.hs
@@ -142,7 +142,7 @@ onVarsWithDelayAndForce f = snd . go 0 $ Just 0
 
     handleApp len args = \case
       App a e1 e2 -> handleApp (len + 1) ((a, e2) : args) e1
-      Var a@(_, _, _, Just meta) i | isConstructorLike meta
+      Var a@(_, _, Just meta) i | isConstructorLike meta
         -> foldl (\e1 (a2, e2) -> App a2 <$> e1 <*> handleExpr' e2) (f delay force a i) args
       e -> foldl (\e1 (a2, e2) -> App a2 <$> e1 <*> snd (go delay Nothing) e2) (snd (go delay (fmap (+ len) force)) e) args
     isConstructorLike = \case
@@ -540,7 +540,7 @@ applyLazinessTransform mn rawItems = let
     _ -> internalError "Unexpected argument to lazifyIdent"
 
   makeForceCall :: Ann -> Ident -> Expr Ann
-  makeForceCall (ss, _, _, _) ident
+  makeForceCall (ss, _, _) ident
     -- We expect the functions produced by `runtimeLazy` to accept one
     -- argument: the line number on which this reference is made. The runtime
     -- code uses this number to generate a message that identifies where the

--- a/src/Language/PureScript/CoreFn/Optimizer.hs
+++ b/src/Language/PureScript/CoreFn/Optimizer.hs
@@ -3,18 +3,12 @@ module Language.PureScript.CoreFn.Optimizer (optimizeCoreFn) where
 import Protolude hiding (Type, moduleName)
 
 import Control.Monad.Supply (Supply)
-import Data.List (lookup)
-import Language.PureScript.AST.Literals (Literal(..))
-import Language.PureScript.AST.SourcePos (nullSourceSpan)
 import Language.PureScript.CoreFn.Ann (Ann)
 import Language.PureScript.CoreFn.CSE (optimizeCommonSubexpressions)
 import Language.PureScript.CoreFn.Expr (Bind, Expr(..))
 import Language.PureScript.CoreFn.Module (Module(..))
 import Language.PureScript.CoreFn.Traversals (everywhereOnValues)
-import Language.PureScript.Label (Label(..))
-import Language.PureScript.Types (pattern REmptyKinded, Type(..))
 import Language.PureScript.Constants.Libs qualified as C
-import Language.PureScript.Constants.Prim qualified as C
 
 -- |
 -- CoreFn optimization pass.
@@ -27,29 +21,7 @@ optimizeModuleDecls = map transformBinds
   where
   (transformBinds, _, _) = everywhereOnValues identity transformExprs identity
   transformExprs
-    = optimizeClosedRecordUpdate
-    . optimizeDataFunctionApply
-
-optimizeClosedRecordUpdate :: Expr Ann -> Expr Ann
-optimizeClosedRecordUpdate ou@(ObjectUpdate a@(_, _, Just t, _) r updatedFields) =
-  case closedRecordFields t of
-    Nothing -> ou
-    Just allFields -> Literal a (ObjectLiteral (map f allFields))
-      where f (Label l) = case lookup l updatedFields of
-              Nothing -> (l, Accessor (nullSourceSpan, [], Nothing, Nothing) l r)
-              Just e -> (l, e)
-optimizeClosedRecordUpdate e = e
-
--- | Return the labels of a closed record, or Nothing for other types or open records.
-closedRecordFields :: Type a -> Maybe [Label]
-closedRecordFields (TypeApp _ (TypeConstructor _ C.Record) row) =
-  collect row
-  where
-    collect :: Type a -> Maybe [Label]
-    collect (REmptyKinded _ _) = Just []
-    collect (RCons _ l _ r) = (l :) <$> collect r
-    collect _ = Nothing
-closedRecordFields _ = Nothing
+    = optimizeDataFunctionApply
 
 optimizeDataFunctionApply :: Expr a -> Expr a
 optimizeDataFunctionApply e = case e of

--- a/src/Language/PureScript/CoreFn/ToJSON.hs
+++ b/src/Language/PureScript/CoreFn/ToJSON.hs
@@ -54,9 +54,9 @@ sourceSpanToJSON (SourceSpan _ spanStart spanEnd) =
          ]
 
 annToJSON :: Ann -> Value
-annToJSON (ss, _, _, m) = object [ "sourceSpan"  .= sourceSpanToJSON ss
-                                 , "meta"        .= maybe Null metaToJSON m
-                                 ]
+annToJSON (ss, _, m) = object [ "sourceSpan"  .= sourceSpanToJSON ss
+                              , "meta"        .= maybe Null metaToJSON m
+                              ]
 
 literalToJSON :: (a -> Value) -> Literal a -> Value
 literalToJSON _ (NumericLiteral (Left n))
@@ -181,9 +181,11 @@ exprToJSON (Accessor ann f r)       = object [ "type"        .= "Accessor"
                                              , "fieldName"   .= f
                                              , "expression"  .= exprToJSON r
                                              ]
-exprToJSON (ObjectUpdate ann r fs)  = object [ "type"        .= "ObjectUpdate"
+exprToJSON (ObjectUpdate ann r copy fs)
+                                    = object [ "type"        .= "ObjectUpdate"
                                              , "annotation"  .= annToJSON ann
                                              , "expression"  .= exprToJSON r
+                                             , "copy"        .= toJSON copy
                                              , "updates"     .= recordToJSON exprToJSON fs
                                              ]
 exprToJSON (Abs ann p b)            = object [ "type"        .= "Abs"

--- a/src/Language/PureScript/CoreFn/Traversals.hs
+++ b/src/Language/PureScript/CoreFn/Traversals.hs
@@ -23,7 +23,7 @@ everywhereOnValues f g h = (f', g', h')
 
   g' (Literal ann e) = g (Literal ann (handleLiteral g' e))
   g' (Accessor ann prop e) = g (Accessor ann prop (g' e))
-  g' (ObjectUpdate ann obj vs) = g (ObjectUpdate ann (g' obj) (map (fmap g') vs))
+  g' (ObjectUpdate ann obj copy vs) = g (ObjectUpdate ann (g' obj) copy (map (fmap g') vs))
   g' (Abs ann name e) = g (Abs ann name (g' e))
   g' (App ann v1 v2) = g (App ann (g' v1) (g' v2))
   g' (Case ann vs alts) = g (Case ann (map g' vs) (map handleCaseAlternative alts))
@@ -66,7 +66,7 @@ traverseCoreFn f g h i = (f', g', h', i')
 
   g' (Literal ann e) = Literal ann <$> handleLiteral g e
   g' (Accessor ann prop e) = Accessor ann prop <$> g e
-  g' (ObjectUpdate ann obj vs) = ObjectUpdate ann <$> g obj <*> traverse (traverse g) vs
+  g' (ObjectUpdate ann obj copy vs) = (\obj' -> ObjectUpdate ann obj' copy) <$> g obj <*> traverse (traverse g) vs
   g' (Abs ann name e) = Abs ann name <$> g e
   g' (App ann v1 v2) = App ann <$> g v1 <*> g v2
   g' (Case ann vs alts) = Case ann <$> traverse g vs <*> traverse i alts

--- a/src/Language/PureScript/Renamer.hs
+++ b/src/Language/PureScript/Renamer.hs
@@ -166,8 +166,8 @@ renameInValue (Literal ann l) =
 renameInValue c@Constructor{} = return c
 renameInValue (Accessor ann prop v) =
   Accessor ann prop <$> renameInValue v
-renameInValue (ObjectUpdate ann obj vs) =
-  ObjectUpdate ann <$> renameInValue obj <*> traverse (\(name, v) -> (name, ) <$> renameInValue v) vs
+renameInValue (ObjectUpdate ann obj copy vs) =
+  (\obj' -> ObjectUpdate ann obj' copy) <$> renameInValue obj <*> traverse (\(name, v) -> (name, ) <$> renameInValue v) vs
 renameInValue (Abs ann name v) =
   newScope $ Abs ann <$> updateScope name <*> renameInValue v
 renameInValue (App ann v1 v2) =

--- a/tests/TestCoreFn.hs
+++ b/tests/TestCoreFn.hs
@@ -128,6 +128,7 @@ spec = context "CoreFnFromJson" $ do
                 [ NonRec ann (Ident "objectUpdate") $
                     ObjectUpdate ann
                       (Literal ann $ ObjectLiteral [(mkString "field", Literal ann (StringLiteral (mkString "abc")))])
+                      (Just [mkString "unchangedField"])
                       [(mkString "field", Literal ann (StringLiteral (mkString "xyz")))]
                 ]
       parseMod m `shouldSatisfy` isSuccess
@@ -191,28 +192,28 @@ spec = context "CoreFnFromJson" $ do
   context "Meta" $ do
     specify "should parse IsConstructor" $ do
       let m = Module ss [] mn mp [] [] M.empty []
-                [ NonRec (ss, [], Nothing, Just (IsConstructor ProductType [Ident "x"])) (Ident "x") $
-                  Literal (ss, [], Nothing, Just (IsConstructor SumType [])) (CharLiteral 'a')
+                [ NonRec (ss, [], Just (IsConstructor ProductType [Ident "x"])) (Ident "x") $
+                  Literal (ss, [], Just (IsConstructor SumType [])) (CharLiteral 'a')
                 ]
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse IsNewtype" $ do
       let m = Module ss [] mn mp [] [] M.empty []
-                [ NonRec (ss, [], Nothing, Just IsNewtype) (Ident "x") $
+                [ NonRec (ss, [], Just IsNewtype) (Ident "x") $
                   Literal ann (CharLiteral 'a')
                 ]
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse IsTypeClassConstructor" $ do
       let m = Module ss [] mn mp [] [] M.empty []
-                [ NonRec (ss, [], Nothing, Just IsTypeClassConstructor) (Ident "x") $
+                [ NonRec (ss, [], Just IsTypeClassConstructor) (Ident "x") $
                   Literal ann (CharLiteral 'a')
                 ]
       parseMod m `shouldSatisfy` isSuccess
 
     specify "should parse IsForeign" $ do
       let m = Module ss [] mn mp [] [] M.empty []
-                [ NonRec (ss, [], Nothing, Just IsForeign) (Ident "x") $
+                [ NonRec (ss, [], Just IsForeign) (Ident "x") $
                   Literal ann (CharLiteral 'a')
                 ]
       parseMod m `shouldSatisfy` isSuccess

--- a/tests/purs/optimize/ObjectUpdate.out.js
+++ b/tests/purs/optimize/ObjectUpdate.out.js
@@ -1,0 +1,27 @@
+var staticUpdate2 = function (x) {
+    return {
+        alpha: x.alpha,
+        bravo: true
+    };
+};
+var staticUpdate1 = function (x) {
+    return {
+        alpha: x.alpha,
+        bravo: "replaced"
+    };
+};
+var dynamicUpdate1 = function (x) {
+    var $3 = {};
+    for (var $4 in x) {
+        if ({}.hasOwnProperty.call(x, $4)) {
+            $3[$4] = x[$4];
+        };
+    };
+    $3.bravo = true;
+    return $3;
+};
+export {
+    staticUpdate1,
+    staticUpdate2,
+    dynamicUpdate1
+};

--- a/tests/purs/optimize/ObjectUpdate.purs
+++ b/tests/purs/optimize/ObjectUpdate.purs
@@ -1,0 +1,10 @@
+module Main where
+
+staticUpdate1 :: { alpha :: Int, bravo :: String } -> { alpha :: Int, bravo :: String }
+staticUpdate1 x = x { bravo = "replaced" }
+
+staticUpdate2 :: { alpha :: Int, bravo :: String } -> { alpha :: Int, bravo :: Boolean }
+staticUpdate2 x = x { bravo = true }
+
+dynamicUpdate1 :: forall r. { alpha :: Int, bravo :: String | r } -> { alpha :: Int, bravo :: Boolean | r }
+dynamicUpdate1 x = x { bravo = true }


### PR DESCRIPTION
For consumers of CoreFn like alternate backends, the optimization of replacing a closed record update with an object literal has now been moved to the point of desugaring CoreFn into JS. The `ObjectUpdate` expression constructor now contains a `Maybe` field holding a list of record labels to be copied as-is, for backends that want to perform this optimization also.

This optimization was the last use of the `Maybe SourceType` member of the `Ann` tuple, so it has been removed. CoreFn is now fully untyped in both its serialized and in-memory forms (previously it was partially typed in memory).

**Description of the change**

Closes #4473

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
