### PR TITLE
Fix compiler crash when a type operator is used in a type argument

### DIFF
--- a/CHANGELOG.d/fix_issue-4535.md
+++ b/CHANGELOG.d/fix_issue-4535.md
@@ -1,0 +1,1 @@
+* Fix compiler crash when a type operator is used in a type argument

--- a/src/Language/PureScript/Sugar/Operators.hs
+++ b/src/Language/PureScript/Sugar/Operators.hs
@@ -409,6 +409,9 @@ updateTypes goType = (goDecl, goExpr, goBinder)
   goExpr pos (TypedValue check v ty) = do
     ty' <- goType' pos ty
     return (pos, TypedValue check v ty')
+  goExpr pos (VisibleTypeApp v ty) = do
+    ty' <- goType' pos ty
+    return (pos, VisibleTypeApp v ty')
   goExpr pos other = return (pos, other)
 
   goBinder :: SourceSpan -> Binder -> m (SourceSpan, Binder)

--- a/tests/purs/passing/4535.purs
+++ b/tests/purs/passing/4535.purs
@@ -1,0 +1,38 @@
+module Main where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Data.Tuple.Nested ((/\), type (/\))
+import Effect (Effect)
+import Effect.Console (log)
+
+singleArgument :: forall @a. a -> Unit
+singleArgument _ = unit
+
+multiArgument :: forall @a @b. a -> b -> Unit
+multiArgument _ _ = unit
+
+singleApplication :: Int /\ Number -> Unit
+singleApplication = singleArgument @(Int /\ Number)
+
+-- Like expression applications, visible type applications are left-associative.
+-- This test accounts for subsequent type applications nested in this manner.
+appNestingWorks :: Int /\ Number -> Number /\ Int -> Unit
+appNestingWorks = multiArgument @(Int /\ Number) @(Number /\ Int)
+
+-- This test accounts for type applications nested within other AST nodes.
+otherNestingWorks :: Array (Maybe (Int /\ Number))
+otherNestingWorks = [Just @(Int /\ Number) (0 /\ 0.0), Just @(Int /\ Number) (1 /\ 1.0)]
+
+type InSynonym = Int /\ Number
+
+-- This test accounts for type synonyms used as type arguments.
+-- Since expansion happens during checking, InSynonym would expand
+-- to an already-desugared type operator. This test exists for the
+-- sake of redundancy.
+inSynonym :: InSynonym -> Unit
+inSynonym = singleArgument @InSynonym
+
+main :: Effect Unit
+main = log "Done"

--- a/tests/purs/passing/4535.purs
+++ b/tests/purs/passing/4535.purs
@@ -6,6 +6,7 @@ import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested ((/\), type (/\))
 import Effect (Effect)
 import Effect.Console (log)
+import Type.Proxy (Proxy(..))
 
 singleArgument :: forall @a. a -> Unit
 singleArgument _ = unit
@@ -33,6 +34,10 @@ type InSynonym = Int /\ Number
 -- sake of redundancy.
 inSynonym :: InSynonym -> Unit
 inSynonym = singleArgument @InSynonym
+
+-- This test accounts for type operators used as type arguments directly.
+operatorAsArgument :: Proxy (/\)
+operatorAsArgument = Proxy @(/\)
 
 main :: Effect Unit
 main = log "Done"


### PR DESCRIPTION
**Description of the change**

Fixes #4535. This fixes a crash in the compiler caused by a missing branch in the traversal performed during desugaring.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
