### PR TITLE
Lts 20.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,14 @@ jobs:
       - name: "(Linux only) Check Stack version and fix working directory ownership"
         if: "contains(matrix.os, 'ubuntu-latest')"
         run: |
-          [ "$(stack --numeric-version)" = "$STACK_VERSION" ]
-          chown root:root .
+          actual_stack_version=$(stack --numeric-version)
+          if [[ "$actual_stack_version" = "$STACK_VERSION" ]]
+          then
+            chown root:root .
+          else
+            echo "Actual stack version ${actual_stack_version} does not match specified stack version ${STACK_VERSION}"
+            exit 1
+          fi
 
       - uses: "actions/cache@v2"
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         include:
           - # If upgrading the Haskell image, also upgrade it in the lint job below
             os: ["ubuntu-latest"]
-            image: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
+            image: haskell:9.2.8@sha256:daf831233850c2953f295e6e71463e84ce222bd9ea2b1fa775bc85ab60ff9f0c
           - os: ["macOS-11"]
           - os: ["windows-2019"]
           - os: ["self-hosted", "macos", "ARM64"]
@@ -222,7 +222,7 @@ jobs:
     # means our published binaries will work on the widest number of platforms.
     # But the HLint binary downloaded by this job requires a newer glibc
     # version.
-    container: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
+    container: haskell:9.2.8@sha256:daf831233850c2953f295e6e71463e84ce222bd9ea2b1fa775bc85ab60ff9f0c
 
     steps:
       - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ defaults:
 env:
   CI_PRERELEASE: "${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}"
   CI_RELEASE: "${{ github.event_name == 'release' }}"
-  STACK_VERSION: "2.9.3"
+  STACK_VERSION: "2.11.1"
 
 concurrency:
   # We never want two prereleases building at the same time, since they would

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -119,7 +119,7 @@ common defaults
     TypeFamilies
     ViewPatterns
   build-tool-depends:
-    happy:happy ==1.20.0
+    happy:happy ==1.20.1.1
   build-depends:
     -- NOTE: Please do not edit these version constraints manually. They are
     -- deliberately made narrow because changing the dependency versions in

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # Please update Haskell image versions under .github/workflows/ci.yml together to use the same GHC version
 # (or the CI build will fail)
-resolver: lts-20.9
+resolver: lts-20.11
 pvp-bounds: both
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # Please update Haskell image versions under .github/workflows/ci.yml together to use the same GHC version
 # (or the CI build will fail)
-resolver: lts-20.12
+resolver: lts-20.24
 pvp-bounds: both
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # Please update Haskell image versions under .github/workflows/ci.yml together to use the same GHC version
 # (or the CI build will fail)
-resolver: lts-20.24
+resolver: lts-20.26
 pvp-bounds: both
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # Please update Haskell image versions under .github/workflows/ci.yml together to use the same GHC version
 # (or the CI build will fail)
-resolver: lts-20.11
+resolver: lts-20.12
 pvp-bounds: both
 packages:
 - '.'


### PR DESCRIPTION
Only a minimal change was required to update the GHC version. Changed the version of `happy` from `1.20.0` to `1.20.1.1`.

From: LTS Haskell 20.9 (ghc-9.2.5) Published on 2023-01-28
To: LTS Haskell 20.26 (ghc-9.2.8) Published on 2023-06-18