### PR TITLE
Install gh on ubuntu-latest run; prep 0.15.12 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,8 @@ jobs:
         name: "(Linux only) Install gh"
         if: "contains(matrix.os, 'ubuntu-latest')"
         run: |
-          sudo apt-get update
-          sudo apt-get install gh
+          apt-get update
+          apt-get install gh
 
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-node@v2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
         name: "(Linux only) Install gh"
         if: "contains(matrix.os, 'ubuntu-latest')"
         run: |
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
           apt-get update
           apt-get install gh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,8 @@ jobs:
         name: "(Linux only) Install gh"
         if: "contains(matrix.os, 'ubuntu-latest')"
         run: |
-          sudo apt update
-          sudo apt install gh
+          sudo apt-get update
+          sudo apt-get install gh
 
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-node@v2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,14 @@ jobs:
           . /etc/os-release
           echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
           apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
+
+      - # We need `gh` installed on the Linux version. Otherwise, release artifacts won't be uploaded.
+        name: "(Linux only) Install gh"
+        if: "contains(matrix.os, 'ubuntu-latest')"
+        run: |
+          sudo apt update
+          sudo apt install gh
+
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-node@v2"
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes to this project are documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.15.11
+## 0.15.12
 
 New features:
 
@@ -54,9 +54,14 @@ Bugfixes:
 
 Internal:
 
-* Use `gh` for release artifacts (#4493 by @rhendric)
+* Use `gh` for release artifacts (#4493 by @rhendric, #4509 by @JordanMartinez)
 
 * Stop triggering CI on non-code-related changes (e.g. Readme) (#4502 by @JordanMartinez)
+
+
+## 0.15.11
+
+Please use `0.15.12` instead of this release. There was an issue with the Linux build. This release notes were moved into `0.15.12`'s release notes.
 
 ## 0.15.10
 

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript",
-  "version": "0.15.11",
+  "version": "0.15.12",
   "license": "ISC",
   "description": "PureScript wrapper that makes it available as a local dependency",
   "author": {
@@ -43,7 +43,7 @@
   ],
   "scripts": {
     "prepublishOnly": "node -e \"require('fs').copyFileSync('purs.bin.placeholder', 'purs.bin');\"",
-    "postinstall": "install-purescript --purs-ver=0.15.11",
+    "postinstall": "install-purescript --purs-ver=0.15.12",
     "test": "echo 'Error: no test specified' && exit 1"
   }
 }

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -2,7 +2,7 @@ cabal-version:  2.4
 
 name:           purescript
 -- Note: don't add prerelease identifiers here! Add them in app/Version.hs and npm-package/package.json instead.
-version:        0.15.11
+version:        0.15.12
 synopsis:       PureScript Programming Language Compiler
 description:    A small strongly, statically typed programming language with expressive types, inspired by Haskell and compiling to JavaScript.
 category:       Language


### PR DESCRIPTION
**Description of the change**

Following instructions [here](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt), attempts to install `gh` on the non-self-hosted Linux runner, so that release artifacts are properly uploaded.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
