### PR TITLE
Uses strict Map to fix a compile time regression

### DIFF
--- a/CHANGELOG.d/fix_compilation_regression-4491.md
+++ b/CHANGELOG.d/fix_compilation_regression-4491.md
@@ -1,0 +1,8 @@
+* Fix a compilation memory regression for very large files
+
+When compiling a a very large file (>12K lines)
+the CSE pass could baloon memory and result in increased
+compilation times.
+
+This fix uses a strict Map instead of a lazy Map to avoid
+building up unnecessary thunks during the optimization pass.

--- a/CHANGELOG.d/fix_compilation_regression-4491.md
+++ b/CHANGELOG.d/fix_compilation_regression-4491.md
@@ -1,8 +1,8 @@
 * Fix a compilation memory regression for very large files
 
-When compiling a a very large file (>12K lines)
-the CSE pass could baloon memory and result in increased
-compilation times.
+  When compiling a a very large file (>12K lines)
+  the CSE pass could balloon memory and result in increased
+  compilation times.
 
-This fix uses a strict Map instead of a lazy Map to avoid
-building up unnecessary thunks during the optimization pass.
+  This fix uses a strict Map instead of a lazy Map to avoid
+  building up unnecessary thunks during the optimization pass.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -102,6 +102,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@milesfrain](https://github.com/milesfrain) | Miles Frain | [MIT license] |
 | [@MiracleBlue](https://github.com/MiracleBlue) | Nicholas Kircher | [MIT license] |
 | [@mjgpy3](https://github.com/mjgpy3) | Michael Gilliland | [MIT license] |
+| [@mjrussell](https://github.com/mjrussell) | Matthew Russell | [MIT license] |
 | [@MonoidMusician](https://github.com/MonoidMusician) | Verity Scheel | [MIT license] |
 | [@mpietrzak](https://github.com/mpietrzak) | Maciej Pietrzak | [MIT license] |
 | [@mrhania](https://github.com/mrhania) | Łukasz Hanuszczak | [MIT license] |

--- a/src/Language/PureScript/CoreFn/CSE.hs
+++ b/src/Language/PureScript/CoreFn/CSE.hs
@@ -12,7 +12,7 @@ import Data.Bitraversable (bitraverse)
 import Data.Functor.Compose (Compose(..))
 import Data.IntMap.Monoidal qualified as IM
 import Data.IntSet qualified as IS
-import Data.Map qualified as M
+import Data.Map.Strict qualified as M
 import Data.Maybe (fromJust)
 import Data.Semigroup (Min(..))
 import Data.Semigroup.Generic (GenericSemigroupMonoid(..))
@@ -216,7 +216,7 @@ newScope isTopLevel body = local goDeeper $ do
     if isTopLevel
     then env{ _depth = depth', _deepestTopLevelScope = depth' }
     else env{ _depth = depth' }
-    where 
+    where
     depth' = succ _depth
 
 -- |


### PR DESCRIPTION
**Description of the change**

For extremely large files (14K lines) with a lot of types and instances memory increases dramatically using Lazy Maps, causing swapping and an big increase in compilation time.

Switching to a strict map brings compilation performance close to 15.2 levels.

Fixes #4491

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
