### PR TITLE
Drop container ID from CI cache key, use image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           path: |
             /root/.stack
             ${{ steps.haskell.outputs.stack-root }}
-          key: "${{ runner.os }}-${{ job.container.id }}-MdyPsf-${{ hashFiles('stack.yaml') }}"
+          key: "${{ matrix.image || runner.os }}--MdyPsf-${{ hashFiles('stack.yaml') }}"
 
       - name: "(Windows only) Configure Stack to store its programs in STACK_ROOT"
         # This ensures that the local GHC and MSYS binaries that Stack installs
@@ -242,7 +242,7 @@ jobs:
         with:
           path: |
             /root/.stack
-          key: "${{ runner.os }}-${{ job.container.id }}-UnWw0N-lint-${{ hashFiles('stack.yaml') }}"
+          key: "lint-${{ hashFiles('stack.yaml') }}"
 
       - run: "ci/fix-home ci/run-hlint.sh --git"
         env:


### PR DESCRIPTION
**Description of the change**

Fix #4515.

See https://github.com/purescript/purescript/actions/runs/6751258116/job/18355031282?pr=4516#step:9:12 for evidence that the cache is now being hit.

The `job.container.id` expression added to the key in #4394 refers to the Docker container ID, which is new every time the container is created from the specified image, and thus not helpful in a cache key. The image ID isn't exposed on the `job` context, but for the main build job we can pull the full image specification string from the build matrix, which should be good enough. (For the lint job, I think we can forgo worrying too much about old cache artifacts messing things up; if this happens, it's always an option to delete a cache by hand.)

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
