### PR TITLE
Stop triggering CI on non-code-related changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,23 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+    paths:
+      - .github/workflows/**/*.yml
+      - app/**/*
+      - bundle/**/*
+      - ci/**/*
+      - license-generator/**/*
+      - src/**/*
+      - test/**/*
+      - .gitignore
+      - .hlint.yaml
+      - .hspec
+      - cabal.project
+      - purescript.cabal
+      - Setup.hs
+      - stack.yaml
+      - update-changelog.hs
+      - weeder.dhall
   release:
     types: [ "published" ]
 

--- a/CHANGELOG.d/internal_stop-building-if-non-significant-change.md
+++ b/CHANGELOG.d/internal_stop-building-if-non-significant-change.md
@@ -1,0 +1,1 @@
+* Stop triggering CI on non-code-related changes (e.g. Readme)


### PR DESCRIPTION
**Description of the change**

In #4501, CI was triggered for a change unrelated to the PR. This PR prevents CI from running on such changes.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
