### PR TITLE
Allow instances that require `Fail` to be empty

### DIFF
--- a/CHANGELOG.d/feature_empty-fail-instances.md
+++ b/CHANGELOG.d/feature_empty-fail-instances.md
@@ -1,0 +1,8 @@
+* Allow instances that require `Fail` to be empty
+
+  A class instance declaration that has `Prim.TypeError.Fail` as a constraint
+  will never be used. In light of this, such instances are now allowed to have
+  empty bodies even if the class has members.
+
+  (Such instances are still allowed to declare all of their members, and it is
+  still an error to specify some but not all members.)

--- a/tests/purs/failing/4483.out
+++ b/tests/purs/failing/4483.out
@@ -1,0 +1,14 @@
+Error found:
+at tests/purs/failing/4483.purs:10:1 - 11:24 (line 10, column 1 - line 11, column 24)
+
+  The following type class members have not been implemented:
+  [33mbar :: Int -> Int[0m
+
+in type class instance
+[33m              [0m
+[33m  Main.Foo Int[0m
+[33m              [0m
+
+See https://github.com/purescript/documentation/blob/master/errors/MissingClassMember.md for more information,
+or to contribute content related to this error.
+

--- a/tests/purs/failing/4483.purs
+++ b/tests/purs/failing/4483.purs
@@ -1,0 +1,13 @@
+-- @shouldFailWith MissingClassMember
+module Main where
+
+import Prim.TypeError
+
+class Foo t where
+  foo :: t -> String
+  bar :: Int -> t
+
+instance fooInt :: Fail (Text "can't use this") => Foo Int where
+  foo _ = "unreachable"
+  -- bar is missing; you can get away with an empty instance here but not a
+  -- half-implemented one

--- a/tests/purs/passing/4483.purs
+++ b/tests/purs/passing/4483.purs
@@ -1,0 +1,12 @@
+module Main where
+
+import Effect.Console (log)
+import Prim.TypeError
+
+class Foo t where
+  foo :: t -> String
+  bar :: Int -> t
+
+instance fooInt :: Fail (Text "can't use this") => Foo Int
+
+main = log "Done"


### PR DESCRIPTION
A class instance declaration that has `Prim.TypeError.Fail` as a constraint will never be used. In light of this, such instances are now allowed to have empty bodies even if the class has members.

(Such instances are still allowed to declare all of their members, and it is still an error to specify some but not all members.)

**Description of the change**

Closes #4483

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
