### PR TITLE
Fix double click select of titles in documentation

### DIFF
--- a/src/Language/PureScript/Docs/AsHtml.hs
+++ b/src/Language/PureScript/Docs/AsHtml.hs
@@ -133,8 +133,7 @@ declAsHtml r d@Declaration{..} = do
     h3 ! A.class_ "decl__title clearfix" $ do
       a ! A.class_ "decl__anchor" ! A.href (v declFragment) $ "#"
       H.span $ text declTitle
-      text " " -- prevent browser from treating
-               -- declTitle + linkToSource as one word
+      text "\x200b" -- Zero-width space to allow double-click selection of title
       for_ declSourceSpan (linkToSource r)
 
     H.div ! A.class_ "decl__body" $ do


### PR DESCRIPTION
Before:
<img width="532" alt="Screenshot 2025-06-08 at 09 24 01" src="https://github.com/user-attachments/assets/4fb82882-2ceb-46e1-b968-56d0983d1fd7" />

After:
<img width="532" alt="Screenshot 2025-06-08 at 09 25 30" src="https://github.com/user-attachments/assets/d55a1f9a-e36e-4e6f-bb4a-c0824e69fb75" />
