### PR TITLE
Upgrade to GHC 9.2.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         include:
           - # If upgrading the Haskell image, also upgrade it in the lint job below
             os: ["ubuntu-latest"]
-            image: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
+            image: haskell:9.2.8@sha256:b3b2f3909c7381bb96b8f18766f9407a3d6f61e0f07ea95e812583ac4f442cbb
           - os: ["macOS-11"]
           - os: ["windows-2019"]
           - os: ["self-hosted", "macos", "ARM64"]
@@ -231,7 +231,7 @@ jobs:
     # means our published binaries will work on the widest number of platforms.
     # But the HLint binary downloaded by this job requires a newer glibc
     # version.
-    container: haskell:9.2.5@sha256:2597b0e2458165a6635906204f7fac43c22e7d2a46aca1235a811194bb6cd419
+    container: haskell:9.2.8@sha256:b3b2f3909c7381bb96b8f18766f9407a3d6f61e0f07ea95e812583ac4f442cbb
 
     steps:
       - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         # and their Haskell environment is instead provided by a nix-shell
         # See https://github.com/purescript/purescript/pulls/4455
         if: "!contains(matrix.os, 'ubuntu-latest') && !contains(matrix.os, 'self-hosted')"
-        uses: "haskell/actions/setup@v1"
+        uses: "haskell-actions/setup@v2"
         with:
           enable-stack: true
           stack-version: "${{ env.STACK_VERSION }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ defaults:
 env:
   CI_PRERELEASE: "${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}"
   CI_RELEASE: "${{ github.event_name == 'release' }}"
-  STACK_VERSION: "2.9.3"
+  STACK_VERSION: "2.15.1"
 
 concurrency:
   # We never want two prereleases building at the same time, since they would

--- a/CHANGELOG.d/misc_ghc-bump.md
+++ b/CHANGELOG.d/misc_ghc-bump.md
@@ -1,0 +1,1 @@
+* Update Stackage snapshot to lts-20.26 and GHC to 9.2.8

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,12 +4,12 @@ If you are having difficulty installing the PureScript compiler, feel free to as
 
 ## Requirements
 
-The PureScript compiler is built using GHC 9.2.5, and should be able to run on any operating system supported by GHC 9.2.5. In particular:
+The PureScript compiler is built using GHC 9.2.8, and should be able to run on any operating system supported by GHC 9.2.8. In particular:
 
 * for Windows users, versions predating Vista are not officially supported,
 * for macOS / OS X users, versions predating Mac OS X 10.7 (Lion) are not officially supported.
 
-See also <https://www.haskell.org/ghc/download_ghc_9_2_5.html> for more details about the operating systems which GHC 9.2.5 supports.
+See also <https://www.haskell.org/ghc/download_ghc_9_2_8.html> for more details about the operating systems which GHC 9.2.8 supports.
 
 ## Official prebuilt binaries
 

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -119,7 +119,7 @@ common defaults
     TypeFamilies
     ViewPatterns
   build-tool-depends:
-    happy:happy ==1.20.0
+    happy:happy ==1.20.1.1
   build-depends:
     -- NOTE: Please do not edit these version constraints manually. They are
     -- deliberately made narrow because changing the dependency versions in

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # Please update Haskell image versions under .github/workflows/ci.yml together to use the same GHC version
 # (or the CI build will fail)
-resolver: lts-20.9
+resolver: lts-20.26
 pvp-bounds: both
 packages:
 - '.'


### PR DESCRIPTION
**Description of the change**

This updates:
* the Stackage snapshot to LTS-20.26
  * requires `happy` to be updated to 1.20.1.1 from 1.20.0
* GHC to 9.2.8
* (internal) `STACK_VERSION` to 2.15.1
  * In the Linux CI, this needs to be updated according to whatever the Haskell image ships

Like #4433, this upgrade is done to keep up with the "recommended" versions of tooling. In particular, 9.2.8 is the latest version of GHC 9.2.x that's still [supported by HLS](https://haskell-language-server.readthedocs.io/en/latest/support/ghc-version-support.html#current-ghc-version-support-status).

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
