### PR TITLE
doc - fixed kind for RowList

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,6 +90,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@LiamGoodacre](https://github.com/LiamGoodacre) | Liam Goodacre | [MIT license] |
 | [@lukerandall](https://github.com/lukerandall) | Luke Randall | [MIT license] |
 | [@lunaris](https://github.com/lunaris) | Will Jones | [MIT license] |
+| [@m-rinaldi](https://github.com/m-rinaldi) | Jorge Rinaldi | [MIT license] |
 | [@marcosh](https://github.com/marcosh) | Marco Perone | [MIT license] |
 | [@matthew-hilty](https://github.com/matthew-hilty) | Matthew Hilty | [MIT license] |
 | [@matthewleon](https://github.com/matthewleon) | Matthew Leon | [MIT license] |

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -357,6 +357,9 @@ tyVar = TypeVar nullSourceAnn
 tyForall :: Text -> SourceType -> SourceType -> SourceType
 tyForall var k ty = ForAll nullSourceAnn TypeVarInvisible var (Just k) ty Nothing
 
+tyForall' :: Text -> SourceType -> SourceType
+tyForall' var ty = ForAll nullSourceAnn TypeVarInvisible var Nothing ty Nothing
+
 -- | Smart constructor for function types
 function :: SourceType -> SourceType -> SourceType
 function = TypeApp nullSourceAnn . TypeApp nullSourceAnn tyFunction
@@ -443,7 +446,7 @@ primRowTypes =
 primRowListTypes :: M.Map (Qualified (ProperName 'TypeName)) (SourceType, TypeKind)
 primRowListTypes =
   M.fromList $
-    [ (C.RowList, (kindType -:> kindType, ExternData [Phantom]))
+    [ (C.RowList, (tyForall' "k" $ tyVar "k" -:> kindType, ExternData [Phantom]))
     , (C.RowListCons, (tyForall "k" kindType $ kindSymbol -:> tyVar "k" -:> kindRowList (tyVar "k") -:> kindRowList (tyVar "k"), ExternData [Phantom, Phantom, Phantom]))
     , (C.RowListNil, (tyForall "k" kindType $ kindRowList (tyVar "k"), ExternData []))
     ] <> mconcat


### PR DESCRIPTION
**Description of the change**

Fixed the following issue in the built-in documentation (`Prim.RowList`):

[`RowList`](https://pursuit.purescript.org/builtins/docs/Prim.RowList#t:RowList)'s kind is **not** `Type -> Type` but `forall k. k -> Type`.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [X] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [X] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
