### PR TITLE
Upgrade CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-node@v2"
         with:
-          node-version: "16"
+          node-version: "22"
 
       - id: "haskell"
         name: "(Non-Linux only) Install Haskell"
@@ -144,7 +144,6 @@ jobs:
         # Moreover, npm has a hook issue that will cause spago to fail to install
         # We upgrade npm to fix this
         run: |
-          npm i -g npm@8.8.0
           ../ci/fix-home stack --haddock exec ../ci/build-package-set.sh
 
       - name: Verify that 'libtinfo' isn't in binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,11 @@ jobs:
         include:
           - # If upgrading the Haskell image, also upgrade it in the lint job below
             os: ["ubuntu-latest"]
-            image: haskell:9.2.8@sha256:203bc96f3f7bf18af230408683d048a8849e9101ee2ddba55588600f2b27ac69
+            image: haskell:9.2.8@sha256:b3b2f3909c7381bb96b8f18766f9407a3d6f61e0f07ea95e812583ac4f442cbb
           - os: ["macOS-14"]
           - os: ["windows-2019"]
-          - os: ["self-hosted", "macOS", "ARM64"]
-          - os: ["self-hosted", "Linux", "ARM64"]
+          - os: [self-hosted, macOS, ARM64]
+          - os: [self-hosted, Linux, ARM64]
 
     runs-on: "${{ matrix.os }}"
     container: "${{ matrix.image }}"
@@ -222,7 +222,7 @@ jobs:
     # means our published binaries will work on the widest number of platforms.
     # But the HLint binary downloaded by this job requires a newer glibc
     # version.
-    container: haskell:9.2.8@sha256:203bc96f3f7bf18af230408683d048a8849e9101ee2ddba55588600f2b27ac69
+    container: haskell:9.2.8@sha256:b3b2f3909c7381bb96b8f18766f9407a3d6f61e0f07ea95e812583ac4f442cbb
 
     steps:
       - uses: "actions/checkout@v2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,10 @@ jobs:
         include:
           - # If upgrading the Haskell image, also upgrade it in the lint job below
             os: ["ubuntu-latest"]
-            image: haskell:9.2.8@sha256:b3b2f3909c7381bb96b8f18766f9407a3d6f61e0f07ea95e812583ac4f442cbb
+            image: haskell:9.2.8@sha256:203bc96f3f7bf18af230408683d048a8849e9101ee2ddba55588600f2b27ac69
           - os: ["macOS-14"]
           - os: ["windows-2019"]
-          - os: ["self-hosted", "macos", "ARM64"]
+          - os: ["self-hosted", "macOS", "ARM64"]
           - os: ["self-hosted", "Linux", "ARM64"]
 
     runs-on: "${{ matrix.os }}"
@@ -199,7 +199,7 @@ jobs:
 
       - name: "(Prerelease only) Upload bundle"
         if: "${{ env.CI_PRERELEASE == 'true' && steps.build.outputs.do-not-prerelease != 'true' }}"
-        uses: "actions/upload-artifact@v3"
+        uses: "actions/upload-artifact@v4.6.0"
         with:
           name: "${{ runner.os }}-${{ runner.arch }}-bundle"
           path: |
@@ -222,7 +222,7 @@ jobs:
     # means our published binaries will work on the widest number of platforms.
     # But the HLint binary downloaded by this job requires a newer glibc
     # version.
-    container: haskell:9.2.8@sha256:b3b2f3909c7381bb96b8f18766f9407a3d6f61e0f07ea95e812583ac4f442cbb
+    container: haskell:9.2.8@sha256:203bc96f3f7bf18af230408683d048a8849e9101ee2ddba55588600f2b27ac69
 
     steps:
       - uses: "actions/checkout@v2"

--- a/ci/build-package-set.sh
+++ b/ci/build-package-set.sh
@@ -16,23 +16,17 @@ export PATH="$tmpdir/node_modules/.bin:$PATH"
 cd "$tmpdir"
 
 echo ::group::Ensure Spago is available
-which spago || npm install spago@0.20.8
+which spago || npm install spago@0.93.43
 echo ::endgroup::
 
 echo ::group::Create dummy project
-echo 'let upstream = https://github.com/purescript/package-sets/releases/download/XXX/packages.dhall in upstream' > packages.dhall
-echo '{ name = "my-project", dependencies = [] : List Text, packages = ./packages.dhall, sources = [] : List Text }' > spago.dhall
-spago upgrade-set
-# Override the `metadata` package's version to match `purs` version
-# so that `spago build` actually works
-sed -i'' "\$c in upstream with metadata.version = \"v$(purs --version | { read v z && echo $v; })\"" packages.dhall
-spago install $(spago ls packages | while read name z; do if [[ $name != metadata ]]; then echo $name; fi; done)
+spago init
 echo ::endgroup::
 
 echo ::group::Compile package set
-spago build
+spago ls packages --json | jq -r 'keys[]' | xargs spago install
 echo ::endgroup::
 
 echo ::group::Document package set
-spago docs --no-search
+spago docs
 echo ::endgroup::


### PR DESCRIPTION
Some CI upgrades required to get back to all green:
- upgrade deprecated `upload-artifact` action to a supported version
- use spago-next for testing the package set to avoid zlib errors from the legacy spago
- upgrade Node version to v22, which is the latest supported LTS