### PR TITLE
Move to windows-2022 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
           - os: macos-13  # x64
           - os: macos-14  # arm64
-          - os: windows-2019  # x64
+          - os: windows-2022  # x64
 
     runs-on: "${{ matrix.os }}"
     container:  "${{ matrix.image }}"


### PR DESCRIPTION
GitHub is sunsetting the `windows-2019` runner that we use in CI. I got this email:
<img width="729" alt="image" src="https://github.com/user-attachments/assets/51e8c5a0-edc7-49db-9fb3-2a1b4c3c6162" />
