### PR TITLE
Upgrade macOS runner to 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           - # If upgrading the Haskell image, also upgrade it in the lint job below
             os: ["ubuntu-latest"]
             image: haskell:9.2.8@sha256:b3b2f3909c7381bb96b8f18766f9407a3d6f61e0f07ea95e812583ac4f442cbb
-          - os: ["macOS-11"]
+          - os: ["macOS-14"]
           - os: ["windows-2019"]
           - os: ["self-hosted", "macos", "ARM64"]
           - os: ["self-hosted", "Linux", "ARM64"]


### PR DESCRIPTION
Since the beginning of July GitHub has deprecated the macOS-11 runners that we were using, see [the announcement](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/)

CI is currently waiting for them 🙂
