### PR TITLE
Remove Git upgrade step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,15 +69,6 @@ jobs:
       version: "${{ steps.build.outputs.version }}"
 
     steps:
-      - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone
-        # if the Git version is less than 2.18.
-        name: "(Linux only) Install a newer version of Git"
-        if: "contains(matrix.os, 'ubuntu-latest')"
-        run: |
-          . /etc/os-release
-          echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
-          apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
-
       - # We need `gh` installed on the Linux version. Otherwise, release artifacts won't be uploaded.
         name: "(Linux only) Install gh"
         if: "contains(matrix.os, 'ubuntu-latest')"
@@ -234,13 +225,6 @@ jobs:
     container: haskell:9.2.8@sha256:b3b2f3909c7381bb96b8f18766f9407a3d6f61e0f07ea95e812583ac4f442cbb
 
     steps:
-      - # We need a proper Git repository, but the checkout step will unpack a tarball instead of doing a clone
-        # if the Git version is less than 2.18.
-        name: "Install a newer version of Git"
-        run: |
-          . /etc/os-release
-          echo deb http://deb.debian.org/debian "$VERSION_CODENAME"-backports main >> /etc/apt/sources.list
-          apt-get update && apt-get install -y git/"$VERSION_CODENAME"-backports
       - uses: "actions/checkout@v2"
 
       - name: "Fix working directory ownership"

--- a/CHANGELOG.d/internal_remove-git-upgrade-step-in-ci.md
+++ b/CHANGELOG.d/internal_remove-git-upgrade-step-in-ci.md
@@ -1,0 +1,1 @@
+* Remove the step that upgraded Git from the CI workflow


### PR DESCRIPTION
buster-backports no longer exists in debian/dists and it's breaking CI. The currently available version of Git in this container is 2.20.1, so we don't need this.

**Description of the change**

Clearly and concisely describe the purpose of the pull request. If this PR relates to an existing issue or change proposal, please link to it. Include any other background context that would help reviewers understand the motivation for this PR.

---

**Checklist:**

- [x] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
