### PR TITLE
Use JS Symbol for sum ADTs

### DIFF
--- a/CHANGELOG.d/feature_use_symbols_for_sum_adts.md
+++ b/CHANGELOG.d/feature_use_symbols_for_sum_adts.md
@@ -1,0 +1,1 @@
+* Generate [`Symbol()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) objects for sum ADTs and use equality (`===`) instead of `instanceof` for comparisons on sum ADTs

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -145,6 +145,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@senju](https://github.com/senju) | senju | [MIT license] |
 | [@seungha-kim](https://github.com/seungha-kim) | Seungha Kim | [MIT license] |
 | [@sharkdp](https://github.com/sharkdp) | David Peter | [MIT license] |
+| [@shybovycha](https://github.com/shybovycha) | Artem Shubovych | [MIT license] |
 | [@sigma-andex](https://github.com/sigma-andex) | Jan Schulte | [MIT license] |
 | [@simonyangme](https://github.com/simonyangme) | Simon Yang | [MIT license] |
 | [@sloosch](https://github.com/sloosch) | Simon Looschen | [MIT license] |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,3 +71,19 @@ Error: EACCES: permission denied
 ```
 
 The best solution is to install [Node.js and npm via a node version manager](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#using-a-node-version-manager-to-install-nodejs-and-npm). This error is due to permissions issues when installing packages globally. You can read more about this error in npm's guide to [resolving EACCES permissions errors when installing packages globally](https://docs.npmjs.com/getting-started/fixing-npm-permissions).
+
+## hGetContents invalid argument error
+
+If you encounter this error while trying to build purescript from sources:
+
+```
+language-javascript> happy: src/Language/JavaScript/Parser/Grammar7.y: hGetContents: invalid argument (invalid byte sequence)
+```
+
+You are most likely not using UTF-8 system-wide. This happens sometimes on Docker / Ubuntu. To fix this, generate the locales for the system:
+
+```bash
+apt-get install -y locales
+echo 'en_US.UTF-8' >> /etc/locale.gen
+locale-gen en_US.UTF-8
+```

--- a/src/Language/PureScript/CodeGen/JS.hs
+++ b/src/Language/PureScript/CodeGen/JS.hs
@@ -339,9 +339,7 @@ moduleBindToJs mn = bindToJs
                   AST.Function Nothing Nothing ["value"]
                     (AST.Block Nothing [AST.Return Nothing $ AST.Var Nothing "value"]))])
   valueToJs' (Constructor _ _ ctor []) =
-    return $ iife (properToJs ctor) [ AST.Function Nothing (Just (properToJs ctor)) [] (AST.Block Nothing [])
-           , AST.Assignment Nothing (accessorString "value" (AST.Var Nothing (properToJs ctor)))
-                (AST.Unary Nothing AST.New $ AST.App Nothing (AST.Var Nothing (properToJs ctor)) []) ]
+    return $ AST.App Nothing (AST.Var Nothing "Symbol") [(AST.StringLiteral Nothing (mkString $ properToJs ctor))]
   valueToJs' (Constructor _ _ ctor fields) =
     let constructor =
           let body = [ AST.Assignment Nothing ((accessorString $ mkString $ identToJs f) (AST.Var Nothing "this")) (var f) | f <- fields ]
@@ -463,7 +461,7 @@ moduleBindToJs mn = bindToJs
     return $ case ctorType of
       ProductType -> js
       SumType ->
-        [AST.IfElse Nothing (AST.InstanceOf Nothing (AST.Var Nothing varName) (qualifiedToJS (Ident . runProperName) ctor))
+        [AST.IfElse Nothing (AST.Binary Nothing AST.EqualTo (AST.Var Nothing varName) (qualifiedToJS (Ident . runProperName) ctor))
                   (AST.Block Nothing js)
                   Nothing]
     where


### PR DESCRIPTION
**Description of the change**

Clearly and concisely describe the purpose of the pull request. If this PR relates to an existing issue or change proposal, please link to it. Include any other background context that would help reviewers understand the motivation for this PR.

Currently PureScript generates a quite outdated, lengthy javascript code for sum ADTs:

```hs
data Msg = Increment | Decrement
```

produces the following JS in `0.15.15`:

```js
// Generated by purs version 0.15.15
var Increment = /* #__PURE__ */ (function () {
    function Increment() {

    };
    Increment.value = new Increment();
    return Increment;
})();
var Decrement = /* #__PURE__ */ (function () {
    function Decrement() {

    };
    Decrement.value = new Decrement();
    return Decrement;
})();
```

When comparing the above ADTs (with pattern matching or `if` expressions), the code generated is as follows:

```hs
main :: Msg -> String
main Increment = "42"
main Decrement = "0"
```

produces in `0.15.15`:

```js
var main = function (v) {
    if (v instanceof Increment) {
        return "42";
    };
    if (v instanceof Decrement) {
        return "0";
    };
    throw new Error("Failed pattern match at Main (line 9, column 1 - line 9, column 22): " + [ v.constructor.name ]);
};
```

A better approach would be to use [Symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) class, available in all the modern browsers and Node.JS versions:

```js
// Generated by purs version 0.15.16
var Increment = /* #__PURE__ */ Symbol("Increment");
var Decrement = /* #__PURE__ */ Symbol("Decrement");
```

so that then the pattern matching can make use of equality (which is stricter than `instanceof`):

```js
var main = function (v) {
    if (v === Increment) {
        return "42";
    };
    if (v === Decrement) {
        return "0";
    };
    throw new Error("Failed pattern match at Main (line 9, column 1 - line 9, column 22): " + [ v.constructor.name ]);
};
```

This PR introduces two changes:

1. generating `Symbol` for sum ADTs
2. comparing the corresponding symbols for pattern matching sum ADTs using equality operator rather than `instanceof`

This should make the generated JS code more reliable when comparing values and shorter (resulting in smaller bundles).

For parametrized types this would still work as before, generating the old-style code:

```hs
data Tree a = Leaf a | Empty

main :: forall a. Tree a -> String
main (Leaf _) = "leaf"
main Empty = "empty"
```

and the JS output:

```js
var Leaf = /* #__PURE__ */ (function () {
    function Leaf(value0) {
        this.value0 = value0;
    };
    Leaf.create = function (value0) {
        return new Leaf(value0);
    };
    return Leaf;
})();
var Empty = /* #__PURE__ */ (function () {
    function Empty() {

    };
    Empty.value = new Empty();
    return Empty;
})();
var main = function (v) {
    if (v instanceof Leaf) {
        return "leaf";
    };
    if (v instanceof Empty) {
        return "empty";
    };
    throw new Error("Failed pattern match at Main (line 9, column 1 - line 9, column 35): " + [ v.constructor.name ]);
};
```

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [x] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] ~~Linked any existing issues or proposals that this pull request should close~~
- [ ] ~~Updated or added relevant documentation~~
- [ ] ~~Added a test for the contribution (if applicable)~~
